### PR TITLE
feat: add CSV dual-write and UI updates for Start Research Project

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -3,22 +3,47 @@ name: Deploy Cloudflare Worker
 
 on:
   push:
-    branches: [ main ]
-  workflow_dispatch:
+    branches: [ main, start-csv ]
+  workflow_dispatch: {}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check required GitHub secrets exist
+        run: |
+          test -n "${{ secrets.CF_API_TOKEN }}" || (echo "CF_API_TOKEN missing"; exit 1)
+          test -n "${{ secrets.CF_ACCOUNT_ID }}" || (echo "CF_ACCOUNT_ID missing"; exit 1)
+          test -n "${{ secrets.GH_PAT }}" || (echo "GH_PAT missing"; exit 1)
+          test -n "${{ secrets.AIRTABLE_API_KEY }}" || (echo "AIRTABLE_API_KEY missing"; exit 1)
+
+      # Install Wrangler explicitly so we can use it in subsequent run steps
+      - name: Install Wrangler
+        run: npm i -g wrangler@4.40.2
+
+      # Set secrets directly on the Worker defined by infra/cloudflare/wrangler.toml
+      - name: Put Worker secrets
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+        run: |
+          echo -n "$GH_PAT" | wrangler secret put GH_TOKEN --config infra/cloudflare/wrangler.toml --yes
+          echo -n "$AIRTABLE_API_KEY" | wrangler secret put AIRTABLE_API_KEY --config infra/cloudflare/wrangler.toml --yes
+
+      # Deploy
       - name: Publish Worker
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          wranglerVersion: '4.40.2'   # or just '4'
-          command: deploy --config infra/cloudflare/wrangler.toml
+          wranglerVersion: '4.40.2'
+          workingDirectory: infra/cloudflare
+          command: deploy --config wrangler.toml

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -23,27 +23,22 @@ jobs:
           test -n "${{ secrets.GH_PAT }}" || (echo "GH_PAT missing"; exit 1)
           test -n "${{ secrets.AIRTABLE_API_KEY }}" || (echo "AIRTABLE_API_KEY missing"; exit 1)
 
-      # Install Wrangler explicitly so we can use it in subsequent run steps
       - name: Install Wrangler
         run: npm i -g wrangler@4.40.2
 
-      # Set secrets directly on the Worker defined by infra/cloudflare/wrangler.toml
+      # Set Worker secrets via Wrangler (no --yes; feed via stdin)
       - name: Put Worker secrets
         env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          GH_PAT: ${{ secrets.GH_PAT }}
-          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          echo -n "$GH_PAT" | wrangler secret put GH_TOKEN --config infra/cloudflare/wrangler.toml --yes
-          echo -n "$AIRTABLE_API_KEY" | wrangler secret put AIRTABLE_API_KEY --config infra/cloudflare/wrangler.toml --yes
+          printf '%s' "${{ secrets.GH_PAT }}" | wrangler secret put GH_TOKEN --config infra/cloudflare/wrangler.toml
+          printf '%s' "${{ secrets.AIRTABLE_API_KEY }}" | wrangler secret put AIRTABLE_API_KEY --config infra/cloudflare/wrangler.toml
 
-      # Deploy
       - name: Publish Worker
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: '4.40.2'
-          workingDirectory: infra/cloudflare
-          command: deploy --config wrangler.toml
+          command: deploy --config infra/cloudflare/wrangler.toml

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -5,200 +5,210 @@
 // - GET  /api/projects.csv  -> Proxy CSV from SharePoint
 
 export default {
-	async fetch(request, env, ctx) {
-		const url = new URL(request.url);
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
 
-		// API routes
-		if (url.pathname.startsWith("/api/")) {
-			return handleApi(request, env, ctx);
-		}
+    // ---- API routes
+    if (url.pathname.startsWith("/api/")) {
+      return handleApi(request, env, ctx);
+    }
 
-		// Static assets via Workers Assets
-		let resp = await env.ASSETS.fetch(request);
-		if (resp.status === 404) {
-			const indexReq = new Request(new URL("/index.html", url), request);
-			resp = await env.ASSETS.fetch(indexReq);
-		}
-		return resp;
-	}
+    // ---- Static assets via Workers Assets
+    let resp = await env.ASSETS.fetch(request);
+    if (resp.status === 404) {
+      const indexReq = new Request(new URL("/index.html", url), request);
+      resp = await env.ASSETS.fetch(indexReq);
+    }
+    return resp;
+  }
 };
 
 async function handleApi(request, env, ctx) {
-	const url = new URL(request.url);
-	const origin = request.headers.get("Origin") || "";
-	const allowed = (env.ALLOWED_ORIGINS || "").split(",").map(s => s.trim()).filter(Boolean);
+  const url = new URL(request.url);
+  const origin = request.headers.get("Origin") || "";
+  const allowed = (env.ALLOWED_ORIGINS || "").split(",").map(s => s.trim()).filter(Boolean);
 
-	// CORS preflight
-	if (request.method === "OPTIONS") {
-		return new Response(null, { headers: corsHeaders(origin, allowed) });
-	}
+  // ---- CORS preflight
+  if (request.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders(origin, allowed) });
+  }
 
-	// Enforce CORS allowlist
-	if (origin && !allowed.includes(origin)) {
-		return json({ error: "Origin not allowed" }, 403, corsHeaders(origin, allowed));
-	}
+  // ---- Enforce CORS allowlist
+  if (origin && !allowed.includes(origin)) {
+    return json({ error: "Origin not allowed" }, 403, corsHeaders(origin, allowed));
+  }
 
-	// Health
-	if (url.pathname === "/api/health") {
-		return json({ ok: true, time: new Date().toISOString() }, 200, corsHeaders(origin, allowed));
-	}
+  // ---- Health
+  if (url.pathname === "/api/health") {
+    return json({ ok: true, time: new Date().toISOString() }, 200, corsHeaders(origin, allowed));
+  }
 
-	// POST /api/projects
-	if (url.pathname === "/api/projects" && request.method === "POST") {
-		let payload;
-		try { payload = await request.json(); }
-		catch { return json({ error: "Invalid JSON" }, 400, corsHeaders(origin, allowed)); }
+  // ====================================================================================
+  // POST /api/projects  -> Create Projects (+ optional linked Project Details)
+  // ====================================================================================
+  if (url.pathname === "/api/projects" && request.method === "POST") {
+    let payload;
+    try { payload = await request.json(); }
+    catch { return json({ error: "Invalid JSON" }, 400, corsHeaders(origin, allowed)); }
 
-		// Required
-		const errs = [];
-		if (!payload.name) errs.push("name");
-		if (!payload.description) errs.push("description");
-		if (errs.length) {
-			return json({ error: "Missing required fields: " + errs.join(", ") }, 400, corsHeaders(origin, allowed));
-		}
+    // Required (Step 1)
+    const errs = [];
+    if (!payload.name) errs.push("name");
+    if (!payload.description) errs.push("description");
+    if (errs.length) {
+      return json({ error: "Missing required fields: " + errs.join(", ") }, 400, corsHeaders(origin, allowed));
+    }
 
-		// Map -> Projects fields (send plain strings for Single select)
-		const projectFields = {
-			Org: payload.org || "Home Office Biometrics",
-			Name: payload.name,
-			Description: payload.description,
-			Phase: typeof payload.phase === "string" ? payload.phase : undefined,   // string label
-			Status: typeof payload.status === "string" ? payload.status : undefined, // string label
-			Objectives: (payload.objectives || []).join("\n"),
-			UserGroups: (payload.user_groups || []).join(", "),
-			Stakeholders: JSON.stringify(payload.stakeholders || []),
-			// Do NOT send CreatedAt if it's a computed field in Airtable
-			LocalId: payload.id || ""
-		};
+    // Send strings for Airtable single-selects (labels must match options in base)
+    const projectFields = {
+      Org: payload.org || "Home Office Biometrics",
+      Name: payload.name,
+      Description: payload.description,
+      Phase: typeof payload.phase === "string" ? payload.phase : undefined,
+      Status: typeof payload.status === "string" ? payload.status : undefined,
+      Objectives: (payload.objectives || []).join("\n"),
+      UserGroups: (payload.user_groups || []).join(", "),
+      Stakeholders: JSON.stringify(payload.stakeholders || []),
+      // Do NOT send CreatedAt if it's a computed "Created time" field
+      LocalId: payload.id || ""
+    };
 
-		// prune empties
-		for (const k of Object.keys(projectFields)) {
-			const v = projectFields[k];
-			if (v === undefined || v === null || (typeof v === "string" && v.trim() === "")) {
-				delete projectFields[k];
-			}
-		}
+    // prune empties
+    for (const k of Object.keys(projectFields)) {
+      const v = projectFields[k];
+      if (v === undefined || v === null || (typeof v === "string" && v.trim() === "")) {
+        delete projectFields[k];
+      }
+    }
 
-		const base = env.AIRTABLE_BASE_ID;
-		const tProjects = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
-		const tDetails  = encodeURIComponent(env.AIRTABLE_TABLE_PROJECT_DETAILS);
+    const base = env.AIRTABLE_BASE_ID;
+    const tProjects = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
+    const tDetails  = encodeURIComponent(env.AIRTABLE_TABLE_PROJECT_DETAILS);
 
-		const atProjectsUrl = `https://api.airtable.com/v0/${base}/${tProjects}`;
-		const atDetailsUrl  = `https://api.airtable.com/v0/${base}/${tDetails}`;
+    const atProjectsUrl = `https://api.airtable.com/v0/${base}/${tProjects}`;
+    const atDetailsUrl  = `https://api.airtable.com/v0/${base}/${tDetails}`;
 
-		// 1) Create Projects record
-		const pRes = await fetch(atProjectsUrl, {
-			method: "POST",
-			headers: {
-				"Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
-				"Content-Type": "application/json"
-			},
-			body: JSON.stringify({ records: [{ fields: projectFields }] })
-		});
-		const pText = await pRes.text();
-		if (!pRes.ok) {
-			return json({ error: `Airtable ${pRes.status}`, detail: safeText(pText) }, pRes.status, corsHeaders(origin, allowed));
-		}
+    // 1) Create Projects record
+    const pRes = await fetch(atProjectsUrl, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ records: [{ fields: projectFields }] })
+    });
+    const pText = await pRes.text();
+    if (!pRes.ok) {
+      return json({ error: `Airtable ${pRes.status}`, detail: safeText(pText) }, pRes.status, corsHeaders(origin, allowed));
+    }
 
-		let pJson; try { pJson = JSON.parse(pText); } catch { pJson = { records: [] }; }
-		const projectRecord = pJson.records?.[0];
-		const projectId = projectRecord?.id;
-		if (!projectId) {
-			return json({ error: "Airtable response missing project id" }, 502, corsHeaders(origin, allowed));
-		}
+    let pJson; try { pJson = JSON.parse(pText); } catch { pJson = { records: [] }; }
+    const projectId = pJson.records?.[0]?.id;
+    if (!projectId) {
+      return json({ error: "Airtable response missing project id" }, 502, corsHeaders(origin, allowed));
+    }
 
-		// 2) Optional Project Details (linked)
-		let detailId = null;
-		const hasDetails = Boolean(
-			payload.lead_researcher || payload.lead_researcher_email || payload.notes
-		);
+    // 2) Optional: Project Details linked to the new project
+    let detailId = null;
+    const hasDetails = Boolean(
+      payload.lead_researcher || payload.lead_researcher_email || payload.notes
+    );
 
-		if (hasDetails) {
-			const detailsFields = {
-				Project: [projectId],
-				"Lead Researcher": payload.lead_researcher || "",
-				"Lead Researcher Email": payload.lead_researcher_email || "",
-				Notes: payload.notes || ""
-			};
-			for (const k of Object.keys(detailsFields)) {
-				const v = detailsFields[k];
-				if (typeof v === "string" && v.trim() === "") delete detailsFields[k];
-			}
+    if (hasDetails) {
+      const detailsFields = {
+        Project: [projectId],                              // linked record expects array of record IDs
+        "Lead Researcher": payload.lead_researcher || "",
+        "Lead Researcher Email": payload.lead_researcher_email || "",
+        Notes: payload.notes || ""
+      };
+      for (const k of Object.keys(detailsFields)) {
+        const v = detailsFields[k];
+        if (typeof v === "string" && v.trim() === "") delete detailsFields[k];
+      }
 
-			const dRes = await fetch(atDetailsUrl, {
-				method: "POST",
-				headers: {
-					"Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
-					"Content-Type": "application/json"
-				},
-				body: JSON.stringify({ records: [{ fields: detailsFields }] })
-			});
-			const dText = await dRes.text();
-			if (!dRes.ok) {
-				// rollback
-				try {
-					await fetch(`${atProjectsUrl}/${projectId}`, {
-						method: "DELETE",
-						headers: { "Authorization": `Bearer ${env.AIRTABLE_API_KEY}` }
-					});
-				} catch {}
-				return json({ error: `Airtable details ${dRes.status}`, detail: safeText(dText) }, dRes.status, corsHeaders(origin, allowed));
-			}
-			try { detailId = JSON.parse(dText).records?.[0]?.id || null; } catch {}
-		}
+      const dRes = await fetch(atDetailsUrl, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ records: [{ fields: detailsFields }] })
+      });
+      const dText = await dRes.text();
+      if (!dRes.ok) {
+        // rollback to avoid orphan
+        try {
+          await fetch(`${atProjectsUrl}/${projectId}`, {
+            method: "DELETE",
+            headers: { "Authorization": `Bearer ${env.AIRTABLE_API_KEY}` }
+          });
+        } catch {}
+        return json({ error: `Airtable details ${dRes.status}`, detail: safeText(dText) }, dRes.status, corsHeaders(origin, allowed));
+      }
+      try { detailId = JSON.parse(dText).records?.[0]?.id || null; } catch {}
+    }
 
-		if (env.AUDIT === "true") {
-			try { console.log("project.created", { id: projectId, hasDetails, name: projectFields.Name }); } catch {}
-		}
+    if (env.AUDIT === "true") {
+      try { console.log("project.created", { id: projectId, name: projectFields.Name, hasDetails }); } catch {}
+    }
 
-		return json({ ok: true, project_id: projectId, detail_id: detailId, project: projectFields }, 200, corsHeaders(origin, allowed));
-	}
+    return json({ ok: true, project_id: projectId, detail_id: detailId, project: projectFields }, 200, corsHeaders(origin, allowed));
+  }
 
-	// GET /api/projects.csv
-	if (url.pathname === "/api/projects.csv" && request.method === "GET") {
-		const spUrl = env.SHAREPOINT_CSV_URL;
-		if (!spUrl) {
-			return json({ error: "SHAREPOINT_CSV_URL not configured" }, 500, corsHeaders(origin, allowed));
-		}
-		const headers = {};
-		if (env.SHAREPOINT_BEARER) headers["Authorization"] = `Bearer ${env.SHAREPOINT_BEARER}`;
+  // ====================================================================================
+  // GET /api/projects.csv  -> Stream CSV from SharePoint
+  // ====================================================================================
+  if (url.pathname === "/api/projects.csv" && request.method === "GET") {
+    const spUrl = env.SHAREPOINT_CSV_URL;
+    if (!spUrl) {
+      return json({ error: "SHAREPOINT_CSV_URL not configured" }, 500, corsHeaders(origin, allowed));
+    }
 
-		const spRes = await fetch(spUrl, { headers });
-		if (!spRes.ok) {
-			const t = await spRes.text();
-			return json({ error: `SharePoint ${spRes.status}`, detail: safeText(t) }, spRes.status, corsHeaders(origin, allowed));
-		}
-		return new Response(spRes.body, {
-			status: 200,
-			headers: {
-				...corsHeaders(origin, allowed),
-				"Content-Type": "text/csv; charset=utf-8",
-				"Content-Disposition": 'attachment; filename="projects.csv"'
-			}
-		});
-	}
+    const headers = {};
+    if (env.SHAREPOINT_BEARER) {
+      headers["Authorization"] = `Bearer ${env.SHAREPOINT_BEARER}`;
+    }
 
-	return json({ error: "Not found" }, 404, corsHeaders(origin, allowed));
+    const spRes = await fetch(spUrl, { headers });
+    if (!spRes.ok) {
+      const t = await spRes.text();
+      return json({ error: `SharePoint ${spRes.status}`, detail: safeText(t) }, spRes.status, corsHeaders(origin, allowed));
+    }
+
+    return new Response(spRes.body, {
+      status: 200,
+      headers: {
+        ...corsHeaders(origin, allowed),
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="projects.csv"'
+      }
+    });
+  }
+
+  // Fallback
+  return json({ error: "Not found" }, 404, corsHeaders(origin, allowed));
 }
 
 // ---------- helpers ----------
 function corsHeaders(origin, allowed) {
-	const h = {
-		"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-		"Access-Control-Allow-Headers": "Content-Type, Authorization",
-		"Vary": "Origin"
-	};
-	if (origin && allowed.includes(origin)) h["Access-Control-Allow-Origin"] = origin;
-	return h;
+  const h = {
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Vary": "Origin"
+  };
+  if (origin && allowed.includes(origin)) {
+    h["Access-Control-Allow-Origin"] = origin;
+  }
+  return h;
 }
 
 function json(body, status = 200, headers = {}) {
-	return new Response(JSON.stringify(body), {
-		status,
-		headers: { "Content-Type": "application/json", ...headers }
-	});
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers }
+  });
 }
 
 function safeText(t) {
-	return t && t.length > 2048 ? t.slice(0, 2048) + "…" : t;
+  return t && t.length > 2048 ? t.slice(0, 2048) + "…" : t;
 }

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -75,7 +75,6 @@ async function handleApi(request, env, ctx) {
       Objectives: (payload.objectives || []).join("\n"),
       UserGroups: (payload.user_groups || []).join(", "),
       Stakeholders: JSON.stringify(payload.stakeholders || []),
-      CreatedAt: payload.created || new Date().toISOString(),
       LocalId: payload.id || ""
     };
 

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -82,7 +82,7 @@ async function handleApi(request, env, ctx) {
 
     const base = env.AIRTABLE_BASE_ID;
     const tProjects = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
-    const tDetails  = encodeURIComponent(env.AIRTABLE_TABLE_PROJECT_DETAILS);
+    const tDetails  = encodeURIComponent(env.AIRTABLE_TABLE_DETAILS);
 
     const atProjectsUrl = `https://api.airtable.com/v0/${base}/${tProjects}`;
     const atDetailsUrl  = `https://api.airtable.com/v0/${base}/${tDetails}`;

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -1,215 +1,242 @@
 // infra/cloudflare/src/worker.js
-// ResearchOps Worker: serves static assets and exposes API routes.
-// - GET /api/health
-// - POST /api/projects            -> Airtable: create Projects (+ Project Details if provided)
-// - GET  /api/projects.csv        -> Proxy CSV from SharePoint
+// ResearchOps Worker: serves static assets (no KV) and exposes API routes.
+// - GET  /api/health
+// - POST /api/projects      -> Airtable: create Projects (+ Project Details if provided)
+// - GET  /api/projects.csv  -> Proxy CSV from SharePoint
 
 export default {
-  async fetch(request, env, ctx) {
-    const url = new URL(request.url);
+	async fetch(request, env, ctx) {
+		const url = new URL(request.url);
 
-    // --- API routes
-    if (url.pathname.startsWith("/api/")) {
-      return handleApi(request, env, ctx);
-    }
+		// --- API routes
+		if (url.pathname.startsWith("/api/")) {
+			return handleApi(request, env, ctx);
+		}
 
-    // --- Static assets via Workers Assets
-    let resp = await env.ASSETS.fetch(request);
-    if (resp.status === 404) {
-      const indexReq = new Request(new URL("/index.html", url), request);
-      resp = await env.ASSETS.fetch(indexReq);
-    }
-    return resp;
-  }
+		// --- Static assets via Workers Assets (no KV)
+		// Try exact asset; on 404, fall back to /index.html (SPA-friendly)
+		let resp = await env.ASSETS.fetch(request);
+		if (resp.status === 404) {
+			const indexReq = new Request(new URL("/index.html", url), request);
+			resp = await env.ASSETS.fetch(indexReq);
+		}
+		return resp;
+	}
 };
 
 async function handleApi(request, env, ctx) {
-  const url = new URL(request.url);
-  const origin = request.headers.get("Origin") || "";
-  const allowed = (env.ALLOWED_ORIGINS || "")
-    .split(",")
-    .map(s => s.trim())
-    .filter(Boolean);
+	const url = new URL(request.url);
+	const origin = request.headers.get("Origin") || "";
+	const allowed = (env.ALLOWED_ORIGINS || "").split(",").map(s => s.trim()).filter(Boolean);
 
-  // --- CORS preflight
-  if (request.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders(origin, allowed) });
-  }
+	// --- CORS preflight for API
+	if (request.method === "OPTIONS") {
+		return new Response(null, { headers: corsHeaders(origin, allowed) });
+	}
 
-  // --- Enforce CORS allowlist
-  if (origin && !allowed.includes(origin)) {
-    return json({ error: "Origin not allowed" }, 403, corsHeaders(origin, allowed));
-  }
+	// --- Enforce CORS allowlist (non-browser clients may omit Origin)
+	if (origin && !allowed.includes(origin)) {
+		return json({ error: "Origin not allowed" }, 403, corsHeaders(origin, allowed));
+	}
 
-  // --- Health
-  if (url.pathname === "/api/health") {
-    return json({ ok: true, time: new Date().toISOString() }, 200, corsHeaders(origin, allowed));
-  }
+	// --- Health
+	if (url.pathname === "/api/health") {
+		return json({ ok: true, time: new Date().toISOString() }, 200, corsHeaders(origin, allowed));
+	}
 
-  // ====================================================================================
-  // POST /api/projects  -> Create record in Airtable (Projects + Project Details)
-  // ====================================================================================
-  if (url.pathname === "/api/projects" && request.method === "POST") {
-    let payload;
-    try {
-      payload = await request.json();
-    } catch {
-      return json({ error: "Invalid JSON" }, 400, corsHeaders(origin, allowed));
-    }
+	// ====================================================================================
+	// POST /api/projects  -> Create record in Airtable (Projects) + linked Project Details
+	// ====================================================================================
+	if (url.pathname === "/api/projects" && request.method === "POST") {
+		let payload;
+		try {
+			payload = await request.json();
+		} catch {
+			return json({ error: "Invalid JSON" }, 400, corsHeaders(origin, allowed));
+		}
 
-    // Required fields
-    const errs = [];
-    if (!payload.name) errs.push("name");
-    if (!payload.description) errs.push("description");
-    if (errs.length) {
-      return json({ error: "Missing required fields: " + errs.join(", ") }, 400, corsHeaders(origin, allowed));
-    }
+		// Required (Step 1)
+		const errs = [];
+		if (!payload.name) errs.push("name");
+		if (!payload.description) errs.push("description");
+		if (errs.length) {
+			return json({ error: "Missing required fields: " + errs.join(", ") }, 400, corsHeaders(origin, allowed));
+		}
 
-    // Map -> Projects fields
-    const projectFields = {
-      Org: payload.org || "Home Office Biometrics",
-      Name: payload.name,
-      Description: payload.description,
-      Phase: payload.phase || "discovery",
-      Status: payload.status || "planning",
-      Objectives: (payload.objectives || []).join("\n"),
-      UserGroups: (payload.user_groups || []).join(", "),
-      Stakeholders: JSON.stringify(payload.stakeholders || []),
-      LocalId: payload.id || ""
-    };
+		// Helpers for Airtable field shapes
+		const toSelect = (v) => {
+			if (typeof v !== "string") return undefined;
+			const s = v.trim();
+			return s ? { name: s } : undefined; // reliable for Single select
+		};
 
-    const base = env.AIRTABLE_BASE_ID;
-    const tProjects = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
-    const tDetails = env.AIRTABLE_TABLE_DETAILS ? encodeURIComponent(env.AIRTABLE_TABLE_DETAILS) : null;
+		// Map -> Projects fields (adjust to your Airtable schema if needed)
+		const projectFields = {
+			Org: payload.org || "Home Office Biometrics",
+			Name: payload.name,
+			Description: payload.description,
+			Phase: toSelect(payload.phase),          // Single select
+			Status: toSelect(payload.status),        // Single select
+			Objectives: (payload.objectives || []).join("\n"),
+			UserGroups: (payload.user_groups || []).join(", "),
+			Stakeholders: JSON.stringify(payload.stakeholders || []),
+			// CreatedAt: (read-only in Airtable if "Created time") -> do NOT send
+			LocalId: payload.id || ""
+		};
 
-    const atProjectsUrl = `https://api.airtable.com/v0/${base}/${tProjects}`;
-    const authHeaders = {
-      "Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
-      "Content-Type": "application/json"
-    };
+		// Remove undefined/empty strings so Airtable doesn't choke
+		for (const k of Object.keys(projectFields)) {
+			const v = projectFields[k];
+			if (
+				v === undefined ||
+				v === null ||
+				(typeof v === "string" && v.trim() === "")
+			) {
+				delete projectFields[k];
+			}
+		}
 
-    // 1) Create Projects record
-    const pRes = await fetch(atProjectsUrl, {
-      method: "POST",
-      headers: authHeaders,
-      body: JSON.stringify({ records: [{ fields: projectFields }] })
-    });
+		const base = env.AIRTABLE_BASE_ID;
+		const tProjects = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
+		const tDetails  = encodeURIComponent(env.AIRTABLE_TABLE_PROJECT_DETAILS);
 
-    const pText = await pRes.text();
-    if (!pRes.ok) {
-      return json({ error: `Airtable ${pRes.status}`, detail: safeText(pText) }, pRes.status, corsHeaders(origin, allowed));
-    }
+		const atProjectsUrl = `https://api.airtable.com/v0/${base}/${tProjects}`;
+		const atDetailsUrl  = `https://api.airtable.com/v0/${base}/${tDetails}`;
 
-    let pJson; try { pJson = JSON.parse(pText); } catch { pJson = { records: [] }; }
-    const projectRecord = pJson.records?.[0];
-    const projectId = projectRecord?.id;
-    if (!projectId) {
-      return json({ error: "Airtable response missing project id" }, 502, corsHeaders(origin, allowed));
-    }
+		// 1) Create Projects record
+		const pRes = await fetch(atProjectsUrl, {
+			method: "POST",
+			headers: {
+				"Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
+				"Content-Type": "application/json"
+			},
+			body: JSON.stringify({ records: [{ fields: projectFields }] })
+		});
 
-    // 2) Optionally create Project Details
-    let detailId = null;
-    const hasDetails = Boolean(payload.lead_researcher || payload.lead_researcher_email || payload.notes);
+		const pText = await pRes.text();
+		if (!pRes.ok) {
+			return json({ error: `Airtable ${pRes.status}`, detail: safeText(pText) }, pRes.status, corsHeaders(origin, allowed));
+		}
 
-    if (hasDetails && tDetails) {
-      const atDetailsUrl = `https://api.airtable.com/v0/${base}/${tDetails}`;
-      const detailsFields = {
-        Project: [projectId],
-        "Lead Researcher": payload.lead_researcher || "",
-        "Lead Researcher Email": payload.lead_researcher_email || "",
-        Notes: payload.notes || ""
-      };
+		let pJson; try { pJson = JSON.parse(pText); } catch { pJson = { records: [] }; }
+		const projectRecord = pJson.records?.[0];
+		const projectId = projectRecord?.id;
+		if (!projectId) {
+			return json({ error: "Airtable response missing project id" }, 502, corsHeaders(origin, allowed));
+		}
 
-      const dRes = await fetch(atDetailsUrl, {
-        method: "POST",
-        headers: authHeaders,
-        body: JSON.stringify({ records: [{ fields: detailsFields }] })
-      });
+		// 2) Create Project Details if provided (linked to the project)
+		let detailId = null;
+		const hasDetails = Boolean(
+			payload.lead_researcher || payload.lead_researcher_email || payload.notes
+		);
 
-      const dText = await dRes.text();
-      if (!dRes.ok) {
-        // Roll back project to avoid orphan
-        try {
-          await fetch(`${atProjectsUrl}/${projectId}`, {
-            method: "DELETE",
-            headers: { "Authorization": `Bearer ${env.AIRTABLE_API_KEY}` }
-          });
-        } catch {}
-        return json({ error: `Airtable details ${dRes.status}`, detail: safeText(dText) }, dRes.status, corsHeaders(origin, allowed));
-      }
+		if (hasDetails) {
+			const detailsFields = {
+				Project: [projectId], // linked record expects array of IDs
+				"Lead Researcher": payload.lead_researcher || "",
+				"Lead Researcher Email": payload.lead_researcher_email || "",
+				Notes: payload.notes || ""
+			};
 
-      try {
-        const dJson = JSON.parse(dText);
-        detailId = dJson.records?.[0]?.id || null;
-      } catch {}
-    }
+			// prune empties
+			for (const k of Object.keys(detailsFields)) {
+				const v = detailsFields[k];
+				if (typeof v === "string" && v.trim() === "") delete detailsFields[k];
+			}
 
-    if (env.AUDIT === "true") {
-      try { console.log("project.created", { id: projectId, hasDetails, name: projectFields.Name }); } catch {}
-    }
+			const dRes = await fetch(atDetailsUrl, {
+				method: "POST",
+				headers: {
+					"Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({ records: [{ fields: detailsFields }] })
+			});
 
-    return json({
-      ok: true,
-      project_id: projectId,
-      detail_id: detailId,
-      project: projectFields
-    }, 200, corsHeaders(origin, allowed));
-  }
+			const dText = await dRes.text();
+			if (!dRes.ok) {
+				// Roll back the project to avoid orphan
+				try {
+					await fetch(`${atProjectsUrl}/${projectId}`, {
+						method: "DELETE",
+						headers: { "Authorization": `Bearer ${env.AIRTABLE_API_KEY}` }
+					});
+				} catch {}
+				return json({ error: `Airtable details ${dRes.status}`, detail: safeText(dText) }, dRes.status, corsHeaders(origin, allowed));
+			}
+			try {
+				const dJson = JSON.parse(dText);
+				detailId = dJson.records?.[0]?.id || null;
+			} catch {}
+		}
 
-  // ====================================================================================
-  // GET /api/projects.csv  -> Proxy CSV from SharePoint
-  // ====================================================================================
-  if (url.pathname === "/api/projects.csv" && request.method === "GET") {
-    const spUrl = env.SHAREPOINT_CSV_URL;
-    if (!spUrl) {
-      return json({ error: "SHAREPOINT_CSV_URL not configured" }, 500, corsHeaders(origin, allowed));
-    }
+		if (env.AUDIT === "true") {
+			try { console.log("project.created", { id: projectId, hasDetails, name: projectFields.Name }); } catch {}
+		}
 
-    const headers = {};
-    if (env.SHAREPOINT_BEARER) {
-      headers["Authorization"] = `Bearer ${env.SHAREPOINT_BEARER}`;
-    }
+		return json({
+			ok: true,
+			project_id: projectId,
+			detail_id: detailId,
+			project: projectFields
+		}, 200, corsHeaders(origin, allowed));
+	}
 
-    const spRes = await fetch(spUrl, { headers });
-    if (!spRes.ok) {
-      const t = await spRes.text();
-      return json({ error: `SharePoint ${spRes.status}`, detail: safeText(t) }, spRes.status, corsHeaders(origin, allowed));
-    }
+	// ====================================================================================
+	// GET /api/projects.csv  -> Stream CSV from SharePoint
+	// ====================================================================================
+	if (url.pathname === "/api/projects.csv" && request.method === "GET") {
+		const spUrl = env.SHAREPOINT_CSV_URL;
+		if (!spUrl) {
+			return json({ error: "SHAREPOINT_CSV_URL not configured" }, 500, corsHeaders(origin, allowed));
+		}
 
-    return new Response(spRes.body, {
-      status: 200,
-      headers: {
-        ...corsHeaders(origin, allowed),
-        "Content-Type": "text/csv; charset=utf-8",
-        "Content-Disposition": 'attachment; filename="projects.csv"'
-      }
-    });
-  }
+		const headers = {};
+		if (env.SHAREPOINT_BEARER) {
+			headers["Authorization"] = `Bearer ${env.SHAREPOINT_BEARER}`;
+		}
 
-  // --- Fallback
-  return json({ error: "Not found" }, 404, corsHeaders(origin, allowed));
+		const spRes = await fetch(spUrl, { headers });
+		if (!spRes.ok) {
+			const t = await spRes.text();
+			return json({ error: `SharePoint ${spRes.status}`, detail: safeText(t) }, spRes.status, corsHeaders(origin, allowed));
+		}
+
+		return new Response(spRes.body, {
+			status: 200,
+			headers: {
+				...corsHeaders(origin, allowed),
+				"Content-Type": "text/csv; charset=utf-8",
+				"Content-Disposition": 'attachment; filename="projects.csv"'
+			}
+		});
+	}
+
+	// --- API fallback
+	return json({ error: "Not found" }, 404, corsHeaders(origin, allowed));
 }
 
 // ---------- helpers ----------
 function corsHeaders(origin, allowed) {
-  const h = {
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    "Vary": "Origin"
-  };
-  if (origin && allowed.includes(origin)) {
-    h["Access-Control-Allow-Origin"] = origin;
-  }
-  return h;
+	const h = {
+		"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+		"Access-Control-Allow-Headers": "Content-Type, Authorization",
+		"Vary": "Origin"
+	};
+	if (origin && allowed.includes(origin)) {
+		h["Access-Control-Allow-Origin"] = origin;
+	}
+	return h;
 }
 
 function json(body, status = 200, headers = {}) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json", ...headers }
-  });
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json", ...headers }
+	});
 }
 
 function safeText(t) {
-  return t && t.length > 2048 ? t.slice(0, 2048) + "…" : t;
+	return t && t.length > 2048 ? t.slice(0, 2048) + "…" : t;
 }

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -1,217 +1,216 @@
 // infra/cloudflare/src/worker.js
-// ResearchOps Worker: serves static assets (no KV) and exposes API routes.
+// ResearchOps Worker: serves static assets and exposes API routes.
 // - GET /api/health
 // - POST /api/projects            -> Airtable: create Projects (+ Project Details if provided)
 // - GET  /api/projects.csv        -> Proxy CSV from SharePoint
 
 export default {
-	async fetch(request, env, ctx) {
-		const url = new URL(request.url);
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
 
-		// --- API routes
-		if (url.pathname.startsWith("/api/")) {
-			return handleApi(request, env, ctx);
-		}
+    // --- API routes
+    if (url.pathname.startsWith("/api/")) {
+      return handleApi(request, env, ctx);
+    }
 
-		// --- Static assets via Workers Assets (no KV)
-		// Try exact asset; on 404, fall back to /index.html (SPA-friendly)
-		let resp = await env.ASSETS.fetch(request);
-		if (resp.status === 404) {
-			const indexReq = new Request(new URL("/index.html", url), request);
-			resp = await env.ASSETS.fetch(indexReq);
-		}
-		return resp;
-	}
+    // --- Static assets via Workers Assets
+    let resp = await env.ASSETS.fetch(request);
+    if (resp.status === 404) {
+      const indexReq = new Request(new URL("/index.html", url), request);
+      resp = await env.ASSETS.fetch(indexReq);
+    }
+    return resp;
+  }
 };
 
 async function handleApi(request, env, ctx) {
-	const url = new URL(request.url);
-	const origin = request.headers.get("Origin") || "";
-	const allowed = (env.ALLOWED_ORIGINS || "").split(",").map(s => s.trim()).filter(Boolean);
+  const url = new URL(request.url);
+  const origin = request.headers.get("Origin") || "";
+  const allowed = (env.ALLOWED_ORIGINS || "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
 
-	// --- CORS preflight for API
-	if (request.method === "OPTIONS") {
-		return new Response(null, { headers: corsHeaders(origin, allowed) });
-	}
+  // --- CORS preflight
+  if (request.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders(origin, allowed) });
+  }
 
-	// --- Enforce CORS allowlist (non-browser clients may omit Origin)
-	if (origin && !allowed.includes(origin)) {
-		return json({ error: "Origin not allowed" }, 403, corsHeaders(origin, allowed));
-	}
+  // --- Enforce CORS allowlist
+  if (origin && !allowed.includes(origin)) {
+    return json({ error: "Origin not allowed" }, 403, corsHeaders(origin, allowed));
+  }
 
-	// --- Health
-	if (url.pathname === "/api/health") {
-		return json({ ok: true, time: new Date().toISOString() }, 200, corsHeaders(origin, allowed));
-	}
+  // --- Health
+  if (url.pathname === "/api/health") {
+    return json({ ok: true, time: new Date().toISOString() }, 200, corsHeaders(origin, allowed));
+  }
 
-	// ====================================================================================
-	// POST /api/projects  -> Create record in Airtable (Projects) + linked Project Details
-	// ====================================================================================
-	if (url.pathname === "/api/projects" && request.method === "POST") {
-		let payload;
-		try {
-			payload = await request.json();
-		} catch {
-			return json({ error: "Invalid JSON" }, 400, corsHeaders(origin, allowed));
-		}
+  // ====================================================================================
+  // POST /api/projects  -> Create record in Airtable (Projects + Project Details)
+  // ====================================================================================
+  if (url.pathname === "/api/projects" && request.method === "POST") {
+    let payload;
+    try {
+      payload = await request.json();
+    } catch {
+      return json({ error: "Invalid JSON" }, 400, corsHeaders(origin, allowed));
+    }
 
-		// Required (Step 1)
-		const errs = [];
-		if (!payload.name) errs.push("name");
-		if (!payload.description) errs.push("description");
-		if (errs.length) {
-			return json({ error: "Missing required fields: " + errs.join(", ") }, 400, corsHeaders(origin, allowed));
-		}
+    // Required fields
+    const errs = [];
+    if (!payload.name) errs.push("name");
+    if (!payload.description) errs.push("description");
+    if (errs.length) {
+      return json({ error: "Missing required fields: " + errs.join(", ") }, 400, corsHeaders(origin, allowed));
+    }
 
-		// Map -> Projects fields (adjust to your Airtable schema if needed)
-		const projectFields = {
-			Org: payload.org || "Home Office Biometrics",
-			Name: payload.name,
-			Description: payload.description,
-			Phase: payload.phase || "discovery",
-			Status: payload.status || "planning",
-			Objectives: (payload.objectives || []).join("\n"),
-			UserGroups: (payload.user_groups || []).join(", "),
-			Stakeholders: JSON.stringify(payload.stakeholders || []),
-			CreatedAt: payload.created || new Date().toISOString(),
-			LocalId: payload.id || ""
-		};
+    // Map -> Projects fields
+    const projectFields = {
+      Org: payload.org || "Home Office Biometrics",
+      Name: payload.name,
+      Description: payload.description,
+      Phase: payload.phase || "discovery",
+      Status: payload.status || "planning",
+      Objectives: (payload.objectives || []).join("\n"),
+      UserGroups: (payload.user_groups || []).join(", "),
+      Stakeholders: JSON.stringify(payload.stakeholders || []),
+      CreatedAt: payload.created || new Date().toISOString(),
+      LocalId: payload.id || ""
+    };
 
-		const base = env.AIRTABLE_BASE_ID;
-		const tProjects = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
-		const tDetails  = encodeURIComponent(env.AIRTABLE_TABLE_PROJECT_DETAILS);
+    const base = env.AIRTABLE_BASE_ID;
+    const tProjects = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
+    const tDetails = env.AIRTABLE_TABLE_DETAILS ? encodeURIComponent(env.AIRTABLE_TABLE_DETAILS) : null;
 
-		const atProjectsUrl = `https://api.airtable.com/v0/${base}/${tProjects}`;
-		const atDetailsUrl  = `https://api.airtable.com/v0/${base}/${tDetails}`;
+    const atProjectsUrl = `https://api.airtable.com/v0/${base}/${tProjects}`;
+    const authHeaders = {
+      "Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
+      "Content-Type": "application/json"
+    };
 
-		// 1) Create Projects record
-		const pRes = await fetch(atProjectsUrl, {
-			method: "POST",
-			headers: {
-				"Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
-				"Content-Type": "application/json"
-			},
-			body: JSON.stringify({ records: [{ fields: projectFields }] })
-		});
+    // 1) Create Projects record
+    const pRes = await fetch(atProjectsUrl, {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({ records: [{ fields: projectFields }] })
+    });
 
-		const pText = await pRes.text();
-		if (!pRes.ok) {
-			return json({ error: `Airtable ${pRes.status}`, detail: safeText(pText) }, pRes.status, corsHeaders(origin, allowed));
-		}
+    const pText = await pRes.text();
+    if (!pRes.ok) {
+      return json({ error: `Airtable ${pRes.status}`, detail: safeText(pText) }, pRes.status, corsHeaders(origin, allowed));
+    }
 
-		let pJson; try { pJson = JSON.parse(pText); } catch { pJson = { records: [] }; }
-		const projectRecord = pJson.records?.[0];
-		const projectId = projectRecord?.id;
-		if (!projectId) {
-			return json({ error: "Airtable response missing project id" }, 502, corsHeaders(origin, allowed));
-		}
+    let pJson; try { pJson = JSON.parse(pText); } catch { pJson = { records: [] }; }
+    const projectRecord = pJson.records?.[0];
+    const projectId = projectRecord?.id;
+    if (!projectId) {
+      return json({ error: "Airtable response missing project id" }, 502, corsHeaders(origin, allowed));
+    }
 
-		// 2) Create Project Details if provided (linked to the project)
-		let detailId = null;
-		const hasDetails = Boolean(
-			payload.lead_researcher || payload.lead_researcher_email || payload.notes
-		);
+    // 2) Optionally create Project Details
+    let detailId = null;
+    const hasDetails = Boolean(payload.lead_researcher || payload.lead_researcher_email || payload.notes);
 
-		if (hasDetails) {
-			const detailsFields = {
-				Project: [projectId], // linked record expects array of IDs
-				"Lead Researcher": payload.lead_researcher || "",
-				"Lead Researcher Email": payload.lead_researcher_email || "",
-				Notes: payload.notes || ""
-			};
+    if (hasDetails && tDetails) {
+      const atDetailsUrl = `https://api.airtable.com/v0/${base}/${tDetails}`;
+      const detailsFields = {
+        Project: [projectId],
+        "Lead Researcher": payload.lead_researcher || "",
+        "Lead Researcher Email": payload.lead_researcher_email || "",
+        Notes: payload.notes || ""
+      };
 
-			const dRes = await fetch(atDetailsUrl, {
-				method: "POST",
-				headers: {
-					"Authorization": `Bearer ${env.AIRTABLE_API_KEY}`,
-					"Content-Type": "application/json"
-				},
-				body: JSON.stringify({ records: [{ fields: detailsFields }] })
-			});
+      const dRes = await fetch(atDetailsUrl, {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ records: [{ fields: detailsFields }] })
+      });
 
-			const dText = await dRes.text();
-			if (!dRes.ok) {
-				// Roll back the project to avoid orphan
-				try {
-					await fetch(`${atProjectsUrl}/${projectId}`, {
-						method: "DELETE",
-						headers: { "Authorization": `Bearer ${env.AIRTABLE_API_KEY}` }
-					});
-				} catch {}
-				return json({ error: `Airtable details ${dRes.status}`, detail: safeText(dText) }, dRes.status, corsHeaders(origin, allowed));
-			}
-			try {
-				const dJson = JSON.parse(dText);
-				detailId = dJson.records?.[0]?.id || null;
-			} catch {}
-		}
+      const dText = await dRes.text();
+      if (!dRes.ok) {
+        // Roll back project to avoid orphan
+        try {
+          await fetch(`${atProjectsUrl}/${projectId}`, {
+            method: "DELETE",
+            headers: { "Authorization": `Bearer ${env.AIRTABLE_API_KEY}` }
+          });
+        } catch {}
+        return json({ error: `Airtable details ${dRes.status}`, detail: safeText(dText) }, dRes.status, corsHeaders(origin, allowed));
+      }
 
-		if (env.AUDIT === "true") {
-			try { console.log("project.created", { id: projectId, hasDetails, name: projectFields.Name }); } catch {}
-		}
+      try {
+        const dJson = JSON.parse(dText);
+        detailId = dJson.records?.[0]?.id || null;
+      } catch {}
+    }
 
-		return json({
-			ok: true,
-			project_id: projectId,
-			detail_id: detailId,
-			project: projectFields
-		}, 200, corsHeaders(origin, allowed));
-	}
+    if (env.AUDIT === "true") {
+      try { console.log("project.created", { id: projectId, hasDetails, name: projectFields.Name }); } catch {}
+    }
 
-	// ====================================================================================
-	// GET /api/projects.csv  -> Stream CSV from SharePoint
-	// ====================================================================================
-	if (url.pathname === "/api/projects.csv" && request.method === "GET") {
-		const spUrl = env.SHAREPOINT_CSV_URL;
-		if (!spUrl) {
-			return json({ error: "SHAREPOINT_CSV_URL not configured" }, 500, corsHeaders(origin, allowed));
-		}
+    return json({
+      ok: true,
+      project_id: projectId,
+      detail_id: detailId,
+      project: projectFields
+    }, 200, corsHeaders(origin, allowed));
+  }
 
-		const headers = {};
-		if (env.SHAREPOINT_BEARER) {
-			headers["Authorization"] = `Bearer ${env.SHAREPOINT_BEARER}`;
-		}
+  // ====================================================================================
+  // GET /api/projects.csv  -> Proxy CSV from SharePoint
+  // ====================================================================================
+  if (url.pathname === "/api/projects.csv" && request.method === "GET") {
+    const spUrl = env.SHAREPOINT_CSV_URL;
+    if (!spUrl) {
+      return json({ error: "SHAREPOINT_CSV_URL not configured" }, 500, corsHeaders(origin, allowed));
+    }
 
-		const spRes = await fetch(spUrl, { headers });
-		if (!spRes.ok) {
-			const t = await spRes.text();
-			return json({ error: `SharePoint ${spRes.status}`, detail: safeText(t) }, spRes.status, corsHeaders(origin, allowed));
-		}
+    const headers = {};
+    if (env.SHAREPOINT_BEARER) {
+      headers["Authorization"] = `Bearer ${env.SHAREPOINT_BEARER}`;
+    }
 
-		return new Response(spRes.body, {
-			status: 200,
-			headers: {
-				...corsHeaders(origin, allowed),
-				"Content-Type": "text/csv; charset=utf-8",
-				"Content-Disposition": 'attachment; filename="projects.csv"'
-			}
-		});
-	}
+    const spRes = await fetch(spUrl, { headers });
+    if (!spRes.ok) {
+      const t = await spRes.text();
+      return json({ error: `SharePoint ${spRes.status}`, detail: safeText(t) }, spRes.status, corsHeaders(origin, allowed));
+    }
 
-	// --- API fallback
-	return json({ error: "Not found" }, 404, corsHeaders(origin, allowed));
+    return new Response(spRes.body, {
+      status: 200,
+      headers: {
+        ...corsHeaders(origin, allowed),
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="projects.csv"'
+      }
+    });
+  }
+
+  // --- Fallback
+  return json({ error: "Not found" }, 404, corsHeaders(origin, allowed));
 }
 
 // ---------- helpers ----------
 function corsHeaders(origin, allowed) {
-	const h = {
-		"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-		"Access-Control-Allow-Headers": "Content-Type, Authorization",
-		"Vary": "Origin"
-	};
-	if (origin && allowed.includes(origin)) {
-		h["Access-Control-Allow-Origin"] = origin;
-	}
-	return h;
+  const h = {
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Vary": "Origin"
+  };
+  if (origin && allowed.includes(origin)) {
+    h["Access-Control-Allow-Origin"] = origin;
+  }
+  return h;
 }
 
 function json(body, status = 200, headers = {}) {
-	return new Response(JSON.stringify(body), {
-		status,
-		headers: { "Content-Type": "application/json", ...headers }
-	});
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers }
+  });
 }
 
 function safeText(t) {
-	return t && t.length > 2048 ? t.slice(0, 2048) + "…" : t;
+  return t && t.length > 2048 ? t.slice(0, 2048) + "…" : t;
 }

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -7,7 +7,7 @@ AIRTABLE_BASE_ID = "appkpzVvkof4RFtkh"
 AIRTABLE_TABLE_PROJECTS = "Projects"
 AIRTABLE_TABLE_DETAILS  = "Project Details"
 SHAREPOINT_CSV_URL = "https://yourtenant.sharepoint.com/sites/ResearchOps/Shared%20Documents/projects.csv"
-ALLOWED_ORIGINS = "http://localhost:8080, https://your-frontend.example.com"
+ALLOWED_ORIGINS = "https://rops-api.digikev-kevin-rapley.workers.dev, http://localhost:8080, http://127.0.0.1:5500"
 AUDIT = "true"
 
 [assets]

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -1,11 +1,11 @@
 name = "rops-api"
 main = "src/worker.js"
-compatibility_date = "2024-09-01"
+compatibility_date = "2025-09-26"
 
 [vars]
 AIRTABLE_BASE_ID = "appkpzVvkof4RFtkh"
 AIRTABLE_TABLE_PROJECTS = "Projects"
-AIRTABLE_TABLE_PROJECTS = "Project Details"
+AIRTABLE_TABLE_DETAILS  = "Project Details"
 SHAREPOINT_CSV_URL = "https://yourtenant.sharepoint.com/sites/ResearchOps/Shared%20Documents/projects.csv"
 ALLOWED_ORIGINS = "http://localhost:8080, https://your-frontend.example.com"
 AUDIT = "true"

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -11,5 +11,4 @@ ALLOWED_ORIGINS = "http://localhost:8080, https://your-frontend.example.com"
 AUDIT = "true"
 
 [assets]
-binding = "ASSETS"
-directory = "../../public"
+bucket = "../../public"

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -11,4 +11,5 @@ ALLOWED_ORIGINS = "http://localhost:8080, https://your-frontend.example.com"
 AUDIT = "true"
 
 [assets]
-bucket = "../../public"
+binding = "ASSETS"
+directory = "../../public"

--- a/public/start.html
+++ b/public/start.html
@@ -134,7 +134,7 @@
 
 	// === Mapping: internal codes -> Airtable labels ===
 	const PHASE_LABEL = {
-		"pre-discovery": "Pre-discovery",
+		"pre-discovery": "Pre-Discovery",
 		"discovery": "Discovery",
 		"alpha": "Alpha",
 		"beta": "Beta",

--- a/public/start.html
+++ b/public/start.html
@@ -126,177 +126,223 @@
 	</x-include>
 
 	<script type="module">
-		const API_BASE = "https://rops-api.digikev-kevin-rapley.workers.dev";
-		const $ = (id) => document.getElementById(id);
+	// === CONFIG ===
+	const API_BASE = "https://rops-api.digikev-kevin-rapley.workers.dev";
 
-		// Sections & nav buttons
-		const step1 = $('step1'),
-			step2 = $('step2'),
-			step3 = $('step3');
-		const next2 = $('next2'),
-			prev1 = $('prev1'),
-			next3 = $('next3'),
-			prev2 = $('prev2'),
-			finish = $('finish');
+	// === DOM helpers ===
+	const $ = (id) => document.getElementById(id);
 
-		// Step 1 fields + inline error holders
-		const nameEl = $('p_name'),
-			descEl = $('p_desc');
-		const phaseEl = $('p_phase'),
-			statusEl = $('p_status');
-		const nameErr = $('p_name_error'),
-			descErr = $('p_desc_error');
+	// === Mapping: internal codes -> Airtable labels ===
+	const PHASE_LABEL = {
+		"pre-discovery": "Pre-discovery",
+		"discovery": "Discovery",
+		"alpha": "Alpha",
+		"beta": "Beta",
+		"live": "Live",
+		"retired": "Retired"
+	};
 
-		// Step 2
-		const stakeholdersEl = $('p_stakeholders'),
-			objectivesEl = $('p_objectives'),
-			groupsEl = $('p_usergroups');
+	const STATUS_LABEL = {
+		"goal-setting": "Goal setting & problem defining",
+		"planning": "Planning research",
+		"conducting": "Conducting research",
+		"synthesis": "Synthesis & analysis",
+		"shared": "Shared & socialised research",
+		"monitoring": "Monitoring metrics"
+	};
 
-		// Step 3
-		const leadNameEl = $('lead_name'),
-			leadEmailEl = $('lead_email'),
-			notesEl = $('p_notes');
+	// Sections & nav buttons
+	const step1 = $('step1');
+	const step2 = $('step2');
+	const step3 = $('step3');
 
-		// Status line
-		let statusLine = document.getElementById('status');
-		if (!statusLine) {
-			statusLine = document.createElement('p');
-			statusLine.id = 'status';
-			statusLine.className = 'lede';
-			step3.appendChild(statusLine);
+	const next2 = $('next2');
+	const prev1 = $('prev1');
+	const next3 = $('next3');
+	const prev2 = $('prev2');
+	const finish = $('finish');
+
+	// Step 1 fields
+	const nameEl = $('p_name');
+	const descEl = $('p_desc');
+	const phaseEl = $('p_phase');
+	const statusEl = $('p_status');
+
+	// Step 1 inline errors
+	const nameErr = $('p_name_error');
+	const descErr = $('p_desc_error');
+
+	// Step 2 fields
+	const stakeholdersEl = $('p_stakeholders');
+	const objectivesEl = $('p_objectives');
+	const groupsEl = $('p_usergroups');
+
+	// Step 3 fields
+	const leadNameEl = $('lead_name');
+	const leadEmailEl = $('lead_email');
+	const notesEl = $('p_notes');
+
+	// Status line on step 3
+	let statusLine = document.getElementById('status');
+	if (!statusLine) {
+		statusLine = document.createElement('p');
+		statusLine.id = 'status';
+		statusLine.className = 'lede';
+		step3.appendChild(statusLine);
+	}
+	const setStatus = (m) => { statusLine.textContent = m; };
+
+	// === Validation (Step 1) ===
+	function setInlineError(input, errEl, message) {
+		if (message) {
+			input.setAttribute('aria-invalid', 'true');
+			errEl.textContent = message;
+			errEl.style.display = '';
+		} else {
+			input.setAttribute('aria-invalid', 'false');
+			errEl.textContent = '';
+			errEl.style.display = 'none';
 		}
-		const setStatus = (m) => { statusLine.textContent = m; };
+	}
 
-		function setInlineError(input, errEl, message) {
-			if (message) {
-				input.setAttribute('aria-invalid', 'true');
-				errEl.textContent = message;
-				errEl.style.display = '';
-			} else {
-				input.setAttribute('aria-invalid', 'false');
-				errEl.textContent = '';
-				errEl.style.display = 'none';
-			}
+	function validateStep1({ showInline = false } = {}) {
+		const name = nameEl.value.trim();
+		const desc = descEl.value.trim();
+
+		const nameError = !name ? 'Enter a project name.' : '';
+		const descError = !desc ? 'Enter a short project description.' : '';
+
+		if (showInline) {
+			setInlineError(nameEl, nameErr, nameError);
+			setInlineError(descEl, descErr, descError);
+		} else {
+			setInlineError(nameEl, nameErr, '');
+			setInlineError(descEl, descErr, '');
 		}
 
-		// showInline=false while typing (hide errors); true on Continue click (show only failing fields)
-		function validateStep1({ showInline = false } = {}) {
-			const name = nameEl.value.trim();
-			const desc = descEl.value.trim();
+		next2.disabled = Boolean(nameError || descError);
 
-			const nameError = !name ? 'Enter a project name.' : '';
-			const descError = !desc ? 'Enter a short project description.' : '';
-
-			if (showInline) {
-				setInlineError(nameEl, nameErr, nameError);
-				setInlineError(descEl, descErr, descError);
-			} else {
-				// keep clean while user types
-				setInlineError(nameEl, nameErr, '');
-				setInlineError(descEl, descErr, '');
-			}
-
-			// On showInline, focus first invalid
-			if (showInline) {
-				if (nameError) { nameEl.focus(); return false; }
-				if (descError) { descEl.focus(); return false; }
-			}
-			return !(nameError || descError);
+		if (showInline) {
+			if (nameError) { nameEl.focus(); return false; }
+			if (descError) { descEl.focus(); return false; }
 		}
+		return !(nameError || descError);
+	}
 
-		// Keep UI responsive but don’t show errors while typing
-		[nameEl, descEl].forEach(el => {
-			el.addEventListener('input', () => validateStep1({ showInline: false }));
-			el.addEventListener('blur', () => validateStep1({ showInline: false }));
+	[nameEl, descEl].forEach(el => {
+		el.addEventListener('input', () => validateStep1({ showInline: false }));
+		el.addEventListener('blur', () => validateStep1({ showInline: false }));
+	});
+	validateStep1({ showInline: false });
+
+	// === Step navigation ===
+	next2.addEventListener('click', () => {
+		const ok = validateStep1({ showInline: true });
+		if (!ok) return;
+		step1.style.display = 'none';
+		step2.style.display = 'block';
+		stakeholdersEl?.focus();
+	});
+
+	prev1.addEventListener('click', () => {
+		step2.style.display = 'none';
+		step1.style.display = 'block';
+		nameEl.focus();
+	});
+
+	next3.addEventListener('click', () => {
+		step2.style.display = 'none';
+		step3.style.display = 'block';
+		leadNameEl?.focus();
+	});
+
+	prev2.addEventListener('click', () => {
+		step3.style.display = 'none';
+		step2.style.display = 'block';
+	});
+
+	// === Helpers ===
+	function parseStakeholders(text) {
+		return String(text || "")
+			.split(/\r?\n/)
+			.map(line => {
+				const [name = "", role = "", email = ""] = line.split("|").map(s => s.trim());
+				return { name, role, email };
+			})
+			.filter(s => s.name);
+	}
+
+	function csvListToArray(text) {
+		return String(text || "")
+			.split(",")
+			.map(s => s.trim())
+			.filter(Boolean);
+	}
+
+	function linesToArray(text) {
+		return String(text || "")
+			.split(/\r?\n/)
+			.map(s => s.trim())
+			.filter(Boolean);
+	}
+
+	// === API ===
+	async function postToAirtable(project) {
+		const res = await fetch(`${API_BASE}/api/projects`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(project),
+			credentials: "omit"
 		});
+		const text = await res.text();
+		if (!res.ok) {
+			let detail = "";
+			try { detail = JSON.parse(text).detail || text; } catch { detail = text; }
+			throw new Error(`Airtable error ${res.status}: ${detail}`);
+		}
+		try { return JSON.parse(text); } catch { return { ok: true }; }
+	}
 
-		// Step navigation
-		next2.addEventListener('click', () => {
-			const ok = validateStep1({ showInline: true });
-			if (!ok) return; // show inline errors and stay on Step 1
-			step1.style.display = 'none';
-			step2.style.display = 'block';
-			stakeholdersEl?.focus();
-		});
-
-		prev1.addEventListener('click', () => { step2.style.display = 'none';
+	// === Finish ===
+	finish.addEventListener('click', async () => {
+		if (!validateStep1({ showInline: true })) {
+			step2.style.display = 'none';
+			step3.style.display = 'none';
 			step1.style.display = 'block';
-			nameEl.focus(); });
-		next3.addEventListener('click', () => { step2.style.display = 'none';
-			step3.style.display = 'block';
-			leadNameEl?.focus(); });
-		prev2.addEventListener('click', () => { step3.style.display = 'none';
-			step2.style.display = 'block'; });
-
-		// Helpers
-		function parseStakeholders(text) {
-			return String(text || "")
-				.split(/\r?\n/)
-				.map(line => {
-					const [name = "", role = "", email = ""] = line.split("|").map(s => s.trim());
-					return { name, role, email };
-				})
-				.filter(s => s.name);
+			return;
 		}
 
-		function csvListToArray(text) { return String(text || "").split(",").map(s => s.trim()).filter(Boolean); }
+		// Map phase/status codes -> Airtable labels
+		const phaseLabel = PHASE_LABEL[phaseEl.value] ?? "Discovery";
+		const statusLabel = STATUS_LABEL[statusEl.value] ?? "Planning research";
 
-		function linesToArray(text) { return String(text || "").split(/\r?\n/).map(s => s.trim()).filter(Boolean); }
+		const project = {
+			org: "Home Office Biometrics",
+			name: nameEl.value.trim(),
+			description: descEl.value.trim(),
+			phase: phaseLabel,
+			status: statusLabel,
+			stakeholders: parseStakeholders(stakeholdersEl?.value || ""),
+			objectives: linesToArray(objectivesEl?.value || ""),
+			user_groups: csvListToArray(groupsEl?.value || ""),
+			lead_researcher: (leadNameEl?.value || "").trim() || undefined,
+			lead_researcher_email: (leadEmailEl?.value || "").trim() || undefined,
+			notes: (notesEl?.value || "").trim() || undefined,
+			created: new Date().toISOString(),
+			id: (crypto.randomUUID?.() || String(Date.now()))
+		};
 
-		// API
-		async function postToAirtable(project) {
-			const res = await fetch(`${API_BASE}/api/projects`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(project),
-				credentials: "omit"
-			});
-			const text = await res.text();
-			if (!res.ok) {
-				let detail = "";
-				try { detail = JSON.parse(text).detail || text; } catch { detail = text; }
-				throw new Error(`Airtable error ${res.status}: ${detail}`);
-			}
-			try { return JSON.parse(text); } catch { return { ok: true }; }
+		try {
+			setStatus("Saving project…");
+			const out = await postToAirtable(project);
+			setStatus("Saved. Redirecting…");
+			localStorage.setItem("rops.lastProjectId", out?.project_id || "");
+			window.location.href = "./projects.html";
+		} catch (e) {
+			console.error(e);
+			setStatus("Failed to create project: " + (e?.message || e));
 		}
-
-		// Finish
-		finish.addEventListener('click', async () => {
-			// Ensure Step 1 valid; show inline errors if not
-			if (!validateStep1({ showInline: true })) {
-				step2.style.display = 'none';
-				step3.style.display = 'none';
-				step1.style.display = 'block';
-				return;
-			}
-
-			const project = {
-				org: "Home Office Biometrics",
-				name: nameEl.value.trim(),
-				description: descEl.value.trim(),
-				phase: phaseEl.value,
-				status: statusEl.value,
-				stakeholders: parseStakeholders(stakeholdersEl?.value || ""),
-				objectives: linesToArray(objectivesEl?.value || ""),
-				user_groups: csvListToArray(groupsEl?.value || ""),
-				lead_researcher: (leadNameEl?.value || "").trim() || undefined,
-				lead_researcher_email: (leadEmailEl?.value || "").trim() || undefined,
-				notes: (notesEl?.value || "").trim() || undefined,
-				created: new Date().toISOString(),
-				id: (crypto.randomUUID?.() || String(Date.now()))
-			};
-
-			try {
-				setStatus("Saving project…");
-				const out = await postToAirtable(project);
-				setStatus("Saved. Redirecting…");
-				localStorage.setItem("rops.lastProjectId", out?.project_id || "");
-				window.location.href = "./projects.html";
-			} catch (e) {
-				console.error(e);
-				setStatus("Failed to create project: " + (e?.message || e));
-			}
-		});
+	});
 	</script>
 </body>
 

--- a/public/start.html
+++ b/public/start.html
@@ -44,7 +44,7 @@
 
 					<label class="govuk-body" for="p_phase">Service phase</label>
 					<select id="p_phase" class="govuk-input">
-						<option value="pre-discovery">Pre-discovery</option>
+						<option value="pre-discovery">Pre-Discovery</option>
 						<option value="discovery">Discovery</option>
 						<option value="alpha">Alpha</option>
 						<option value="beta">Beta</option>


### PR DESCRIPTION
This PR introduces CSV persistence alongside Airtable for research projects, plus UI validation enhancements:
	•	Worker (Cloudflare)
	•	Dual-write support: projects and details are written to Airtable and appended to CSV in the GitHub repo.
	•	New API endpoints:
	•	POST /api/projects → Airtable + CSV append
	•	GET /api/projects.csv → stream projects CSV from GitHub
	•	GET /api/project-details.csv → stream details CSV from GitHub
	•	Config updated with GH_* variables for GitHub repo integration.
	•	UI
	•	Inline validation for project name and description (“Enter a project name.” / “Enter a short project description.”).
	•	Project list (projects.html) now renders from CSV via the Worker.
	•	Phase and Status fields mapped to Airtable labels for correct single-select parsing.
	•	Repo
	•	Added .gitattributes to normalize CSV diffs in Git.
	•	Added data/projects.csv and data/project-details.csv as flat-file persistence.
	•	Updated GitHub Actions workflow for Worker deployment with GitHub token support.