### PR TITLE
Allow configuring Mural boards Airtable table name

### DIFF
--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -48,6 +48,7 @@ import * as Diag from "./dev/diag.js";
  * @property {string} AIRTABLE_TABLE_SESSIONS
  * @property {string} AIRTABLE_TABLE_SESSION_NOTES
  * @property {string} AIRTABLE_TABLE_COMMSLOG
+ * @property {string} [AIRTABLE_TABLE_MURAL_BOARDS]
  * @property {string} AIRTABLE_API_KEY
  * @property {string} GH_OWNER
  * @property {string} GH_REPO

--- a/infra/cloudflare/src/service/internals/mural.js
+++ b/infra/cloudflare/src/service/internals/mural.js
@@ -64,6 +64,10 @@ function _airtableHeaders(env) {
   };
 }
 
+function _boardsTableName(env) {
+  return env.AIRTABLE_TABLE_MURAL_BOARDS || "Mural Boards";
+}
+
 function _encodeTableUrl(env, tableName) {
   return `https://api.airtable.com/v0/${encodeURIComponent(env.AIRTABLE_BASE_ID)}/${encodeURIComponent(tableName)}`;
 }
@@ -110,7 +114,7 @@ function _buildBoardsFilter({ /* projectId intentionally omitted */ uid, purpose
  *  - single-line text (=== projectId)
  */
 async function _airtableListBoards(env, { projectId, uid, purpose, active = true, max = 25 }) {
-  const url = new URL(_encodeTableUrl(env, "Mural Boards"));
+  const url = new URL(_encodeTableUrl(env, _boardsTableName(env)));
   const filterByFormula = _buildBoardsFilter({ uid, purpose, active });
   if (filterByFormula) url.searchParams.set("filterByFormula", filterByFormula);
   url.searchParams.set("maxRecords", String(max));
@@ -141,7 +145,7 @@ async function _airtableListBoards(env, { projectId, uid, purpose, active = true
 
 /** Create a board mapping row in Airtable. */
 async function _airtableCreateBoard(env, { projectId, uid, purpose, muralId, boardUrl = null, workspaceId = null, primary = false, active = true }) {
-  const url = _encodeTableUrl(env, "Mural Boards");
+  const url = _encodeTableUrl(env, _boardsTableName(env));
 
   const mkBodyLinked = () => ({
     records: [{


### PR DESCRIPTION
## Summary
- allow the Mural integration to honour an optional `AIRTABLE_TABLE_MURAL_BOARDS` override when resolving or creating board mappings
- document the new Airtable configuration key on the worker service environment

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1a3690ec832f95ef1e8b21bd24fe)