### PR TITLE
Fix workspace lookup for Mural setup

### DIFF
--- a/infra/cloudflare/src/lib/mural.js
+++ b/infra/cloudflare/src/lib/mural.js
@@ -96,6 +96,36 @@ export async function getMe(env, accessToken) {
 }
 
 /**
+ * Retrieve metadata for a workspace by ID/key.
+ * Tolerates either numeric IDs or legacy short codes.
+ */
+export async function getWorkspace(env, accessToken, workspaceId) {
+  const id = String(workspaceId || "").trim();
+  if (!id) throw new Error("workspaceId required");
+
+  const url = `https://app.mural.co/api/public/v1/workspaces/${id}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  const js = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw Object.assign(new Error(`Get workspace failed: ${res.status}`), { status: res.status, body: js });
+  }
+  return js;
+}
+
+/** List workspaces available to the current user (single page). */
+export async function listUserWorkspaces(env, accessToken, { cursor } = {}) {
+  const url = new URL("https://app.mural.co/api/public/v1/users/me/workspaces");
+  if (cursor) url.searchParams.set("cursor", cursor);
+
+  const res = await fetch(url.toString(), { headers: { Authorization: `Bearer ${accessToken}` } });
+  const js = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw Object.assign(new Error(`List user workspaces failed: ${res.status}`), { status: res.status, body: js });
+  }
+  return js || {};
+}
+
+/**
  * Extract active workspace ID from /users/me response.
  * Supports multiple shapes: activeWorkspace.id, activeWorkspaceId, lastActiveWorkspace.
  */

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -48,6 +48,7 @@ import * as Diag from "./dev/diag.js";
  * @property {string} AIRTABLE_TABLE_SESSIONS
  * @property {string} AIRTABLE_TABLE_SESSION_NOTES
  * @property {string} AIRTABLE_TABLE_COMMSLOG
+ * @property {string} [AIRTABLE_TABLE_MURAL_BOARDS]
  * @property {string} AIRTABLE_API_KEY
  * @property {string} GH_OWNER
  * @property {string} GH_REPO

--- a/infra/cloudflare/src/service/internals/mural.js
+++ b/infra/cloudflare/src/service/internals/mural.js
@@ -3,7 +3,7 @@
  * @module service/internals/mural
  * @summary Mural routes logic (OAuth + provisioning + journal sync) with Airtable-backed board mapping.
  *
- * Airtable table expected: "Mural Boards"
+ * Airtable table expected: "Mural Boards" (override with env.AIRTABLE_TABLE_MURAL_BOARDS).
  *  - Project        (Link to "Projects" or Single line text)
  *  - UID            (Single line text)
  *  - Purpose        (Single select e.g., "reflexive_journal")
@@ -31,7 +31,9 @@ import {
   createMural,
   getMural,
   getMe,
+  getWorkspace,
   getActiveWorkspaceIdFromMe,
+  listUserWorkspaces,
   getWidgets,
   createSticky,
   updateSticky,
@@ -62,6 +64,13 @@ function _airtableHeaders(env) {
     Authorization: `Bearer ${env.AIRTABLE_API_KEY}`,
     "Content-Type": "application/json"
   };
+}
+
+function _boardsTableName(env) {
+  const override = typeof env.AIRTABLE_TABLE_MURAL_BOARDS === "string"
+    ? env.AIRTABLE_TABLE_MURAL_BOARDS.trim()
+    : "";
+  return override || "Mural Boards";
 }
 
 function _encodeTableUrl(env, tableName) {
@@ -110,7 +119,7 @@ function _buildBoardsFilter({ /* projectId intentionally omitted */ uid, purpose
  *  - single-line text (=== projectId)
  */
 async function _airtableListBoards(env, { projectId, uid, purpose, active = true, max = 25 }) {
-  const url = new URL(_encodeTableUrl(env, "Mural Boards"));
+  const url = new URL(_encodeTableUrl(env, _boardsTableName(env)));
   const filterByFormula = _buildBoardsFilter({ uid, purpose, active });
   if (filterByFormula) url.searchParams.set("filterByFormula", filterByFormula);
   url.searchParams.set("maxRecords", String(max));
@@ -141,7 +150,7 @@ async function _airtableListBoards(env, { projectId, uid, purpose, active = true
 
 /** Create a board mapping row in Airtable. */
 async function _airtableCreateBoard(env, { projectId, uid, purpose, muralId, boardUrl = null, workspaceId = null, primary = false, active = true }) {
-  const url = _encodeTableUrl(env, "Mural Boards");
+  const url = _encodeTableUrl(env, _boardsTableName(env));
 
   const mkBodyLinked = () => ({
     records: [{
@@ -226,6 +235,143 @@ async function _kvProjectMapping(env, { uid, projectId }) {
   try { return JSON.parse(raw); } catch { return null; }
 }
 
+/* ───────────────────────── Workspace helpers ───────────────────────── */
+
+function _workspaceCandidateShapes(entry) {
+  if (!entry || typeof entry !== "object") return [];
+  const shapes = [entry];
+  if (entry.value && typeof entry.value === "object") shapes.push(entry.value);
+  if (entry.workspace && typeof entry.workspace === "object") {
+    shapes.push(entry.workspace);
+    if (entry.workspace.value && typeof entry.workspace.value === "object") {
+      shapes.push(entry.workspace.value);
+    }
+  }
+
+  const seen = new Set();
+  const candidates = [];
+
+  for (const shape of shapes) {
+    if (!shape || typeof shape !== "object" || seen.has(shape)) continue;
+    seen.add(shape);
+    const id = shape.id || shape.workspaceId || shape.workspaceID || null;
+    const key = shape.key || shape.shortId || shape.workspaceKey || shape.slug || null;
+    const name = shape.name || shape.title || shape.displayName || null;
+    const companyId = shape.companyId || shape.company?.id || null;
+    const shortId = shape.shortId || null;
+
+    if (id || key || shortId) {
+      candidates.push({ id, key, shortId, name, companyId });
+    }
+  }
+
+  return candidates;
+}
+
+async function _resolveWorkspace(env, accessToken, { workspaceHint, companyId } = {}) {
+  const hint = String(workspaceHint || "").trim();
+  if (!hint) return null;
+
+  const hintLower = hint.toLowerCase();
+
+  // First attempt: treat hint as actual workspace id.
+  try {
+    const direct = await getWorkspace(env, accessToken, hint);
+    const val = direct?.value || direct || {};
+    return {
+      id: val.id || val.workspaceId || hint,
+      key: val.key || val.shortId || hint,
+      name: val.name || val.title || val.displayName || null
+    };
+  } catch (err) {
+    if (Number(err?.status || 0) && Number(err.status) !== 404) throw err;
+  }
+
+  // Fallback: list workspaces available to user and match against hint.
+  const matches = [];
+  let cursor = null;
+  const maxPages = 4;
+
+  for (let page = 0; page < maxPages; page += 1) {
+    let payload;
+    try {
+      payload = await listUserWorkspaces(env, accessToken, { cursor });
+    } catch (err) {
+      if (Number(err?.status || 0) === 404) break;
+      throw err;
+    }
+
+    const list = Array.isArray(payload?.value)
+      ? payload.value
+      : Array.isArray(payload?.workspaces)
+        ? payload.workspaces
+        : [];
+
+    for (const entry of list) {
+      for (const cand of _workspaceCandidateShapes(entry)) {
+        matches.push(cand);
+      }
+    }
+
+    cursor = payload?.cursor
+      || payload?.nextCursor
+      || payload?.pagination?.nextCursor
+      || payload?.pagination?.next
+      || null;
+
+    if (!cursor) break;
+  }
+
+  const matched = matches.find(cand => {
+    const values = [cand.id, cand.key, cand.shortId]
+      .filter(Boolean)
+      .map(v => String(v).toLowerCase());
+    return values.includes(hintLower);
+  }) || matches.find(cand => {
+    if (!companyId) return false;
+    const cid = String(cand.companyId || "").toLowerCase();
+    return Boolean(cid && cid === String(companyId).toLowerCase() && (cand.name || "").toLowerCase() === hintLower);
+  });
+
+  if (matched) {
+    const idCandidate = matched.id || matched.key || matched.shortId || hint;
+    try {
+      const detail = await getWorkspace(env, accessToken, idCandidate);
+      const val = detail?.value || detail || {};
+      return {
+        id: val.id || val.workspaceId || idCandidate,
+        key: val.key || val.shortId || matched.key || matched.shortId || hint,
+        name: val.name || val.title || val.displayName || matched.name || null
+      };
+    } catch (err) {
+      if (Number(err?.status || 0) && Number(err.status) !== 404) throw err;
+      return {
+        id: idCandidate,
+        key: matched.key || matched.shortId || idCandidate,
+        name: matched.name || null
+      };
+    }
+  }
+
+  // Final attempt: composite "company:workspace" id (observed in some tenants).
+  if (companyId) {
+    const composite = `${String(companyId).trim()}:${hint}`;
+    try {
+      const detail = await getWorkspace(env, accessToken, composite);
+      const val = detail?.value || detail || {};
+      return {
+        id: val.id || val.workspaceId || composite,
+        key: val.key || val.shortId || hint,
+        name: val.name || val.title || val.displayName || null
+      };
+    } catch (err) {
+      if (Number(err?.status || 0) && Number(err.status) !== 404) throw err;
+    }
+  }
+
+  return { id: hint, key: hint };
+}
+
 /* ───────────────────────── Shape helpers ───────────────────────── */
 
 // Coerce an ID out of many possible Mural shapes
@@ -256,16 +402,27 @@ export class MuralServicePart {
     if (!inCompany) throw Object.assign(new Error("not_in_home_office_workspace"), { code: 403 });
 
     const me = await getMe(env, accessToken);
-    const wsId = getActiveWorkspaceIdFromMe(me);
-    if (!wsId) throw new Error("no_active_workspace");
-    return { id: wsId };
+    const wsHint = getActiveWorkspaceIdFromMe(me);
+    if (!wsHint) throw new Error("no_active_workspace");
+
+    const companyId = me?.value?.companyId || me?.companyId || null;
+    const resolved = await _resolveWorkspace(env, accessToken, { workspaceHint: wsHint, companyId });
+    if (!resolved?.id) {
+      return { id: wsHint, key: wsHint };
+    }
+
+    return {
+      id: resolved.id,
+      key: resolved.key || null,
+      name: resolved.name || null
+    };
   }
 
   /**
    * Resolve a Mural board by (projectId[, uid], purpose).
    * Priority:
    *  1) explicitMuralId (if provided)
-   *  2) Airtable "Mural Boards" (cached)
+   *  2) Airtable "Mural Boards" table (configurable via env.AIRTABLE_TABLE_MURAL_BOARDS) cached in-memory
    *  2b) KV fallback (Airtable not yet visible)
    *  3) env.MURAL_REFLEXIVE_MURAL_ID (deprecated)
    */


### PR DESCRIPTION
## Summary
- add workspace lookup helpers to the Cloudflare worker Mural client so we can fetch workspace metadata or list accessible workspaces
- resolve a user’s active workspace hint into a concrete workspace id before provisioning rooms during Mural setup

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1a3690ec832f95ef1e8b21bd24fe)