### PR TITLE
Fix Mural setup to select personal rooms

### DIFF
--- a/infra/cloudflare/src/service/internals/mural.js
+++ b/infra/cloudflare/src/service/internals/mural.js
@@ -706,11 +706,16 @@ export class MuralServicePart {
 
       step = "get_me";
       const me = await getMe(this.root.env, accessToken).catch(() => null);
-      const username = me?.value?.firstName || me?.name || "Private";
+      const profile = _profileFromMe(me);
+      const username = profile?.firstName || profile?.name || "Private";
 
       step = "ensure_room";
       try {
-        room = await ensureUserRoom(this.root.env, accessToken, ws.id, username);
+        room = await ensureUserRoom(this.root.env, accessToken, ws.id, {
+          username,
+          userId: profile?.id,
+          userEmail: profile?.email
+        });
       } catch (e) {
         if (e?.code === "no_existing_room" || Number(e?.status) === 409) {
           return this.root.json({


### PR DESCRIPTION
## Summary
- refine the Mural room resolver to score rooms by owner/member information and fall back gracefully
- pass the authenticated user's profile details to the resolver during setup so the correct personal room is chosen

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a77a7484832f8c1d1c5bf82b0bb6)