### PR TITLE
Fix Mural viewer link detection for new invitation URLs

### DIFF
--- a/infra/cloudflare/src/service/internals/mural.js
+++ b/infra/cloudflare/src/service/internals/mural.js
@@ -182,8 +182,18 @@ async function _airtableCreateBoard(env, { projectId, uid, purpose, muralId, boa
 function _looksLikeMuralViewerUrl(u) {
   try {
     const x = new URL(u);
-    return x.hostname === "app.mural.co" && /^\/t\/[^/]+\/m\/[^/]+/i.test(x.pathname);
-  } catch { return false; }
+    if (x.hostname !== "app.mural.co") return false;
+
+    const path = x.pathname || "";
+    if (/^\/t\/[^/]+\/m\/[^/]+/i.test(path)) return true;
+    if (/^\/invitation\/mural\/[a-z0-9.-]+/i.test(path)) return true;
+    if (/^\/viewer\//i.test(path)) return true;
+    if (/^\/share\/[^/]+\/mural\/[a-z0-9.-]+/i.test(path)) return true;
+
+    return false;
+  } catch {
+    return false;
+  }
 }
 
 function _extractViewerUrl(payload) {


### PR DESCRIPTION
## Summary
- expand the Mural viewer URL detector to recognise new invitation and share paths

## Testing
- npm run lint
- npm run typecheck # fails: Missing script "typecheck"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910abebe40c832fafb1b2a5ebc09e0c)