### PR TITLE
Add validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,38 @@
+name: Validate ResearchOps
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate repository contract
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run validation contract
+        run: npm run validate
+
+      - name: Run lint
+        run: npm run lint


### PR DESCRIPTION
## Summary
- add a dedicated `Validate ResearchOps` GitHub Actions workflow
- run the restored validation contract on pull requests, pushes to `main`, and manual dispatch
- install dependencies with `npm ci`, then run `npm run validate` and `npm run lint`

## Conformance rationale
This turns the repaired validation contract from a local script into an enforced CI gate. It keeps deployment workflow repair separate from validation enforcement so the change remains small and reviewable.

## Testing
- Not run locally through this connector
- Expected CI command path: `npm ci` → `npm run validate` → `npm run lint`

## Follow-up
- Repair workflow naming/alignment for Sourcebook, Worker, and Pages deployments
- Decide whether to add explicit `test` and `typecheck` scripts or remove references to those checks from PR expectations