### PR TITLE
Align Worker deployment workflow

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,29 +1,46 @@
-name: Deploy Sourcebook to Cloudflare Pages
+name: Deploy ResearchOps Worker
 
 on:
   push:
     branches: [ main ]
     paths:
-      - "docs/sourcebook/**"
-      - ".github/workflows/deploy-sourcebook.yml"
+      - "infra/cloudflare/**"
+      - "functions/**"
+      - "config/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/deploy-worker.yml"
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
+    name: Deploy Cloudflare Worker
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: reops-sourcebook
-          branch: main
-          directory: docs/sourcebook
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run validation contract
+        run: npm run validate
+
+      - name: Deploy Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: npx wrangler@latest deploy --config infra/cloudflare/wrangler.toml


### PR DESCRIPTION
## Summary
- convert `.github/workflows/deploy-worker.yml` into an actual ResearchOps Worker deployment workflow
- keep the existing `.github/workflows/deploy-sourcebook.yml` as the Sourcebook deployment workflow
- run `npm ci` and `npm run validate` before deploying the Worker
- deploy with `npx wrangler@latest deploy --config infra/cloudflare/wrangler.toml`

## Conformance rationale
The previous `deploy-worker.yml` duplicated Sourcebook deployment behaviour while its filename implied Worker deployment. This change aligns file name, workflow name, trigger paths, and deployment target.

## Deployment behaviour
The workflow now runs on pushes to `main` that affect Worker/runtime-relevant paths:

- `infra/cloudflare/**`
- `functions/**`
- `config/**`
- `package.json`
- `package-lock.json`
- `.github/workflows/deploy-worker.yml`

It also supports manual dispatch.

## Required secrets
- `CF_API_TOKEN`
- `CF_ACCOUNT_ID`

## Testing
- Not run locally through this connector
- Expected checks: `Validate ResearchOps`, `CI`, `QA — Broken links`, `Accessibility audit (pa11y-ci)`, and workflow syntax validation by GitHub Actions

## Follow-up
- Confirm Cloudflare deployment succeeds after merge or manual dispatch
- Consider pinning Wrangler to a known-good major version instead of `latest` once the deployment path is stable