### PR TITLE
Add deterministic project ordering

### DIFF
--- a/infra/cloudflare/src/service/projects.js
+++ b/infra/cloudflare/src/service/projects.js
@@ -85,6 +85,22 @@ function mapProject(r) {
   };
 }
 
+function compareProjects(a = {}, b = {}) {
+  const dateOrder = toMs(b.createdAt) - toMs(a.createdAt);
+  if (dateOrder !== 0) return dateOrder;
+
+  const an = String(a.name || "").toLocaleLowerCase();
+  const bn = String(b.name || "").toLocaleLowerCase();
+  if (an && !bn) return -1;
+  if (!an && bn) return 1;
+  if (an < bn) return -1;
+  if (an > bn) return 1;
+
+  const ai = String(a.id || a.LocalId || "");
+  const bi = String(b.id || b.LocalId || "");
+  return ai.localeCompare(bi);
+}
+
 function jsonHeaders(ctx, origin, extra = {}) {
   return {
     ...ctx.corsHeaders(origin),
@@ -181,7 +197,7 @@ export async function listProjectsFromAirtable(ctx, origin, url) {
       ctx.log.warn("airtable.details.join.fail", { status: dRes.status, contentType: dCt, preview: safeText(dTxt).slice(0, 160) });
     }
 
-    projects.sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
+    projects.sort(compareProjects);
     return { projects, source: "airtable" };
   };
 
@@ -197,7 +213,7 @@ export async function listProjectsFromAirtable(ctx, origin, url) {
       const rows = await fetchProjectsCsvFromGitHub(ctx.env);
       let projects = rows.map(coerceCsvRowToProject);
       if (projects.length > limit) projects = projects.slice(0, limit);
-      projects.sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
+      projects.sort(compareProjects);
       payload = { projects, source: "csv" };
     } catch (csvErr) {
       return ctx.json(


### PR DESCRIPTION
## Summary
- add a shared project comparator in the Worker projects service
- keep newest-first ordering by `createdAt`
- add deterministic secondary ordering by project name, case-insensitive A–Z
- add final fallback ordering by `id` / `LocalId`
- apply the same comparator to Airtable results and CSV fallback results

## Issue
Closes #4

## Acceptance criteria
- Projects with distinct `createdAt` values remain newest-first
- Projects with identical `createdAt` values are ordered by name A–Z
- Projects with matching or missing names are ordered by `id` / `LocalId`
- No projects are filtered out or removed by sorting
- Airtable and CSV fallback ordering use the same behaviour

## Testing
- Not run locally through this connector
- Expected checks: `Validate ResearchOps`, `CI`, `QA — Broken links`, `Accessibility audit (pa11y-ci)`, and `qa-bdd` if configured

## Notes
The UI currently performs its own newest-first sort before rendering. This PR fixes the Worker response order first, as requested in the issue, so downstream clients receive deterministic ordering from the API.