### PR TITLE
Route Projects API through composed service

### DIFF
--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -1,14 +1,16 @@
 /**
  * @file worker.js
  * @summary Cloudflare Worker entrypoint with hard Response guard + uniform CORS.
- * @version 2.1.0
+ * @version 2.2.0
  *
  * - Preserves Response coercion to avoid 1101 errors.
  * - Adds ALLOWED_ORIGINS-based CORS to all responses (success + errors).
  * - Handles OPTIONS preflight centrally.
+ * - Routes GET /api/projects through the composed Projects service contract.
  */
 
 import { handleRequest } from "./core/router.js";
+import { ResearchOpsService } from "./service/index.js";
 
 /** Coerce any value to a Response object. */
 function coerceResponse(res) {
@@ -75,10 +77,35 @@ function withCORS(env, request, response) {
   }
 }
 
+function normaliseApiPath(pathname) {
+  let path = pathname || "/";
+  path = path.replace(/\/{2,}/g, "/");
+  if (path.startsWith("/api/") && path.endsWith("/") && path !== "/api/") {
+    path = path.slice(0, -1);
+  }
+  return path;
+}
+
+function envCompat(env) {
+  const allowed = Array.isArray(env.ALLOWED_ORIGINS) ? env.ALLOWED_ORIGINS.join(",") : String(env.ALLOWED_ORIGINS || "");
+  return {
+    ...env,
+    ALLOWED_ORIGINS: allowed
+  };
+}
+
+async function handleCanonicalProjectsRoute(request, env) {
+  const url = new URL(request.url);
+  const origin = request.headers.get("Origin") || "";
+  const service = new ResearchOpsService(envCompat(env));
+  return service.listProjectsFromAirtable(origin, url);
+}
+
 export default {
   async fetch(request, env, ctx) {
     const { method, url } = request;
     const pathname = new URL(url).pathname;
+    const apiPath = normaliseApiPath(pathname);
 
     // Centralised preflight
     if (method === "OPTIONS") {
@@ -87,6 +114,16 @@ export default {
 
     try {
       console.log("[worker] Handling:", method, pathname);
+
+      if (method === "GET" && apiPath === "/api/projects") {
+        console.log("[worker] Routing /api/projects through ResearchOpsService");
+        const result = await handleCanonicalProjectsRoute(request, env);
+        const coerced = coerceResponse(result);
+        const finalRes = withCORS(env, request, coerced);
+        console.log("[worker] Response status:", finalRes.status);
+        return finalRes;
+      }
+
       const result = await handleRequest(request, env, ctx);
       const coerced = coerceResponse(result);
       const finalRes = withCORS(env, request, coerced);


### PR DESCRIPTION
## Summary
- route `GET /api/projects` through `ResearchOpsService.listProjectsFromAirtable()` at the Worker entrypoint
- ensure the canonical Projects service implementation is used before the legacy router direct handler can respond
- preserve `/api/projects.csv` and all other router behaviour

## Rationale
`/api/projects` currently has two implementations:

1. a direct Airtable handler in `core/router.js`
2. the composed Projects service in `service/projects.js`

The composed service is the richer contract. It normalises project records, joins project detail records, provides CSV fallback, and now applies deterministic ordering from Issue #4. The direct router handler bypasses that logic.

This PR makes the live `GET /api/projects` route use the composed Projects service without rewriting the large router file in the same change.

## Behavioural impact
- `GET /api/projects` now uses the service-layer canonical model
- newest-first plus deterministic secondary ordering applies to the live API route
- CSV fallback applies to the live API route when Airtable listing fails
- frontend project rendering should continue to work because it already supports both raw Airtable field names and normalised service field names

## Technical debt retained intentionally
The old `projectsJsonDirect()` function still exists in `core/router.js`, but it is bypassed for `GET /api/projects` by the Worker entrypoint. A follow-up router refactor can safely remove that function once the new route path is proven in CI and deployment.

## Testing
- Not run locally through this connector
- Expected checks: `Validate ResearchOps`, `CI`, `QA — Broken links`, `Accessibility audit (pa11y-ci)`, and Worker deployment after merge

## Acceptance criteria
- `npm run validate` passes
- `/api/projects` response still has `{ ok: true, projects: [...] }`
- projects are returned from the composed service path
- deterministic project ordering from Issue #4 applies to the live route
- `/api/projects.csv` remains unchanged