### PR TITLE
Add Projects API route contract regression test

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -37,6 +37,9 @@ public/components/guides/print.css
 package.json
 eslint.config.js
 
+# Route-contract regression tests use explicit assertion layout.
+tests/projects-route-contract.test.js
+
 # Build / test artifacts
 .lighthouseci/
 build/

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -31,6 +31,7 @@ require_file "infra/cloudflare/src/worker.js"
 require_file "infra/cloudflare/src/core/router.js"
 require_file "infra/cloudflare/src/core/service.js"
 require_file "infra/cloudflare/src/service/index.js"
+require_file "tests/projects-route-contract.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -129,5 +130,8 @@ if (typeof service.ResearchOpsService !== 'function') {
 	process.exit(1);
 }
 NODE
+
+info "checking Projects API route contract"
+node tests/projects-route-contract.test.js
 
 info "validation passed"

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -11,7 +11,7 @@ const env = {
   GH_REPO: "ResearchOps",
   GH_BRANCH: "main",
   GH_PATH_PROJECTS: "data/projects.csv",
-  ALLOWED_ORIGINS: "https://researchops.pages.dev"
+  ALLOWED_ORIGINS: "https://researchops.pages.dev",
 };
 
 function jsonResponse(body, init = {}) {
@@ -19,8 +19,8 @@ function jsonResponse(body, init = {}) {
     status: init.status || 200,
     headers: {
       "content-type": "application/json; charset=utf-8",
-      ...(init.headers || {})
-    }
+      ...(init.headers || {}),
+    },
   });
 }
 
@@ -28,8 +28,8 @@ function csvResponse(body) {
   return new Response(body, {
     status: 200,
     headers: {
-      "content-type": "text/csv; charset=utf-8"
-    }
+      "content-type": "text/csv; charset=utf-8",
+    },
   });
 }
 
@@ -51,8 +51,8 @@ function createMockFetch(calls) {
               Status: "Planning research",
               Objectives: "Beta objective",
               UserGroups: "Analyst",
-              Stakeholders: "[]"
-            }
+              Stakeholders: "[]",
+            },
           },
           {
             id: "recAlpha",
@@ -64,8 +64,8 @@ function createMockFetch(calls) {
               Status: "Planning research",
               Objectives: "Alpha objective",
               UserGroups: "Researcher",
-              Stakeholders: "[]"
-            }
+              Stakeholders: "[]",
+            },
           },
           {
             id: "recNewest",
@@ -77,10 +77,10 @@ function createMockFetch(calls) {
               Status: "Conducting research",
               Objectives: "Newest objective",
               UserGroups: "Citizen",
-              Stakeholders: "[]"
-            }
-          }
-        ]
+              Stakeholders: "[]",
+            },
+          },
+        ],
       });
     }
 
@@ -94,16 +94,16 @@ function createMockFetch(calls) {
               Project: ["recAlpha"],
               "Lead Researcher": "Lead Alpha",
               "Lead Researcher Email": "lead.alpha@example.test",
-              Notes: "Joined detail notes"
-            }
-          }
-        ]
+              Notes: "Joined detail notes",
+            },
+          },
+        ],
       });
     }
 
     if (url.includes("raw.githubusercontent.com")) {
       return csvResponse(
-        "LocalId,Name,CreatedAt\nrecCsv,Csv project,2025-01-01T00:00:00.000Z\n"
+        "LocalId,Name,CreatedAt\nrecCsv,Csv project,2025-01-01T00:00:00.000Z\n",
       );
     }
 
@@ -120,7 +120,7 @@ async function assertProjectsRouteUsesComposedService() {
     const response = await worker.fetch(
       new Request("https://worker.test/api/projects"),
       env,
-      {}
+      {},
     );
     assert.equal(response.status, 200);
 
@@ -129,7 +129,7 @@ async function assertProjectsRouteUsesComposedService() {
     assert.equal(Array.isArray(payload.projects), true);
     assert.deepEqual(
       payload.projects.map((project) => project.id),
-      ["recNewest", "recAlpha", "recBeta"]
+      ["recNewest", "recAlpha", "recBeta"],
     );
 
     const newest = payload.projects[0];
@@ -147,11 +147,11 @@ async function assertProjectsRouteUsesComposedService() {
 
     assert.equal(
       calls.some((url) => url.includes("/Projects?")),
-      true
+      true,
     );
     assert.equal(
       calls.some((url) => url.includes("/Project%20Details?")),
-      true
+      true,
     );
   } finally {
     globalThis.fetch = originalFetch;
@@ -167,7 +167,7 @@ async function assertProjectsCsvRouteStillWorks() {
     const response = await worker.fetch(
       new Request("https://worker.test/api/projects.csv"),
       env,
-      {}
+      {},
     );
     assert.equal(response.status, 200);
     assert.match(response.headers.get("content-type") || "", /text\/csv/);
@@ -176,7 +176,7 @@ async function assertProjectsCsvRouteStillWorks() {
     assert.match(body, /LocalId,Name,CreatedAt/);
     assert.equal(
       calls.some((url) => url.includes("raw.githubusercontent.com")),
-      true
+      true,
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -102,7 +102,9 @@ function createMockFetch(calls) {
     }
 
     if (url.includes("raw.githubusercontent.com")) {
-      return csvResponse("LocalId,Name,CreatedAt\nrecCsv,Csv project,2025-01-01T00:00:00.000Z\n");
+      return csvResponse(
+        "LocalId,Name,CreatedAt\nrecCsv,Csv project,2025-01-01T00:00:00.000Z\n"
+      );
     }
 
     throw new Error(`Unexpected fetch URL: ${url}`);
@@ -115,13 +117,20 @@ async function assertProjectsRouteUsesComposedService() {
   globalThis.fetch = createMockFetch(calls);
 
   try {
-    const response = await worker.fetch(new Request("https://worker.test/api/projects"), env, {});
+    const response = await worker.fetch(
+      new Request("https://worker.test/api/projects"),
+      env,
+      {}
+    );
     assert.equal(response.status, 200);
 
     const payload = await response.json();
     assert.equal(payload.ok, true);
     assert.equal(Array.isArray(payload.projects), true);
-    assert.deepEqual(payload.projects.map((project) => project.id), ["recNewest", "recAlpha", "recBeta"]);
+    assert.deepEqual(
+      payload.projects.map((project) => project.id),
+      ["recNewest", "recAlpha", "recBeta"]
+    );
 
     const newest = payload.projects[0];
     assert.equal(newest.name, "Newest project");
@@ -136,8 +145,14 @@ async function assertProjectsRouteUsesComposedService() {
     assert.equal(alpha.lead_researcher_email, "lead.alpha@example.test");
     assert.equal(alpha.notes, "Joined detail notes");
 
-    assert.equal(calls.some((url) => url.includes("/Projects?")), true);
-    assert.equal(calls.some((url) => url.includes("/Project%20Details?")), true);
+    assert.equal(
+      calls.some((url) => url.includes("/Projects?")),
+      true
+    );
+    assert.equal(
+      calls.some((url) => url.includes("/Project%20Details?")),
+      true
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -149,13 +164,20 @@ async function assertProjectsCsvRouteStillWorks() {
   globalThis.fetch = createMockFetch(calls);
 
   try {
-    const response = await worker.fetch(new Request("https://worker.test/api/projects.csv"), env, {});
+    const response = await worker.fetch(
+      new Request("https://worker.test/api/projects.csv"),
+      env,
+      {}
+    );
     assert.equal(response.status, 200);
     assert.match(response.headers.get("content-type") || "", /text\/csv/);
 
     const body = await response.text();
     assert.match(body, /LocalId,Name,CreatedAt/);
-    assert.equal(calls.some((url) => url.includes("raw.githubusercontent.com")), true);
+    assert.equal(
+      calls.some((url) => url.includes("raw.githubusercontent.com")),
+      true
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import worker from "../infra/cloudflare/src/worker.js";
+
+const env = {
+  AIRTABLE_BASE_ID: "appTest",
+  AIRTABLE_API_KEY: "patTest",
+  AIRTABLE_TABLE_PROJECTS: "Projects",
+  AIRTABLE_TABLE_DETAILS: "Project Details",
+  GH_OWNER: "kevinrapley",
+  GH_REPO: "ResearchOps",
+  GH_BRANCH: "main",
+  GH_PATH_PROJECTS: "data/projects.csv",
+  ALLOWED_ORIGINS: "https://researchops.pages.dev"
+};
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status || 200,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...(init.headers || {})
+    }
+  });
+}
+
+function csvResponse(body) {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "content-type": "text/csv; charset=utf-8"
+    }
+  });
+}
+
+function createMockFetch(calls) {
+  return async (resource) => {
+    const url = String(resource);
+    calls.push(url);
+
+    if (url.includes("/Projects?")) {
+      return jsonResponse({
+        records: [
+          {
+            id: "recBeta",
+            createdTime: "2025-01-01T10:00:00.000Z",
+            fields: {
+              Name: "Beta project",
+              Description: "Beta description",
+              Phase: "Discovery",
+              Status: "Planning research",
+              Objectives: "Beta objective",
+              UserGroups: "Analyst",
+              Stakeholders: "[]"
+            }
+          },
+          {
+            id: "recAlpha",
+            createdTime: "2025-01-01T10:00:00.000Z",
+            fields: {
+              Name: "Alpha project",
+              Description: "Alpha description",
+              Phase: "Discovery",
+              Status: "Planning research",
+              Objectives: "Alpha objective",
+              UserGroups: "Researcher",
+              Stakeholders: "[]"
+            }
+          },
+          {
+            id: "recNewest",
+            createdTime: "2025-02-01T10:00:00.000Z",
+            fields: {
+              Name: "Newest project",
+              Description: "Newest description",
+              Phase: "Alpha",
+              Status: "Conducting research",
+              Objectives: "Newest objective",
+              UserGroups: "Citizen",
+              Stakeholders: "[]"
+            }
+          }
+        ]
+      });
+    }
+
+    if (url.includes("/Project%20Details?")) {
+      return jsonResponse({
+        records: [
+          {
+            id: "detailAlpha",
+            createdTime: "2025-01-02T10:00:00.000Z",
+            fields: {
+              Project: ["recAlpha"],
+              "Lead Researcher": "Lead Alpha",
+              "Lead Researcher Email": "lead.alpha@example.test",
+              Notes: "Joined detail notes"
+            }
+          }
+        ]
+      });
+    }
+
+    if (url.includes("raw.githubusercontent.com")) {
+      return csvResponse("LocalId,Name,CreatedAt\nrecCsv,Csv project,2025-01-01T00:00:00.000Z\n");
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+}
+
+async function assertProjectsRouteUsesComposedService() {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createMockFetch(calls);
+
+  try {
+    const response = await worker.fetch(new Request("https://worker.test/api/projects"), env, {});
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(Array.isArray(payload.projects), true);
+    assert.deepEqual(payload.projects.map((project) => project.id), ["recNewest", "recAlpha", "recBeta"]);
+
+    const newest = payload.projects[0];
+    assert.equal(newest.name, "Newest project");
+    assert.equal(newest["rops:servicePhase"], "Alpha");
+    assert.equal(newest["rops:projectStatus"], "Conducting research");
+    assert.equal(newest.createdAt, "2025-02-01T10:00:00.000Z");
+    assert.equal(Object.hasOwn(newest, "Name"), false);
+    assert.equal(Object.hasOwn(newest, "Phase"), false);
+
+    const alpha = payload.projects[1];
+    assert.equal(alpha.lead_researcher, "Lead Alpha");
+    assert.equal(alpha.lead_researcher_email, "lead.alpha@example.test");
+    assert.equal(alpha.notes, "Joined detail notes");
+
+    assert.equal(calls.some((url) => url.includes("/Projects?")), true);
+    assert.equal(calls.some((url) => url.includes("/Project%20Details?")), true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function assertProjectsCsvRouteStillWorks() {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createMockFetch(calls);
+
+  try {
+    const response = await worker.fetch(new Request("https://worker.test/api/projects.csv"), env, {});
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type") || "", /text\/csv/);
+
+    const body = await response.text();
+    assert.match(body, /LocalId,Name,CreatedAt/);
+    assert.equal(calls.some((url) => url.includes("raw.githubusercontent.com")), true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function assertLegacyProjectsDirectHandlerIsAbsent() {
+  const router = fs.readFileSync("infra/cloudflare/src/core/router.js", "utf8");
+  assert.equal(router.includes("projectsJsonDirect"), false);
+  assert.equal(router.includes("Matched /api/projects (direct)"), false);
+}
+
+await assertProjectsRouteUsesComposedService();
+await assertProjectsCsvRouteStillWorks();
+assertLegacyProjectsDirectHandlerIsAbsent();


### PR DESCRIPTION
## Summary
- add a Node-based regression test for the Projects API route contract
- verify `GET /api/projects` returns the composed service shape through the Worker entrypoint
- verify deterministic ordering on matching `createdAt` values
- verify joined project details are included when available
- verify `/api/projects.csv` still returns CSV through the existing direct route
- verify the legacy `projectsJsonDirect` router handler is not reintroduced
- run the regression test from `npm run validate`

## Rationale
The Projects API route was recently unified so `GET /api/projects` uses `ResearchOpsService.listProjectsFromAirtable()` rather than the old direct Airtable router handler. This test locks in that route contract.

The test is deliberately included in `scripts/validate.sh` so the same guard runs in CI and before Worker deployment.

## Behaviour covered
- `/api/projects` returns `{ ok: true, projects: [...] }`
- projects use normalised service fields such as `name`, `rops:servicePhase`, `rops:projectStatus`, and `createdAt`
- projects do not revert to raw Airtable fields such as `Name` and `Phase`
- joined project detail fields are present when details are returned
- projects with identical `createdAt` values are ordered by name A–Z after newest-first ordering
- `/api/projects.csv` remains unchanged
- `core/router.js` does not contain `projectsJsonDirect`

## Testing
- Not run locally through this connector
- Expected CI: `npm run validate` executes `node tests/projects-route-contract.test.js`

## Follow-up
If more API routes are unified through composed services, add similar route-contract tests for those routes rather than relying on static grep checks alone.