### PR TITLE
Fix Mural return path and connected state

### DIFF
--- a/public/components/mural-integration.js
+++ b/public/components/mural-integration.js
@@ -61,7 +61,20 @@
 		span.textContent = text;
 	}
 
+	function showConnectButton() {
+		if (!els.btnConnect) return;
+		els.btnConnect.hidden = false;
+		els.btnConnect.disabled = false;
+	}
+
+	function hideConnectButton() {
+		if (!els.btnConnect) return;
+		els.btnConnect.hidden = true;
+		els.btnConnect.disabled = true;
+	}
+
 	function setConnectedStatus(folderDenied = false) {
+		hideConnectButton();
 		if (folderDenied) {
 			pill(els.status, "warn", "Board created but we couldn't create a folder in your Mural room.");
 		} else {
@@ -91,8 +104,8 @@
 		return ($("main")?.dataset?.projectName || "").trim();
 	}
 
-	function absolutePagesUrl(pathAndQuery) {
-		return new URL(pathAndQuery, location.origin).toString();
+	function projectDashboardPath(projectId) {
+		return `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
 	}
 
 	async function resolveProjectIdByName(name) {
@@ -119,7 +132,7 @@
 	};
 
 	function disableAll() {
-		if (els.btnConnect) els.btnConnect.disabled = false;
+		showConnectButton();
 		if (els.btnSetup) els.btnSetup.disabled = true;
 	}
 
@@ -148,9 +161,9 @@
 		els.btnConnect.disabled = false;
 		els.btnConnect.onclick = () => {
 			const effectiveId = canonicalProjectId(projectId);
-			const backAbs = absolutePagesUrl(`/pages/project-dashboard/?id=${encodeURIComponent(effectiveId)}`);
-			const href = addDebug(`${API_ORIGIN}/api/mural/auth?uid=${encodeURIComponent(uid())}&return=${encodeURIComponent(backAbs)}`);
-			debugLog("connect click", { href });
+			const backPath = projectDashboardPath(effectiveId);
+			const href = addDebug(`${API_ORIGIN}/api/mural/auth?uid=${encodeURIComponent(uid())}&return=${encodeURIComponent(backPath)}`);
+			debugLog("connect click", { href, backPath });
 			location.href = href;
 		};
 		debugLog("connect button wired");
@@ -236,7 +249,7 @@
 			} else {
 				pill(els.status, "warn", "Mural is having trouble right now. You can still write journal entries; we'll sync later.");
 			}
-			if (els.btnConnect) els.btnConnect.disabled = false;
+			showConnectButton();
 			if (els.btnSetup) els.btnSetup.disabled = true;
 			return;
 		}


### PR DESCRIPTION
## Summary
- preserve the current project dashboard path when starting Mural OAuth from a project dashboard
- send a relative return path to the API instead of an absolute Pages URL
- hide and disable the Connect Mural button once Mural verification succeeds
- keep the Open "Reflexive Journal" button visible when a board mapping exists

## Issue observed
After connecting to Mural from a project dashboard, the OAuth callback returned the user to:

    https://researchops.pages.dev/pages/projects/

instead of the originating dashboard:

    https://researchops.pages.dev/pages/project-dashboard/?id=<project-id>

When navigating back to the dashboard manually, Mural showed as connected, but the Connect Mural button was still visible.

## Cause
The frontend sent an absolute Pages-origin return URL to the Worker:

    https://researchops.pages.dev/pages/project-dashboard/?id=<project-id>

The Mural auth route receives the request on the API Worker origin, so its origin comparison rejects the Pages-origin return URL and falls back to `/pages/projects/`.

## Fix
The frontend now sends a relative return path:

    /pages/project-dashboard/?id=<project-id>

That path survives the existing auth handler validation and is later resolved by the callback against the configured Pages origin.

The dashboard UI also now hides the Connect Mural button once verification succeeds, so the visible actions match the connected state.

## Behavioural impact
- OAuth return from Mural should land back on the originating project dashboard
- Connected dashboards should show Connected plus Open "Reflexive Journal"
- Connected dashboards should not still show Connect Mural as the primary action
- Unauthenticated or failed Mural verification states still show Connect Mural

## Testing
- Not run locally through this connector
- Expected checks: lint, validate, Pa11y

## Follow-up
Consider adding a small Mural UI route-state regression test so this return-path behaviour is locked in.