### PR TITLE
Add Mural UI route-state regression test

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -39,6 +39,7 @@ eslint.config.js
 
 # Route-contract regression tests use explicit assertion layout.
 tests/projects-route-contract.test.js
+tests/mural-ui-route-state.test.js
 
 # Build / test artifacts
 .lighthouseci/

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -32,6 +32,7 @@ require_file "infra/cloudflare/src/core/router.js"
 require_file "infra/cloudflare/src/core/service.js"
 require_file "infra/cloudflare/src/service/index.js"
 require_file "tests/projects-route-contract.test.js"
+require_file "tests/mural-ui-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -133,5 +134,8 @@ NODE
 
 info "checking Projects API route contract"
 node tests/projects-route-contract.test.js
+
+info "checking Mural UI route-state contract"
+node tests/mural-ui-route-state.test.js
 
 info "validation passed"

--- a/tests/mural-ui-route-state.test.js
+++ b/tests/mural-ui-route-state.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync("public/components/mural-integration.js", "utf8");
+
+function includes(text) {
+  assert.equal(
+    source.includes(text),
+    true,
+    `Expected mural-integration.js to include: ${text}`,
+  );
+}
+
+function excludes(text) {
+  assert.equal(
+    source.includes(text),
+    false,
+    `Expected mural-integration.js not to include: ${text}`,
+  );
+}
+
+includes("function projectDashboardPath(projectId)");
+includes("/pages/project-dashboard/?id=");
+includes("const backPath = projectDashboardPath(effectiveId);");
+includes("return=${encodeURIComponent(backPath)}");
+includes("function hideConnectButton()");
+includes("els.btnConnect.hidden = true;");
+includes("els.btnConnect.disabled = true;");
+includes("hideConnectButton();");
+
+excludes("const backAbs = absolutePagesUrl");
+excludes("return=${encodeURIComponent(backAbs)}");
+excludes("function absolutePagesUrl(pathAndQuery)");


### PR DESCRIPTION
## Summary
- add a small Node regression test for the Mural dashboard route-state contract
- verify Mural connect uses a relative project-dashboard return path
- verify the old absolute Pages URL return helper is not reintroduced
- verify connected state hides and disables the Connect Mural button
- run the test from `npm run validate`

## Rationale
A recent defect returned users from Mural OAuth to:

    /pages/projects/

instead of:

    /pages/project-dashboard/?id=<project-id>

The cause was the frontend sending an absolute Pages-origin return URL to the Worker auth route. The Worker received the request on the API origin, rejected that return URL, and fell back to the projects page.

This regression test locks in the safer frontend contract: send a relative project-dashboard return path and hide Connect Mural once verification succeeds.

## Behaviour covered
- `projectDashboardPath(projectId)` exists
- the route path includes `/pages/project-dashboard/?id=`
- the Mural auth URL encodes `backPath`, not `backAbs`
- the old `absolutePagesUrl()` helper is not present
- the Connect Mural button is hidden and disabled in connected state

## Testing
- Not run locally through this connector
- Expected CI: `npm run validate` executes `node tests/mural-ui-route-state.test.js`

## Limitations
This is a static route-state contract test. It does not run the full OAuth flow. A browser-level test can be added later if the dashboard gets broader Mural UI coverage.