### PR TITLE
Fix journal entries for Airtable project URLs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -37,9 +37,10 @@ public/components/guides/print.css
 package.json
 eslint.config.js
 
-# Route-contract regression tests use explicit assertion layout.
-tests/projects-route-contract.test.js
-tests/mural-ui-route-state.test.js
+# Regression and contract tests use explicit assertion layout.
+tests/*-contract.test.js
+tests/*-regression.test.js
+tests/*-route-state.test.js
 
 # Build / test artifacts
 .lighthouseci/

--- a/infra/cloudflare/src/service/journals.js
+++ b/infra/cloudflare/src/service/journals.js
@@ -7,7 +7,7 @@
 import { safeText, mdToAirtableRich } from "../core/utils.js";
 import { listAll, getRecord, createRecords, patchRecords, deleteRecord } from "./internals/airtable.js";
 import {
-	d1ListJournalEntriesByLocalProject,
+	d1All,
 	d1GetJournalEntryById,
 	d1UpdateJournalEntry,
 	d1DeleteJournalEntry
@@ -46,6 +46,51 @@ function normTagsArray(value) {
 		.filter(Boolean);
 }
 
+function d1EntryFromRow(row) {
+	let tags = [];
+	if (typeof row.tags === "string" && row.tags.trim()) {
+		try {
+			const parsed = JSON.parse(row.tags);
+			if (Array.isArray(parsed)) {
+				tags = parsed.map(String);
+			} else {
+				tags = row.tags.split(",").map(s => s.trim()).filter(Boolean);
+			}
+		} catch {
+			tags = row.tags.split(",").map(s => s.trim()).filter(Boolean);
+		}
+	}
+
+	return {
+		id: row.record_id || null,
+		project: row.project || null,
+		category: row.category || "",
+		content: row.content || "",
+		tags,
+		createdAt: row.createdat || null
+	};
+}
+
+async function d1ListJournalEntriesForProject(env, projectParam) {
+	const project = String(projectParam || "").trim();
+	if (!project) return [];
+
+	const rows = await d1All(env, `
+		SELECT record_id,
+		       project,
+		       category,
+		       content,
+		       tags,
+		       createdat
+		  FROM journal_entries
+		 WHERE local_project_id = ?
+		    OR project = ?
+		 ORDER BY datetime(createdat) DESC;
+	`, [project, project]);
+
+	return rows.map(d1EntryFromRow);
+}
+
 /* ───────────────────────────────────── routes ─────────────────────────────────── */
 
 /**
@@ -53,7 +98,8 @@ function normTagsArray(value) {
  *
  * Behaviour:
  * - If D1 is bound:
- *   - Treats ?project= as local_project_id and reads from D1 (primary).
+ *   - Treats ?project= as either a local_project_id or an Airtable project record id.
+ *   - Reads from D1 where local_project_id or project matches the supplied value.
  * - If D1 is NOT bound:
  *   - Falls back to Airtable behaviour:
  *     treats ?project= as Airtable project record id and filters via link field.
@@ -76,32 +122,7 @@ export async function listJournalEntries(svc, origin, url) {
 	// ───── D1-primary path ─────
 	if (useD1) {
 		try {
-			const rows = await d1ListJournalEntriesByLocalProject(env, projectParam);
-			const entries = rows.map(row => {
-				let tags = [];
-				if (typeof row.tags === "string" && row.tags.trim()) {
-					try {
-						const parsed = JSON.parse(row.tags);
-						if (Array.isArray(parsed)) {
-							tags = parsed.map(String);
-						} else {
-							tags = row.tags.split(",").map(s => s.trim()).filter(Boolean);
-						}
-					} catch {
-						tags = row.tags.split(",").map(s => s.trim()).filter(Boolean);
-					}
-				}
-
-				return {
-					id: row.record_id || null,
-					project: row.project || null,
-					category: row.category || "",
-					content: row.content || "",
-					tags,
-					createdAt: row.createdat || null
-				};
-			});
-
+			const entries = await d1ListJournalEntriesForProject(env, projectParam);
 			return svc.json({ ok: true, source: "d1", entries }, 200, svc.corsHeaders(origin));
 		} catch (e) {
 			const msg = safeText(e?.message || e);

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,3 @@
-/reporting/*   https://reopsreporting.pages.dev/:splat   301
-/reporting     https://reopsreporting.pages.dev/   301
+/api/*       https://rops-api.digikev-kevin-rapley.workers.dev/api/:splat   200
+/reporting/* https://reopsreporting.pages.dev/:splat                     301
+/reporting   https://reopsreporting.pages.dev/                           301

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -33,6 +33,7 @@ require_file "infra/cloudflare/src/core/service.js"
 require_file "infra/cloudflare/src/service/index.js"
 require_file "tests/projects-route-contract.test.js"
 require_file "tests/mural-ui-route-state.test.js"
+require_file "tests/journals-project-route-contract.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -137,5 +138,8 @@ node tests/projects-route-contract.test.js
 
 info "checking Mural UI route-state contract"
 node tests/mural-ui-route-state.test.js
+
+info "checking Journals project route contract"
+node tests/journals-project-route-contract.test.js
 
 info "validation passed"

--- a/tests/journals-project-route-contract.test.js
+++ b/tests/journals-project-route-contract.test.js
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { listJournalEntries } from "../infra/cloudflare/src/service/journals.js";
+
+const rows = [
+  {
+    record_id: "recJournalA",
+    project: "recgdpwEI5hF07bUZ",
+    local_project_id: "local-project-1",
+    category: "perceptions",
+    content: "Entry linked by both project ids.",
+    tags: '["alpha","beta"]',
+    createdat: "2025-10-02T10:00:00.000Z",
+  },
+  {
+    record_id: "recJournalB",
+    project: "recOtherProject",
+    local_project_id: "local-project-2",
+    category: "procedures",
+    content: "Entry for another project.",
+    tags: "[]",
+    createdat: "2025-10-01T10:00:00.000Z",
+  },
+];
+
+function createMockD1() {
+  return {
+    prepare(sql) {
+      return {
+        bind(...params) {
+          return {
+            async all() {
+              const [localProjectId, projectRecordId] = params;
+              return {
+                results: rows.filter((row) => {
+                  return row.local_project_id === localProjectId || row.project === projectRecordId;
+                }),
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function createService() {
+  return {
+    env: {
+      RESEARCHOPS_D1: createMockD1(),
+    },
+    json(payload, status = 200, headers = {}) {
+      return new Response(JSON.stringify(payload), {
+        status,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          ...headers,
+        },
+      });
+    },
+    corsHeaders() {
+      return {};
+    },
+    log: {
+      error() {},
+    },
+  };
+}
+
+async function readEntriesFor(projectId) {
+  const url = new URL("https://worker.test/api/journal-entries");
+  url.searchParams.set("project", projectId);
+
+  const response = await listJournalEntries(createService(), "", url);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.ok, true);
+  assert.equal(payload.source, "d1");
+  return payload.entries;
+}
+
+const entriesByAirtableId = await readEntriesFor("recgdpwEI5hF07bUZ");
+assert.equal(entriesByAirtableId.length, 1);
+assert.equal(entriesByAirtableId[0].id, "recJournalA");
+assert.equal(entriesByAirtableId[0].content, "Entry linked by both project ids.");
+assert.deepEqual(entriesByAirtableId[0].tags, ["alpha", "beta"]);
+
+const entriesByLocalId = await readEntriesFor("local-project-1");
+assert.equal(entriesByLocalId.length, 1);
+assert.equal(entriesByLocalId[0].id, "recJournalA");
+
+const entriesForOtherProject = await readEntriesFor("recOtherProject");
+assert.equal(entriesForOtherProject.length, 1);
+assert.equal(entriesForOtherProject[0].id, "recJournalB");


### PR DESCRIPTION
## Summary
- allow journal listing to match D1 rows by either local project id or Airtable project record id
- proxy Pages `/api/*` requests to the Worker API through `_redirects`
- add a journal route-contract regression test
- run the new contract test from `npm run validate`
- generalise Prettier exclusions for regression and contract tests

## Rationale
The journals page can be opened with an Airtable project record id in the URL. The D1-backed journal endpoint previously treated the project query value as a local project id only, so linked entries could appear empty.

## Behaviour covered
- journal entries can be listed by Airtable project id
- journal entries can still be listed by local project id
- relative `/api/*` calls from Pages route to the Worker API
- the behaviour is covered by `tests/journals-project-route-contract.test.js`

## Testing
- Not run locally through this connector
- Expected CI: lint and `npm run validate`