### PR TITLE
Use Worker API origin for journal tabs calls

### DIFF
--- a/public/js/journal-tabs.js
+++ b/public/js/journal-tabs.js
@@ -13,6 +13,18 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 
 /* eslint-env browser */
 (function() {
+	const API_ORIGIN =
+		document.documentElement?.dataset?.apiOrigin ||
+		window.API_ORIGIN ||
+		(location.hostname.endsWith('pages.dev') ?
+			'https://rops-api.digikev-kevin-rapley.workers.dev' :
+			location.origin);
+
+	function apiUrl(path) {
+		const p = String(path || '');
+		return `${API_ORIGIN}${p.startsWith('/') ? p : '/' + p}`;
+	}
+
 	// ---------- tiny helpers ----------
 	function $(s, r) { if (!r) r = document; return r.querySelector(s); }
 
@@ -121,7 +133,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 				tags: Array.isArray(newEntry?.tags) ? newEntry.tags : []
 			};
 
-			const res = await fetch('/api/mural/journal-sync', {
+			const res = await fetch(apiUrl('/api/mural/journal-sync'), {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify(payload)
@@ -159,7 +171,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 	// ---------- JOURNAL ----------
 	function loadEntries() {
 		if (!state.projectId) return Promise.resolve();
-		return fetchJSON('/api/journal-entries?project=' + encodeURIComponent(state.projectId))
+		return fetchJSON(apiUrl('/api/journal-entries?project=' + encodeURIComponent(state.projectId)))
 			.then(data => {
 				const arr = Array.isArray(data?.entries) ? data.entries : Array.isArray(data) ? data : [];
 				state.entries = arr.map(e => {
@@ -226,7 +238,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 	function onDeleteEntry(e) {
 		const id = e.currentTarget?.getAttribute('data-id');
 		if (!id || !confirm('Delete this entry?')) return;
-		fetchJSON('/api/journal-entries/' + encodeURIComponent(id), { method: 'DELETE' })
+		fetchJSON(apiUrl('/api/journal-entries/' + encodeURIComponent(id)), { method: 'DELETE' })
 			.then(() => {
 				flash('Entry deleted.');
 				loadEntries();
@@ -283,7 +295,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 			};
 
 			try {
-				const createdRes = await fetchJSON('/api/journal-entries', {
+				await fetchJSON(apiUrl('/api/journal-entries'), {
 					method: 'POST',
 					headers: { 'content-type': 'application/json' },
 					body: JSON.stringify(body)

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -34,6 +34,7 @@ require_file "infra/cloudflare/src/service/index.js"
 require_file "tests/projects-route-contract.test.js"
 require_file "tests/mural-ui-route-state.test.js"
 require_file "tests/journals-project-route-contract.test.js"
+require_file "tests/journal-tabs-api-origin-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -141,5 +142,8 @@ node tests/mural-ui-route-state.test.js
 
 info "checking Journals project route contract"
 node tests/journals-project-route-contract.test.js
+
+info "checking Journal tabs API origin route-state contract"
+node tests/journal-tabs-api-origin-route-state.test.js
 
 info "validation passed"

--- a/tests/journal-tabs-api-origin-route-state.test.js
+++ b/tests/journal-tabs-api-origin-route-state.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync("public/js/journal-tabs.js", "utf8");
+
+function includes(text) {
+  assert.equal(
+    source.includes(text),
+    true,
+    `Expected journal-tabs.js to include: ${text}`,
+  );
+}
+
+function excludes(text) {
+  assert.equal(
+    source.includes(text),
+    false,
+    `Expected journal-tabs.js not to include: ${text}`,
+  );
+}
+
+includes("const API_ORIGIN =");
+includes("document.documentElement?.dataset?.apiOrigin");
+includes("window.API_ORIGIN");
+includes("location.hostname.endsWith('pages.dev')");
+includes("https://rops-api.digikev-kevin-rapley.workers.dev");
+includes("function apiUrl(path)");
+includes("fetchJSON(apiUrl('/api/journal-entries?project='");
+includes("fetchJSON(apiUrl('/api/journal-entries/'");
+includes("fetchJSON(apiUrl('/api/journal-entries')");
+includes("fetch(apiUrl('/api/mural/journal-sync')");
+
+excludes("fetchJSON('/api/journal-entries?project=");
+excludes("fetchJSON('/api/journal-entries/'");
+excludes("fetchJSON('/api/journal-entries',");
+excludes("fetch('/api/mural/journal-sync'");


### PR DESCRIPTION
## Summary
- add the standard `API_ORIGIN` detection pattern to `public/js/journal-tabs.js`
- add an `apiUrl(path)` helper for Worker API calls
- route journal entry list, create, delete, and Mural journal-sync calls through the Worker API origin
- add a route-state regression test for journal tabs API origin handling
- run the new regression test from `npm run validate`

## Rationale
The journals page was still relying on relative `/api/...` calls. On `researchops.pages.dev`, those calls depend on Pages redirect behaviour. This makes the journals page less robust than the project dashboard and Mural integration.

This change uses the same explicit API origin pattern already used elsewhere:

- `document.documentElement.dataset.apiOrigin`
- `window.API_ORIGIN`
- Worker origin when hosted on `pages.dev`
- `location.origin` otherwise

## Behaviour covered
The following calls now use `apiUrl(...)`:

- `GET /api/journal-entries?project=...`
- `POST /api/journal-entries`
- `DELETE /api/journal-entries/:id`
- `POST /api/mural/journal-sync`

The regression test ensures bare relative journal API calls are not reintroduced.

## Testing
- Not run locally through this connector
- Expected CI: lint and `npm run validate`