### PR TITLE
Stabilise journal entry filter state

### DIFF
--- a/public/js/journal-tabs.js
+++ b/public/js/journal-tabs.js
@@ -47,6 +47,31 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 		return text.slice(0, limit) + '…';
 	}
 
+	function normalizeCategoryKey(value) {
+		const raw = String(value || '').trim().toLowerCase();
+		if (!raw || raw === '—') return 'uncategorised';
+		if (raw === 'perceptions' || raw.includes('perception')) return 'perceptions';
+		if (raw === 'procedures' || raw.includes('procedure') || raw.includes('day-to-day')) return 'procedures';
+		if (raw === 'decisions' || raw.includes('decision') || raw.includes('methodological')) return 'decisions';
+		if (raw === 'introspections' || raw.includes('introspection') || raw.includes('personal')) return 'introspections';
+		return raw.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'uncategorised';
+	}
+
+	function categoryLabel(value) {
+		const raw = String(value || '').trim();
+		if (!raw) return '—';
+		const key = normalizeCategoryKey(raw);
+		if (key === 'perceptions') return 'Perceptions';
+		if (key === 'procedures') return 'Procedures';
+		if (key === 'decisions') return 'Decisions';
+		if (key === 'introspections') return 'Introspections';
+		return raw;
+	}
+
+	function emptyEntriesHtml() {
+		return '<div class="empty-state" id="empty-journal"><p class="govuk-body">No entries match the current filter.</p></div>';
+	}
+
 	function toHex8(input) {
 		if (!input) return '#1d70b8ff';
 		var v = String(input).trim().toLowerCase();
@@ -175,12 +200,14 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 			.then(data => {
 				const arr = Array.isArray(data?.entries) ? data.entries : Array.isArray(data) ? data : [];
 				state.entries = arr.map(e => {
+					const rawCategory = e.category || '—';
 					let tags = Array.isArray(e.tags) ?
 						e.tags :
 						String(e.tags || '').split(',').map(s => s.trim()).filter(Boolean);
 					return {
 						id: e.id,
-						category: e.category || '—',
+						category: categoryLabel(rawCategory),
+						categoryKey: normalizeCategoryKey(rawCategory),
 						content: e.content ?? e.body ?? '',
 						tags,
 						createdAt: e.createdAt || e.created_at || ''
@@ -200,31 +227,29 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 
 	function renderEntries() {
 		const wrap = document.getElementById('entries-container');
-		const empty = document.getElementById('empty-journal');
 		if (!wrap) return;
 
 		const filter = currentEntryFilter();
-		const list = state.entries.filter(en => filter === 'all' || String(en.category || '').toLowerCase() === filter);
+		const list = state.entries.filter(en => filter === 'all' || String(en.categoryKey || normalizeCategoryKey(en.category)).toLowerCase() === filter);
 
-		if (!list.length) { wrap.innerHTML = ''; if (empty) empty.hidden = false; return; }
-		if (empty) empty.hidden = true;
+		if (!list.length) { wrap.innerHTML = emptyEntriesHtml(); return; }
 
 		wrap.innerHTML = list.map(en => {
 			const snippet = truncateWords(en.content || '', 200);
 			const wasShortened = snippet.length < String(en.content || '').trim().length;
 			const tagsHTML = (en.tags || []).map(t => `<span class="tag" aria-label="Tag: ${esc(t)}">${esc(t)}</span>`).join('');
 			return `
-				<article class="entry-card" data-id="${esc(en.id)}" data-category="${esc(en.category)}">
+				<article class="entry-card" data-id="${esc(en.id)}" data-category="${esc(en.categoryKey || normalizeCategoryKey(en.category))}">
 					<header class="entry-header">
 						<div class="entry-meta">
 							<a class="entry-link" href="${ROUTES.viewEntry(en.id)}">
-								<span class="entry-category-badge" data-category="${esc(en.category)}">${esc(en.category)}</span>
+								<span class="entry-category-badge" data-category="${esc(en.categoryKey || normalizeCategoryKey(en.category))}">${esc(en.category)}</span>
 								<span class="entry-timestamp">${when(en.createdAt)}</span>
 							</a>
 						</div>
 						<div class="entry-actions" role="group">
 							<a class="btn-quiet" href="${ROUTES.editEntry(en.id)}">Edit</a>
-							<button class="btn-quiet danger" data-act="delete" data-id="${esc(en.id)}">Delete</button>
+							<button type="button" class="btn-quiet danger" data-act="delete" data-id="${esc(en.id)}">Delete</button>
 						</div>
 					</header>
 					<div class="entry-content">${esc(snippet)}${wasShortened ? ` <a class="read-more" href="${ROUTES.viewEntry(en.id)}">Read full entry</a>` : ''}</div>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -35,6 +35,7 @@ require_file "tests/projects-route-contract.test.js"
 require_file "tests/mural-ui-route-state.test.js"
 require_file "tests/journals-project-route-contract.test.js"
 require_file "tests/journal-tabs-api-origin-route-state.test.js"
+require_file "tests/journal-tabs-filter-state-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -145,5 +146,8 @@ node tests/journals-project-route-contract.test.js
 
 info "checking Journal tabs API origin route-state contract"
 node tests/journal-tabs-api-origin-route-state.test.js
+
+info "checking Journal tabs filter-state route-state contract"
+node tests/journal-tabs-filter-state-route-state.test.js
 
 info "validation passed"

--- a/tests/journal-tabs-filter-state-route-state.test.js
+++ b/tests/journal-tabs-filter-state-route-state.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync("public/js/journal-tabs.js", "utf8");
+
+function includes(text) {
+  assert.equal(
+    source.includes(text),
+    true,
+    `Expected journal-tabs.js to include: ${text}`,
+  );
+}
+
+function excludes(text) {
+  assert.equal(
+    source.includes(text),
+    false,
+    `Expected journal-tabs.js not to include: ${text}`,
+  );
+}
+
+includes("function normalizeCategoryKey(value)");
+includes("function categoryLabel(value)");
+includes("function emptyEntriesHtml()");
+includes("categoryKey: normalizeCategoryKey(rawCategory)");
+includes("filter === 'all' || String(en.categoryKey || normalizeCategoryKey(en.category)).toLowerCase() === filter");
+includes("data-category=\"${esc(en.categoryKey || normalizeCategoryKey(en.category))}\"");
+includes("wrap.innerHTML = emptyEntriesHtml(); return;");
+includes("<button type=\"button\" class=\"btn-quiet danger\"");
+
+excludes("const empty = document.getElementById('empty-journal');");
+excludes("wrap.innerHTML = ''; if (empty) empty.hidden = false; return;");
+excludes("String(en.category || '').toLowerCase() === filter");


### PR DESCRIPTION
## Summary
- normalise journal entry categories into stable filter keys
- keep display labels separate from filter values
- make the empty-state rendering safe so the placeholder is not removed from the DOM and then reused incorrectly
- ensure rendered entry cards use canonical category keys in `data-category`
- add a route-state regression test for journal filter behaviour
- run the new regression test from `npm run validate`

## Issue observed
Journal entries now load on the journals page, but interacting with the journal tabs or the filter chips, including **All entries**, can make the entries disappear.

## Likely cause
The UI was comparing the selected filter value directly against the displayed category text:

    String(en.category || '').toLowerCase() === filter

That is fragile because stored categories can arrive as display labels or longer text, while the filter chips use canonical values such as `perceptions`, `procedures`, `decisions`, and `introspections`.

The empty-state handling also relied on an element inside the same container that gets replaced by `innerHTML`, which makes repeated empty/non-empty renders fragile.

## Fix
Each journal entry now stores:

- `category` as a display label
- `categoryKey` as the canonical filter value

Filtering now uses `categoryKey`, not the display label.

The empty state is rendered from a small HTML helper when needed, rather than being looked up and toggled after the container has been rewritten.

## Testing
- Not run locally through this connector
- Expected CI: lint and `npm run validate`