### PR TITLE
Preserve journal entries during tab reload failures

### DIFF
--- a/public/js/journal-tabs.js
+++ b/public/js/journal-tabs.js
@@ -181,6 +181,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 		projectLocalId: '',
 		projectAirtableId: '',
 		entries: [],
+		entriesLoadSeq: 0,
 		entryFilter: 'all',
 		codes: [],
 		memos: [],
@@ -196,8 +197,13 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 	// ---------- JOURNAL ----------
 	function loadEntries() {
 		if (!state.projectId) return Promise.resolve();
+		const loadSeq = state.entriesLoadSeq + 1;
+		state.entriesLoadSeq = loadSeq;
+
 		return fetchJSON(apiUrl('/api/journal-entries?project=' + encodeURIComponent(state.projectId)))
 			.then(data => {
+				if (loadSeq !== state.entriesLoadSeq) return;
+
 				const arr = Array.isArray(data?.entries) ? data.entries : Array.isArray(data) ? data : [];
 				state.entries = arr.map(e => {
 					const rawCategory = e.category || '—';
@@ -216,10 +222,13 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 				renderEntries();
 			})
 			.catch(err => {
+				if (loadSeq !== state.entriesLoadSeq) return;
+
 				console.error('loadEntries', err);
-				state.entries = [];
-				renderEntries();
-				flash('Could not load journal entries.');
+				if (!state.entries.length) {
+					renderEntries();
+				}
+				flash('Could not refresh journal entries.');
 			});
 	}
 
@@ -389,8 +398,8 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 	// ---------- TAB lifecycle ----------
 	function onTabShown(id) {
 		if (id === 'journal-entries') loadEntries();
-		if (id === 'codes') loadCodes();
-		if (id === 'memos') loadMemos();
+		if (id === 'codes' && typeof loadCodes === 'function') loadCodes();
+		if (id === 'memos' && typeof loadMemos === 'function') loadMemos();
 	}
 
 	// ---------- boot ----------
@@ -410,9 +419,9 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 
 		setupEntryAddForm();
 		setupEntryFilters();
-		setupCodeAdd();
-		setupMemoAddForm();
-		setupMemoFilters();
+		if (typeof setupCodeAdd === 'function') setupCodeAdd();
+		if (typeof setupMemoAddForm === 'function') setupMemoAddForm();
+		if (typeof setupMemoFilters === 'function') setupMemoFilters();
 		setupAnalysisButtons();
 
 		var active = (location.hash || '').replace(/^#/, '') || 'journal-entries';

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -36,6 +36,7 @@ require_file "tests/mural-ui-route-state.test.js"
 require_file "tests/journals-project-route-contract.test.js"
 require_file "tests/journal-tabs-api-origin-route-state.test.js"
 require_file "tests/journal-tabs-filter-state-route-state.test.js"
+require_file "tests/journal-tabs-resilience-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -149,5 +150,8 @@ node tests/journal-tabs-api-origin-route-state.test.js
 
 info "checking Journal tabs filter-state route-state contract"
 node tests/journal-tabs-filter-state-route-state.test.js
+
+info "checking Journal tabs resilience route-state contract"
+node tests/journal-tabs-resilience-route-state.test.js
 
 info "validation passed"

--- a/tests/journal-tabs-resilience-route-state.test.js
+++ b/tests/journal-tabs-resilience-route-state.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync("public/js/journal-tabs.js", "utf8");
+
+function includes(text) {
+  assert.equal(
+    source.includes(text),
+    true,
+    `Expected journal-tabs.js to include: ${text}`,
+  );
+}
+
+function excludes(text) {
+  assert.equal(
+    source.includes(text),
+    false,
+    `Expected journal-tabs.js not to include: ${text}`,
+  );
+}
+
+includes("entriesLoadSeq: 0");
+includes("const loadSeq = state.entriesLoadSeq + 1;");
+includes("state.entriesLoadSeq = loadSeq;");
+includes("if (loadSeq !== state.entriesLoadSeq) return;");
+includes("if (!state.entries.length) {");
+includes("flash('Could not refresh journal entries.');");
+includes("if (id === 'codes' && typeof loadCodes === 'function') loadCodes();");
+includes("if (id === 'memos' && typeof loadMemos === 'function') loadMemos();");
+includes("if (typeof setupCodeAdd === 'function') setupCodeAdd();");
+includes("if (typeof setupMemoAddForm === 'function') setupMemoAddForm();");
+includes("if (typeof setupMemoFilters === 'function') setupMemoFilters();");
+
+excludes("state.entries = [];\n\t\t\t\trenderEntries();\n\t\t\t\tflash('Could not load journal entries.');");
+excludes("if (id === 'codes') loadCodes();");
+excludes("if (id === 'memos') loadMemos();");
+excludes("setupCodeAdd();\n\t\tsetupMemoAddForm();\n\t\tsetupMemoFilters();");


### PR DESCRIPTION
## Summary
- preserve already-rendered journal entries if a later refresh fails
- add a sequence guard so stale journal-entry loads cannot overwrite newer state
- guard optional Codes and Memos tab loaders before calling them
- guard optional Codes and Memos setup functions before calling them
- add a route-state regression test for journal tab resilience
- run the new regression test from `npm run validate`

## Issue observed
Journal entries appear on the journals page, but after interacting with journal tabs or filters the entries can disappear.

## Cause addressed
The journal reload error path cleared `state.entries` whenever a refresh failed. A tab interaction can trigger a refresh. If that refresh fails because of an API, cache, CORS, timing, or runtime issue, the visible entries are wiped even though valid entries were already loaded.

The tab lifecycle also called optional functions such as `loadCodes()` and `loadMemos()` without checking whether they exist in the current bundle. That can throw during tab navigation and leave the page in a partially updated state.

## Fix
Failed journal refreshes no longer clear existing entries. Existing entries remain visible and the user gets a refresh warning.

Journal loads now use an `entriesLoadSeq` guard so stale async responses cannot overwrite newer state.

Optional Codes and Memos setup/load functions are guarded with `typeof ... === 'function'`.

## Testing
- Not run locally through this connector
- Expected CI: lint and `npm run validate`