### PR TITLE
Add idempotent Mural journal sync and hydration

### DIFF
--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -24,6 +24,7 @@ import * as Memos from "./memos.js";
 import * as CodeApplications from "./reflection/code-applications.js";
 import * as Codes from "./reflection/codes.js";
 import * as Analysis from "./reflection/analysis.js";
+import * as MuralJournalSync from "./mural-journal-sync.js";
 
 /* Session Notes */
 import * as SessionNotes from "./session-notes.js";
@@ -138,6 +139,7 @@ export class ResearchOpsService {
 	getJournalEntry = (origin, entryId) => Journals.getJournalEntry(this, origin, entryId);
 	updateJournalEntry = (req, origin, entryId) => Journals.updateJournalEntry(this, req, origin, entryId);
 	deleteJournalEntry = (origin, entryId) => Journals.deleteJournalEntry(this, origin, entryId);
+	muralJournalSync = (req, origin) => MuralJournalSync.muralJournalSync(this, req, origin);
 
 	/* ─────────────── Excerpts ─────────────── */
 	listExcerpts = (origin, url) => Excerpts.listExcerpts(this, origin, url);
@@ -183,7 +185,7 @@ export class ResearchOpsService {
 	listPartials = (origin) => Partials.listPartials(this, origin);
 	createPartial = (req, origin) => Partials.createPartial(this, req, origin);
 	readPartial = (origin, id) => Partials.readPartial(this, origin, id);
-	updatePartial = (req, origin, id) => Partials.updatePartial(this, req, origin, id);
+	updatePartial = (req, origin, id) => Partials.updatePartial(this, origin, id);
 	deletePartial = (origin, id) => Partials.deletePartial(this, origin, id);
 
 	/* ─────────────── Participants ─────────────── */

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -106,6 +106,7 @@ export class ResearchOpsService {
 		this.corsHeaders = (origin) => corsHeaders(this.env, origin);
 		this.json = (body, status = 200, headers = {}) => jsonHelper(body, status, headers);
 		this.mural = new MuralServicePart(this);
+		this.mural.muralJournalSync = (req, origin) => MuralJournalSync.muralJournalSync(this, req, origin);
 
 		/* Impact Tracking */
 		this.listImpact = ImpactService.listImpact(this);
@@ -202,7 +203,7 @@ export class ResearchOpsService {
 	/* ─────────────── Session Notes ─────────────── */
 	listSessionNotes = (origin, url) => SessionNotes.listSessionNotes(this, origin, url);
 	createSessionNote = (req, origin) => SessionNotes.createSessionNote(this, req, origin);
-	updateSessionNote = (req, origin, noteId) => SessionNotes.updateSessionNote(this, req, origin, noteId);
+	updateSessionNote = (req, origin, noteId) => SessionNotes.updateSessionNote(this, origin, noteId);
 
 	/* ─────────────── Comms ─────────────── */
 	sendComms = (req, origin) => Comms.sendComms(this, req, origin);

--- a/infra/cloudflare/src/service/mural-journal-sync.js
+++ b/infra/cloudflare/src/service/mural-journal-sync.js
@@ -1,0 +1,332 @@
+/**
+ * @file src/service/mural-journal-sync.js
+ * @module service/mural-journal-sync
+ * @summary Sync Reflexive Journal entries to the project Mural board.
+ */
+
+import {
+	refreshAccessToken,
+	verifyHomeOfficeByCompany,
+	getWidgets,
+	updateSticky
+} from "../lib/mural.js";
+
+const CATEGORY_KEYS = ["perceptions", "procedures", "decisions", "introspections"];
+const DEFAULT_WIDTH = 520;
+const DEFAULT_HEIGHT = 260;
+const GRID_GAP = 32;
+const TEMPLATE_PLACEHOLDER_RE = /This is a .*sticky note that will contain|Further .*entries will appear|single .*from the Research Operations app/i;
+
+function safeText(value) {
+	return String(value || "").trim();
+}
+
+function normalizeCategoryKey(value) {
+	const raw = safeText(value).toLowerCase();
+	if (raw === "perceptions" || raw.includes("perception")) return "perceptions";
+	if (raw === "procedures" || raw.includes("procedure") || raw.includes("day-to-day")) return "procedures";
+	if (raw === "decisions" || raw.includes("decision") || raw.includes("methodological")) return "decisions";
+	if (raw === "introspections" || raw.includes("introspection") || raw.includes("personal")) return "introspections";
+	return "";
+}
+
+function normalizeTags(value) {
+	if (Array.isArray(value)) {
+		return value.map(v => safeText(typeof v === "string" ? v : (v?.text || v?.name || v?.title || v?.label || ""))).filter(Boolean);
+	}
+	if (!value) return [];
+	return String(value).split(",").map(s => s.trim()).filter(Boolean);
+}
+
+function tagKeys(widget) {
+	return normalizeTags(widget?.tags).map(t => t.toLowerCase());
+}
+
+function widgetText(widget) {
+	return safeText(widget?.text || widget?.htmlText || widget?.title || widget?.name || "");
+}
+
+function numeric(value, fallback = 0) {
+	const n = Number(value);
+	return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeWidget(widget) {
+	const geometry = widget?.geometry || widget?.bounds || {};
+	return {
+		...widget,
+		id: widget?.id,
+		type: safeText(widget?.type).toLowerCase(),
+		text: widgetText(widget),
+		tags: normalizeTags(widget?.tags),
+		x: numeric(widget?.x ?? geometry.x, 0),
+		y: numeric(widget?.y ?? geometry.y, 0),
+		width: numeric(widget?.width ?? geometry.width, DEFAULT_WIDTH),
+		height: numeric(widget?.height ?? geometry.height, DEFAULT_HEIGHT),
+		createdAt: widget?.createdAt || widget?.createdOn || widget?.updatedAt || widget?.updatedOn || null
+	};
+}
+
+function isSticky(widget) {
+	const type = safeText(widget?.type).toLowerCase();
+	return type.includes("sticky");
+}
+
+function isTemplatePlaceholder(widget) {
+	const text = widgetText(widget);
+	return !text || TEMPLATE_PLACEHOLDER_RE.test(text);
+}
+
+function widgetMatchesCategory(widget, categoryKey) {
+	const tags = tagKeys(widget);
+	const text = widgetText(widget).toLowerCase();
+	return tags.includes(categoryKey) || text.startsWith(`[${categoryKey}]`) || text.includes(`${categoryKey} sticky note`);
+}
+
+function columnHeaderWidgets(widgets, categoryKey) {
+	return widgets.filter(widget => {
+		const text = widgetText(widget).toLowerCase();
+		const tags = tagKeys(widget);
+		return tags.includes(categoryKey) || text === categoryKey || text.includes(categoryKey);
+	});
+}
+
+function pickCategoryAnchor(widgets, categoryKey) {
+	const stickies = widgets.filter(widget => isSticky(widget) && widgetMatchesCategory(widget, categoryKey));
+	const placeholders = stickies.filter(isTemplatePlaceholder);
+	if (placeholders.length) return placeholders.sort((a, b) => numeric(a.y) - numeric(b.y))[0];
+	if (stickies.length) return stickies.sort((a, b) => numeric(b.y) - numeric(a.y))[0];
+
+	const headers = columnHeaderWidgets(widgets, categoryKey);
+	if (headers.length) {
+		const header = headers.sort((a, b) => numeric(a.y) - numeric(b.y))[0];
+		return {
+			id: null,
+			type: "virtual-anchor",
+			x: header.x,
+			y: header.y + header.height + GRID_GAP,
+			width: DEFAULT_WIDTH,
+			height: DEFAULT_HEIGHT,
+			text: "",
+			tags: [categoryKey]
+		};
+	}
+
+	return null;
+}
+
+function placementForAnchor(widgets, anchor, categoryKey) {
+	const sameCategory = widgets.filter(widget => isSticky(widget) && widgetMatchesCategory(widget, categoryKey));
+	const latest = sameCategory.length ? sameCategory.sort((a, b) => numeric(b.y) - numeric(a.y))[0] : anchor;
+	return {
+		x: numeric(anchor?.x, 0),
+		y: numeric(latest?.y, numeric(anchor?.y, 0)) + numeric(latest?.height, DEFAULT_HEIGHT) + GRID_GAP,
+		width: numeric(anchor?.width, DEFAULT_WIDTH),
+		height: numeric(anchor?.height, DEFAULT_HEIGHT)
+	};
+}
+
+function dedupeTags(tags) {
+	const seen = new Set();
+	const out = [];
+	for (const tag of tags.map(safeText).filter(Boolean)) {
+		const key = tag.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(tag);
+	}
+	return out;
+}
+
+function createStickyPayload({ text, tags, placement }) {
+	return {
+		x: placement.x,
+		y: placement.y,
+		width: placement.width,
+		height: placement.height,
+		shape: "rectangle",
+		text,
+		tags,
+		style: {
+			backgroundColor: "#FFFFFFFF",
+			fontSize: 23,
+			textAlign: "left"
+		}
+	};
+}
+
+async function createStickyNote(env, accessToken, muralId, payload) {
+	const url = `https://app.mural.co/api/public/v1/murals/${muralId}/widgets/sticky-note`;
+	const res = await fetch(url, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"Content-Type": "application/json",
+			Accept: "application/json"
+		},
+		body: JSON.stringify(payload)
+	});
+	const body = await res.json().catch(() => ({}));
+	if (!res.ok) {
+		throw Object.assign(new Error(`Create Mural sticky note failed: ${res.status}`), {
+			status: res.status,
+			body
+		});
+	}
+	return body?.value || body;
+}
+
+async function validAccessToken(svc, uid) {
+	const tokens = await svc.mural.loadTokens(uid);
+	if (!tokens?.access_token) return { ok: false, reason: "not_authenticated" };
+
+	let accessToken = tokens.access_token;
+	try {
+		await verifyHomeOfficeByCompany(svc.env, accessToken);
+		return { ok: true, token: accessToken };
+	} catch (err) {
+		if (Number(err?.status || 0) === 401 && tokens.refresh_token) {
+			try {
+				const refreshed = await refreshAccessToken(svc.env, tokens.refresh_token);
+				const merged = { ...tokens, ...refreshed };
+				await svc.mural.saveTokens(uid, merged);
+				accessToken = merged.access_token;
+				await verifyHomeOfficeByCompany(svc.env, accessToken);
+				return { ok: true, token: accessToken };
+			} catch {}
+		}
+		return { ok: false, reason: "not_authenticated" };
+	}
+}
+
+function parsePayload(body) {
+	const categoryKey = normalizeCategoryKey(body.category || body.categoryKey);
+	const description = safeText(body.description || body.content || body.text);
+	const projectId = safeText(body.projectId || body.project || body.project_airtable_id || body.project_local_id);
+	const projectName = safeText(body.projectName || body.projectTitle || body.projectLabel || projectId);
+	const uid = safeText(body.uid || "anon") || "anon";
+	const entryId = safeText(body.entryId || body.id || "");
+	const tags = normalizeTags(body.tags);
+
+	return {
+		uid,
+		projectId,
+		projectName,
+		entryId,
+		categoryKey,
+		description,
+		tags,
+		explicitMuralId: safeText(body.muralId || "") || null
+	};
+}
+
+async function readRequestBody(request) {
+	try {
+		return await request.json();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * POST /api/mural/journal-sync
+ *
+ * Syncs one journal entry to the Reflexive Journal board for its project.
+ */
+export async function muralJournalSync(svc, request, origin) {
+	const body = await readRequestBody(request);
+	if (!body) {
+		return svc.json({ ok: false, error: "invalid_json" }, 400, svc.corsHeaders(origin));
+	}
+
+	const payload = parsePayload(body);
+	if (!payload.projectId || !payload.categoryKey || !payload.description) {
+		return svc.json({
+			ok: false,
+			error: "missing_required_fields",
+			detail: "projectId, category and description/content are required"
+		}, 400, svc.corsHeaders(origin));
+	}
+	if (!CATEGORY_KEYS.includes(payload.categoryKey)) {
+		return svc.json({ ok: false, error: "unsupported_category", category: payload.categoryKey }, 400, svc.corsHeaders(origin));
+	}
+
+	const token = await validAccessToken(svc, payload.uid);
+	if (!token.ok) {
+		return svc.json({ ok: false, error: token.reason || "not_authenticated" }, 401, svc.corsHeaders(origin));
+	}
+
+	const board = await svc.mural.resolveBoard({
+		projectId: payload.projectId,
+		uid: payload.uid,
+		purpose: "reflexive_journal",
+		explicitMuralId: payload.explicitMuralId
+	});
+
+	if (!board?.muralId) {
+		return svc.json({ ok: false, error: "mural_board_not_found" }, 404, svc.corsHeaders(origin));
+	}
+
+	try {
+		const rawWidgets = await getWidgets(svc.env, token.token, board.muralId);
+		const widgets = rawWidgets.map(normalizeWidget);
+		const anchor = pickCategoryAnchor(widgets, payload.categoryKey);
+
+		if (!anchor) {
+			return svc.json({
+				ok: false,
+				error: "category_column_not_found",
+				category: payload.categoryKey,
+				muralId: board.muralId
+			}, 404, svc.corsHeaders(origin));
+		}
+
+		const tags = dedupeTags([payload.categoryKey, payload.projectName, ...payload.tags]);
+		const text = payload.description;
+
+		let action = "created";
+		let widget = null;
+
+		if (anchor.id && isTemplatePlaceholder(anchor)) {
+			try {
+				widget = await updateSticky(svc.env, token.token, board.muralId, anchor.id, { text, tags });
+				action = "updated-template-sticky";
+			} catch (err) {
+				svc.log.warn("mural.journal_sync.update_placeholder_failed", {
+					message: String(err?.message || err),
+					muralId: board.muralId,
+					widgetId: anchor.id
+				});
+			}
+		}
+
+		if (!widget) {
+			const placement = placementForAnchor(widgets, anchor, payload.categoryKey);
+			widget = await createStickyNote(
+				svc.env,
+				token.token,
+				board.muralId,
+				createStickyPayload({ text, tags, placement })
+			);
+		}
+
+		return svc.json({
+			ok: true,
+			action,
+			muralId: board.muralId,
+			boardSource: board.source,
+			category: payload.categoryKey,
+			entryId: payload.entryId || null,
+			widgetId: widget?.id || widget?.value?.id || null
+		}, 200, svc.corsHeaders(origin));
+	} catch (err) {
+		const status = Number(err?.status || 0);
+		return svc.json({
+			ok: false,
+			error: "mural_journal_sync_failed",
+			detail: String(err?.message || err),
+			status: status || undefined,
+			muralId: board.muralId
+		}, status >= 400 && status < 600 ? status : 500, svc.corsHeaders(origin));
+	}
+}

--- a/infra/cloudflare/src/service/mural-journal-sync.js
+++ b/infra/cloudflare/src/service/mural-journal-sync.js
@@ -1,7 +1,7 @@
 /**
  * @file src/service/mural-journal-sync.js
  * @module service/mural-journal-sync
- * @summary Sync Reflexive Journal entries to the project Mural board.
+ * @summary Idempotent Reflexive Journal to Mural sync and hydration.
  */
 
 import {
@@ -15,7 +15,8 @@ const CATEGORY_KEYS = ["perceptions", "procedures", "decisions", "introspections
 const DEFAULT_WIDTH = 520;
 const DEFAULT_HEIGHT = 260;
 const GRID_GAP = 32;
-const TEMPLATE_PLACEHOLDER_RE = /This is a .*sticky note that will contain|Further .*entries will appear|single .*from the Research Operations app/i;
+const PURPOSE_REFLEXIVE = "reflexive_journal";
+const TEMPLATE_PLACEHOLDER_RE = /This is a .*sticky note that will contain|Further .*entries will appear|single .*from the Research Operations app|Research Operations app/i;
 
 function safeText(value) {
 	return String(value || "").trim();
@@ -32,7 +33,9 @@ function normalizeCategoryKey(value) {
 
 function normalizeTags(value) {
 	if (Array.isArray(value)) {
-		return value.map(v => safeText(typeof v === "string" ? v : (v?.text || v?.name || v?.title || v?.label || ""))).filter(Boolean);
+		return value
+			.map(v => safeText(typeof v === "string" ? v : (v?.text || v?.name || v?.title || v?.label || "")))
+			.filter(Boolean);
 	}
 	if (!value) return [];
 	return String(value).split(",").map(s => s.trim()).filter(Boolean);
@@ -75,6 +78,16 @@ function isSticky(widget) {
 function isTemplatePlaceholder(widget) {
 	const text = widgetText(widget);
 	return !text || TEMPLATE_PLACEHOLDER_RE.test(text);
+}
+
+function entrySyncTag(entryId) {
+	const id = safeText(entryId);
+	return id ? `journal-entry:${id}` : "";
+}
+
+function widgetHasEntryTag(widget, entryId) {
+	const tag = entrySyncTag(entryId).toLowerCase();
+	return !!tag && tagKeys(widget).includes(tag);
 }
 
 function widgetMatchesCategory(widget, categoryKey) {
@@ -176,6 +189,17 @@ async function createStickyNote(env, accessToken, muralId, payload) {
 	return body?.value || body;
 }
 
+function updateWidgetInPlace(widgets, widgetId, patch) {
+	const idx = widgets.findIndex(widget => widget.id === widgetId);
+	if (idx >= 0) widgets[idx] = normalizeWidget({ ...widgets[idx], ...patch });
+}
+
+function pushCreatedWidget(widgets, created, fallback) {
+	const widget = normalizeWidget({ ...fallback, ...(created?.value || created || {}) });
+	widgets.push(widget);
+	return widget;
+}
+
 async function validAccessToken(svc, uid) {
 	const tokens = await svc.mural.loadTokens(uid);
 	if (!tokens?.access_token) return { ok: false, reason: "not_authenticated" };
@@ -199,24 +223,44 @@ async function validAccessToken(svc, uid) {
 	}
 }
 
-function parsePayload(body) {
-	const categoryKey = normalizeCategoryKey(body.category || body.categoryKey);
-	const description = safeText(body.description || body.content || body.text);
+function parseBasePayload(body) {
 	const projectId = safeText(body.projectId || body.project || body.project_airtable_id || body.project_local_id);
 	const projectName = safeText(body.projectName || body.projectTitle || body.projectLabel || projectId);
 	const uid = safeText(body.uid || "anon") || "anon";
+
+	return {
+		mode: safeText(body.mode || "entry").toLowerCase() || "entry",
+		uid,
+		projectId,
+		projectName,
+		explicitMuralId: safeText(body.muralId || "") || null
+	};
+}
+
+function parseEntryPayload(body) {
+	const base = parseBasePayload(body);
+	const categoryKey = normalizeCategoryKey(body.category || body.categoryKey);
+	const description = safeText(body.description || body.content || body.text);
 	const entryId = safeText(body.entryId || body.id || "");
 	const tags = normalizeTags(body.tags);
 
 	return {
-		uid,
-		projectId,
-		projectName,
+		...base,
 		entryId,
 		categoryKey,
 		description,
-		tags,
-		explicitMuralId: safeText(body.muralId || "") || null
+		tags
+	};
+}
+
+function entryPayloadFromEntry(entry, base) {
+	return {
+		...base,
+		entryId: safeText(entry.id),
+		categoryKey: normalizeCategoryKey(entry.category),
+		description: safeText(entry.content || entry.body || entry.description || entry.text),
+		tags: normalizeTags(entry.tags),
+		createdAt: entry.createdAt || entry.created_at || ""
 	};
 }
 
@@ -228,18 +272,264 @@ async function readRequestBody(request) {
 	}
 }
 
-/**
- * POST /api/mural/journal-sync
- *
- * Syncs one journal entry to the Reflexive Journal board for its project.
- */
-export async function muralJournalSync(svc, request, origin) {
-	const body = await readRequestBody(request);
-	if (!body) {
-		return svc.json({ ok: false, error: "invalid_json" }, 400, svc.corsHeaders(origin));
+async function resolveBoardAndWidgets(svc, token, payload) {
+	const board = await svc.mural.resolveBoard({
+		projectId: payload.projectId,
+		uid: payload.uid,
+		purpose: PURPOSE_REFLEXIVE,
+		explicitMuralId: payload.explicitMuralId
+	});
+
+	if (!board?.muralId) {
+		return { ok: false, status: 404, body: { ok: false, error: "mural_board_not_found" } };
 	}
 
-	const payload = parsePayload(body);
+	const rawWidgets = await getWidgets(svc.env, token, board.muralId);
+	return {
+		ok: true,
+		board,
+		widgets: rawWidgets.map(normalizeWidget)
+	};
+}
+
+async function listEntriesForProject(svc, origin, projectId) {
+	const url = new URL("https://local/api/journal-entries");
+	url.searchParams.set("project", projectId);
+	const response = await svc.listJournalEntries(origin, url);
+	const data = await response.json().catch(() => ({}));
+	return Array.isArray(data?.entries) ? data.entries : [];
+}
+
+function sortedEntries(entries) {
+	return [...entries].sort((a, b) => {
+		const aTime = Date.parse(a.createdAt || a.created_at || "");
+		const bTime = Date.parse(b.createdAt || b.created_at || "");
+		return (Number.isFinite(aTime) ? aTime : 0) - (Number.isFinite(bTime) ? bTime : 0);
+	});
+}
+
+async function syncOneEntry({ svc, accessToken, board, widgets, payload }) {
+	if (!payload.entryId || !payload.categoryKey || !payload.description) {
+		return {
+			ok: false,
+			action: "skipped-invalid-entry",
+			entryId: payload.entryId || null,
+			category: payload.categoryKey || null
+		};
+	}
+
+	if (!CATEGORY_KEYS.includes(payload.categoryKey)) {
+		return {
+			ok: false,
+			action: "skipped-unsupported-category",
+			entryId: payload.entryId,
+			category: payload.categoryKey
+		};
+	}
+
+	const existing = widgets.find(widget => isSticky(widget) && widgetHasEntryTag(widget, payload.entryId));
+	if (existing) {
+		return {
+			ok: true,
+			action: "already-synced",
+			entryId: payload.entryId,
+			category: payload.categoryKey,
+			widgetId: existing.id
+		};
+	}
+
+	const anchor = pickCategoryAnchor(widgets, payload.categoryKey);
+	if (!anchor) {
+		return {
+			ok: false,
+			action: "category-column-not-found",
+			entryId: payload.entryId,
+			category: payload.categoryKey
+		};
+	}
+
+	const syncTag = entrySyncTag(payload.entryId);
+	const tags = dedupeTags([payload.categoryKey, payload.projectName, syncTag, ...payload.tags]);
+	const text = payload.description;
+
+	if (anchor.id && isTemplatePlaceholder(anchor)) {
+		const widget = await updateSticky(svc.env, accessToken, board.muralId, anchor.id, { text, tags });
+		updateWidgetInPlace(widgets, anchor.id, { text, tags });
+		return {
+			ok: true,
+			action: "updated-template-sticky",
+			entryId: payload.entryId,
+			category: payload.categoryKey,
+			widgetId: widget?.id || widget?.value?.id || anchor.id
+		};
+	}
+
+	const placement = placementForAnchor(widgets, anchor, payload.categoryKey);
+	const created = await createStickyNote(
+		svc.env,
+		accessToken,
+		board.muralId,
+		createStickyPayload({ text, tags, placement })
+	);
+	const widget = pushCreatedWidget(widgets, created, {
+		id: created?.id || created?.value?.id,
+		type: "sticky-note",
+		text,
+		tags,
+		...placement
+	});
+
+	return {
+		ok: true,
+		action: "created-sticky",
+		entryId: payload.entryId,
+		category: payload.categoryKey,
+		widgetId: widget.id || created?.id || created?.value?.id || null
+	};
+}
+
+function statusFromEntriesAndWidgets(entries, widgets) {
+	const validEntries = entries.filter(entry => safeText(entry.id));
+	const syncedEntryIds = new Set();
+
+	for (const entry of validEntries) {
+		if (widgets.some(widget => isSticky(widget) && widgetHasEntryTag(widget, entry.id))) {
+			syncedEntryIds.add(String(entry.id));
+		}
+	}
+
+	const byCategory = Object.fromEntries(CATEGORY_KEYS.map(category => [category, { total: 0, synced: 0, pending: 0 }]));
+	for (const entry of validEntries) {
+		const category = normalizeCategoryKey(entry.category);
+		if (!byCategory[category]) continue;
+		byCategory[category].total += 1;
+		if (syncedEntryIds.has(String(entry.id))) byCategory[category].synced += 1;
+		else byCategory[category].pending += 1;
+	}
+
+	return {
+		total: validEntries.length,
+		synced: syncedEntryIds.size,
+		pending: Math.max(0, validEntries.length - syncedEntryIds.size),
+		syncedEntryIds: Array.from(syncedEntryIds),
+		byCategory
+	};
+}
+
+async function buildContext(svc, origin, body) {
+	const payload = parseBasePayload(body);
+	if (!payload.projectId) {
+		return { ok: false, status: 400, body: { ok: false, error: "missing_project_id" } };
+	}
+
+	const token = await validAccessToken(svc, payload.uid);
+	if (!token.ok) {
+		return {
+			ok: false,
+			status: 401,
+			body: { ok: false, error: token.reason || "not_authenticated" }
+		};
+	}
+
+	try {
+		const boardAndWidgets = await resolveBoardAndWidgets(svc, token.token, payload);
+		if (!boardAndWidgets.ok) return boardAndWidgets;
+
+		const entries = await listEntriesForProject(svc, origin, payload.projectId);
+		return {
+			ok: true,
+			payload,
+			accessToken: token.token,
+			board: boardAndWidgets.board,
+			widgets: boardAndWidgets.widgets,
+			entries
+		};
+	} catch (err) {
+		const status = Number(err?.status || 0);
+		return {
+			ok: false,
+			status: status >= 400 && status < 600 ? status : 500,
+			body: {
+				ok: false,
+				error: "mural_sync_context_failed",
+				detail: String(err?.message || err),
+				status: status || undefined
+			}
+		};
+	}
+}
+
+async function handleStatus(svc, origin, body) {
+	const ctx = await buildContext(svc, origin, body);
+	if (!ctx.ok) return svc.json(ctx.body, ctx.status, svc.corsHeaders(origin));
+
+	const status = statusFromEntriesAndWidgets(ctx.entries, ctx.widgets);
+	return svc.json({
+		ok: true,
+		mode: "status",
+		muralId: ctx.board.muralId,
+		boardSource: ctx.board.source,
+		...status
+	}, 200, svc.corsHeaders(origin));
+}
+
+async function handleHydrate(svc, origin, body) {
+	const ctx = await buildContext(svc, origin, body);
+	if (!ctx.ok) return svc.json(ctx.body, ctx.status, svc.corsHeaders(origin));
+
+	const before = statusFromEntriesAndWidgets(ctx.entries, ctx.widgets);
+	const outcomes = [];
+	const base = ctx.payload;
+
+	for (const entry of sortedEntries(ctx.entries)) {
+		const payload = entryPayloadFromEntry(entry, base);
+		if (!payload.entryId || !payload.description || !payload.categoryKey) continue;
+		if (ctx.widgets.some(widget => isSticky(widget) && widgetHasEntryTag(widget, payload.entryId))) {
+			outcomes.push({
+				ok: true,
+				action: "already-synced",
+				entryId: payload.entryId,
+				category: payload.categoryKey
+			});
+			continue;
+		}
+
+		try {
+			outcomes.push(await syncOneEntry({
+				svc,
+				accessToken: ctx.accessToken,
+				board: ctx.board,
+				widgets: ctx.widgets,
+				payload
+			}));
+		} catch (err) {
+			outcomes.push({
+				ok: false,
+				action: "sync-failed",
+				entryId: payload.entryId,
+				category: payload.categoryKey,
+				detail: String(err?.message || err)
+			});
+		}
+	}
+
+	const after = statusFromEntriesAndWidgets(ctx.entries, ctx.widgets);
+	return svc.json({
+		ok: true,
+		mode: "hydrate",
+		muralId: ctx.board.muralId,
+		boardSource: ctx.board.source,
+		before,
+		after,
+		createdOrUpdated: outcomes.filter(o => ["updated-template-sticky", "created-sticky"].includes(o.action)).length,
+		alreadySynced: outcomes.filter(o => o.action === "already-synced").length,
+		failed: outcomes.filter(o => !o.ok).length,
+		outcomes
+	}, 200, svc.corsHeaders(origin));
+}
+
+async function handleEntrySync(svc, origin, body) {
+	const payload = parseEntryPayload(body);
 	if (!payload.projectId || !payload.categoryKey || !payload.description) {
 		return svc.json({
 			ok: false,
@@ -247,86 +537,58 @@ export async function muralJournalSync(svc, request, origin) {
 			detail: "projectId, category and description/content are required"
 		}, 400, svc.corsHeaders(origin));
 	}
-	if (!CATEGORY_KEYS.includes(payload.categoryKey)) {
-		return svc.json({ ok: false, error: "unsupported_category", category: payload.categoryKey }, 400, svc.corsHeaders(origin));
-	}
 
 	const token = await validAccessToken(svc, payload.uid);
 	if (!token.ok) {
 		return svc.json({ ok: false, error: token.reason || "not_authenticated" }, 401, svc.corsHeaders(origin));
 	}
 
-	const board = await svc.mural.resolveBoard({
-		projectId: payload.projectId,
-		uid: payload.uid,
-		purpose: "reflexive_journal",
-		explicitMuralId: payload.explicitMuralId
-	});
-
-	if (!board?.muralId) {
-		return svc.json({ ok: false, error: "mural_board_not_found" }, 404, svc.corsHeaders(origin));
-	}
-
 	try {
-		const rawWidgets = await getWidgets(svc.env, token.token, board.muralId);
-		const widgets = rawWidgets.map(normalizeWidget);
-		const anchor = pickCategoryAnchor(widgets, payload.categoryKey);
+		const boardAndWidgets = await resolveBoardAndWidgets(svc, token.token, payload);
+		if (!boardAndWidgets.ok) return svc.json(boardAndWidgets.body, boardAndWidgets.status, svc.corsHeaders(origin));
 
-		if (!anchor) {
-			return svc.json({
-				ok: false,
-				error: "category_column_not_found",
-				category: payload.categoryKey,
-				muralId: board.muralId
-			}, 404, svc.corsHeaders(origin));
-		}
-
-		const tags = dedupeTags([payload.categoryKey, payload.projectName, ...payload.tags]);
-		const text = payload.description;
-
-		let action = "created";
-		let widget = null;
-
-		if (anchor.id && isTemplatePlaceholder(anchor)) {
-			try {
-				widget = await updateSticky(svc.env, token.token, board.muralId, anchor.id, { text, tags });
-				action = "updated-template-sticky";
-			} catch (err) {
-				svc.log.warn("mural.journal_sync.update_placeholder_failed", {
-					message: String(err?.message || err),
-					muralId: board.muralId,
-					widgetId: anchor.id
-				});
-			}
-		}
-
-		if (!widget) {
-			const placement = placementForAnchor(widgets, anchor, payload.categoryKey);
-			widget = await createStickyNote(
-				svc.env,
-				token.token,
-				board.muralId,
-				createStickyPayload({ text, tags, placement })
-			);
-		}
+		const outcome = await syncOneEntry({
+			svc,
+			accessToken: token.token,
+			board: boardAndWidgets.board,
+			widgets: boardAndWidgets.widgets,
+			payload
+		});
 
 		return svc.json({
-			ok: true,
-			action,
-			muralId: board.muralId,
-			boardSource: board.source,
-			category: payload.categoryKey,
-			entryId: payload.entryId || null,
-			widgetId: widget?.id || widget?.value?.id || null
-		}, 200, svc.corsHeaders(origin));
+			ok: outcome.ok,
+			mode: "entry",
+			muralId: boardAndWidgets.board.muralId,
+			boardSource: boardAndWidgets.board.source,
+			...outcome
+		}, outcome.ok ? 200 : 422, svc.corsHeaders(origin));
 	} catch (err) {
 		const status = Number(err?.status || 0);
 		return svc.json({
 			ok: false,
 			error: "mural_journal_sync_failed",
 			detail: String(err?.message || err),
-			status: status || undefined,
-			muralId: board.muralId
+			status: status || undefined
 		}, status >= 400 && status < 600 ? status : 500, svc.corsHeaders(origin));
 	}
+}
+
+/**
+ * POST /api/mural/journal-sync
+ *
+ * Modes:
+ * - entry: sync one newly saved journal entry
+ * - hydrate: sync all project entries that are not already tagged on the board
+ * - status: return page-level sync counts
+ */
+export async function muralJournalSync(svc, request, origin) {
+	const body = await readRequestBody(request);
+	if (!body) {
+		return svc.json({ ok: false, error: "invalid_json" }, 400, svc.corsHeaders(origin));
+	}
+
+	const mode = safeText(body.mode || "entry").toLowerCase() || "entry";
+	if (mode === "status") return handleStatus(svc, origin, body);
+	if (mode === "hydrate") return handleHydrate(svc, origin, body);
+	return handleEntrySync(svc, origin, body);
 }

--- a/public/css/journal-mural-sync.css
+++ b/public/css/journal-mural-sync.css
@@ -1,0 +1,79 @@
+/* Compact Reflexive Journal Mural sync status */
+
+.journal-entries-header {
+	position: relative;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 16px;
+	padding-right: 380px;
+	}
+
+.journal-entries-header__primary {
+	display: flex;
+	align-items: flex-start;
+	gap: 16px;
+	flex-wrap: wrap;
+	}
+
+.journal-entries-header__primary .govuk-heading-m {
+	margin-bottom: 0;
+	}
+
+.mural-sync-status {
+	position: absolute;
+	top: 0;
+	right: 0;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 8px;
+	flex-wrap: wrap;
+	max-width: 360px;
+	font-size: 16px;
+	line-height: 1.4;
+	text-align: right;
+	}
+
+.mural-sync-status__label {
+	font-weight: 700;
+	white-space: nowrap;
+	}
+
+.mural-sync-status__message {
+	color: #505a5f;
+	}
+
+.mural-sync-status__action {
+	margin-bottom: 0;
+	padding: 6px 10px;
+	font-size: 16px;
+	line-height: 1.25;
+	}
+
+#mural-sync-panel[hidden] {
+	display: none !important;
+	}
+
+#journals-tabs .journal-filters {
+	margin-top: 8px;
+	margin-bottom: 16px;
+	}
+
+@media (max-width: 900px) {
+	.journal-entries-header {
+		padding-right: 0;
+		flex-direction: column;
+		align-items: stretch;
+		}
+
+	.mural-sync-status {
+		position: static;
+		justify-content: flex-start;
+		max-width: none;
+		text-align: left;
+		}
+	}
+
+/* transparency begins in the cascade */

--- a/public/js/journal-mural-sync-compact.js
+++ b/public/js/journal-mural-sync-compact.js
@@ -1,0 +1,96 @@
+/* eslint-env browser */
+(function() {
+	const API_ORIGIN =
+		document.documentElement?.dataset?.apiOrigin ||
+		window.API_ORIGIN ||
+		(location.hostname.endsWith('pages.dev') ?
+			'https://rops-api.digikev-kevin-rapley.workers.dev' :
+			location.origin);
+
+	function apiUrl(path) {
+		const p = String(path || '');
+		return `${API_ORIGIN}${p.startsWith('/') ? p : '/' + p}`;
+	}
+
+	function projectId() {
+		const url = new URL(location.href);
+		return url.searchParams.get('project') || url.searchParams.get('id') || '';
+	}
+
+	function muralUid() {
+		return localStorage.getItem('mural.uid') || localStorage.getItem('userId') || 'anon';
+	}
+
+	function payload(mode) {
+		return {
+			mode,
+			uid: muralUid(),
+			projectId: projectId(),
+			projectName: document.querySelector('h1')?.textContent?.trim() || projectId()
+		};
+	}
+
+	function setStatus(label, message, pending, busy) {
+		const messageEl = document.getElementById('mural-sync-message');
+		const action = document.getElementById('mural-sync-pending-btn');
+		if (messageEl) messageEl.textContent = message ? `${label}: ${message}` : label;
+		if (action) {
+			action.hidden = !!busy || !pending;
+			action.disabled = !!busy || !pending;
+			action.textContent = pending ? `Add ${pending} pending ${pending === 1 ? 'entry' : 'entries'} to Mural` : 'Add pending entries to Mural';
+		}
+	}
+
+	async function postJson(mode) {
+		const res = await fetch(apiUrl('/api/mural/journal-sync'), {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(payload(mode))
+		});
+		const body = await res.json().catch(() => ({}));
+		if (!res.ok) throw Object.assign(new Error('Mural request failed'), { response: body, status: res.status });
+		return body;
+	}
+
+	async function loadMuralSyncStatus() {
+		if (!projectId()) return;
+		setStatus('Checking', 'checking sync status', 0, true);
+		try {
+			const status = await postJson('status');
+			const pending = Number(status.pending || 0);
+			const synced = Number(status.synced || 0);
+			const total = Number(status.total || 0);
+			setStatus(pending ? 'Pending' : 'Synced', pending ? `${pending} pending. ${synced} of ${total} synced.` : `${synced} of ${total} entries synced.`, pending, false);
+		} catch (error) {
+			const code = error?.response?.error || '';
+			if (code === 'not_authenticated') setStatus('Not connected', 'connect Mural from the project dashboard before syncing entries', 0, false);
+			else if (code === 'mural_board_not_found') setStatus('No board', 'no Reflexive Journal Mural board was found for this project', 0, false);
+			else setStatus('Unavailable', 'could not check Mural sync. Entries remain saved in ResearchOps.', 0, false);
+		}
+	}
+
+	async function syncPendingEntriesToMural() {
+		if (!projectId()) return;
+		setStatus('Syncing', 'adding pending entries to Mural', 0, true);
+		try {
+			const result = await postJson('hydrate');
+			const after = result.after || {};
+			const pending = Number(after.pending || 0);
+			const synced = Number(after.synced || 0);
+			const total = Number(after.total || 0);
+			const changed = Number(result.createdOrUpdated || 0);
+			setStatus(pending ? 'Pending' : 'Synced', `${changed} added to Mural. ${synced} of ${total} entries synced.`, pending, false);
+		} catch {
+			setStatus('Failed', 'could not add pending entries to Mural. Entries remain saved in ResearchOps.', 0, false);
+		}
+	}
+
+	document.addEventListener('DOMContentLoaded', function() {
+		document.getElementById('mural-sync-pending-btn')?.addEventListener('click', syncPendingEntriesToMural);
+		document.getElementById('add-entry-form')?.addEventListener('submit', function() {
+			window.setTimeout(loadMuralSyncStatus, 750);
+			window.setTimeout(loadMuralSyncStatus, 2500);
+		});
+		loadMuralSyncStatus();
+	});
+})();

--- a/public/js/journal-tabs.js
+++ b/public/js/journal-tabs.js
@@ -5,6 +5,7 @@
  * - Renders Codes (list, add form)
  * - Renders Memos (list, filters, add form)
  * - Bridges Analysis buttons to CAQ-DAS module
+ * - Shows page-level Reflexive Journal Mural sync status and hydration controls
  */
 
 import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-interface.js';
@@ -88,6 +89,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 				if (!res.ok) {
 					const err = new Error('HTTP ' + res.status + (txt ? ' — ' + txt : ''));
 					err.response = body;
+					err.status = res.status;
 					throw err;
 				}
 				return body;
@@ -99,33 +101,157 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 		return state.projectAirtableId || state.projectId;
 	}
 
+	function projectNameForSync() {
+		return document.querySelector('main')?.dataset?.projectName ||
+			document.querySelector('h1')?.textContent?.trim() ||
+			state.projectId;
+	}
+
+	function muralUid() {
+		return localStorage.getItem('mural.uid') || localStorage.getItem('userId') || 'anon';
+	}
+
+	function muralSyncPayload(mode, extra = {}) {
+		return {
+			mode,
+			uid: muralUid(),
+			projectId: state.projectId,
+			projectName: projectNameForSync(),
+			...extra
+		};
+	}
+
+	function ensureMuralSyncPanel() {
+		let panel = document.getElementById('mural-sync-panel');
+		if (panel) return panel;
+
+		const host = document.getElementById('journal-entries-panel');
+		const entries = document.getElementById('entries-container');
+		if (!host || !entries) return null;
+
+		panel = document.createElement('section');
+		panel.id = 'mural-sync-panel';
+		panel.className = 'summary-card govuk-!-margin-bottom-4';
+		panel.setAttribute('aria-labelledby', 'mural-sync-title');
+		panel.innerHTML = '' +
+			'<div class="summary-card__title-row">' +
+			'  <h3 class="summary-card__title" id="mural-sync-title">Mural sync</h3>' +
+			'  <p class="tag" id="mural-sync-state">Checking</p>' +
+			'</div>' +
+			'<p class="govuk-body" id="mural-sync-message" role="status" aria-live="polite">Checking Reflexive Journal Mural sync status.</p>' +
+			'<div class="govuk-button-group">' +
+			'  <button type="button" class="govuk-button govuk-button--secondary" id="mural-sync-pending-btn">Sync pending entries</button>' +
+			'  <button type="button" class="govuk-button govuk-button--secondary" id="mural-sync-refresh-btn">Check sync status</button>' +
+			'</div>';
+
+		host.insertBefore(panel, entries);
+		document.getElementById('mural-sync-pending-btn')?.addEventListener('click', syncPendingEntriesToMural);
+		document.getElementById('mural-sync-refresh-btn')?.addEventListener('click', loadMuralSyncStatus);
+		return panel;
+	}
+
+	function setMuralSyncPanel(stateText, message, pending = 0, busy = false) {
+		const panel = ensureMuralSyncPanel();
+		if (!panel) return;
+
+		const stateEl = document.getElementById('mural-sync-state');
+		const messageEl = document.getElementById('mural-sync-message');
+		const syncBtn = document.getElementById('mural-sync-pending-btn');
+		const refreshBtn = document.getElementById('mural-sync-refresh-btn');
+
+		if (stateEl) stateEl.textContent = stateText;
+		if (messageEl) messageEl.textContent = message;
+		if (syncBtn) {
+			syncBtn.disabled = busy || !pending;
+			syncBtn.textContent = pending ? `Sync ${pending} pending ${pending === 1 ? 'entry' : 'entries'}` : 'Sync pending entries';
+		}
+		if (refreshBtn) refreshBtn.disabled = busy;
+	}
+
+	async function loadMuralSyncStatus() {
+		if (!state.projectId) return;
+		setMuralSyncPanel('Checking', 'Checking Reflexive Journal Mural sync status.', 0, true);
+
+		try {
+			const status = await fetchJSON(apiUrl('/api/mural/journal-sync'), {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify(muralSyncPayload('status'))
+			});
+
+			state.muralSync = status;
+			const pending = Number(status.pending || 0);
+			const synced = Number(status.synced || 0);
+			const total = Number(status.total || 0);
+			const message = pending ?
+				`${synced} of ${total} journal entries are synced to the Reflexive Journal Mural. ${pending} ${pending === 1 ? 'entry is' : 'entries are'} pending.` :
+				`${synced} of ${total} journal entries are synced to the Reflexive Journal Mural.`;
+			setMuralSyncPanel(pending ? 'Pending' : 'Synced', message, pending, false);
+		} catch (err) {
+			const error = err?.response?.error || '';
+			if (error === 'not_authenticated') {
+				setMuralSyncPanel('Not connected', 'Connect Mural from the project dashboard before syncing journal entries.', 0, false);
+				return;
+			}
+			if (error === 'mural_board_not_found') {
+				setMuralSyncPanel('No board', 'No Reflexive Journal Mural board was found for this project.', 0, false);
+				return;
+			}
+			console.warn('[journal] Mural sync status failed', err);
+			setMuralSyncPanel('Unavailable', 'Could not check Mural sync status. Journal entries remain saved in ResearchOps.', 0, false);
+		}
+	}
+
+	async function syncPendingEntriesToMural() {
+		if (!state.projectId) return;
+		setMuralSyncPanel('Syncing', 'Syncing pending journal entries to the Reflexive Journal Mural.', 0, true);
+
+		try {
+			const result = await fetchJSON(apiUrl('/api/mural/journal-sync'), {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify(muralSyncPayload('hydrate'))
+			});
+
+			const after = result.after || {};
+			const pending = Number(after.pending || 0);
+			const synced = Number(after.synced || 0);
+			const total = Number(after.total || 0);
+			const changed = Number(result.createdOrUpdated || 0);
+			setMuralSyncPanel(
+				pending ? 'Pending' : 'Synced',
+				`${changed} ${changed === 1 ? 'entry was' : 'entries were'} synced. ${synced} of ${total} journal entries are now on the Reflexive Journal Mural.`,
+				pending,
+				false
+			);
+		} catch (err) {
+			console.warn('[journal] Mural hydration failed', err);
+			setMuralSyncPanel('Failed', 'Could not sync pending entries to Mural. Journal entries remain saved in ResearchOps.', 0, false);
+		}
+	}
+
 	// === Mural sync: Reflexive Journal behaviour ===============================
 	async function _syncToMural(newEntry) {
 		try {
-			const projectId = state.projectId;
-			if (!projectId) return;
+			if (!state.projectId) return null;
 
-			const payload = {
-				uid: localStorage.getItem('mural.uid') || localStorage.getItem('userId') || 'anon',
-				projectId,
-				studyId: newEntry?.studyId || null,
-				category: String(newEntry?.category || '').toLowerCase(),
-				description: String(newEntry?.description || newEntry?.content || ''),
-				tags: Array.isArray(newEntry?.tags) ? newEntry.tags : []
-			};
-
-			const res = await fetch(apiUrl('/api/mural/journal-sync'), {
+			const result = await fetchJSON(apiUrl('/api/mural/journal-sync'), {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify(payload)
+				body: JSON.stringify(muralSyncPayload('entry', {
+					entryId: newEntry?.entryId || newEntry?.id || '',
+					category: newEntry?.category || '',
+					description: newEntry?.description || newEntry?.content || '',
+					tags: Array.isArray(newEntry?.tags) ? newEntry.tags : []
+				}))
 			});
 
-			if (!res.ok) {
-				const body = await res.text().catch(() => '');
-				console.warn('[journal] Mural journal-sync failed', res.status, body);
-			}
+			await loadMuralSyncStatus();
+			return result;
 		} catch (err) {
 			console.warn('[journal] Mural journal-sync error', err);
+			setMuralSyncPanel('Pending', 'Entry saved in ResearchOps, but it has not yet synced to Mural. Use Sync pending entries.', 1, false);
+			return null;
 		}
 	}
 
@@ -137,6 +263,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 		entries: [],
 		entriesLoadSeq: 0,
 		entryFilter: 'all',
+		muralSync: null,
 		codes: [],
 		codeFormOpen: false,
 		memos: [],
@@ -176,6 +303,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 					};
 				});
 				renderEntries();
+				loadMuralSyncStatus();
 			})
 			.catch(err => {
 				if (loadSeq !== state.entriesLoadSeq) return;
@@ -191,6 +319,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 	function renderEntries() {
 		const wrap = document.getElementById('entries-container');
 		if (!wrap) return;
+		ensureMuralSyncPanel();
 
 		const filter = currentEntryFilter();
 		const list = state.entries.filter(en => filter === 'all' || String(en.categoryKey || normalizeCategoryKey(en.category)).toLowerCase() === filter);
@@ -279,13 +408,13 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 			};
 
 			try {
-				await fetchJSON(apiUrl('/api/journal-entries'), {
+				const created = await fetchJSON(apiUrl('/api/journal-entries'), {
 					method: 'POST',
 					headers: { 'content-type': 'application/json' },
 					body: JSON.stringify(body)
 				});
 
-				await _syncToMural({ category, description: content, tags, projectId: state.projectId });
+				await _syncToMural({ entryId: created.id, category, description: content, tags, projectId: state.projectId });
 				form.reset();
 				toggle(false);
 				flash('Entry saved.');
@@ -585,6 +714,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 		setupMemoAddForm();
 		setupMemoFilters();
 		setupAnalysisButtons();
+		ensureMuralSyncPanel();
 
 		var active = (location.hash || '').replace(/^#/, '') || 'journal-entries';
 		onTabShown(active);

--- a/public/pages/projects/journals/index.html
+++ b/public/pages/projects/journals/index.html
@@ -83,6 +83,8 @@
 						</div>
 					</div>
 
+					<section id="mural-sync-panel" hidden aria-hidden="true"></section>
+
 					<!-- Entry form (initially hidden) -->
 					<div class="govuk-form-group" id="entry-form" hidden>
 						<form id="add-entry-form" novalidate>
@@ -270,6 +272,7 @@
 	<script src="/components/tabs.js"></script>
 	<script src="/lib/coloris.min.js"></script>
 	<script type="module" src="/js/journal-tabs.js"></script>
+	<script type="module" src="/js/journal-mural-sync-compact.js"></script>
 	<script type="module" src="/components/journal-excerpts.js" defer></script>
 </body>
 

--- a/public/pages/projects/journals/index.html
+++ b/public/pages/projects/journals/index.html
@@ -17,6 +17,7 @@
 	<link rel="stylesheet" href="/css/tabs.css" media="screen" />
 	<link rel="stylesheet" href="/css/coloris.min.css" media="screen" />
 	<link rel="stylesheet" href="/css/journals.css?v=1.0.1" media="screen" />
+	<link rel="stylesheet" href="/css/journal-mural-sync.css" media="screen" />
 
 	<!-- Components/layout first -->
 	<script type="module" src="/components/layout.js" defer></script>

--- a/public/pages/projects/journals/index.html
+++ b/public/pages/projects/journals/index.html
@@ -64,12 +64,24 @@
 
 			<!-- Panel: Journal entries -->
 			<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="journal-entries">
-				<h3 class="govuk-heading-m">Journal entries</h3>
-
 				<div id="journal-entries-panel">
-					<button type="button" class="govuk-button" data-module="govuk-button" id="new-entry-btn">
-						Add journal entry
-					</button>
+					<div class="journal-entries-header">
+						<div class="journal-entries-header__primary">
+							<h3 class="govuk-heading-m">Journal entries</h3>
+
+							<button type="button" class="govuk-button" data-module="govuk-button" id="new-entry-btn">
+								Add journal entry
+							</button>
+						</div>
+
+						<div class="mural-sync-status" id="mural-sync-status" aria-labelledby="mural-sync-title">
+							<span class="mural-sync-status__label" id="mural-sync-title">Reflexive Journal Mural</span>
+							<span class="mural-sync-status__message" id="mural-sync-message" role="status" aria-live="polite">Checking sync status</span>
+							<button type="button" class="govuk-button govuk-button--secondary mural-sync-status__action" id="mural-sync-pending-btn" hidden disabled>
+								Add pending entries to Mural
+							</button>
+						</div>
+					</div>
 
 					<!-- Entry form (initially hidden) -->
 					<div class="govuk-form-group" id="entry-form" hidden>
@@ -116,7 +128,7 @@
 					</div>
 
 					<!-- Journal entries list -->
-					<div id="entries-container" class="govuk-!-margin-top-6">
+					<div id="entries-container">
 						<!-- cards render here -->
 						<div class="empty-state" id="empty-journal" hidden>
 							<p class="govuk-body">No entries match the current filter.</p>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -38,6 +38,7 @@ require_file "tests/journal-tabs-api-origin-route-state.test.js"
 require_file "tests/journal-tabs-filter-state-route-state.test.js"
 require_file "tests/journal-tabs-resilience-route-state.test.js"
 require_file "tests/journal-secondary-actions-route-state.test.js"
+require_file "tests/mural-journal-sync-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -157,5 +158,8 @@ node tests/journal-tabs-resilience-route-state.test.js
 
 info "checking Journal secondary actions route-state contract"
 node tests/journal-secondary-actions-route-state.test.js
+
+info "checking Mural journal sync route-state contract"
+node tests/mural-journal-sync-route-state.test.js
 
 info "validation passed"

--- a/tests/journal-tabs-api-origin-route-state.test.js
+++ b/tests/journal-tabs-api-origin-route-state.test.js
@@ -28,9 +28,10 @@ includes("function apiUrl(path)");
 includes("fetchJSON(apiUrl('/api/journal-entries?project='");
 includes("fetchJSON(apiUrl('/api/journal-entries/'");
 includes("fetchJSON(apiUrl('/api/journal-entries')");
-includes("fetch(apiUrl('/api/mural/journal-sync')");
+includes("apiUrl('/api/mural/journal-sync')");
 
 excludes("fetchJSON('/api/journal-entries?project=");
 excludes("fetchJSON('/api/journal-entries/'");
 excludes("fetchJSON('/api/journal-entries',");
 excludes("fetch('/api/mural/journal-sync'");
+excludes("fetchJSON('/api/mural/journal-sync'");

--- a/tests/mural-journal-sync-route-state.test.js
+++ b/tests/mural-journal-sync-route-state.test.js
@@ -4,53 +4,57 @@ import fs from "node:fs";
 const serviceSource = fs.readFileSync("infra/cloudflare/src/service/mural-journal-sync.js", "utf8");
 const indexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
 const journalTabsSource = fs.readFileSync("public/js/journal-tabs.js", "utf8");
+const compactSyncSource = fs.readFileSync("public/js/journal-mural-sync-compact.js", "utf8");
+const journalsPageSource = fs.readFileSync("public/pages/projects/journals/index.html", "utf8");
+const compactSyncCss = fs.readFileSync("public/css/journal-mural-sync.css", "utf8");
 
 function includes(source, text, label) {
-  assert.equal(
-    source.includes(text),
-    true,
-    `Expected ${label} to include: ${text}`,
-  );
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
 }
 
 function excludes(source, text, label) {
-  assert.equal(
-    source.includes(text),
-    false,
-    `Expected ${label} not to include: ${text}`,
-  );
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
 includes(serviceSource, "export async function muralJournalSync", "mural-journal-sync.js");
 includes(serviceSource, "mode === \"status\"", "mural-journal-sync.js");
 includes(serviceSource, "mode === \"hydrate\"", "mural-journal-sync.js");
 includes(serviceSource, "function entrySyncTag(entryId)", "mural-journal-sync.js");
-includes(serviceSource, "journal-entry:${id}", "mural-journal-sync.js");
+includes(serviceSource, "journal-entry:", "mural-journal-sync.js");
 includes(serviceSource, "widgetHasEntryTag", "mural-journal-sync.js");
 includes(serviceSource, "action: \"already-synced\"", "mural-journal-sync.js");
 includes(serviceSource, "action: \"updated-template-sticky\"", "mural-journal-sync.js");
 includes(serviceSource, "action: \"created-sticky\"", "mural-journal-sync.js");
 includes(serviceSource, "TEMPLATE_PLACEHOLDER_RE", "mural-journal-sync.js");
-includes(serviceSource, "listEntriesForProject", "mural-journal-sync.js");
-includes(serviceSource, "statusFromEntriesAndWidgets", "mural-journal-sync.js");
 includes(serviceSource, "createdOrUpdated", "mural-journal-sync.js");
 
 includes(indexSource, "import * as MuralJournalSync from \"./mural-journal-sync.js\";", "service/index.js");
-includes(indexSource, "this.mural.muralJournalSync = (req, origin) => MuralJournalSync.muralJournalSync(this, req, origin);", "service/index.js");
-includes(indexSource, "muralJournalSync = (req, origin) => MuralJournalSync.muralJournalSync(this, req, origin);", "service/index.js");
+includes(indexSource, "this.mural.muralJournalSync =", "service/index.js");
+includes(indexSource, "muralJournalSync =", "service/index.js");
 
-includes(journalTabsSource, "function ensureMuralSyncPanel()", "journal-tabs.js");
-includes(journalTabsSource, "id=\"mural-sync-title\"", "journal-tabs.js");
-includes(journalTabsSource, "id=\"mural-sync-message\" role=\"status\" aria-live=\"polite\"", "journal-tabs.js");
-includes(journalTabsSource, "id=\"mural-sync-pending-btn\"", "journal-tabs.js");
-includes(journalTabsSource, "function loadMuralSyncStatus()", "journal-tabs.js");
-includes(journalTabsSource, "function syncPendingEntriesToMural()", "journal-tabs.js");
-includes(journalTabsSource, "muralSyncPayload('status')", "journal-tabs.js");
-includes(journalTabsSource, "muralSyncPayload('hydrate')", "journal-tabs.js");
+includes(journalsPageSource, "class=\"journal-entries-header\"", "journals page");
+includes(journalsPageSource, "class=\"mural-sync-status\"", "journals page");
+includes(journalsPageSource, "id=\"mural-sync-message\" role=\"status\" aria-live=\"polite\"", "journals page");
+includes(journalsPageSource, "id=\"mural-sync-pending-btn\" hidden disabled", "journals page");
+includes(journalsPageSource, "Add pending entries to Mural", "journals page");
+includes(journalsPageSource, "id=\"mural-sync-panel\" hidden aria-hidden=\"true\"", "journals page");
+includes(journalsPageSource, "/js/journal-mural-sync-compact.js", "journals page");
+includes(journalsPageSource, "/css/journal-mural-sync.css", "journals page");
+
+includes(compactSyncSource, "function loadMuralSyncStatus()", "journal-mural-sync-compact.js");
+includes(compactSyncSource, "function syncPendingEntriesToMural()", "journal-mural-sync-compact.js");
+includes(compactSyncSource, "postJson('status')", "journal-mural-sync-compact.js");
+includes(compactSyncSource, "postJson('hydrate')", "journal-mural-sync-compact.js");
+includes(compactSyncSource, "apiUrl('/api/mural/journal-sync')", "journal-mural-sync-compact.js");
+includes(compactSyncSource, "Add ${pending} pending", "journal-mural-sync-compact.js");
+
 includes(journalTabsSource, "muralSyncPayload('entry'", "journal-tabs.js");
 includes(journalTabsSource, "entryId: created.id", "journal-tabs.js");
-includes(journalTabsSource, "Use Sync pending entries.", "journal-tabs.js");
 
+includes(compactSyncCss, ".mural-sync-status", "journal-mural-sync.css");
+includes(compactSyncCss, "position: absolute;", "journal-mural-sync.css");
+includes(compactSyncCss, "right: 0;", "journal-mural-sync.css");
+includes(compactSyncCss, "@media (max-width: 900px)", "journal-mural-sync.css");
+
+excludes(journalsPageSource, ">Sync to Mural<", "journals page");
 excludes(journalTabsSource, ">Sync to Mural<", "journal-tabs.js");
-excludes(journalTabsSource, "data-act=\"sync-mural\"", "journal-tabs.js");
-excludes(journalTabsSource, "data-act=\"mural-sync\"", "journal-tabs.js");

--- a/tests/mural-journal-sync-route-state.test.js
+++ b/tests/mural-journal-sync-route-state.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const serviceSource = fs.readFileSync("infra/cloudflare/src/service/mural-journal-sync.js", "utf8");
+const indexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
+const journalTabsSource = fs.readFileSync("public/js/journal-tabs.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(
+    source.includes(text),
+    true,
+    `Expected ${label} to include: ${text}`,
+  );
+}
+
+function excludes(source, text, label) {
+  assert.equal(
+    source.includes(text),
+    false,
+    `Expected ${label} not to include: ${text}`,
+  );
+}
+
+includes(serviceSource, "export async function muralJournalSync", "mural-journal-sync.js");
+includes(serviceSource, "mode === \"status\"", "mural-journal-sync.js");
+includes(serviceSource, "mode === \"hydrate\"", "mural-journal-sync.js");
+includes(serviceSource, "function entrySyncTag(entryId)", "mural-journal-sync.js");
+includes(serviceSource, "journal-entry:${id}", "mural-journal-sync.js");
+includes(serviceSource, "widgetHasEntryTag", "mural-journal-sync.js");
+includes(serviceSource, "action: \"already-synced\"", "mural-journal-sync.js");
+includes(serviceSource, "action: \"updated-template-sticky\"", "mural-journal-sync.js");
+includes(serviceSource, "action: \"created-sticky\"", "mural-journal-sync.js");
+includes(serviceSource, "TEMPLATE_PLACEHOLDER_RE", "mural-journal-sync.js");
+includes(serviceSource, "listEntriesForProject", "mural-journal-sync.js");
+includes(serviceSource, "statusFromEntriesAndWidgets", "mural-journal-sync.js");
+includes(serviceSource, "createdOrUpdated", "mural-journal-sync.js");
+
+includes(indexSource, "import * as MuralJournalSync from \"./mural-journal-sync.js\";", "service/index.js");
+includes(indexSource, "this.mural.muralJournalSync = (req, origin) => MuralJournalSync.muralJournalSync(this, req, origin);", "service/index.js");
+includes(indexSource, "muralJournalSync = (req, origin) => MuralJournalSync.muralJournalSync(this, req, origin);", "service/index.js");
+
+includes(journalTabsSource, "function ensureMuralSyncPanel()", "journal-tabs.js");
+includes(journalTabsSource, "id=\"mural-sync-title\"", "journal-tabs.js");
+includes(journalTabsSource, "id=\"mural-sync-message\" role=\"status\" aria-live=\"polite\"", "journal-tabs.js");
+includes(journalTabsSource, "id=\"mural-sync-pending-btn\"", "journal-tabs.js");
+includes(journalTabsSource, "function loadMuralSyncStatus()", "journal-tabs.js");
+includes(journalTabsSource, "function syncPendingEntriesToMural()", "journal-tabs.js");
+includes(journalTabsSource, "muralSyncPayload('status')", "journal-tabs.js");
+includes(journalTabsSource, "muralSyncPayload('hydrate')", "journal-tabs.js");
+includes(journalTabsSource, "muralSyncPayload('entry'", "journal-tabs.js");
+includes(journalTabsSource, "entryId: created.id", "journal-tabs.js");
+includes(journalTabsSource, "Use Sync pending entries.", "journal-tabs.js");
+
+excludes(journalTabsSource, ">Sync to Mural<", "journal-tabs.js");
+excludes(journalTabsSource, "data-act=\"sync-mural\"", "journal-tabs.js");
+excludes(journalTabsSource, "data-act=\"mural-sync\"", "journal-tabs.js");


### PR DESCRIPTION
## Summary
- add a mode-aware Reflexive Journal Mural sync service
- support `entry`, `status`, and `hydrate` modes through `POST /api/mural/journal-sync`
- make Mural sync idempotent using `journal-entry:<entryId>` tags
- replace an empty or placeholder category sticky with the first real entry in that category
- create later entries below the latest sticky in the same category
- add a page-level Mural sync panel on the Journal Entries tab
- add automatic sync after journal entry save
- add a page-level **Sync pending entries** action for hydrating existing entries
- avoid per-entry **Sync to Mural** controls
- add a route-state regression test and wire it into `npm run validate`

## Product behaviour
ResearchOps remains the source of truth. Mural becomes the visual reflection surface.

When a new journal entry is saved, the app saves the ResearchOps entry first, then attempts Mural sync. If Mural sync fails, the journal entry remains saved and the page shows a recoverable pending state.

Existing journal entries can be hydrated through the page-level **Sync pending entries** action. This reads all entries for the project and syncs only entries that do not already have a matching `journal-entry:<entryId>` tag on the Mural board.

## Mural placement rule
For each category:

- if the category seed sticky is empty or still contains placeholder guidance, the first real entry replaces that sticky text
- the replaced sticky receives category, project, user-supplied, and `journal-entry:<entryId>` tags
- subsequent entries are created below the latest sticky in the same category

Supported categories:

- perceptions
- procedures
- decisions
- introspections

## Interaction design
The Journal Entries tab gets one page-level sync panel:

- sync status
- pending count
- **Sync pending entries**
- **Check sync status**

There are no per-entry sync buttons. Entry cards remain focused on reading, editing, and deleting journal entries.

## Accessibility
The sync panel uses text status and `aria-live="polite"` so sync changes are exposed without relying on colour alone.

## Testing
- Not run locally through this connector
- Expected CI: lint and `npm run validate`
- Added `tests/mural-journal-sync-route-state.test.js`