### PR TITLE
Refine Mural journal sync copy and compact status

### DIFF
--- a/public/css/journal-mural-sync.css
+++ b/public/css/journal-mural-sync.css
@@ -6,8 +6,8 @@
 	align-items: flex-start;
 	justify-content: space-between;
 	gap: 16px;
-	margin-bottom: 16px;
-	padding-right: 380px;
+	margin-bottom: 16px;	
+	padding-right: 420px;
 	}
 
 .journal-entries-header__primary {
@@ -26,11 +26,11 @@
 	top: 0;
 	right: 0;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: flex-end;
 	gap: 8px;
 	flex-wrap: wrap;
-	max-width: 360px;
+	max-width: 400px;
 	font-size: 16px;
 	line-height: 1.4;
 	text-align: right;
@@ -47,11 +47,17 @@
 
 .mural-sync-status__action {
 	margin-bottom: 0;
-	padding: 6px 10px;
+	padding: 4px 8px;
 	font-size: 16px;
 	line-height: 1.25;
+	box-shadow: none;
 	}
 
+.mural-sync-status__action:not([hidden]) {
+	display: inline-block;
+	}
+
+#mural-sync-panel,
 #mural-sync-panel[hidden] {
 	display: none !important;
 	}

--- a/public/js/journal-mural-sync-compact.js
+++ b/public/js/journal-mural-sync-compact.js
@@ -7,6 +7,9 @@
 			'https://rops-api.digikev-kevin-rapley.workers.dev' :
 			location.origin);
 
+	let lastStatus = null;
+	let applying = false;
+
 	function apiUrl(path) {
 		const p = String(path || '');
 		return `${API_ORIGIN}${p.startsWith('/') ? p : '/' + p}`;
@@ -30,14 +33,42 @@
 		};
 	}
 
+	function actionText(pending) {
+		return pending ? `Add ${pending} ${pending === 1 ? 'entry' : 'entries'} to Mural` : 'Add entries to Mural';
+	}
+
+	function statusMessage(pending, synced, total) {
+		if (pending) {
+			return `${pending} ${pending === 1 ? 'entry is' : 'entries are'} not yet on Mural. ${synced} of ${total} ${total === 1 ? 'entry is' : 'entries are'} on Mural.`;
+		}
+		return `${synced} of ${total} ${total === 1 ? 'entry is' : 'entries are'} on Mural.`;
+	}
+
 	function setStatus(label, message, pending, busy) {
 		const messageEl = document.getElementById('mural-sync-message');
 		const action = document.getElementById('mural-sync-pending-btn');
+
+		lastStatus = { label, message, pending, busy };
+		applying = true;
+
 		if (messageEl) messageEl.textContent = message ? `${label}: ${message}` : label;
 		if (action) {
 			action.hidden = !!busy || !pending;
 			action.disabled = !!busy || !pending;
-			action.textContent = pending ? `Add ${pending} pending ${pending === 1 ? 'entry' : 'entries'} to Mural` : 'Add pending entries to Mural';
+			action.textContent = actionText(Number(pending || 0));
+		}
+
+		applying = false;
+	}
+
+	function restoreStatusText() {
+		if (applying || !lastStatus) return;
+		const action = document.getElementById('mural-sync-pending-btn');
+		if (!action) return;
+
+		const expected = actionText(Number(lastStatus.pending || 0));
+		if (action.textContent.trim() !== expected) {
+			setStatus(lastStatus.label, lastStatus.message, lastStatus.pending, lastStatus.busy);
 		}
 	}
 
@@ -54,24 +85,24 @@
 
 	async function loadMuralSyncStatus() {
 		if (!projectId()) return;
-		setStatus('Checking', 'checking sync status', 0, true);
+		setStatus('Checking', 'checking whether journal entries are on Mural', 0, true);
 		try {
 			const status = await postJson('status');
 			const pending = Number(status.pending || 0);
 			const synced = Number(status.synced || 0);
 			const total = Number(status.total || 0);
-			setStatus(pending ? 'Pending' : 'Synced', pending ? `${pending} pending. ${synced} of ${total} synced.` : `${synced} of ${total} entries synced.`, pending, false);
+			setStatus(pending ? 'Action needed' : 'Up to date', statusMessage(pending, synced, total), pending, false);
 		} catch (error) {
 			const code = error?.response?.error || '';
-			if (code === 'not_authenticated') setStatus('Not connected', 'connect Mural from the project dashboard before syncing entries', 0, false);
-			else if (code === 'mural_board_not_found') setStatus('No board', 'no Reflexive Journal Mural board was found for this project', 0, false);
-			else setStatus('Unavailable', 'could not check Mural sync. Entries remain saved in ResearchOps.', 0, false);
+			if (code === 'not_authenticated') setStatus('Not connected', 'connect Mural from the project dashboard before adding entries to Mural', 0, false);
+			else if (code === 'mural_board_not_found') setStatus('No board found', 'create or reconnect the Reflexive Journal Mural from the project dashboard', 0, false);
+			else setStatus('Unavailable', 'could not check Mural. Entries remain saved in ResearchOps.', 0, false);
 		}
 	}
 
-	async function syncPendingEntriesToMural() {
+	async function addPendingEntriesToMural() {
 		if (!projectId()) return;
-		setStatus('Syncing', 'adding pending entries to Mural', 0, true);
+		setStatus('Adding to Mural', 'adding entries to the Reflexive Journal Mural', 0, true);
 		try {
 			const result = await postJson('hydrate');
 			const after = result.after || {};
@@ -79,18 +110,34 @@
 			const synced = Number(after.synced || 0);
 			const total = Number(after.total || 0);
 			const changed = Number(result.createdOrUpdated || 0);
-			setStatus(pending ? 'Pending' : 'Synced', `${changed} added to Mural. ${synced} of ${total} entries synced.`, pending, false);
+			const added = `${changed} ${changed === 1 ? 'entry was' : 'entries were'} added to Mural.`;
+			setStatus(pending ? 'Action needed' : 'Up to date', `${added} ${statusMessage(pending, synced, total)}`, pending, false);
 		} catch {
-			setStatus('Failed', 'could not add pending entries to Mural. Entries remain saved in ResearchOps.', 0, false);
+			setStatus('Not added', 'could not add entries to Mural. Entries remain saved in ResearchOps.', 0, false);
 		}
 	}
 
+	function observeStatusAction() {
+		const target = document.getElementById('mural-sync-pending-btn');
+		if (!target || typeof MutationObserver !== 'function') return;
+
+		const observer = new MutationObserver(restoreStatusText);
+		observer.observe(target, {
+			childList: true,
+			characterData: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: ['disabled', 'hidden']
+		});
+	}
+
 	document.addEventListener('DOMContentLoaded', function() {
-		document.getElementById('mural-sync-pending-btn')?.addEventListener('click', syncPendingEntriesToMural);
+		document.getElementById('mural-sync-pending-btn')?.addEventListener('click', addPendingEntriesToMural);
 		document.getElementById('add-entry-form')?.addEventListener('submit', function() {
 			window.setTimeout(loadMuralSyncStatus, 750);
 			window.setTimeout(loadMuralSyncStatus, 2500);
 		});
+		observeStatusAction();
 		loadMuralSyncStatus();
 	});
 })();

--- a/tests/mural-journal-sync-route-state.test.js
+++ b/tests/mural-journal-sync-route-state.test.js
@@ -4,9 +4,9 @@ import fs from "node:fs";
 const serviceSource = fs.readFileSync("infra/cloudflare/src/service/mural-journal-sync.js", "utf8");
 const indexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
 const journalTabsSource = fs.readFileSync("public/js/journal-tabs.js", "utf8");
-const compactSyncSource = fs.readFileSync("public/js/journal-mural-sync-compact.js", "utf8");
-const journalsPageSource = fs.readFileSync("public/pages/projects/journals/index.html", "utf8");
-const compactSyncCss = fs.readFileSync("public/css/journal-mural-sync.css", "utf8");
+const compactSource = fs.readFileSync("public/js/journal-mural-sync-compact.js", "utf8");
+const pageSource = fs.readFileSync("public/pages/projects/journals/index.html", "utf8");
+const compactCss = fs.readFileSync("public/css/journal-mural-sync.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -16,45 +16,42 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
-includes(serviceSource, "export async function muralJournalSync", "mural-journal-sync.js");
-includes(serviceSource, "mode === \"status\"", "mural-journal-sync.js");
-includes(serviceSource, "mode === \"hydrate\"", "mural-journal-sync.js");
-includes(serviceSource, "function entrySyncTag(entryId)", "mural-journal-sync.js");
-includes(serviceSource, "journal-entry:", "mural-journal-sync.js");
-includes(serviceSource, "widgetHasEntryTag", "mural-journal-sync.js");
-includes(serviceSource, "action: \"already-synced\"", "mural-journal-sync.js");
-includes(serviceSource, "action: \"updated-template-sticky\"", "mural-journal-sync.js");
-includes(serviceSource, "action: \"created-sticky\"", "mural-journal-sync.js");
-includes(serviceSource, "TEMPLATE_PLACEHOLDER_RE", "mural-journal-sync.js");
-includes(serviceSource, "createdOrUpdated", "mural-journal-sync.js");
+includes(serviceSource, "export async function muralJournalSync", "service");
+includes(serviceSource, "mode === \"status\"", "service");
+includes(serviceSource, "mode === \"hydrate\"", "service");
+includes(serviceSource, "journal-entry:", "service");
+includes(serviceSource, "widgetHasEntryTag", "service");
+includes(serviceSource, "updated-template-sticky", "service");
+includes(serviceSource, "created-sticky", "service");
+includes(serviceSource, "createdOrUpdated", "service");
 
-includes(indexSource, "import * as MuralJournalSync from \"./mural-journal-sync.js\";", "service/index.js");
-includes(indexSource, "this.mural.muralJournalSync =", "service/index.js");
-includes(indexSource, "muralJournalSync =", "service/index.js");
+includes(indexSource, "MuralJournalSync", "service index");
+includes(indexSource, "this.mural.muralJournalSync =", "service index");
 
-includes(journalsPageSource, "class=\"journal-entries-header\"", "journals page");
-includes(journalsPageSource, "class=\"mural-sync-status\"", "journals page");
-includes(journalsPageSource, "id=\"mural-sync-message\" role=\"status\" aria-live=\"polite\"", "journals page");
-includes(journalsPageSource, "id=\"mural-sync-pending-btn\" hidden disabled", "journals page");
-includes(journalsPageSource, "Add pending entries to Mural", "journals page");
-includes(journalsPageSource, "id=\"mural-sync-panel\" hidden aria-hidden=\"true\"", "journals page");
-includes(journalsPageSource, "/js/journal-mural-sync-compact.js", "journals page");
-includes(journalsPageSource, "/css/journal-mural-sync.css", "journals page");
+includes(pageSource, "class=\"journal-entries-header\"", "page");
+includes(pageSource, "class=\"mural-sync-status\"", "page");
+includes(pageSource, "aria-live=\"polite\"", "page");
+includes(pageSource, "id=\"mural-sync-pending-btn\" hidden disabled", "page");
+includes(pageSource, "Add pending entries to Mural", "page");
+includes(pageSource, "id=\"mural-sync-panel\" hidden aria-hidden=\"true\"", "page");
+includes(pageSource, "journal-mural-sync-compact.js", "page");
+includes(pageSource, "journal-mural-sync.css", "page");
 
-includes(compactSyncSource, "function loadMuralSyncStatus()", "journal-mural-sync-compact.js");
-includes(compactSyncSource, "function syncPendingEntriesToMural()", "journal-mural-sync-compact.js");
-includes(compactSyncSource, "postJson('status')", "journal-mural-sync-compact.js");
-includes(compactSyncSource, "postJson('hydrate')", "journal-mural-sync-compact.js");
-includes(compactSyncSource, "apiUrl('/api/mural/journal-sync')", "journal-mural-sync-compact.js");
-includes(compactSyncSource, "Add ${pending} pending", "journal-mural-sync-compact.js");
+includes(compactSource, "function loadMuralSyncStatus()", "compact script");
+includes(compactSource, "function addPendingEntriesToMural()", "compact script");
+includes(compactSource, "postJson('status')", "compact script");
+includes(compactSource, "postJson('hydrate')", "compact script");
+includes(compactSource, "not yet on Mural", "compact script");
+includes(compactSource, "remain saved in ResearchOps", "compact script");
+includes(compactSource, "MutationObserver", "compact script");
 
-includes(journalTabsSource, "muralSyncPayload('entry'", "journal-tabs.js");
-includes(journalTabsSource, "entryId: created.id", "journal-tabs.js");
+includes(journalTabsSource, "muralSyncPayload('entry'", "journal tabs");
+includes(journalTabsSource, "entryId: created.id", "journal tabs");
 
-includes(compactSyncCss, ".mural-sync-status", "journal-mural-sync.css");
-includes(compactSyncCss, "position: absolute;", "journal-mural-sync.css");
-includes(compactSyncCss, "right: 0;", "journal-mural-sync.css");
-includes(compactSyncCss, "@media (max-width: 900px)", "journal-mural-sync.css");
+includes(compactCss, ".mural-sync-status", "compact css");
+includes(compactCss, "position: absolute;", "compact css");
+includes(compactCss, "right: 0;", "compact css");
+includes(compactCss, "box-shadow: none;", "compact css");
 
-excludes(journalsPageSource, ">Sync to Mural<", "journals page");
-excludes(journalTabsSource, ">Sync to Mural<", "journal-tabs.js");
+excludes(compactSource, "Sync ${pending}", "compact script");
+excludes(compactSource, "Sync pending entries", "compact script");


### PR DESCRIPTION
## Summary
- apply the IxD recommendation that the Mural action must remain visually secondary
- apply the Content Designer recommendation to avoid user-facing “sync” action language
- change the compact action copy from “Sync pending entries” style wording to “Add entries to Mural” wording
- describe pending entries as “not yet on Mural” rather than as a system sync backlog
- retain the compact right-aligned status pattern in the Journal Entries header
- keep ResearchOps positioned as the saved record when Mural is unavailable or fails
- add a defensive observer so legacy status writes cannot overwrite the compact action copy
- update the route-state regression test to protect the IxD/content contract

## Product rationale
The Mural action should not compete with **Add journal entry**. The primary task on the page remains journaling.

The integration should be framed as adding saved ResearchOps entries to the Reflexive Journal Mural visual surface, not as asking users to manage a technical sync process.

## User-facing copy changes
Before:

- `Sync 12 pending entries`
- `12 pending`

After:

- `12 entries are not yet on Mural`
- `Add 12 entries to Mural`
- `Entries remain saved in ResearchOps` on failure

## Testing
- Not run locally through this connector
- Expected CI: `npm run validate`