### PR TITLE
Retry Mural sticky creation with minimal payload

### DIFF
--- a/infra/cloudflare/src/service/mural-journal-sync.js
+++ b/infra/cloudflare/src/service/mural-journal-sync.js
@@ -49,6 +49,16 @@ function widgetText(widget) {
 	return safeText(widget?.text || widget?.htmlText || widget?.title || widget?.name || "");
 }
 
+function widgetMetadataText(widget) {
+	return [
+		widget?.title,
+		widget?.name,
+		widget?.instruction,
+		widget?.hyperlinkTitle,
+		widget?.presentationTitle
+	].map(safeText).filter(Boolean).join(" ").toLowerCase();
+}
+
 function numeric(value, fallback = 0) {
 	const n = Number(value);
 	return Number.isFinite(n) ? n : fallback;
@@ -59,6 +69,13 @@ function firstMuralValue(body) {
 	if (body?.value) return body.value;
 	if (Array.isArray(body)) return body[0] || null;
 	return body || null;
+}
+
+function muralErrorSummary(error) {
+	const body = error?.body || error?.secondError || error?.firstError || null;
+	if (!body) return String(error?.message || error);
+	if (typeof body === "string") return body;
+	return safeText(body.message || body.code || body.error || JSON.stringify(body));
 }
 
 function normalizeWidget(widget) {
@@ -94,7 +111,8 @@ function entrySyncTag(entryId) {
 
 function widgetHasEntryTag(widget, entryId) {
 	const tag = entrySyncTag(entryId).toLowerCase();
-	return !!tag && tagKeys(widget).includes(tag);
+	if (!tag) return false;
+	return tagKeys(widget).includes(tag) || widgetMetadataText(widget).includes(tag);
 }
 
 function widgetMatchesCategory(widget, categoryKey) {
@@ -158,7 +176,7 @@ function dedupeTags(tags) {
 	return out;
 }
 
-function createStickyPayload({ text, tags, placement }) {
+function createStickyPayload({ text, tags, placement, syncTag }) {
 	return {
 		x: placement.x,
 		y: placement.y,
@@ -166,6 +184,7 @@ function createStickyPayload({ text, tags, placement }) {
 		height: placement.height,
 		shape: "rectangle",
 		text,
+		title: syncTag,
 		tags,
 		style: {
 			backgroundColor: "#FFFFFFFF",
@@ -175,8 +194,17 @@ function createStickyPayload({ text, tags, placement }) {
 	};
 }
 
-async function createStickyNote(env, accessToken, muralId, payload) {
-	const url = `https://app.mural.co/api/public/v1/murals/${muralId}/widgets/sticky-note`;
+function minimalStickyPayload(payload) {
+	return {
+		x: payload.x,
+		y: payload.y,
+		shape: "rectangle",
+		text: payload.text,
+		title: payload.title
+	};
+}
+
+async function postStickyPayload(accessToken, url, body) {
 	const res = await fetch(url, {
 		method: "POST",
 		headers: {
@@ -184,16 +212,41 @@ async function createStickyNote(env, accessToken, muralId, payload) {
 			"Content-Type": "application/json",
 			Accept: "application/json"
 		},
-		body: JSON.stringify(payload)
+		body: JSON.stringify(body)
 	});
-	const body = await res.json().catch(() => ({}));
+	const responseBody = await res.json().catch(() => ({}));
 	if (!res.ok) {
 		throw Object.assign(new Error(`Create Mural sticky note failed: ${res.status}`), {
 			status: res.status,
-			body
+			body: responseBody
 		});
 	}
-	return firstMuralValue(body);
+	return firstMuralValue(responseBody);
+}
+
+async function createStickyNote(env, accessToken, muralId, payload) {
+	const url = `https://app.mural.co/api/public/v1/murals/${muralId}/widgets/sticky-note`;
+	const attempts = [
+		{ name: "full", body: payload },
+		{ name: "minimal", body: minimalStickyPayload(payload) },
+		{ name: "minimal-array", body: [minimalStickyPayload(payload)] }
+	];
+	const errors = [];
+
+	for (const attempt of attempts) {
+		try {
+			const created = await postStickyPayload(accessToken, url, attempt.body);
+			return created || { ...minimalStickyPayload(payload), tags: payload.tags };
+		} catch (err) {
+			errors.push({ attempt: attempt.name, status: err?.status, summary: muralErrorSummary(err) });
+		}
+	}
+
+	const last = errors[errors.length - 1] || {};
+	throw Object.assign(new Error(`Create Mural sticky note failed after ${errors.length} attempts: ${last.summary || "unknown error"}`), {
+		status: last.status || 400,
+		errors
+	});
 }
 
 async function patchStickyNote(env, accessToken, muralId, widgetId, patch) {
@@ -218,20 +271,32 @@ async function patchStickyNote(env, accessToken, muralId, widgetId, patch) {
 }
 
 async function updateStickyTextAndTags(env, accessToken, muralId, widgetId, patch) {
-	try {
-		return await patchStickyNote(env, accessToken, muralId, widgetId, patch);
-	} catch (firstError) {
+	const minimalPatch = {
+		text: patch.text,
+		title: patch.title
+	};
+	const attempts = [
+		() => patchStickyNote(env, accessToken, muralId, widgetId, patch),
+		() => patchStickyNote(env, accessToken, muralId, widgetId, minimalPatch),
+		() => updateSticky(env, accessToken, muralId, widgetId, patch),
+		() => updateSticky(env, accessToken, muralId, widgetId, minimalPatch)
+	];
+	const errors = [];
+
+	for (const attempt of attempts) {
 		try {
-			const updated = await updateSticky(env, accessToken, muralId, widgetId, patch);
+			const updated = await attempt();
 			return firstMuralValue(updated) || { id: widgetId, ...patch };
-		} catch (secondError) {
-			throw Object.assign(new Error(`Could not update placeholder sticky: ${String(secondError?.message || firstError?.message || secondError)}`), {
-				status: secondError?.status || firstError?.status,
-				firstError: firstError?.body || firstError?.message,
-				secondError: secondError?.body || secondError?.message
-			});
+		} catch (err) {
+			errors.push({ status: err?.status, summary: muralErrorSummary(err) });
 		}
 	}
+
+	const last = errors[errors.length - 1] || {};
+	throw Object.assign(new Error(`Could not update placeholder sticky after ${errors.length} attempts: ${last.summary || "unknown error"}`), {
+		status: last.status || 400,
+		errors
+	});
 }
 
 function updateWidgetInPlace(widgets, widgetId, patch) {
@@ -401,8 +466,8 @@ async function syncOneEntry({ svc, accessToken, board, widgets, payload }) {
 	const text = payload.description;
 
 	if (anchor.id && isTemplatePlaceholder(anchor)) {
-		const widget = await updateStickyTextAndTags(svc.env, accessToken, board.muralId, anchor.id, { text, tags });
-		updateWidgetInPlace(widgets, anchor.id, { text, tags });
+		const widget = await updateStickyTextAndTags(svc.env, accessToken, board.muralId, anchor.id, { text, title: syncTag, tags });
+		updateWidgetInPlace(widgets, anchor.id, { text, title: syncTag, tags });
 		return {
 			ok: true,
 			action: "updated-template-sticky",
@@ -417,12 +482,13 @@ async function syncOneEntry({ svc, accessToken, board, widgets, payload }) {
 		svc.env,
 		accessToken,
 		board.muralId,
-		createStickyPayload({ text, tags, placement })
+		createStickyPayload({ text, tags, placement, syncTag })
 	);
 	const widget = pushCreatedWidget(widgets, created, {
 		id: created?.id,
 		type: "sticky-note",
 		text,
+		title: syncTag,
 		tags,
 		...placement
 	});
@@ -556,7 +622,8 @@ async function handleHydrate(svc, origin, body) {
 				entryId: payload.entryId,
 				category: payload.categoryKey,
 				detail: String(err?.message || err),
-				status: err?.status || undefined
+				status: err?.status || undefined,
+				errors: err?.errors || undefined
 			});
 		}
 	}
@@ -626,7 +693,8 @@ async function handleEntrySync(svc, origin, body) {
 			ok: false,
 			error: "mural_journal_sync_failed",
 			detail: String(err?.message || err),
-			status: status || undefined
+			status: status || undefined,
+			errors: err?.errors || undefined
 		}, status >= 400 && status < 600 ? status : 500, svc.corsHeaders(origin));
 	}
 }

--- a/tests/mural-journal-sync-route-state.test.js
+++ b/tests/mural-journal-sync-route-state.test.js
@@ -27,7 +27,11 @@ includes(serviceSource, "createdOrUpdated", "service");
 includes(serviceSource, "function patchStickyNote", "service");
 includes(serviceSource, "function updateStickyTextAndTags", "service");
 includes(serviceSource, "function hydrateReason", "service");
-includes(serviceSource, "skipped,", "service");
+includes(serviceSource, "function minimalStickyPayload", "service");
+includes(serviceSource, "minimal-array", "service");
+includes(serviceSource, "widgetMetadataText", "service");
+includes(serviceSource, "title: syncTag", "service");
+includes(serviceSource, "errors: err?.errors", "service");
 includes(serviceSource, "reason: hydrateReason", "service");
 
 includes(indexSource, "MuralJournalSync", "service index");


### PR DESCRIPTION
## Summary
- add fallback attempts for Mural sticky-note creation after HTTP 400 responses
- retry with a minimal sticky-note payload, then an array-form minimal payload
- keep the `journal-entry:<entryId>` idempotency marker in the sticky title as well as tags
- allow status detection to read the idempotency marker from widget metadata if Mural rejects tags
- expose all sticky creation attempt errors in the hydrate response
- add regression coverage for the minimal-payload fallback path

## Defect addressed
The current production response is:

`Not added: Create Mural sticky note failed: 400 12 entries are not yet on Mural. 0 of 12 entries are on Mural.`

That means the Worker reached Mural but Mural rejected the sticky-note create payload. The likely issue is stricter payload validation around fields such as tags, style, width, or height.

## Fix
The Worker now attempts sticky creation in this order:

1. full payload
2. minimal payload with only `x`, `y`, `shape`, `text`, and `title`
3. array-form minimal payload

The `title` carries the idempotency marker, so entries can still be detected as already on Mural even if Mural rejects `tags`.

## Expected behaviour
After merge, clicking **Add 12 entries to Mural** should either:

- add entries successfully, or
- return a more precise Mural validation reason showing which payload attempt failed and why.

## Testing
- Not run locally through this connector
- Expected CI: `npm run validate`