### PR TITLE
Use column layout for Reflexive Journal Mural entries

### DIFF
--- a/infra/cloudflare/src/service/mural-journal-sync-layout.js
+++ b/infra/cloudflare/src/service/mural-journal-sync-layout.js
@@ -1,0 +1,696 @@
+/**
+ * @file src/service/mural-journal-sync-layout.js
+ * @module service/mural-journal-sync-layout
+ * @summary Column-driven Reflexive Journal to Mural sync and hydration.
+ */
+
+import {
+	refreshAccessToken,
+	verifyHomeOfficeByCompany,
+	getWidgets,
+	updateSticky
+} from "../lib/mural.js";
+
+const CATEGORY_KEYS = ["perceptions", "procedures", "decisions", "introspections"];
+const DEFAULT_WIDTH = 260;
+const DEFAULT_HEIGHT = 160;
+const GRID_GAP = 32;
+const PURPOSE_REFLEXIVE = "reflexive_journal";
+const ENTRY_MARKER_RE = /journal-entry:[a-z0-9_-]+/i;
+
+function safeText(value) {
+	return String(value || "").trim();
+}
+
+function categoryLabel(categoryKey) {
+	return {
+		perceptions: "perceptions",
+		procedures: "procedures",
+		decisions: "decisions",
+		introspections: "introspections"
+	}[categoryKey] || categoryKey;
+}
+
+function normalizeCategoryKey(value) {
+	const raw = safeText(value).toLowerCase();
+	if (raw === "perceptions" || raw.includes("perception")) return "perceptions";
+	if (raw === "procedures" || raw.includes("procedure") || raw.includes("day-to-day")) return "procedures";
+	if (raw === "decisions" || raw.includes("decision") || raw.includes("methodological")) return "decisions";
+	if (raw === "introspections" || raw.includes("introspection") || raw.includes("personal")) return "introspections";
+	return "";
+}
+
+function normalizeTags(value) {
+	if (Array.isArray(value)) {
+		return value
+			.map(v => safeText(typeof v === "string" ? v : (v?.text || v?.name || v?.title || v?.label || "")))
+			.filter(Boolean);
+	}
+	if (!value) return [];
+	return String(value).split(",").map(s => s.trim()).filter(Boolean);
+}
+
+function dedupeTags(tags) {
+	const seen = new Set();
+	const out = [];
+	for (const tag of tags.map(safeText).filter(Boolean)) {
+		const key = tag.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(tag);
+	}
+	return out;
+}
+
+function userFacingTags(tags) {
+	return dedupeTags(normalizeTags(tags).filter(tag => !tag.toLowerCase().startsWith("journal-entry:")));
+}
+
+function tagKeys(widget) {
+	return normalizeTags(widget?.tags).map(t => t.toLowerCase());
+}
+
+function widgetText(widget) {
+	return safeText(widget?.text || widget?.htmlText || widget?.title || widget?.name || "");
+}
+
+function widgetMetadataText(widget) {
+	return [
+		widget?.title,
+		widget?.name,
+		widget?.instruction,
+		widget?.hyperlinkTitle,
+		widget?.presentationTitle
+	].map(safeText).filter(Boolean).join(" ").toLowerCase();
+}
+
+function numeric(value, fallback = 0) {
+	const n = Number(value);
+	return Number.isFinite(n) ? n : fallback;
+}
+
+function rounded(value, fallback = 0) {
+	return Math.round(numeric(value, fallback));
+}
+
+function normalizeWidget(widget) {
+	const geometry = widget?.geometry || widget?.bounds || {};
+	return {
+		...widget,
+		id: widget?.id,
+		type: safeText(widget?.type).toLowerCase(),
+		text: widgetText(widget),
+		tags: normalizeTags(widget?.tags),
+		x: numeric(widget?.x ?? geometry.x, 0),
+		y: numeric(widget?.y ?? geometry.y, 0),
+		width: numeric(widget?.width ?? geometry.width, DEFAULT_WIDTH),
+		height: numeric(widget?.height ?? geometry.height, DEFAULT_HEIGHT),
+		createdAt: widget?.createdAt || widget?.createdOn || widget?.updatedAt || widget?.updatedOn || null
+	};
+}
+
+function firstMuralValue(body) {
+	if (Array.isArray(body?.value)) return body.value[0] || null;
+	if (body?.value) return body.value;
+	if (Array.isArray(body)) return body[0] || null;
+	return body || null;
+}
+
+function muralErrorSummary(error) {
+	const body = error?.body || error?.secondError || error?.firstError || null;
+	if (!body) return String(error?.message || error);
+	if (typeof body === "string") return body;
+	return safeText(body.message || body.code || body.error || JSON.stringify(body));
+}
+
+function entrySyncTag(entryId) {
+	const id = safeText(entryId);
+	return id ? `journal-entry:${id}` : "";
+}
+
+function widgetHasAnyEntryTag(widget) {
+	return ENTRY_MARKER_RE.test([widgetMetadataText(widget), tagKeys(widget).join(" ")].join(" "));
+}
+
+function widgetHasEntryTag(widget, entryId) {
+	const tag = entrySyncTag(entryId).toLowerCase();
+	if (!tag) return false;
+	return tagKeys(widget).includes(tag) || widgetMetadataText(widget).includes(tag);
+}
+
+function isStickyLike(widget) {
+	const type = safeText(widget?.type).toLowerCase();
+	return type.includes("sticky") || type.includes("note") || type.includes("shape") || type === "";
+}
+
+function isHeaderWidget(widget, categoryKey) {
+	const label = categoryLabel(categoryKey);
+	const text = widgetText(widget).toLowerCase();
+	return text === label && numeric(widget.width) > numeric(widget.height);
+}
+
+function categoryHeaderWidget(widgets, categoryKey) {
+	return widgets
+		.filter(widget => isHeaderWidget(widget, categoryKey))
+		.sort((a, b) => numeric(a.y) - numeric(b.y) || numeric(a.x) - numeric(b.x))[0] || null;
+}
+
+function centreX(widget) {
+	return numeric(widget.x) + numeric(widget.width) / 2;
+}
+
+function isInHeaderColumn(widget, header) {
+	if (!header) return false;
+	const x = numeric(widget.x);
+	const y = numeric(widget.y);
+	const width = numeric(widget.width, DEFAULT_WIDTH);
+	const centre = x + width / 2;
+	const left = numeric(header.x) - Math.max(24, numeric(header.width) * 0.1);
+	const right = numeric(header.x) + numeric(header.width) + Math.max(24, numeric(header.width) * 0.1);
+	return y > numeric(header.y) + numeric(header.height) && centre >= left && centre <= right;
+}
+
+function columnTemplateWidget(widgets, categoryKey) {
+	const header = categoryHeaderWidget(widgets, categoryKey);
+	if (!header) return null;
+
+	return widgets
+		.filter(widget => widget.id !== header.id)
+		.filter(isStickyLike)
+		.filter(widget => isInHeaderColumn(widget, header))
+		.sort((a, b) => numeric(a.y) - numeric(b.y) || Math.abs(centreX(a) - centreX(header)) - Math.abs(centreX(b) - centreX(header)))[0] || null;
+}
+
+function columnLayout(widgets, categoryKey) {
+	const header = categoryHeaderWidget(widgets, categoryKey);
+	const template = columnTemplateWidget(widgets, categoryKey);
+	if (!header && !template) return null;
+
+	const source = template || header;
+	const width = rounded(header?.width ?? source?.width, DEFAULT_WIDTH);
+	const height = rounded(template?.height, DEFAULT_HEIGHT);
+	const x = rounded(header?.x ?? source?.x, 0);
+	const y = rounded(template?.y ?? (numeric(header?.y, 0) + numeric(header?.height, 0) + GRID_GAP), 0);
+
+	return {
+		categoryKey,
+		header,
+		template: template || {
+			id: null,
+			type: "virtual-template",
+			x,
+			y,
+			width,
+			height,
+			text: "",
+			tags: [categoryKey]
+		},
+		x,
+		y,
+		width,
+		height
+	};
+}
+
+function widgetMatchesColumnLayout(widget, layout) {
+	if (!widget || !layout) return false;
+	const xDiff = Math.abs(numeric(widget.x) - numeric(layout.x));
+	const widthDiff = Math.abs(numeric(widget.width, layout.width) - numeric(layout.width));
+	const heightDiff = Math.abs(numeric(widget.height, layout.height) - numeric(layout.height));
+	return xDiff <= 8 && widthDiff <= 8 && heightDiff <= 8;
+}
+
+function widgetMatchesCategory(widget, categoryKey, layout) {
+	const tags = tagKeys(widget);
+	const meta = widgetMetadataText(widget);
+	return tags.includes(categoryKey) || meta.includes(categoryKey) || widgetMatchesColumnLayout(widget, layout);
+}
+
+function canonicalExistingWidget(widgets, entry, layout) {
+	return widgets.find(widget => {
+		return widgetHasEntryTag(widget, entry.entryId) &&
+			widgetMatchesCategory(widget, entry.categoryKey, layout) &&
+			widgetMatchesColumnLayout(widget, layout);
+	});
+}
+
+function latestCanonicalWidget(widgets, categoryKey, layout) {
+	return widgets
+		.filter(widget => widgetHasAnyEntryTag(widget))
+		.filter(widget => widgetMatchesCategory(widget, categoryKey, layout))
+		.filter(widget => widgetMatchesColumnLayout(widget, layout))
+		.sort((a, b) => numeric(b.y) - numeric(a.y))[0] || null;
+}
+
+function placementBelow(layout, latest) {
+	const from = latest || layout.template;
+	return {
+		x: layout.x,
+		y: rounded(numeric(from.y, layout.y) + numeric(from.height, layout.height) + GRID_GAP),
+		width: layout.width,
+		height: layout.height
+	};
+}
+
+function stickyBackground(template) {
+	return safeText(template?.style?.backgroundColor || template?.backgroundColor || "#FFFFFFFF") || "#FFFFFFFF";
+}
+
+function stickyStyle(template) {
+	const source = template?.style || {};
+	const style = {
+		backgroundColor: stickyBackground(template),
+		fontSize: rounded(source.fontSize ?? template?.fontSize, 23),
+		textAlign: safeText(source.textAlign || template?.textAlign || "left") || "left"
+	};
+	if (source.bold !== undefined) style.bold = !!source.bold;
+	if (source.italic !== undefined) style.italic = !!source.italic;
+	if (source.underline !== undefined) style.underline = !!source.underline;
+	if (source.font) style.font = source.font;
+	if (source.border !== undefined) style.border = !!source.border;
+	return style;
+}
+
+function tagsForEntry(layout, entry) {
+	const templateTags = userFacingTags(layout.template?.tags);
+	return dedupeTags([
+		...templateTags,
+		entry.categoryKey,
+		entry.projectName,
+		...userFacingTags(entry.tags)
+	]);
+}
+
+function localEntryWidget(widget, entry, layout, tags, placement = {}) {
+	return normalizeWidget({
+		...widget,
+		...placement,
+		tags: dedupeTags([...tags, entry.categoryKey, entrySyncTag(entry.entryId)]),
+		title: entrySyncTag(entry.entryId),
+		text: entry.description,
+		type: widget?.type || "sticky-note",
+		width: placement.width ?? layout.width,
+		height: placement.height ?? layout.height
+	});
+}
+
+function replaceWidget(widgets, widgetId, nextWidget) {
+	const index = widgets.findIndex(widget => widget.id === widgetId);
+	if (index >= 0) widgets[index] = nextWidget;
+	else widgets.push(nextWidget);
+}
+
+async function patchSticky(accessToken, muralId, widgetId, template, text, tags) {
+	const full = {
+		text,
+		tags,
+		style: stickyStyle(template),
+		backgroundColor: stickyBackground(template)
+	};
+	const minimal = {
+		text,
+		backgroundColor: stickyBackground(template)
+	};
+	const attempts = [
+		() => updateSticky(null, accessToken, muralId, widgetId, full),
+		() => updateSticky(null, accessToken, muralId, widgetId, minimal),
+		() => patchStickyNote(accessToken, muralId, widgetId, full),
+		() => patchStickyNote(accessToken, muralId, widgetId, minimal)
+	];
+	const errors = [];
+
+	for (const attempt of attempts) {
+		try {
+			return await attempt();
+		} catch (err) {
+			errors.push(muralErrorSummary(err));
+		}
+	}
+
+	throw new Error(`Update Mural template sticky failed after ${errors.length} attempts: ${errors.at(-1) || "unknown error"}`);
+}
+
+async function patchStickyNote(accessToken, muralId, widgetId, body) {
+	const url = `https://app.mural.co/api/public/v1/murals/${muralId}/widgets/sticky-note/${widgetId}`;
+	const res = await fetch(url, {
+		method: "PATCH",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"Content-Type": "application/json",
+			Accept: "application/json"
+		},
+		body: JSON.stringify(body)
+	});
+	const data = await res.json().catch(() => ({}));
+	if (!res.ok) {
+		throw Object.assign(new Error(`Update Mural sticky note failed: ${res.status}`), { status: res.status, body: data });
+	}
+	return firstMuralValue(data) || { id: widgetId, ...body };
+}
+
+function createPayload(template, placement, text, tags) {
+	return {
+		x: placement.x,
+		y: placement.y,
+		width: placement.width,
+		height: placement.height,
+		shape: safeText(template?.shape || "rectangle") || "rectangle",
+		text,
+		tags,
+		style: stickyStyle(template),
+		backgroundColor: stickyBackground(template)
+	};
+}
+
+async function postSticky(accessToken, muralId, body) {
+	const url = `https://app.mural.co/api/public/v1/murals/${muralId}/widgets/sticky-note`;
+	const res = await fetch(url, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"Content-Type": "application/json",
+			Accept: "application/json"
+		},
+		body: JSON.stringify(body)
+	});
+	const data = await res.json().catch(() => ({}));
+	if (!res.ok) {
+		throw Object.assign(new Error(`Create Mural template sticky failed: ${res.status}`), { status: res.status, body: data });
+	}
+	return firstMuralValue(data) || body;
+}
+
+async function createStickyFromTemplate(accessToken, muralId, template, placement, text, tags) {
+	const full = createPayload(template, placement, text, tags);
+	const minimal = {
+		x: placement.x,
+		y: placement.y,
+		width: placement.width,
+		height: placement.height,
+		text,
+		backgroundColor: stickyBackground(template)
+	};
+	const attempts = [full, minimal, [minimal]];
+	const errors = [];
+
+	for (const body of attempts) {
+		try {
+			return await postSticky(accessToken, muralId, body);
+		} catch (err) {
+			errors.push(muralErrorSummary(err));
+		}
+	}
+
+	throw new Error(`Create Mural template sticky failed after ${errors.length} attempts: ${errors.at(-1) || "unknown error"}`);
+}
+
+async function validAccessToken(svc, uid) {
+	const tokens = await svc.mural.loadTokens(uid);
+	if (!tokens?.access_token) return { ok: false, reason: "not_authenticated" };
+
+	try {
+		await verifyHomeOfficeByCompany(svc.env, tokens.access_token);
+		return { ok: true, token: tokens.access_token };
+	} catch (err) {
+		if (Number(err?.status || 0) === 401 && tokens.refresh_token) {
+			try {
+				const refreshed = await refreshAccessToken(svc.env, tokens.refresh_token);
+				const merged = { ...tokens, ...refreshed };
+				await svc.mural.saveTokens(uid, merged);
+				await verifyHomeOfficeByCompany(svc.env, merged.access_token);
+				return { ok: true, token: merged.access_token };
+			} catch {}
+		}
+		return { ok: false, reason: "not_authenticated" };
+	}
+}
+
+function parseBasePayload(body) {
+	const projectId = safeText(body.projectId || body.project || body.project_airtable_id || body.project_local_id);
+	const projectName = safeText(body.projectName || body.projectTitle || body.projectLabel || projectId);
+	const uid = safeText(body.uid || "anon") || "anon";
+	return {
+		mode: safeText(body.mode || "entry").toLowerCase() || "entry",
+		uid,
+		projectId,
+		projectName,
+		explicitMuralId: safeText(body.muralId || "") || null
+	};
+}
+
+function parseEntryPayload(body) {
+	const base = parseBasePayload(body);
+	return {
+		...base,
+		entryId: safeText(body.entryId || body.id || ""),
+		categoryKey: normalizeCategoryKey(body.category || body.categoryKey),
+		description: safeText(body.description || body.content || body.text),
+		tags: normalizeTags(body.tags),
+		createdAt: body.createdAt || body.created_at || ""
+	};
+}
+
+function entryPayloadFromEntry(entry, base) {
+	return {
+		...base,
+		entryId: safeText(entry.id),
+		categoryKey: normalizeCategoryKey(entry.category),
+		description: safeText(entry.content || entry.body || entry.description || entry.text),
+		tags: normalizeTags(entry.tags),
+		createdAt: entry.createdAt || entry.created_at || ""
+	};
+}
+
+async function readRequestBody(request) {
+	try {
+		return await request.json();
+	} catch {
+		return null;
+	}
+}
+
+async function listEntriesForProject(svc, origin, projectId) {
+	const url = new URL("https://local/api/journal-entries");
+	url.searchParams.set("project", projectId);
+	const response = await svc.listJournalEntries(origin, url);
+	const data = await response.json().catch(() => ({}));
+	return Array.isArray(data?.entries) ? data.entries : [];
+}
+
+function sortedEntries(entries) {
+	return [...entries].sort((a, b) => {
+		const aTime = Date.parse(a.createdAt || a.created_at || "");
+		const bTime = Date.parse(b.createdAt || b.created_at || "");
+		return (Number.isFinite(aTime) ? aTime : 0) - (Number.isFinite(bTime) ? bTime : 0);
+	});
+}
+
+async function resolveBoardAndWidgets(svc, accessToken, payload) {
+	const board = await svc.mural.resolveBoard({
+		projectId: payload.projectId,
+		uid: payload.uid,
+		purpose: PURPOSE_REFLEXIVE,
+		explicitMuralId: payload.explicitMuralId
+	});
+
+	if (!board?.muralId) {
+		return { ok: false, status: 404, body: { ok: false, error: "mural_board_not_found" } };
+	}
+
+	const rawWidgets = await getWidgets(svc.env, accessToken, board.muralId);
+	return {
+		ok: true,
+		board,
+		widgets: rawWidgets.map(normalizeWidget)
+	};
+}
+
+async function buildContext(svc, origin, body) {
+	const payload = parseBasePayload(body);
+	if (!payload.projectId) {
+		return { ok: false, status: 400, body: { ok: false, error: "missing_project_id" } };
+	}
+
+	const token = await validAccessToken(svc, payload.uid);
+	if (!token.ok) {
+		return { ok: false, status: 401, body: { ok: false, error: token.reason || "not_authenticated" } };
+	}
+
+	try {
+		const boardAndWidgets = await resolveBoardAndWidgets(svc, token.token, payload);
+		if (!boardAndWidgets.ok) return boardAndWidgets;
+		const entries = await listEntriesForProject(svc, origin, payload.projectId);
+		return { ok: true, payload, accessToken: token.token, board: boardAndWidgets.board, widgets: boardAndWidgets.widgets, entries };
+	} catch (err) {
+		const status = Number(err?.status || 0);
+		return {
+			ok: false,
+			status: status >= 400 && status < 600 ? status : 500,
+			body: { ok: false, error: "mural_sync_context_failed", detail: String(err?.message || err), status: status || undefined }
+		};
+	}
+}
+
+function statusFromEntriesAndWidgets(entries, widgets) {
+	const validEntries = entries.filter(entry => safeText(entry.id));
+	const syncedEntryIds = new Set();
+	const layouts = Object.fromEntries(CATEGORY_KEYS.map(category => [category, columnLayout(widgets, category)]));
+
+	for (const entry of validEntries) {
+		const category = normalizeCategoryKey(entry.category);
+		const layout = layouts[category];
+		if (!layout) continue;
+		if (widgets.some(widget => widgetHasEntryTag(widget, entry.id) && widgetMatchesCategory(widget, category, layout) && widgetMatchesColumnLayout(widget, layout))) {
+			syncedEntryIds.add(String(entry.id));
+		}
+	}
+
+	const byCategory = Object.fromEntries(CATEGORY_KEYS.map(category => [category, { total: 0, synced: 0, pending: 0 }]));
+	for (const entry of validEntries) {
+		const category = normalizeCategoryKey(entry.category);
+		if (!byCategory[category]) continue;
+		byCategory[category].total += 1;
+		if (syncedEntryIds.has(String(entry.id))) byCategory[category].synced += 1;
+		else byCategory[category].pending += 1;
+	}
+
+	return {
+		total: validEntries.length,
+		synced: syncedEntryIds.size,
+		pending: Math.max(0, validEntries.length - syncedEntryIds.size),
+		syncedEntryIds: Array.from(syncedEntryIds),
+		byCategory
+	};
+}
+
+async function syncOneEntry({ accessToken, board, widgets, entry }) {
+	if (!entry.entryId || !entry.categoryKey || !entry.description) {
+		return { ok: false, action: "skipped-invalid-entry", entryId: entry.entryId || null, category: entry.categoryKey || null, detail: "Entry is missing an id, category, or description." };
+	}
+	if (!CATEGORY_KEYS.includes(entry.categoryKey)) {
+		return { ok: false, action: "skipped-unsupported-category", entryId: entry.entryId, category: entry.categoryKey, detail: "Entry category does not map to a Reflexive Journal Mural column." };
+	}
+
+	const layout = columnLayout(widgets, entry.categoryKey);
+	if (!layout) {
+		return { ok: false, action: "category-column-not-found", entryId: entry.entryId, category: entry.categoryKey, detail: `No ${entry.categoryKey} column heading was found on the Mural board.` };
+	}
+
+	const existing = canonicalExistingWidget(widgets, entry, layout);
+	if (existing) {
+		return { ok: true, action: "already-synced", entryId: entry.entryId, category: entry.categoryKey, widgetId: existing.id };
+	}
+
+	const tags = tagsForEntry(layout, entry);
+	const seed = layout.template;
+
+	if (seed.id && !widgetHasAnyEntryTag(seed)) {
+		const updated = await patchSticky(accessToken, board.muralId, seed.id, seed, entry.description, tags);
+		const local = localEntryWidget({ ...seed, ...firstMuralValue(updated) }, entry, layout, tags, {
+			x: layout.x,
+			y: numeric(seed.y, layout.y),
+			width: layout.width,
+			height: layout.height
+		});
+		replaceWidget(widgets, seed.id, local);
+		return { ok: true, action: "updated-template-widget", entryId: entry.entryId, category: entry.categoryKey, widgetId: local.id || seed.id, tags };
+	}
+
+	const latest = latestCanonicalWidget(widgets, entry.categoryKey, layout);
+	const placement = placementBelow(layout, latest);
+	const created = await createStickyFromTemplate(accessToken, board.muralId, seed, placement, entry.description, tags);
+	const local = localEntryWidget({ ...seed, ...firstMuralValue(created) }, entry, layout, tags, placement);
+	widgets.push(local);
+	return { ok: true, action: "created-template-sticky", entryId: entry.entryId, category: entry.categoryKey, widgetId: local.id || created?.id || null, tags };
+}
+
+async function handleStatus(svc, origin, body) {
+	const ctx = await buildContext(svc, origin, body);
+	if (!ctx.ok) return svc.json(ctx.body, ctx.status, svc.corsHeaders(origin));
+	const status = statusFromEntriesAndWidgets(ctx.entries, ctx.widgets);
+	return svc.json({ ok: true, mode: "status", muralId: ctx.board.muralId, boardSource: ctx.board.source, ...status }, 200, svc.corsHeaders(origin));
+}
+
+function hydrateReason({ outcomes, failed, skipped, pending }) {
+	if (!pending) return "All entries are on Mural.";
+	const firstFailure = outcomes.find(o => !o.ok && o.detail);
+	if (firstFailure) return firstFailure.detail;
+	if (failed) return `${failed} ${failed === 1 ? "entry could" : "entries could"} not be added to Mural.`;
+	if (skipped) return `${skipped} ${skipped === 1 ? "entry was" : "entries were"} skipped because required data was missing.`;
+	return "No entries were added to Mural.";
+}
+
+async function handleHydrate(svc, origin, body) {
+	const ctx = await buildContext(svc, origin, body);
+	if (!ctx.ok) return svc.json(ctx.body, ctx.status, svc.corsHeaders(origin));
+
+	const before = statusFromEntriesAndWidgets(ctx.entries, ctx.widgets);
+	const outcomes = [];
+	const base = ctx.payload;
+
+	for (const category of CATEGORY_KEYS) {
+		const entries = sortedEntries(ctx.entries)
+			.map(entry => entryPayloadFromEntry(entry, base))
+			.filter(entry => entry.categoryKey === category);
+		for (const entry of entries) {
+			try {
+				outcomes.push(await syncOneEntry({ accessToken: ctx.accessToken, board: ctx.board, widgets: ctx.widgets, entry }));
+			} catch (err) {
+				outcomes.push({ ok: false, action: "sync-failed", entryId: entry.entryId, category: entry.categoryKey, detail: String(err?.message || err), status: err?.status || undefined, errors: err?.errors || undefined });
+			}
+		}
+	}
+
+	const after = statusFromEntriesAndWidgets(ctx.entries, ctx.widgets);
+	const createdOrUpdated = outcomes.filter(o => ["updated-template-widget", "created-template-sticky"].includes(o.action)).length;
+	const alreadySynced = outcomes.filter(o => o.action === "already-synced").length;
+	const skipped = outcomes.filter(o => String(o.action || "").startsWith("skipped-")).length;
+	const failed = outcomes.filter(o => !o.ok).length;
+
+	return svc.json({
+		ok: true,
+		mode: "hydrate",
+		muralId: ctx.board.muralId,
+		boardSource: ctx.board.source,
+		before,
+		after,
+		total: after.total,
+		synced: after.synced,
+		pending: after.pending,
+		createdOrUpdated,
+		alreadySynced,
+		skipped,
+		failed,
+		reason: hydrateReason({ outcomes, failed, skipped, pending: after.pending }),
+		outcomes
+	}, 200, svc.corsHeaders(origin));
+}
+
+async function handleEntrySync(svc, origin, body) {
+	const entry = parseEntryPayload(body);
+	if (!entry.projectId || !entry.categoryKey || !entry.description) {
+		return svc.json({ ok: false, error: "missing_required_fields", detail: "projectId, category and description/content are required" }, 400, svc.corsHeaders(origin));
+	}
+
+	const token = await validAccessToken(svc, entry.uid);
+	if (!token.ok) return svc.json({ ok: false, error: token.reason || "not_authenticated" }, 401, svc.corsHeaders(origin));
+
+	try {
+		const boardAndWidgets = await resolveBoardAndWidgets(svc, token.token, entry);
+		if (!boardAndWidgets.ok) return svc.json(boardAndWidgets.body, boardAndWidgets.status, svc.corsHeaders(origin));
+		const outcome = await syncOneEntry({ accessToken: token.token, board: boardAndWidgets.board, widgets: boardAndWidgets.widgets, entry });
+		return svc.json({ ok: outcome.ok, mode: "entry", muralId: boardAndWidgets.board.muralId, boardSource: boardAndWidgets.board.source, ...outcome }, outcome.ok ? 200 : 422, svc.corsHeaders(origin));
+	} catch (err) {
+		const status = Number(err?.status || 0);
+		return svc.json({ ok: false, error: "mural_journal_sync_failed", detail: String(err?.message || err), status: status || undefined, errors: err?.errors || undefined }, status >= 400 && status < 600 ? status : 500, svc.corsHeaders(origin));
+	}
+}
+
+export async function muralJournalSync(svc, request, origin) {
+	const body = await readRequestBody(request);
+	if (!body) return svc.json({ ok: false, error: "invalid_json" }, 400, svc.corsHeaders(origin));
+	const mode = safeText(body.mode || "entry").toLowerCase() || "entry";
+	if (mode === "status") return handleStatus(svc, origin, body);
+	if (mode === "hydrate") return handleHydrate(svc, origin, body);
+	return handleEntrySync(svc, origin, body);
+}

--- a/infra/cloudflare/src/service/mural-journal-sync-safe-tags.js
+++ b/infra/cloudflare/src/service/mural-journal-sync-safe-tags.js
@@ -4,11 +4,12 @@
  * @summary Creates missing Mural tags and persists journal-entry/widget mappings in D1 and Airtable.
  */
 
-import * as BaseMuralJournalSync from "./mural-journal-sync.js";
+import * as BaseMuralJournalSync from "./mural-journal-sync-layout.js";
 import { createRecords } from "./internals/airtable.js";
 import { d1All, d1Run } from "./internals/researchops-d1.js";
 
 const SYSTEM_TAG_RE = /^journal-entry:/i;
+const MURAL_ROOT = "https://app.mural.co/api/public/v1";
 
 function safeText(value) {
 	return String(value || "").trim();
@@ -16,9 +17,7 @@ function safeText(value) {
 
 function normalizeTags(value) {
 	if (Array.isArray(value)) {
-		return value
-			.map(tag => safeText(typeof tag === "string" ? tag : (tag?.text || tag?.name || tag?.title || tag?.label || "")))
-			.filter(Boolean);
+		return value.map(tag => safeText(typeof tag === "string" ? tag : (tag?.text || tag?.name || tag?.title || tag?.label || ""))).filter(Boolean);
 	}
 	if (!value) return [];
 	return String(value).split(",").map(tag => tag.trim()).filter(Boolean);
@@ -29,9 +28,10 @@ function dedupeTags(tags) {
 	const out = [];
 	for (const tag of tags.map(safeText).filter(Boolean)) {
 		const key = tag.toLowerCase();
-		if (seen.has(key)) continue;
-		seen.add(key);
-		out.push(tag);
+		if (!seen.has(key)) {
+			seen.add(key);
+			out.push(tag);
+		}
 	}
 	return out;
 }
@@ -42,10 +42,15 @@ function truncateMuralTag(tag) {
 }
 
 function userFacingTags(tags) {
-	return dedupeTags(normalizeTags(tags)
-		.filter(tag => !SYSTEM_TAG_RE.test(tag))
-		.map(truncateMuralTag)
-		.filter(Boolean));
+	return dedupeTags(normalizeTags(tags).filter(tag => !SYSTEM_TAG_RE.test(tag)).map(truncateMuralTag).filter(Boolean));
+}
+
+function hasAirtable(env) {
+	return !!((env?.AIRTABLE_BASE_ID || env?.AIRTABLE_BASE) && (env?.AIRTABLE_API_KEY || env?.AIRTABLE_PAT || env?.AIRTABLE_ACCESS_TOKEN));
+}
+
+function hasD1(env) {
+	return !!env?.RESEARCHOPS_D1;
 }
 
 function headerValue(headers, key) {
@@ -59,8 +64,7 @@ function headerValue(headers, key) {
 }
 
 function accessTokenFromHeaders(headers) {
-	const auth = headerValue(headers, "Authorization");
-	const match = auth.match(/^Bearer\s+(.+)$/i);
+	const match = headerValue(headers, "Authorization").match(/^Bearer\s+(.+)$/i);
 	return match ? match[1] : "";
 }
 
@@ -71,26 +75,21 @@ function muralIdFromUrl(url) {
 
 function isMuralWidgetWrite(url, init) {
 	const method = String(init?.method || "GET").toUpperCase();
-	if (method !== "POST" && method !== "PATCH") return false;
-	return /app\.mural\.co\/api\/public\/v1\/murals\/[^/]+\/widgets(?:\/|$)/.test(String(url || ""));
+	return (method === "POST" || method === "PATCH") && /app\.mural\.co\/api\/public\/v1\/murals\/[^/]+\/widgets(?:\/|$)/.test(String(url || ""));
 }
 
 function isMuralWidgetsRead(url, init) {
 	const method = String(init?.method || "GET").toUpperCase();
-	if (method !== "GET") return false;
-	return /app\.mural\.co\/api\/public\/v1\/murals\/[^/]+\/widgets(?:\?|$)/.test(String(url || ""));
+	return method === "GET" && /app\.mural\.co\/api\/public\/v1\/murals\/[^/]+\/widgets(?:\?|$)/.test(String(url || ""));
 }
 
 async function bodyAsJson(body) {
-	if (!body) return null;
-	if (typeof body === "string") {
-		try {
-			return JSON.parse(body);
-		} catch {
-			return null;
-		}
+	if (!body || typeof body !== "string") return null;
+	try {
+		return JSON.parse(body);
+	} catch {
+		return null;
 	}
-	return null;
 }
 
 async function requestBody(request) {
@@ -102,20 +101,7 @@ async function requestBody(request) {
 }
 
 function airtableTableName(env) {
-	return env?.AIRTABLE_TABLE_MURAL_JOURNAL_SYNC ||
-		env?.AIRTABLE_TABLE_MURAL_JOURNAL_MAPPINGS ||
-		"Mural Journal Sync";
-}
-
-function hasAirtable(env) {
-	return !!(
-		(env?.AIRTABLE_BASE_ID || env?.AIRTABLE_BASE) &&
-		(env?.AIRTABLE_API_KEY || env?.AIRTABLE_PAT || env?.AIRTABLE_ACCESS_TOKEN)
-	);
-}
-
-function hasD1(env) {
-	return !!env?.RESEARCHOPS_D1;
+	return env?.AIRTABLE_TABLE_MURAL_JOURNAL_SYNC || env?.AIRTABLE_TABLE_MURAL_JOURNAL_MAPPINGS || "Mural Journal Sync";
 }
 
 async function ensureD1MappingTable(env) {
@@ -140,16 +126,7 @@ async function listD1MappingsForMural(env, muralId) {
 	if (!hasD1(env) || !muralId) return [];
 	await ensureD1MappingTable(env);
 	return d1All(env, `
-		SELECT
-			journal_entry_id,
-			mural_id,
-			widget_id,
-			project_id,
-			category,
-			sync_status,
-			action,
-			synced_at,
-			updated_at
+		SELECT journal_entry_id, mural_id, widget_id, project_id, category, sync_status, action, synced_at, updated_at
 		FROM mural_journal_entry_widgets
 		WHERE mural_id = ?;
 	`, [muralId]);
@@ -159,15 +136,7 @@ async function upsertD1Mapping(env, mapping) {
 	await ensureD1MappingTable(env);
 	await d1Run(env, `
 		INSERT INTO mural_journal_entry_widgets (
-			journal_entry_id,
-			mural_id,
-			widget_id,
-			project_id,
-			category,
-			sync_status,
-			action,
-			synced_at,
-			updated_at
+			journal_entry_id, mural_id, widget_id, project_id, category, sync_status, action, synced_at, updated_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(journal_entry_id, mural_id)
 		DO UPDATE SET
@@ -209,9 +178,7 @@ async function appendAirtableMapping(svc, mapping) {
 }
 
 function successfulOutcomes(data) {
-	if (Array.isArray(data?.outcomes)) {
-		return data.outcomes.filter(outcome => outcome?.ok && outcome?.entryId && outcome?.widgetId);
-	}
+	if (Array.isArray(data?.outcomes)) return data.outcomes.filter(outcome => outcome?.ok && outcome?.entryId && outcome?.widgetId);
 	if (data?.ok && data?.entryId && data?.widgetId) return [data];
 	return [];
 }
@@ -261,7 +228,7 @@ async function persistMappings(svc, body, data) {
 }
 
 async function listMuralTags(accessToken, muralId) {
-	const res = await fetch(`https://app.mural.co/api/public/v1/murals/${muralId}/tags`, {
+	const res = await fetch(`${MURAL_ROOT}/murals/${muralId}/tags`, {
 		headers: {
 			Authorization: `Bearer ${accessToken}`,
 			Accept: "application/json"
@@ -275,19 +242,10 @@ async function listMuralTags(accessToken, muralId) {
 async function createMuralTag(accessToken, muralId, tag) {
 	const text = truncateMuralTag(tag);
 	if (!text) return "";
+	const bodies = [{ text }, { text, backgroundColor: "#F6D6FF", borderColor: "#B15FD1", color: "#0B0C0C" }];
 
-	const attempts = [
-		{ text },
-		{
-			text,
-			backgroundColor: "#F6D6FF",
-			borderColor: "#B15FD1",
-			color: "#0B0C0C"
-		}
-	];
-
-	for (const body of attempts) {
-		const res = await fetch(`https://app.mural.co/api/public/v1/murals/${muralId}/tags`, {
+	for (const body of bodies) {
+		const res = await fetch(`${MURAL_ROOT}/murals/${muralId}/tags`, {
 			method: "POST",
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
@@ -302,7 +260,6 @@ async function createMuralTag(accessToken, muralId, tag) {
 			return truncateMuralTag(created?.text || text);
 		}
 	}
-
 	return "";
 }
 
@@ -310,9 +267,8 @@ async function ensureKnownTags(accessToken, muralId, tags) {
 	const desired = userFacingTags(tags);
 	if (!desired.length || !accessToken || !muralId) return [];
 
-	const existing = await listMuralTags(accessToken, muralId);
 	const known = new Map();
-	for (const tag of existing) {
+	for (const tag of await listMuralTags(accessToken, muralId)) {
 		const text = truncateMuralTag(tag?.text || tag?.name || tag?.title || tag);
 		if (text) known.set(text.toLowerCase(), text);
 	}
@@ -324,21 +280,18 @@ async function ensureKnownTags(accessToken, muralId, tags) {
 			safe.push(known.get(key));
 			continue;
 		}
-
 		const created = await createMuralTag(accessToken, muralId, tag).catch(() => "");
 		if (created) {
 			known.set(created.toLowerCase(), created);
 			safe.push(created);
 		}
 	}
-
 	return dedupeTags(safe);
 }
 
 async function responseMentionsMissingTag(response) {
 	if (!response || response.ok || response.status !== 400) return false;
-	const clone = response.clone();
-	const body = await clone.json().catch(() => ({}));
+	const body = await response.clone().json().catch(() => ({}));
 	const text = JSON.stringify(body).toLowerCase();
 	return text.includes("specified tag does not exist") || text.includes("tag does not exist");
 }
@@ -395,11 +348,7 @@ function annotateWidgetsWithMappings(body, mappings) {
 		const marker = byWidgetId.get(safeText(widget?.id));
 		if (!marker) return widget;
 		const tags = dedupeTags([...(normalizeTags(widget.tags)), marker.category, `journal-entry:${marker.entryId}`]);
-		return {
-			...widget,
-			title: `journal-entry:${marker.entryId}`,
-			tags
-		};
+		return { ...widget, title: `journal-entry:${marker.entryId}`, tags };
 	}
 
 	if (Array.isArray(body?.value)) return { ...body, value: body.value.map(annotate) };
@@ -411,11 +360,7 @@ function annotateWidgetsWithMappings(body, mappings) {
 function jsonResponseFrom(original, body) {
 	const headers = new Headers(original.headers);
 	headers.set("content-type", "application/json; charset=utf-8");
-	return new Response(JSON.stringify(body), {
-		status: original.status,
-		statusText: original.statusText,
-		headers
-	});
+	return new Response(JSON.stringify(body), { status: original.status, statusText: original.statusText, headers });
 }
 
 function installSafeMuralFetch(svc, originalFetch) {
@@ -437,35 +382,21 @@ function installSafeMuralFetch(svc, originalFetch) {
 		const body = await bodyAsJson(init.body);
 		const desiredTags = tagsFromBody(body);
 		if (!body || !desiredTags.length) {
-			return originalFetch(input, {
-				...init,
-				body: body ? JSON.stringify(removeUnsupportedFields(body)) : init.body
-			});
+			return originalFetch(input, { ...init, body: body ? JSON.stringify(removeUnsupportedFields(body)) : init.body });
 		}
 
 		const accessToken = accessTokenFromHeaders(init.headers);
 		const confirmedTags = await ensureKnownTags(accessToken, muralId, desiredTags).catch(() => []);
-		const bodyWithConfirmedTags = confirmedTags.length ? withTags(body, confirmedTags) : withoutTags(body);
-
-		const firstResponse = await originalFetch(input, {
-			...init,
-			body: JSON.stringify(bodyWithConfirmedTags)
-		});
+		const firstResponse = await originalFetch(input, { ...init, body: JSON.stringify(confirmedTags.length ? withTags(body, confirmedTags) : withoutTags(body)) });
 
 		if (!(await responseMentionsMissingTag(firstResponse))) return firstResponse;
-
-		return originalFetch(input, {
-			...init,
-			body: JSON.stringify(withoutTags(body))
-		});
+		return originalFetch(input, { ...init, body: JSON.stringify(withoutTags(body)) });
 	};
 }
 
 async function responseWithMappings(response, svc, body) {
 	const data = await response.clone().json().catch(() => null);
-	if (!data || !data.ok) return response;
-	if (data.mode !== "hydrate" && data.mode !== "entry") return response;
-
+	if (!data || !data.ok || (data.mode !== "hydrate" && data.mode !== "entry")) return response;
 	const mappings = await persistMappings(svc, body, data);
 	return jsonResponseFrom(response, { ...data, mappings });
 }

--- a/tests/mural-journal-sync-route-state.test.js
+++ b/tests/mural-journal-sync-route-state.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const serviceSource = fs.readFileSync("infra/cloudflare/src/service/mural-journal-sync.js", "utf8");
+const layoutSource = fs.readFileSync("infra/cloudflare/src/service/mural-journal-sync-layout.js", "utf8");
 const safeTagsSource = fs.readFileSync("infra/cloudflare/src/service/mural-journal-sync-safe-tags.js", "utf8");
 const indexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
 const journalTabsSource = fs.readFileSync("public/js/journal-tabs.js", "utf8");
@@ -44,7 +45,20 @@ includes(serviceSource, "tags: patch.tags", "service");
 includes(serviceSource, "errors: err?.errors", "service");
 includes(serviceSource, "reason: hydrateReason", "service");
 
-includes(safeTagsSource, "import * as BaseMuralJournalSync from \"./mural-journal-sync.js\";", "safe tags");
+includes(layoutSource, "export async function muralJournalSync", "layout service");
+includes(layoutSource, "function categoryHeaderWidget", "layout service");
+includes(layoutSource, "function columnTemplateWidget", "layout service");
+includes(layoutSource, "function columnLayout", "layout service");
+includes(layoutSource, "function widgetMatchesColumnLayout", "layout service");
+includes(layoutSource, "for (const category of CATEGORY_KEYS)", "layout service");
+includes(layoutSource, "placementBelow", "layout service");
+includes(layoutSource, "updated-template-widget", "layout service");
+includes(layoutSource, "created-template-sticky", "layout service");
+includes(layoutSource, "widgets/sticky-note", "layout service");
+includes(layoutSource, "tagsForEntry", "layout service");
+includes(layoutSource, "userFacingTags", "layout service");
+
+includes(safeTagsSource, "import * as BaseMuralJournalSync from \"./mural-journal-sync-layout.js\";", "safe tags");
 includes(safeTagsSource, "import { createRecords } from \"./internals/airtable.js\";", "safe tags");
 includes(safeTagsSource, "import { d1All, d1Run } from \"./internals/researchops-d1.js\";", "safe tags");
 includes(safeTagsSource, "const SYSTEM_TAG_RE = /^journal-entry:/i;", "safe tags");
@@ -96,6 +110,7 @@ excludes(serviceSource, "https://app.mural.co/api/public/v1/murals/${muralId}/wi
 excludes(serviceSource, "created-template-widget", "service");
 excludes(serviceSource, "updated-template-sticky", "service");
 excludes(serviceSource, "created-sticky", "service");
+excludes(layoutSource, "created-template-widget", "layout service");
 excludes(safeTagsSource, "tags: [...", "safe tags");
 excludes(compactSource, "Sync ${pending}", "compact script");
 excludes(compactSource, "Sync pending entries", "compact script");


### PR DESCRIPTION
## Summary
- introduce a column-driven Mural journal sync implementation
- derive each Reflexive Journal column from the purple heading widget
- use the heading x-position and width as the canonical column geometry
- locate the first sticky/card under each heading and use it as the first entry target
- update the first sticky/card in each category with the first ResearchOps journal entry
- create later entries below the latest entry in the same column
- keep created entries aligned to the original column and template dimensions
- process one category column fully before moving to the next category
- keep Mural tag handling separate from sticky geometry and text placement
- keep ResearchOps idempotency in D1 and Airtable mappings rather than visible Mural tags

## Why this is a new PR
PR #63 had already been merged. The later column-layout work was committed to the same branch after that merge, so it needs to be reviewed and merged through a fresh PR.

## Testing
Not run locally through this connector. Expected CI: `npm run validate`.