### PR TITLE
Rework study page as readiness control page

### DIFF
--- a/public/js/study-page.js
+++ b/public/js/study-page.js
@@ -1,0 +1,198 @@
+/**
+ * @file public/js/study-page.js
+ * @module study-page
+ * @summary Loads a study page and renders a readiness-led control page.
+ */
+
+const API_ORIGIN = window.RESEARCHOPS_API_ORIGIN || "https://rops-api.kevinrapley.workers.dev";
+
+const $ = (selector, root = document) => root.querySelector(selector);
+
+function apiUrl(path) {
+	return new URL(path, API_ORIGIN).toString();
+}
+
+function route(path, params) {
+	const url = new URL(path, window.location.origin);
+	for (const [key, value] of Object.entries(params)) {
+		if (value) url.searchParams.set(key, value);
+	}
+	return `${url.pathname}${url.search}`;
+}
+
+function setText(selector, value) {
+	const el = $(selector);
+	if (el) el.textContent = value || "—";
+}
+
+function fallbackTitle(study = {}) {
+	const method = (study.method || "Study").trim();
+	const d = study.createdAt ? new Date(study.createdAt) : new Date();
+	const yyyy = d.getUTCFullYear();
+	const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+	const dd = String(d.getUTCDate()).padStart(2, "0");
+	return `${method} — ${yyyy}-${mm}-${dd}`;
+}
+
+function studyTitle(study = {}) {
+	return (study.title || study.Title || "").trim() || fallbackTitle(study);
+}
+
+function showError(message) {
+	const summary = $("#study-error");
+	const messageEl = $("#study-error-message");
+	if (!summary || !messageEl) return;
+	summary.hidden = false;
+	summary.removeAttribute("aria-hidden");
+	messageEl.textContent = message;
+	summary.focus();
+}
+
+function hideError() {
+	const summary = $("#study-error");
+	if (!summary) return;
+	summary.hidden = true;
+	summary.setAttribute("aria-hidden", "true");
+}
+
+async function jsonFetch(url) {
+	const response = await fetch(url, { cache: "no-store" });
+	const body = await response.json().catch(() => ({}));
+	if (!response.ok) {
+		throw new Error(body?.error || `Request failed (${response.status})`);
+	}
+	return body;
+}
+
+async function loadProject(projectId) {
+	const body = await jsonFetch(apiUrl("/api/projects"));
+	const projects = Array.isArray(body?.projects) ? body.projects : [];
+	return projects.find(project => project.id === projectId) || null;
+}
+
+async function loadStudies(projectId) {
+	const url = new URL(apiUrl("/api/studies"));
+	url.searchParams.set("project", projectId);
+	const body = await jsonFetch(url);
+	if (body?.ok !== true || !Array.isArray(body.studies)) {
+		throw new Error(body?.error || "Could not load studies");
+	}
+	return body.studies;
+}
+
+function enableLink(selector, href) {
+	const el = $(selector);
+	if (!el) return;
+	el.href = href;
+	el.classList.remove("link--disabled");
+	el.removeAttribute("aria-disabled");
+	el.removeAttribute("tabindex");
+}
+
+function disableLink(selector, reason) {
+	const el = $(selector);
+	if (!el) return;
+	el.href = "#";
+	el.classList.add("link--disabled");
+	el.setAttribute("aria-disabled", "true");
+	el.setAttribute("tabindex", "-1");
+	const reasonEl = el.querySelector(".study-action__reason");
+	if (reasonEl) reasonEl.textContent = reason;
+}
+
+function setReadinessItem(key, state, text) {
+	const item = document.querySelector(`[data-readiness-item="${key}"]`);
+	if (!item) return;
+	const status = item.querySelector(".readiness-item__status");
+	const body = item.querySelector(".readiness-item__body");
+	if (status) status.textContent = state;
+	if (body) body.textContent = text;
+}
+
+function renderReadiness(study) {
+	const hasDescription = !!String(study.description || "").trim();
+	const status = String(study.status || "").trim() || "Planned";
+
+	setReadinessItem("description", hasDescription ? "Ready" : "Needs attention", hasDescription ? "The study has a description." : "Add a short description before running sessions.");
+	setReadinessItem("status", status ? "Set" : "Needs attention", `Study status is ${status}.`);
+	setReadinessItem("participants", "Action needed", "Schedule participants or confirm existing participant arrangements.");
+	setReadinessItem("guide", "Action needed", "Create or review the discussion guide before running a session.");
+	setReadinessItem("consent", "Action needed", "Consent materials and participant consent need to be confirmed.");
+	setReadinessItem("session", "Available", "Open the session workspace when the study setup is ready.");
+}
+
+function renderRoutes(projectId, studyId) {
+	const params = { pid: projectId, sid: studyId };
+	enableLink("#back-to-project", route("/pages/project-dashboard/", { id: projectId }));
+	enableLink("#breadcrumb-project", route("/pages/project-dashboard/", { id: projectId }));
+	enableLink("#link-guides", route("/pages/study/guides/", params));
+	enableLink("#link-participants", route("/pages/study/participants/", params));
+	enableLink("#link-session", route("/pages/study/session/", params));
+
+	disableLink("#link-consent-forms", "Consent form generation has not been connected yet.");
+	disableLink("#link-consent-manage", "Participant consent management has not been connected yet.");
+	disableLink("#link-observers", "Observer and note taker setup has not been connected yet.");
+
+	const editStudy = $("#edit-study");
+	if (editStudy) editStudy.href = `${route("/pages/study/", params)}#edit`;
+}
+
+function renderStudy(project, study, projectId, studyId) {
+	const projectName = project?.name || "Project";
+	document.body.setAttribute("data-study-id", studyId);
+	document.body.setAttribute("data-project-id", projectId);
+
+	setText("#breadcrumb-project", projectName);
+	setText("#study-title", studyTitle(study));
+	setText("#description", String(study.description || "").trim() || "No study description has been added yet.");
+	setText("#kv-method", study.method || "—");
+	setText("#kv-status", study.status || "—");
+	setText("#kv-studyid", String(study.studyId || "—").toUpperCase());
+
+	renderRoutes(projectId, studyId);
+	renderReadiness(study);
+}
+
+async function init() {
+	hideError();
+	const params = new URLSearchParams(window.location.search);
+	const projectId = params.get("pid") || "";
+	const studyId = params.get("sid") || "";
+
+	if (!projectId || !studyId) {
+		showError("The study page needs a project ID and study ID in the URL.");
+		return;
+	}
+
+	try {
+		const [project, studies] = await Promise.all([
+			loadProject(projectId),
+			loadStudies(projectId)
+		]);
+		const study = studies.find(item => item.id === studyId);
+		if (!study) {
+			showError("The requested study could not be found for this project.");
+			return;
+		}
+		renderStudy(project, study, projectId, studyId);
+	} catch (error) {
+		console.error("[study-page] init failed", error);
+		showError("Could not load the study. Check the project and study links, then try again.");
+	}
+}
+
+document.addEventListener("study:desc:save", async event => {
+	const studyId = document.body.getAttribute("data-study-id") || "";
+	if (!studyId) return;
+	try {
+		await fetch(apiUrl(`/api/studies/${encodeURIComponent(studyId)}`), {
+			method: "PATCH",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ description: event.detail?.markdown || "" })
+		});
+	} catch (error) {
+		console.error("[study-page] description save failed", error);
+	}
+});
+
+init();

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -11,20 +11,19 @@
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 
 	<script type="module" src="/components/layout.js"></script>
+	<script type="module" src="/js/study-page.js" defer></script>
 	<script type="module" src="study-desc-controller.js" defer></script>
 </head>
 
 <body>
 	<x-include src="/partials/debug-boot.html" debug-only></x-include>
-	
+
 	<x-include src="/partials/header.html" vars='{
     "active":"Projects",
     "subtitle":"Study"
   }'></x-include>
 
-	<!-- Use container to match global layout spacing -->
 	<main id="main" class="container govuk-body" role="main">
-		<!-- Breadcrumb -->
 		<nav class="breadcrumbs" aria-label="Breadcrumb">
 			<ol>
 				<li><a href="/pages/projects/">Projects</a></li>
@@ -33,17 +32,20 @@
 			</ol>
 		</nav>
 
+		<div id="study-error" class="panel" role="alert" tabindex="-1" hidden aria-hidden="true">
+			<h2 class="govuk-heading-s">There is a problem loading this study</h2>
+			<p id="study-error-message" class="govuk-body">Could not load the study.</p>
+		</div>
+
 		<div class="actions-bar">
 			<a id="back-to-project" href="/pages/projects/" class="btn btn--secondary">← Back to Project</a>
 			<a id="edit-study" href="#" class="btn">✎ Edit Study</a>
 		</div>
 
-		<!-- Hero -->
 		<div class="dashboard-hero">
 			<p id="study-eyebrow" class="project-org">Study</p>
 			<h1 id="study-title" class="govuk-heading-l">Study</h1>
 
-			<!-- Description lives under the title -->
 			<div id="desc-view-wrap">
 				<div id="description" class="govuk-body">—</div>
 				<div class="actions-bar" style="margin-top:8px;">
@@ -51,7 +53,6 @@
 				</div>
 			</div>
 
-			<!-- Inline editor (hidden by default) -->
 			<form id="desc-editor" class="panel" hidden>
 				<label class="govuk-label" for="desc-input">Description (Markdown)</label>
 				<textarea id="desc-input" class="govuk-textarea" rows="8" spellcheck="true" autocomplete="off"></textarea>
@@ -78,12 +79,11 @@
 
 				<div class="actions-bar" style="gap:8px;">
 					<button id="btn-save-desc" class="btn" type="submit">Save</button>
-					<button id="btn-cancel-desc" class="btn btn--secondary" type="button">Cancel</button>
+					<button id="desc-cancel" class="btn btn--secondary" type="button">Cancel</button>
 				</div>
 			</form>
 		</div>
 
-		<!-- Key info -->
 		<section class="kv">
 			<ul class="kv__list">
 				<li><span class="kv__term">Method</span>&nbsp;<span class="kv__desc" id="kv-method">–</span></li>
@@ -92,175 +92,41 @@
 			</ul>
 		</section>
 
-		<!-- Materials hubs -->
-		<nav class="board" aria-label="Study setup">
-			<a href="#" class="board__item link--disabled" aria-disabled="true" tabindex="-1">Produce consent forms</a>
-			<a href="#" class="board__item link--disabled" aria-disabled="true" tabindex="-1">Manage consent</a>
-			<a id="participants" href="#" class="board__item link--disabled" aria-disabled="true" tabindex="-1">Schedule participants</a>
-			<a id="link-guides" href="#" class="board__item link--disabled" aria-disabled="true" tabindex="-1">Discussion Guides</a>
-			<a href="#" class="board__item link--disabled" aria-disabled="true" tabindex="-1">Note takers &amp; observers</a>
-			<a href="/pages/study/session/" class="board__item link--disabled" aria-disabled="true" tabindex="-1">Begin a session</a>
-		</nav>
-
-		<section class="section">
+		<section class="section" aria-labelledby="study-readiness-title">
 			<header class="section__header">
-				<h2 class="section__title govuk-heading-m">Overview</h2>
+				<h2 id="study-readiness-title" class="section__title govuk-heading-m">Study readiness</h2>
 			</header>
 			<div class="section__body">
 				<div class="panel">
-					<p class="govuk-body">Set up your study materials and workflows here.</p>
+					<p class="govuk-body">Check whether the essential study setup is ready before running a session.</p>
+					<ul class="study-readiness-list">
+						<li data-readiness-item="description"><strong>Description</strong> <span class="readiness-item__status">Checking</span><br /><span class="readiness-item__body">Checking study description.</span></li>
+						<li data-readiness-item="status"><strong>Status</strong> <span class="readiness-item__status">Checking</span><br /><span class="readiness-item__body">Checking study status.</span></li>
+						<li data-readiness-item="participants"><strong>Participants</strong> <span class="readiness-item__status">Action needed</span><br /><span class="readiness-item__body">Schedule participants or confirm participant arrangements.</span></li>
+						<li data-readiness-item="guide"><strong>Discussion guide</strong> <span class="readiness-item__status">Action needed</span><br /><span class="readiness-item__body">Create or review the discussion guide.</span></li>
+						<li data-readiness-item="consent"><strong>Consent</strong> <span class="readiness-item__status">Action needed</span><br /><span class="readiness-item__body">Confirm consent materials and participant consent.</span></li>
+						<li data-readiness-item="session"><strong>Session workspace</strong> <span class="readiness-item__status">Available</span><br /><span class="readiness-item__body">Open the session workspace when setup is ready.</span></li>
+					</ul>
+					<p><a id="link-session" href="#" class="btn">Begin session</a></p>
 				</div>
 			</div>
+		</section>
+
+		<section class="section" aria-labelledby="study-setup-title">
+			<header class="section__header">
+				<h2 id="study-setup-title" class="section__title govuk-heading-m">Study setup tasks</h2>
+			</header>
+			<nav class="board" aria-label="Study setup tasks">
+				<a id="link-consent-forms" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Create consent forms</strong><br /><span class="study-action__reason">Not connected yet.</span></a>
+				<a id="link-consent-manage" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Manage participant consent</strong><br /><span class="study-action__reason">Not connected yet.</span></a>
+				<a id="link-participants" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Schedule participants</strong><br /><span class="study-action__reason">Requires study context.</span></a>
+				<a id="link-guides" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Create or manage discussion guides</strong><br /><span class="study-action__reason">Requires study context.</span></a>
+				<a id="link-observers" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Add note takers and observers</strong><br /><span class="study-action__reason">Not connected yet.</span></a>
+			</nav>
 		</section>
 	</main>
 
 	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
-
-	<script type="module">
-		/**
-		 * @file study/index.html (bootstrap)
-		 * @module StudyPage
-		 * @summary Fetches study data via Worker API and renders the page.
-		 * @description
-		 * - Title logic: prefer `study.title`; otherwise compute “Method — YYYY-MM-DD”.
-		 * - Description is shown under the H1, never used as the title.
-		 * - “Discussion Guides” tile routes to `/pages/study/guides/?pid=…&sid=…`.
-		 */
-
-		/* ── tiny helpers ───────────────────────────────────────────── */
-
-		/** @param {string} sel @param {ParentNode} [root=document] */
-		const $ = (sel, root = document) => root.querySelector(sel);
-
-		/**
-		 * Compute Airtable-like fallback title.
-		 * @param {{ method?: string, createdAt?: string }} s
-		 */
-		function fallbackTitle(s = {}) {
-			const method = (s.method || "Study").trim();
-			const d = s.createdAt ? new Date(s.createdAt) : new Date();
-			const yyyy = d.getUTCFullYear();
-			const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-			const dd = String(d.getUTCDate()).padStart(2, "0");
-			return `${method} — ${yyyy}-${mm}-${dd}`;
-		}
-
-		/**
-		 * Title to display in the H1.
-		 * @param {{ title?: string, Title?: string, method?: string, createdAt?: string }} s
-		 * @returns {string}
-		 */
-		function pickH1Title(s = {}) {
-			return (s.title || s.Title || "").trim() || fallbackTitle(s);
-		}
-
-		/**
-		 * Fetch all studies for a project.
-		 * @param {string} projectAirtableId
-		 * @returns {Promise<Array<any>>}
-		 */
-		async function loadStudies(projectAirtableId) {
-			const url = `/api/studies?project=${encodeURIComponent(projectAirtableId)}`;
-			const res = await fetch(url, { cache: "no-store" });
-			const js = await res.json().catch(() => ({}));
-			if (!res.ok || js?.ok !== true || !Array.isArray(js.studies)) {
-				throw new Error(js?.error || `Studies fetch failed (${res.status})`);
-			}
-			return js.studies;
-		}
-
-		/**
-		 * Fetch the single project from /api/projects (no /:id route exists).
-		 * @param {string} pid
-		 * @returns {Promise<{id:string,name:string}|null>}
-		 */
-		async function loadProject(pid) {
-			try {
-				const res = await fetch(`/api/projects`, { cache: "no-store" });
-				const js = await res.json().catch(() => ({}));
-				const list = Array.isArray(js?.projects) ? js.projects : [];
-				return list.find(p => p.id === pid) || null;
-			} catch { return null; }
-		}
-
-		/* ── bootstrap ─────────────────────────────────────────────── */
-
-		(async function init() {
-			try {
-				const usp = new URLSearchParams(location.search);
-				const pid = usp.get("pid") || "";
-				const sid = usp.get("sid") || "";
-				if (!pid || !sid) throw new Error("Missing pid or sid in URL");
-
-				// Back to project route
-				$("#back-to-project")?.setAttribute("href", `/pages/project-dashboard/?id=${encodeURIComponent(pid)}`);
-
-				// Fetch data
-				const [project, studies] = await Promise.all([
-					loadProject(pid),
-					loadStudies(pid)
-				]);
-
-				const study = studies.find(s => s.id === sid) || {};
-
-				// Breadcrumbs
-				const projName = (project && project.name) ? project.name : "Project";
-				const bcProj = $("#breadcrumb-project");
-				if (bcProj) {
-					bcProj.href = `/pages/project-dashboard/?id=${encodeURIComponent(pid)}`;
-					bcProj.textContent = projName;
-				}
-				// (No #breadcrumb-study element in this page’s HTML, so we don’t touch it.)
-
-				// Header title
-				$("#study-title").textContent = pickH1Title(study);
-
-				// Key-value facts
-				$("#kv-method").textContent = (study.method || "—");
-				$("#kv-status").textContent = (study.status || "—");
-				$("#kv-studyid").textContent = String(study.studyId || "—").toUpperCase();
-
-				// Description (plain text for now)
-				const desc = (study.description || "").trim();
-				$("#description").textContent = desc || "—";
-
-				// Optional “edit” deep link
-				$("#edit-study")?.setAttribute(
-					"href",
-					`/pages/study/?pid=${encodeURIComponent(pid)}&sid=${encodeURIComponent(sid)}#edit`
-				);
-
-				/** @param {HTMLAnchorElement|null} el @param {string} href */
-				function enableTile(el, href) {
-					if (!el) return;
-					el.setAttribute('href', href);
-					el.removeAttribute('aria-disabled');
-					el.removeAttribute('tabindex');
-					el.classList.remove('link--disabled');
-				}
-
-				// Enable “Discussion Guides” route
-				const guides = $('#link-guides');
-				enableTile(
-					guides,
-					`/pages/study/guides/?pid=${encodeURIComponent(pid)}&sid=${encodeURIComponent(sid)}`
-				);
-
-				// Enable “Schedule Participants” route
-				const participants = $('#participants');
-				enableTile(
-					participants,
-					`/pages/study/participants/?pid=${encodeURIComponent(pid)}&sid=${encodeURIComponent(sid)}`
-				);
-
-				// Expose id for inline editor wiring (if needed elsewhere)
-				document.body.setAttribute("data-study-id", sid);
-			} catch (err) {
-				console.error("[study] init error:", err);
-				alert("Could not load study.");
-			}
-		})();
-	</script>
 </body>
 
 </html>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -39,6 +39,7 @@ require_file "tests/journal-tabs-filter-state-route-state.test.js"
 require_file "tests/journal-tabs-resilience-route-state.test.js"
 require_file "tests/journal-secondary-actions-route-state.test.js"
 require_file "tests/mural-journal-sync-route-state.test.js"
+require_file "tests/study-page-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -161,5 +162,8 @@ node tests/journal-secondary-actions-route-state.test.js
 
 info "checking Mural journal sync route-state contract"
 node tests/mural-journal-sync-route-state.test.js
+
+info "checking Study page route-state contract"
+node tests/study-page-route-state.test.js
 
 info "validation passed"

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/study/index.html", "utf8");
+const controllerSource = fs.readFileSync("public/js/study-page.js", "utf8");
+const descControllerSource = fs.readFileSync("public/pages/study/study-desc-controller.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "/js/study-page.js", "study page");
+includes(pageSource, "id=\"study-error\"", "study page");
+includes(pageSource, "role=\"alert\"", "study page");
+includes(pageSource, "Study readiness", "study page");
+includes(pageSource, "Study setup tasks", "study page");
+includes(pageSource, "id=\"link-session\"", "study page");
+includes(pageSource, "id=\"link-guides\"", "study page");
+includes(pageSource, "id=\"link-participants\"", "study page");
+includes(pageSource, "id=\"desc-cancel\"", "study page");
+excludes(pageSource, "alert(\"Could not load study.\")", "study page");
+excludes(pageSource, "<script type=\"module\">", "study page");
+
+includes(descControllerSource, "cancelBtnSel: '#desc-cancel'", "description controller");
+
+includes(controllerSource, "const API_ORIGIN", "study page controller");
+includes(controllerSource, "function apiUrl", "study page controller");
+includes(controllerSource, "apiUrl(\"/api/projects\")", "study page controller");
+includes(controllerSource, "apiUrl(\"/api/studies\")", "study page controller");
+includes(controllerSource, "showError", "study page controller");
+includes(controllerSource, "renderReadiness", "study page controller");
+includes(controllerSource, "route(\"/pages/study/guides/\", params)", "study page controller");
+includes(controllerSource, "route(\"/pages/study/participants/\", params)", "study page controller");
+includes(controllerSource, "route(\"/pages/study/session/\", params)", "study page controller");
+includes(controllerSource, "pid", "study page controller");
+includes(controllerSource, "sid", "study page controller");
+includes(controllerSource, "study:desc:save", "study page controller");
+includes(controllerSource, "/api/studies/${encodeURIComponent(studyId)}", "study page controller");
+excludes(controllerSource, "alert(", "study page controller");


### PR DESCRIPTION
## Summary
- rework the study page from a flat tile grid into a readiness-led study control page
- extract page loading, API calls, route state, and action enablement into `/public/js/study-page.js`
- use the Worker API origin pattern for `/api/projects` and `/api/studies`
- preserve `pid` and `sid` through study action routes
- replace the blocking `alert()` load failure with an inline `role="alert"` error panel
- fix the description editor cancel control contract by aligning the DOM with `#desc-cancel`
- move setup work into task-led action cards with visible unavailable reasons
- add a primary `Begin session` action in the readiness panel
- add a study page route-state regression test and wire it into `scripts/validate.sh`

## Role consultation reflected
- SD: split page controller from HTML and guard route-state behaviour with a regression test
- UR: make the page answer whether the study is ready to run
- CS: preserve route state but keep server-side ownership checks as the required security boundary
- CD: use task-led labels and visible unavailable reasons
- Accessibility: replace alert dialogs with inline alert region; avoid unexplained disabled links
- IxD: move `Begin session` into the readiness panel instead of treating it as one equal tile

## Testing
Not run locally through this connector. Expected CI: `npm run validate`.