### PR TITLE
Fix study page API origin

### DIFF
--- a/public/js/study-page.js
+++ b/public/js/study-page.js
@@ -4,12 +4,19 @@
  * @summary Loads a study page and renders a readiness-led control page.
  */
 
-const API_ORIGIN = window.RESEARCHOPS_API_ORIGIN || "https://rops-api.kevinrapley.workers.dev";
+const API_ORIGIN =
+	document.documentElement?.dataset?.apiOrigin ||
+	window.API_ORIGIN ||
+	window.RESEARCHOPS_API_ORIGIN ||
+	(location.hostname.endsWith("pages.dev") ?
+		"https://rops-api.digikev-kevin-rapley.workers.dev" :
+		location.origin);
 
 const $ = (selector, root = document) => root.querySelector(selector);
 
 function apiUrl(path) {
-	return new URL(path, API_ORIGIN).toString();
+	const p = String(path || "");
+	return `${API_ORIGIN}${p.startsWith("/") ? p : "/" + p}`;
 }
 
 function route(path, params) {
@@ -57,7 +64,8 @@ function hideError() {
 
 async function jsonFetch(url) {
 	const response = await fetch(url, { cache: "no-store" });
-	const body = await response.json().catch(() => ({}));
+	const text = await response.text();
+	const body = text ? JSON.parse(text) : {};
 	if (!response.ok) {
 		throw new Error(body?.error || `Request failed (${response.status})`);
 	}
@@ -65,15 +73,20 @@ async function jsonFetch(url) {
 }
 
 async function loadProject(projectId) {
-	const body = await jsonFetch(apiUrl("/api/projects"));
-	const projects = Array.isArray(body?.projects) ? body.projects : [];
-	return projects.find(project => project.id === projectId) || null;
+	try {
+		const body = await jsonFetch(apiUrl("/api/projects"));
+		const projects = Array.isArray(body?.projects) ? body.projects : [];
+		return projects.find(project => project.id === projectId) || null;
+	} catch (error) {
+		console.warn("[study-page] project lookup failed", error);
+		return null;
+	}
 }
 
 async function loadStudies(projectId) {
 	const url = new URL(apiUrl("/api/studies"));
 	url.searchParams.set("project", projectId);
-	const body = await jsonFetch(url);
+	const body = await jsonFetch(url.toString());
 	if (body?.ok !== true || !Array.isArray(body.studies)) {
 		throw new Error(body?.error || "Could not load studies");
 	}

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -28,6 +28,8 @@ excludes(pageSource, "<script type=\"module\">", "study page");
 includes(descControllerSource, "cancelBtnSel: '#desc-cancel'", "description controller");
 
 includes(controllerSource, "const API_ORIGIN", "study page controller");
+includes(controllerSource, "window.API_ORIGIN", "study page controller");
+includes(controllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "study page controller");
 includes(controllerSource, "function apiUrl", "study page controller");
 includes(controllerSource, "apiUrl(\"/api/projects\")", "study page controller");
 includes(controllerSource, "apiUrl(\"/api/studies\")", "study page controller");
@@ -40,4 +42,5 @@ includes(controllerSource, "pid", "study page controller");
 includes(controllerSource, "sid", "study page controller");
 includes(controllerSource, "study:desc:save", "study page controller");
 includes(controllerSource, "/api/studies/${encodeURIComponent(studyId)}", "study page controller");
+excludes(controllerSource, "https://rops-api.kevinrapley.workers.dev", "study page controller");
 excludes(controllerSource, "alert(", "study page controller");


### PR DESCRIPTION
## Summary
- fix the study page loading failure after the readiness-control-page merge
- align `public/js/study-page.js` with the canonical API origin pattern used elsewhere in the app
- replace the incorrect fallback `https://rops-api.kevinrapley.workers.dev` with `https://rops-api.digikev-kevin-rapley.workers.dev`
- keep support for `document.documentElement.dataset.apiOrigin`, `window.API_ORIGIN`, and `window.RESEARCHOPS_API_ORIGIN`
- make project lookup non-fatal so the study can still render if `/api/projects` fails while `/api/studies` succeeds
- update the study page route-state regression test to guard the canonical Worker origin

## Why
The page is currently showing the generic loading error because the study controller calls the wrong Worker origin. That makes `/api/studies?project=...` fail before the page can render. The journals page already uses the correct Worker origin pattern.

## Testing
Not run locally through this connector. Expected CI: `npm run validate`.