### PR TITLE
Improve study readiness and setup task layout

### DIFF
--- a/public/css/study-page.css
+++ b/public/css/study-page.css
@@ -1,0 +1,124 @@
+/* ==========================================================================
+   ResearchOps UI • Study page
+   Service:    Home Office Biometrics — ResearchOps
+   ========================================================================== */
+
+.study-description {
+	max-width: 760px;
+	}
+
+.study-description__actions {
+	margin-top: 8px;
+	}
+
+.study-section {
+	border-radius: 4px;
+	}
+
+.study-section__header {
+	padding-bottom: 8px;
+	}
+
+.study-readiness-panel {
+	padding: 12px;
+	border: 1px solid #b1b4b6;
+	background: #ffffff;
+	}
+
+.study-readiness-list {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 0;
+	margin: 16px 0 0 0;
+	padding: 0;
+	list-style: none;
+	border-top: 1px solid #b1b4b6;
+	}
+
+.readiness-item {
+	padding: 12px 0;
+	border-bottom: 1px solid #b1b4b6;
+	}
+
+.readiness-item__header {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px 12px;
+	align-items: baseline;
+	justify-content: space-between;
+	}
+
+.readiness-item__status,
+.study-task-card__status {
+	display: inline-block;
+	margin: 0;
+	padding: 2px 8px;
+	border: 1px solid #b1b4b6;
+	background: #f3f2f1;
+	color: #0b0c0c;
+	font-weight: 700;
+	font-size: 0.9rem;
+	}
+
+.readiness-item__body {
+	margin: 4px 0 0 0;
+	color: #0b0c0c;
+	}
+
+.study-readiness-panel__actions {
+	margin-top: 16px;
+	}
+
+.study-task-list {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 16px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	}
+
+.study-task-card {
+	padding: 16px;
+	border: 1px solid #b1b4b6;
+	background: #ffffff;
+	color: #0b0c0c;
+	}
+
+.study-task-card__title {
+	margin: 0 0 8px 0;
+	font-size: 1.1rem;
+	line-height: 1.25;
+	}
+
+.study-task-card__title a {
+	color: #1d70b8;
+	font-weight: 700;
+	}
+
+.study-task-card__body {
+	margin: 8px 0 0 0;
+	color: #0b0c0c;
+	}
+
+.study-task-card--unavailable {
+	background: #f8f8f8;
+	}
+
+.study-task-card--unavailable .study-task-card__title {
+	color: #505a5f;
+	}
+
+@media (min-width: 740px) {
+	.study-task-list {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+@media (min-width: 1000px) {
+	.study-task-list {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
+	}
+
+/* transparency begins in the cascade */

--- a/public/js/study-page.js
+++ b/public/js/study-page.js
@@ -102,17 +102,6 @@ function enableLink(selector, href) {
 	el.removeAttribute("tabindex");
 }
 
-function disableLink(selector, reason) {
-	const el = $(selector);
-	if (!el) return;
-	el.href = "#";
-	el.classList.add("link--disabled");
-	el.setAttribute("aria-disabled", "true");
-	el.setAttribute("tabindex", "-1");
-	const reasonEl = el.querySelector(".study-action__reason");
-	if (reasonEl) reasonEl.textContent = reason;
-}
-
 function setReadinessItem(key, state, text) {
 	const item = document.querySelector(`[data-readiness-item="${key}"]`);
 	if (!item) return;
@@ -128,9 +117,9 @@ function renderReadiness(study) {
 
 	setReadinessItem("description", hasDescription ? "Ready" : "Needs attention", hasDescription ? "The study has a description." : "Add a short description before running sessions.");
 	setReadinessItem("status", status ? "Set" : "Needs attention", `Study status is ${status}.`);
-	setReadinessItem("participants", "Action needed", "Schedule participants or confirm existing participant arrangements.");
+	setReadinessItem("participants", "Action needed", "Add or review participants for this study.");
 	setReadinessItem("guide", "Action needed", "Create or review the discussion guide before running a session.");
-	setReadinessItem("consent", "Action needed", "Consent materials and participant consent need to be confirmed.");
+	setReadinessItem("consent", "Action needed", "Confirm consent materials and participant consent.");
 	setReadinessItem("session", "Available", "Open the session workspace when the study setup is ready.");
 }
 
@@ -141,10 +130,6 @@ function renderRoutes(projectId, studyId) {
 	enableLink("#link-guides", route("/pages/study/guides/", params));
 	enableLink("#link-participants", route("/pages/study/participants/", params));
 	enableLink("#link-session", route("/pages/study/session/", params));
-
-	disableLink("#link-consent-forms", "Consent form generation has not been connected yet.");
-	disableLink("#link-consent-manage", "Participant consent management has not been connected yet.");
-	disableLink("#link-observers", "Observer and note taker setup has not been connected yet.");
 
 	const editStudy = $("#edit-study");
 	if (editStudy) editStudy.href = `${route("/pages/study/", params)}#edit`;

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/study-page.css" media="screen" />
 
 	<script type="module" src="/components/layout.js"></script>
 	<script type="module" src="/js/study-page.js" defer></script>
@@ -46,9 +47,9 @@
 			<p id="study-eyebrow" class="project-org">Study</p>
 			<h1 id="study-title" class="govuk-heading-l">Study</h1>
 
-			<div id="desc-view-wrap">
+			<div id="desc-view-wrap" class="study-description">
 				<div id="description" class="govuk-body">—</div>
-				<div class="actions-bar" style="margin-top:8px;">
+				<div class="study-description__actions">
 					<button id="btn-edit-desc" type="button" class="btn btn--outline">✎ Edit description</button>
 				</div>
 			</div>
@@ -92,37 +93,79 @@
 			</ul>
 		</section>
 
-		<section class="section" aria-labelledby="study-readiness-title">
-			<header class="section__header">
+		<section class="section study-section" aria-labelledby="study-readiness-title">
+			<header class="section__header study-section__header">
 				<h2 id="study-readiness-title" class="section__title govuk-heading-m">Study readiness</h2>
 			</header>
 			<div class="section__body">
-				<div class="panel">
-					<p class="govuk-body">Check whether the essential study setup is ready before running a session.</p>
+				<div class="study-readiness-panel">
+					<p class="govuk-body">Check the essentials before you run a session.</p>
 					<ul class="study-readiness-list">
-						<li data-readiness-item="description"><strong>Description</strong> <span class="readiness-item__status">Checking</span><br /><span class="readiness-item__body">Checking study description.</span></li>
-						<li data-readiness-item="status"><strong>Status</strong> <span class="readiness-item__status">Checking</span><br /><span class="readiness-item__body">Checking study status.</span></li>
-						<li data-readiness-item="participants"><strong>Participants</strong> <span class="readiness-item__status">Action needed</span><br /><span class="readiness-item__body">Schedule participants or confirm participant arrangements.</span></li>
-						<li data-readiness-item="guide"><strong>Discussion guide</strong> <span class="readiness-item__status">Action needed</span><br /><span class="readiness-item__body">Create or review the discussion guide.</span></li>
-						<li data-readiness-item="consent"><strong>Consent</strong> <span class="readiness-item__status">Action needed</span><br /><span class="readiness-item__body">Confirm consent materials and participant consent.</span></li>
-						<li data-readiness-item="session"><strong>Session workspace</strong> <span class="readiness-item__status">Available</span><br /><span class="readiness-item__body">Open the session workspace when setup is ready.</span></li>
+						<li class="readiness-item" data-readiness-item="description">
+							<div class="readiness-item__header"><strong>Description</strong> <span class="readiness-item__status">Checking</span></div>
+							<p class="readiness-item__body">Checking study description.</p>
+						</li>
+						<li class="readiness-item" data-readiness-item="status">
+							<div class="readiness-item__header"><strong>Status</strong> <span class="readiness-item__status">Checking</span></div>
+							<p class="readiness-item__body">Checking study status.</p>
+						</li>
+						<li class="readiness-item" data-readiness-item="participants">
+							<div class="readiness-item__header"><strong>Participants</strong> <span class="readiness-item__status">Action needed</span></div>
+							<p class="readiness-item__body">Add or review participants for this study.</p>
+						</li>
+						<li class="readiness-item" data-readiness-item="guide">
+							<div class="readiness-item__header"><strong>Discussion guide</strong> <span class="readiness-item__status">Action needed</span></div>
+							<p class="readiness-item__body">Create or review the discussion guide.</p>
+						</li>
+						<li class="readiness-item" data-readiness-item="consent">
+							<div class="readiness-item__header"><strong>Consent</strong> <span class="readiness-item__status">Action needed</span></div>
+							<p class="readiness-item__body">Confirm consent materials and participant consent.</p>
+						</li>
+						<li class="readiness-item" data-readiness-item="session">
+							<div class="readiness-item__header"><strong>Session workspace</strong> <span class="readiness-item__status">Available</span></div>
+							<p class="readiness-item__body">Open the session workspace when setup is ready.</p>
+						</li>
 					</ul>
-					<p><a id="link-session" href="#" class="btn">Begin session</a></p>
+					<div class="study-readiness-panel__actions">
+						<a id="link-session" href="#" class="btn">Begin session</a>
+					</div>
 				</div>
 			</div>
 		</section>
 
-		<section class="section" aria-labelledby="study-setup-title">
-			<header class="section__header">
+		<section class="section study-section" aria-labelledby="study-setup-title">
+			<header class="section__header study-section__header">
 				<h2 id="study-setup-title" class="section__title govuk-heading-m">Study setup tasks</h2>
 			</header>
-			<nav class="board" aria-label="Study setup tasks">
-				<a id="link-consent-forms" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Create consent forms</strong><br /><span class="study-action__reason">Not connected yet.</span></a>
-				<a id="link-consent-manage" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Manage participant consent</strong><br /><span class="study-action__reason">Not connected yet.</span></a>
-				<a id="link-participants" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Schedule participants</strong><br /><span class="study-action__reason">Requires study context.</span></a>
-				<a id="link-guides" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Create or manage discussion guides</strong><br /><span class="study-action__reason">Requires study context.</span></a>
-				<a id="link-observers" href="#" class="board__item study-action link--disabled" aria-disabled="true" tabindex="-1"><strong>Add note takers and observers</strong><br /><span class="study-action__reason">Not connected yet.</span></a>
-			</nav>
+			<div class="section__body">
+				<ul class="study-task-list">
+					<li class="study-task-card study-task-card--unavailable">
+						<h3 class="study-task-card__title">Create consent forms</h3>
+						<p class="study-task-card__status">Not available yet</p>
+						<p class="study-task-card__body">Consent form generation has not been connected yet.</p>
+					</li>
+					<li class="study-task-card study-task-card--unavailable">
+						<h3 class="study-task-card__title">Manage participant consent</h3>
+						<p class="study-task-card__status">Not available yet</p>
+						<p class="study-task-card__body">Participant consent management has not been connected yet.</p>
+					</li>
+					<li class="study-task-card">
+						<h3 class="study-task-card__title"><a id="link-participants" href="#">Schedule participants</a></h3>
+						<p class="study-task-card__status">Action needed</p>
+						<p class="study-task-card__body">Add or review participants for this study.</p>
+					</li>
+					<li class="study-task-card">
+						<h3 class="study-task-card__title"><a id="link-guides" href="#">Create or manage discussion guides</a></h3>
+						<p class="study-task-card__status">Action needed</p>
+						<p class="study-task-card__body">Create or review the guide before running a session.</p>
+					</li>
+					<li class="study-task-card study-task-card--unavailable">
+						<h3 class="study-task-card__title">Add note takers and observers</h3>
+						<p class="study-task-card__status">Not available yet</p>
+						<p class="study-task-card__body">Observer and note taker setup has not been connected yet.</p>
+					</li>
+				</ul>
+			</div>
 		</section>
 	</main>
 

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -4,6 +4,7 @@ import fs from "node:fs";
 const pageSource = fs.readFileSync("public/pages/study/index.html", "utf8");
 const controllerSource = fs.readFileSync("public/js/study-page.js", "utf8");
 const descControllerSource = fs.readFileSync("public/pages/study/study-desc-controller.js", "utf8");
+const studyCssSource = fs.readFileSync("public/css/study-page.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -14,14 +15,22 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "/js/study-page.js", "study page");
+includes(pageSource, "/css/study-page.css", "study page");
 includes(pageSource, "id=\"study-error\"", "study page");
 includes(pageSource, "role=\"alert\"", "study page");
 includes(pageSource, "Study readiness", "study page");
 includes(pageSource, "Study setup tasks", "study page");
+includes(pageSource, "class=\"study-readiness-list\"", "study page");
+includes(pageSource, "class=\"readiness-item\"", "study page");
+includes(pageSource, "class=\"study-task-list\"", "study page");
+includes(pageSource, "class=\"study-task-card", "study page");
 includes(pageSource, "id=\"link-session\"", "study page");
 includes(pageSource, "id=\"link-guides\"", "study page");
 includes(pageSource, "id=\"link-participants\"", "study page");
 includes(pageSource, "id=\"desc-cancel\"", "study page");
+excludes(pageSource, "class=\"board\"", "study page");
+excludes(pageSource, "board__item study-action", "study page");
+excludes(pageSource, "Requires study context", "study page");
 excludes(pageSource, "alert(\"Could not load study.\")", "study page");
 excludes(pageSource, "<script type=\"module\">", "study page");
 
@@ -42,5 +51,12 @@ includes(controllerSource, "pid", "study page controller");
 includes(controllerSource, "sid", "study page controller");
 includes(controllerSource, "study:desc:save", "study page controller");
 includes(controllerSource, "/api/studies/${encodeURIComponent(studyId)}", "study page controller");
+excludes(controllerSource, "disableLink", "study page controller");
 excludes(controllerSource, "https://rops-api.kevinrapley.workers.dev", "study page controller");
 excludes(controllerSource, "alert(", "study page controller");
+
+includes(studyCssSource, ".study-task-list", "study css");
+includes(studyCssSource, ".study-task-card", "study css");
+includes(studyCssSource, ".study-readiness-list", "study css");
+includes(studyCssSource, ".readiness-item__status", "study css");
+includes(studyCssSource, "/* transparency begins in the cascade */", "study css");


### PR DESCRIPTION
## Summary
- replace the broken study setup tile grid with a study-specific task card pattern
- add `/public/css/study-page.css` for readiness and setup task layout
- keep unavailable actions as non-interactive cards instead of disabled links
- keep active actions as normal links for participants and discussion guides
- restyle readiness items as checklist-style rows with status badges
- remove the misleading “Requires study context” copy
- remove the generic `.board` / `.board__item study-action` pattern from the study page
- update the study page route-state regression test to guard the new layout contract

## Role consultation reflected
- SD: use page-specific layout classes instead of reusing generic board tiles
- UR: make readiness and setup actions easier to scan and act on
- CS: no new client-side trust assumptions; route state remains route state only
- CD: replace “Requires study context” with actionable task copy
- Accessibility: unavailable actions are non-interactive content, not disabled links
- IxD: separate readiness from setup tasks and prevent the compressed table-like layout

## Testing
Not run locally through this connector. Expected CI: `npm run validate`.