### PR TITLE
Build Consent Forms route

### DIFF
--- a/infra/cloudflare/src/core/fields.js
+++ b/infra/cloudflare/src/core/fields.js
@@ -18,6 +18,29 @@ export const GUIDE_FIELD_NAMES = {
 	variables: ["Variables (JSON)", "Variables", "Vars"]
 };
 
+/** Candidate names for the Consent Forms↔Study link field */
+export const CONSENT_FORM_LINK_FIELD_CANDIDATES = [
+	"Study", "Project Study", "Study Link", "Study Record", "Studies", "Project Studies"
+];
+
+/** Candidate names for common fields in the Consent Forms table */
+export const CONSENT_FORM_FIELD_NAMES = {
+	title: ["Title", "Name"],
+	formType: ["Form Type", "Type", "Consent Form Type"],
+	status: ["Status"],
+	version: ["Version", "Revision", "v"],
+	source: ["Source Markdown", "Markdown", "Source"],
+	variables: ["Variables (JSON)", "Variables", "Vars"],
+	consentItems: ["Consent Items (JSON)", "Consent Items", "Statements (JSON)"],
+	summary: ["Plain English Summary", "Summary", "Plain English"],
+	accessibilityNotes: ["Accessibility Notes", "Access Notes", "Reasonable Adjustments"],
+	reviewNotes: ["Review Notes", "Ethics Review Notes", "Notes"],
+	owner: ["Owner", "Created By", "Maintainer"],
+	publishedAt: ["Published At", "Published"],
+	createdAt: ["Created At", "CreatedAt"],
+	updatedAt: ["Updated At", "UpdatedAt"]
+};
+
 /** Participants & Sessions Airtable field names */
 export const PARTICIPANT_FIELDS = {
 	display_name: ["Display Name", "Name", "Participant"],

--- a/infra/cloudflare/src/service/consent-forms.js
+++ b/infra/cloudflare/src/service/consent-forms.js
@@ -1,0 +1,359 @@
+/**
+ * @file consent-forms.js
+ * @module consent-forms
+ * @summary Consent Forms endpoints for ResearchOps Worker (Airtable-backed Markdown + Mustache templates).
+ *
+ * @description
+ * Encapsulates:
+ * - listConsentForms (GET /api/consent-forms?study=...)
+ * - readConsentForm (GET /api/consent-forms/:id)
+ * - createConsentForm (POST /api/consent-forms)
+ * - updateConsentForm (PATCH /api/consent-forms/:id)
+ * - publishConsentForm (POST /api/consent-forms/:id/publish)
+ */
+
+import {
+	fetchWithTimeout,
+	mdToAirtableRich,
+	pickFirstField,
+	safeText,
+	toMs
+} from "../core/utils.js";
+import {
+	CONSENT_FORM_LINK_FIELD_CANDIDATES,
+	CONSENT_FORM_FIELD_NAMES
+} from "../core/fields.js";
+import { airtableTryWrite } from "../core/utils.js";
+import { getRecord } from "./internals/airtable.js";
+
+const DEFAULT_CONSENT_ITEMS = [
+	{
+		id: "participation",
+		label: "I understand what taking part involves and I agree to take part in this research.",
+		required: true
+	},
+	{
+		id: "voluntary",
+		label: "I understand that taking part is voluntary and that I can stop the session at any time.",
+		required: true
+	},
+	{
+		id: "data-use",
+		label: "I understand how my information will be used for this research.",
+		required: true
+	},
+	{
+		id: "recording",
+		label: "I agree to the session being recorded if recording is being used for this study.",
+		required: false
+	}
+];
+
+const DEFAULT_VARIABLES = {
+	studyTitle: "{{studyTitle}}",
+	organisation: "Home Office Biometrics",
+	researcherName: "Researcher name",
+	researcherEmail: "research@example.gov.uk",
+	sessionFormat: "remote research session",
+	recordingSummary: "The session may be audio or video recorded if you agree.",
+	withdrawalPeriod: "14 days after your session"
+};
+
+const DEFAULT_SOURCE_MARKDOWN = `# {{studyTitle}} participant information and consent form
+
+## About this research
+
+We are doing research for {{organisation}}. The session will help us understand how people use or experience this service.
+
+## What taking part involves
+
+You will take part in a {{sessionFormat}} with a researcher. You can choose not to answer any question. You can stop the session at any time.
+
+## Recording and observers
+
+{{recordingSummary}}
+
+## How your information will be used
+
+We will use what we learn to improve the service. Research notes and outputs should not identify you directly.
+
+## Withdrawal
+
+You can ask for your contribution to be withdrawn up to {{withdrawalPeriod}}, where this is possible.
+
+## Consent statements
+
+{{#consentItems}}
+- {{label}}
+{{/consentItems}}
+
+## Contact
+
+If you have questions, contact {{researcherName}} at {{researcherEmail}}.
+`;
+
+function consentFormsTable(svc) {
+	return encodeURIComponent(svc.env.AIRTABLE_TABLE_CONSENT_FORMS || "Consent Forms");
+}
+
+function airtableBase(svc) {
+	return svc.env.AIRTABLE_BASE || svc.env.AIRTABLE_BASE_ID;
+}
+
+function airtableKey(svc) {
+	return svc.env.AIRTABLE_API_KEY || svc.env.AIRTABLE_PAT || svc.env.AIRTABLE_ACCESS_TOKEN;
+}
+
+function atBaseUrl(svc) {
+	return `https://api.airtable.com/v0/${airtableBase(svc)}/${consentFormsTable(svc)}`;
+}
+
+function atHeaders(svc) {
+	return { "Authorization": `Bearer ${airtableKey(svc)}` };
+}
+
+function normaliseStatus(value) {
+	const raw = String(value || "Draft").trim();
+	if (/^draft$/i.test(raw)) return "Draft";
+	if (/^in review$/i.test(raw)) return "In review";
+	if (/^published$/i.test(raw)) return "Published";
+	if (/^archived$/i.test(raw)) return "Archived";
+	return raw || "Draft";
+}
+
+function normaliseFormType(value) {
+	const raw = String(value || "Consent form").trim();
+	if (/^participant information sheet$/i.test(raw)) return "Participant information sheet";
+	if (/^consent form$/i.test(raw)) return "Consent form";
+	if (/^privacy notice$/i.test(raw)) return "Privacy notice";
+	if (/^debrief sheet$/i.test(raw)) return "Debrief sheet";
+	if (/^screening consent$/i.test(raw)) return "Screening consent";
+	if (/^other$/i.test(raw)) return "Other";
+	return raw || "Consent form";
+}
+
+function parseJsonField(value, fallback) {
+	if (value == null || value === "") return fallback;
+	if (typeof value === "object") return value;
+	try {
+		return JSON.parse(String(value));
+	} catch {
+		return fallback;
+	}
+}
+
+function recordToConsentForm(record) {
+	const f = record?.fields || {};
+	const titleKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.title);
+	const formTypeKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.formType);
+	const statusKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.status);
+	const versionKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.version);
+	const sourceKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.source);
+	const variablesKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.variables);
+	const itemsKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.consentItems);
+	const summaryKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.summary);
+	const accessibilityKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.accessibilityNotes);
+	const reviewKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.reviewNotes);
+	const ownerKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.owner);
+	const publishedAtKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.publishedAt);
+	const createdAtKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.createdAt);
+	const updatedAtKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.updatedAt);
+
+	return {
+		id: record.id,
+		title: titleKey ? f[titleKey] : "Untitled consent form",
+		formType: formTypeKey ? f[formTypeKey] : "Consent form",
+		status: statusKey ? f[statusKey] : "Draft",
+		version: versionKey ? f[versionKey] : 1,
+		sourceMarkdown: sourceKey ? (f[sourceKey] || "") : "",
+		variables: parseJsonField(variablesKey ? f[variablesKey] : "{}", {}),
+		consentItems: parseJsonField(itemsKey ? f[itemsKey] : "[]", []),
+		plainEnglishSummary: summaryKey ? (f[summaryKey] || "") : "",
+		accessibilityNotes: accessibilityKey ? (f[accessibilityKey] || "") : "",
+		reviewNotes: reviewKey ? (f[reviewKey] || "") : "",
+		owner: ownerKey ? (f[ownerKey] || "") : "",
+		publishedAt: publishedAtKey ? (f[publishedAtKey] || "") : "",
+		createdAt: createdAtKey ? (f[createdAtKey] || record.createdTime || "") : (record.createdTime || ""),
+		updatedAt: updatedAtKey ? (f[updatedAtKey] || "") : ""
+	};
+}
+
+function fieldsFromPayload(payload, { includeDefaults = false } = {}) {
+	const fields = {};
+	const set = (names, value) => {
+		if (value === undefined || value === null) return;
+		fields[names[0]] = value;
+	};
+
+	set(CONSENT_FORM_FIELD_NAMES.title, String(payload.title || (includeDefaults ? "Participant information and consent form" : "")) || undefined);
+	set(CONSENT_FORM_FIELD_NAMES.formType, normaliseFormType(payload.formType || (includeDefaults ? "Consent form" : undefined)));
+	set(CONSENT_FORM_FIELD_NAMES.status, normaliseStatus(payload.status || (includeDefaults ? "Draft" : undefined)));
+	set(CONSENT_FORM_FIELD_NAMES.version, Number.isFinite(payload.version) ? payload.version : (includeDefaults ? 1 : undefined));
+	set(CONSENT_FORM_FIELD_NAMES.source, typeof payload.sourceMarkdown === "string" ? mdToAirtableRich(payload.sourceMarkdown) : (includeDefaults ? mdToAirtableRich(DEFAULT_SOURCE_MARKDOWN) : undefined));
+	set(CONSENT_FORM_FIELD_NAMES.variables, payload.variables != null ? JSON.stringify(payload.variables) : (includeDefaults ? JSON.stringify(DEFAULT_VARIABLES, null, 2) : undefined));
+	set(CONSENT_FORM_FIELD_NAMES.consentItems, payload.consentItems != null ? JSON.stringify(payload.consentItems) : (includeDefaults ? JSON.stringify(DEFAULT_CONSENT_ITEMS, null, 2) : undefined));
+	set(CONSENT_FORM_FIELD_NAMES.summary, typeof payload.plainEnglishSummary === "string" ? payload.plainEnglishSummary : (includeDefaults ? "Participant-facing consent material for this study." : undefined));
+	set(CONSENT_FORM_FIELD_NAMES.accessibilityNotes, typeof payload.accessibilityNotes === "string" ? payload.accessibilityNotes : undefined);
+	set(CONSENT_FORM_FIELD_NAMES.reviewNotes, typeof payload.reviewNotes === "string" ? payload.reviewNotes : undefined);
+	set(CONSENT_FORM_FIELD_NAMES.owner, typeof payload.owner === "string" ? payload.owner : undefined);
+	set(CONSENT_FORM_FIELD_NAMES.updatedAt, new Date().toISOString());
+	if (includeDefaults) set(CONSENT_FORM_FIELD_NAMES.createdAt, new Date().toISOString());
+	if (payload.publishedAt) set(CONSENT_FORM_FIELD_NAMES.publishedAt, payload.publishedAt);
+
+	return fields;
+}
+
+async function readBody(svc, request) {
+	const body = await request.arrayBuffer();
+	if (body.byteLength > svc.cfg.MAX_BODY_BYTES) {
+		throw Object.assign(new Error("Payload too large"), { status: 413 });
+	}
+	try {
+		return JSON.parse(new TextDecoder().decode(body || new ArrayBuffer(0)) || "{}");
+	} catch {
+		throw Object.assign(new Error("Invalid JSON"), { status: 400 });
+	}
+}
+
+async function getAllRecords(svc) {
+	const records = [];
+	let offset;
+	do {
+		const params = new URLSearchParams({ pageSize: "100" });
+		if (offset) params.set("offset", offset);
+		const resp = await fetchWithTimeout(`${atBaseUrl(svc)}?${params.toString()}`, { headers: atHeaders(svc) }, svc.cfg.TIMEOUT_MS);
+		const txt = await resp.text();
+		if (!resp.ok) {
+			throw Object.assign(new Error(`Airtable ${resp.status}`), { status: resp.status, detail: safeText(txt) });
+		}
+		let js;
+		try { js = JSON.parse(txt); } catch { js = { records: [] }; }
+		records.push(...(js.records || []));
+		offset = js.offset;
+	} while (offset);
+	return records;
+}
+
+export async function listConsentForms(svc, origin, url) {
+	const studyId = url.searchParams.get("study");
+	if (!studyId) return svc.json({ ok: false, error: "Missing study query" }, 400, svc.corsHeaders(origin));
+
+	try {
+		const records = await getAllRecords(svc);
+		const forms = [];
+		for (const record of records) {
+			const f = record.fields || {};
+			const linkKey = pickFirstField(f, CONSENT_FORM_LINK_FIELD_CANDIDATES);
+			const links = linkKey ? f[linkKey] : undefined;
+			if (Array.isArray(links) && links.includes(studyId)) forms.push(recordToConsentForm(record));
+		}
+		forms.sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
+		return svc.json({ ok: true, consentForms: forms }, 200, svc.corsHeaders(origin));
+	} catch (err) {
+		svc.log.error("airtable.consent_forms.list.fail", { status: err.status, detail: err.detail || err.message });
+		return svc.json({ ok: false, error: err.message || "Airtable error", detail: err.detail }, err.status || 500, svc.corsHeaders(origin));
+	}
+}
+
+export async function createConsentForm(svc, request, origin) {
+	let payload;
+	try { payload = await readBody(svc, request); }
+	catch (err) { return svc.json({ ok: false, error: err.message }, err.status || 400, svc.corsHeaders(origin)); }
+
+	if (!payload.study_airtable_id && !payload.studyId) {
+		return svc.json({ ok: false, error: "Missing field: study_airtable_id" }, 400, svc.corsHeaders(origin));
+	}
+
+	const studyId = payload.study_airtable_id || payload.studyId;
+	const atUrl = atBaseUrl(svc);
+	const fieldsTemplate = fieldsFromPayload(payload, { includeDefaults: true });
+	let lastDetail = "";
+
+	for (const linkName of CONSENT_FORM_LINK_FIELD_CANDIDATES) {
+		const fields = { ...fieldsTemplate, [linkName]: [studyId] };
+		let attempt = await airtableTryWrite(atUrl, airtableKey(svc), "POST", fields, svc.cfg.TIMEOUT_MS);
+		if (attempt.ok) {
+			const id = attempt.json.records?.[0]?.id;
+			return svc.json({ ok: true, id }, 200, svc.corsHeaders(origin));
+		}
+		lastDetail = attempt.detail || lastDetail;
+
+		const isSelectErr = attempt.status === 422 && /INVALID_MULTIPLE_CHOICE_OPTIONS/i.test(String(attempt.detail || ""));
+		if (isSelectErr) {
+			const withoutSelects = { ...fields };
+			delete withoutSelects[CONSENT_FORM_FIELD_NAMES.status[0]];
+			delete withoutSelects[CONSENT_FORM_FIELD_NAMES.formType[0]];
+			attempt = await airtableTryWrite(atUrl, airtableKey(svc), "POST", withoutSelects, svc.cfg.TIMEOUT_MS);
+			if (attempt.ok) {
+				const id = attempt.json.records?.[0]?.id;
+				return svc.json({ ok: true, id, select_fallback: "omitted" }, 200, svc.corsHeaders(origin));
+			}
+			lastDetail = attempt.detail || lastDetail;
+		}
+
+		if (!attempt.retry) {
+			return svc.json({ ok: false, error: `Airtable ${attempt.status}`, detail: attempt.detail }, attempt.status || 500, svc.corsHeaders(origin));
+		}
+	}
+
+	return svc.json({ ok: false, error: "Airtable 422", detail: lastDetail || "No matching Consent Forms↔Study link field found." }, 422, svc.corsHeaders(origin));
+}
+
+export async function readConsentForm(svc, origin, formId) {
+	if (!formId) return svc.json({ ok: false, error: "Missing consent form id" }, 400, svc.corsHeaders(origin));
+	try {
+		const record = await getRecord(svc.env, svc.env.AIRTABLE_TABLE_CONSENT_FORMS || "Consent Forms", formId);
+		return svc.json({ ok: true, consentForm: recordToConsentForm(record) }, 200, svc.corsHeaders(origin));
+	} catch (err) {
+		const msg = String(err?.message || "");
+		const isNotFound = /Airtable\s*404/i.test(msg) || /NOT_FOUND/i.test(msg);
+		return svc.json({ ok: false, error: isNotFound ? "Airtable 404" : "Airtable error", detail: msg }, isNotFound ? 404 : 500, svc.corsHeaders(origin));
+	}
+}
+
+export async function updateConsentForm(svc, request, origin, formId) {
+	if (!formId) return svc.json({ ok: false, error: "Missing consent form id" }, 400, svc.corsHeaders(origin));
+	let payload;
+	try { payload = await readBody(svc, request); }
+	catch (err) { return svc.json({ ok: false, error: err.message }, err.status || 400, svc.corsHeaders(origin)); }
+
+	const fields = fieldsFromPayload(payload);
+	if (!Object.keys(fields).length) return svc.json({ ok: false, error: "No updatable fields provided" }, 400, svc.corsHeaders(origin));
+
+	const resp = await fetchWithTimeout(atBaseUrl(svc), {
+		method: "PATCH",
+		headers: { ...atHeaders(svc), "Content-Type": "application/json" },
+		body: JSON.stringify({ records: [{ id: formId, fields }] })
+	}, svc.cfg.TIMEOUT_MS);
+	const text = await resp.text();
+	if (resp.ok) return svc.json({ ok: true }, 200, svc.corsHeaders(origin));
+	return svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(text) }, resp.status, svc.corsHeaders(origin));
+}
+
+export async function publishConsentForm(svc, origin, formId) {
+	if (!formId) return svc.json({ ok: false, error: "Missing consent form id" }, 400, svc.corsHeaders(origin));
+
+	let currentVersion = 0;
+	try {
+		const record = await getRecord(svc.env, svc.env.AIRTABLE_TABLE_CONSENT_FORMS || "Consent Forms", formId);
+		const f = record?.fields || {};
+		const versionKey = pickFirstField(f, CONSENT_FORM_FIELD_NAMES.version);
+		currentVersion = Number.parseInt(f[versionKey], 10) || 0;
+	} catch {}
+
+	const fields = {
+		[CONSENT_FORM_FIELD_NAMES.status[0]]: "Published",
+		[CONSENT_FORM_FIELD_NAMES.version[0]]: currentVersion + 1,
+		[CONSENT_FORM_FIELD_NAMES.publishedAt[0]]: new Date().toISOString(),
+		[CONSENT_FORM_FIELD_NAMES.updatedAt[0]]: new Date().toISOString()
+	};
+
+	const resp = await fetchWithTimeout(atBaseUrl(svc), {
+		method: "PATCH",
+		headers: { ...atHeaders(svc), "Content-Type": "application/json" },
+		body: JSON.stringify({ records: [{ id: formId, fields }] })
+	}, svc.cfg.TIMEOUT_MS);
+	const text = await resp.text();
+	if (resp.ok) return svc.json({ ok: true, version: currentVersion + 1, status: "Published" }, 200, svc.corsHeaders(origin));
+	return svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(text) }, resp.status, svc.corsHeaders(origin));
+}

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -11,6 +11,7 @@ import { json as jsonHelper } from "./internals/responders.js";
 import * as Projects from "./projects.js";
 import * as Studies from "./studies.js";
 import * as Guides from "./guides.js";
+import * as ConsentForms from "./consent-forms.js";
 import * as Participants from "./participants.js";
 import * as Sessions from "./sessions.js";
 import * as Partials from "./partials.js";
@@ -48,6 +49,7 @@ import { recordProvenanceEvent } from "./provenance.js";
  * @property {string} AIRTABLE_TABLE_DETAILS
  * @property {string} AIRTABLE_TABLE_STUDIES
  * @property {string} AIRTABLE_TABLE_GUIDES
+ * @property {string} AIRTABLE_TABLE_CONSENT_FORMS
  * @property {string} AIRTABLE_TABLE_PARTIALS
  * @property {string} AIRTABLE_TABLE_PARTICIPANTS
  * @property {string} AIRTABLE_TABLE_SESSIONS
@@ -181,6 +183,13 @@ export class ResearchOpsService {
 	updateGuide = (req, origin, guideId) => Guides.updateGuide(this, req, origin, guideId);
 	publishGuide = (origin, guideId) => Guides.publishGuide(this, origin, guideId);
 	readGuide = (origin, guideId) => Guides.readGuide(this, origin, guideId);
+
+	/* ─────────────── Consent Forms ─────────────── */
+	listConsentForms = (origin, url) => ConsentForms.listConsentForms(this, origin, url);
+	createConsentForm = (req, origin) => ConsentForms.createConsentForm(this, req, origin);
+	readConsentForm = (origin, formId) => ConsentForms.readConsentForm(this, origin, formId);
+	updateConsentForm = (req, origin, formId) => ConsentForms.updateConsentForm(this, req, origin, formId);
+	publishConsentForm = (origin, formId) => ConsentForms.publishConsentForm(this, origin, formId);
 
 	/* ─────────────── Partials ─────────────── */
 	listPartials = (origin) => Partials.listPartials(this, origin);

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -1,60 +1,33 @@
-/**
- * @file worker.js
- * @summary Cloudflare Worker entrypoint with hard Response guard + uniform CORS.
- * @version 2.2.0
- *
- * - Preserves Response coercion to avoid 1101 errors.
- * - Adds ALLOWED_ORIGINS-based CORS to all responses (success + errors).
- * - Handles OPTIONS preflight centrally.
- * - Routes GET /api/projects through the composed Projects service contract.
- */
-
 import { handleRequest } from "./core/router.js";
 import { ResearchOpsService } from "./service/index.js";
 
-/** Coerce any value to a Response object. */
 function coerceResponse(res) {
   if (res instanceof Response) return res;
-
   if (res === undefined || res === null) {
-    console.error("[worker] Handler returned no response");
     return new Response(JSON.stringify({ error: "Handler returned no response" }), {
       status: 500,
       headers: { "content-type": "application/json; charset=utf-8" }
     });
   }
-
-  if (typeof res === "string" || res instanceof ArrayBuffer || res instanceof Uint8Array) {
-    return new Response(res);
-  }
-
-  return new Response(JSON.stringify(res), {
-    status: 200,
-    headers: { "content-type": "application/json; charset=utf-8" }
-  });
+  if (typeof res === "string" || res instanceof ArrayBuffer || res instanceof Uint8Array) return new Response(res);
+  return new Response(JSON.stringify(res), { status: 200, headers: { "content-type": "application/json; charset=utf-8" } });
 }
 
-/** Resolve an allowed Origin from env.ALLOWED_ORIGINS (array or CSV). */
 function resolveAllowedOrigin(env, request) {
   try {
     const origin = request.headers.get("Origin") || "";
     const raw = env.ALLOWED_ORIGINS;
-    const list = Array.isArray(raw) ? raw : String(raw || "")
-      .split(",")
-      .map(s => s.trim())
-      .filter(Boolean);
-    if (!origin) return "*"; // non-CORS request
+    const list = Array.isArray(raw) ? raw : String(raw || "").split(",").map(s => s.trim()).filter(Boolean);
+    if (!origin) return "*";
     return list.includes(origin) ? origin : "null";
   } catch {
     return "*";
   }
 }
 
-/** Build CORS headers for the current request. */
 function buildCorsHeaders(env, request) {
-  const allowOrigin = resolveAllowedOrigin(env, request);
   return {
-    "Access-Control-Allow-Origin": allowOrigin,
+    "Access-Control-Allow-Origin": resolveAllowedOrigin(env, request),
     "Vary": "Origin",
     "Access-Control-Allow-Methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
     "Access-Control-Allow-Headers": "Authorization, Content-Type",
@@ -62,17 +35,14 @@ function buildCorsHeaders(env, request) {
   };
 }
 
-/** Attach/merge CORS headers onto a Response. */
 function withCORS(env, request, response) {
   try {
-    const cors = buildCorsHeaders(env, request);
     const headers = new Headers(response.headers);
-    for (const [k, v] of Object.entries(cors)) {
-      if (!headers.has(k)) headers.set(k, v);
+    for (const [key, value] of Object.entries(buildCorsHeaders(env, request))) {
+      if (!headers.has(key)) headers.set(key, value);
     }
     return new Response(response.body, { status: response.status, headers });
   } catch {
-    // Fallback: if cloning fails, just return original response.
     return response;
   }
 }
@@ -80,25 +50,39 @@ function withCORS(env, request, response) {
 function normaliseApiPath(pathname) {
   let path = pathname || "/";
   path = path.replace(/\/{2,}/g, "/");
-  if (path.startsWith("/api/") && path.endsWith("/") && path !== "/api/") {
-    path = path.slice(0, -1);
-  }
+  if (path.startsWith("/api/") && path.endsWith("/") && path !== "/api/") path = path.slice(0, -1);
   return path;
 }
 
 function envCompat(env) {
   const allowed = Array.isArray(env.ALLOWED_ORIGINS) ? env.ALLOWED_ORIGINS.join(",") : String(env.ALLOWED_ORIGINS || "");
-  return {
-    ...env,
-    ALLOWED_ORIGINS: allowed
-  };
+  return { ...env, ALLOWED_ORIGINS: allowed };
 }
 
-async function handleCanonicalProjectsRoute(request, env) {
+function serviceFor(env) {
+  return new ResearchOpsService(envCompat(env));
+}
+
+async function handleProjects(request, env) {
   const url = new URL(request.url);
   const origin = request.headers.get("Origin") || "";
-  const service = new ResearchOpsService(envCompat(env));
-  return service.listProjectsFromAirtable(origin, url);
+  return serviceFor(env).listProjectsFromAirtable(origin, url);
+}
+
+async function handleConsentForms(request, env, apiPath) {
+  const url = new URL(request.url);
+  const origin = request.headers.get("Origin") || "";
+  const service = serviceFor(env);
+  if (apiPath === "/api/consent-forms" && request.method === "GET") return service.listConsentForms(origin, url);
+  if (apiPath === "/api/consent-forms" && request.method === "POST") return service.createConsentForm(request, origin);
+  const match = apiPath.match(/^\/api\/consent-forms\/([^/]+)(\/publish)?$/);
+  if (!match) return new Response(JSON.stringify({ error: "Not found", path: apiPath }), { status: 404, headers: { "content-type": "application/json; charset=utf-8" } });
+  const id = decodeURIComponent(match[1]);
+  const publish = match[2] === "/publish";
+  if (request.method === "GET" && !publish) return service.readConsentForm(origin, id);
+  if (request.method === "PATCH" && !publish) return service.updateConsentForm(request, origin, id);
+  if (request.method === "POST" && publish) return service.publishConsentForm(origin, id);
+  return new Response(JSON.stringify({ error: "Method not allowed" }), { status: 405, headers: { "content-type": "application/json; charset=utf-8" } });
 }
 
 export default {
@@ -107,38 +91,19 @@ export default {
     const pathname = new URL(url).pathname;
     const apiPath = normaliseApiPath(pathname);
 
-    // Centralised preflight
-    if (method === "OPTIONS") {
-      return withCORS(env, request, new Response(null, { status: 204 }));
-    }
+    if (method === "OPTIONS") return withCORS(env, request, new Response(null, { status: 204 }));
 
     try {
-      console.log("[worker] Handling:", method, pathname);
-
-      if (method === "GET" && apiPath === "/api/projects") {
-        console.log("[worker] Routing /api/projects through ResearchOpsService");
-        const result = await handleCanonicalProjectsRoute(request, env);
-        const coerced = coerceResponse(result);
-        const finalRes = withCORS(env, request, coerced);
-        console.log("[worker] Response status:", finalRes.status);
-        return finalRes;
-      }
-
-      const result = await handleRequest(request, env, ctx);
-      const coerced = coerceResponse(result);
-      const finalRes = withCORS(env, request, coerced);
-      console.log("[worker] Response status:", finalRes.status);
-      return finalRes;
+      let result;
+      if (method === "GET" && apiPath === "/api/projects") result = await handleProjects(request, env);
+      else if (apiPath === "/api/consent-forms" || apiPath.startsWith("/api/consent-forms/")) result = await handleConsentForms(request, env, apiPath);
+      else result = await handleRequest(request, env, ctx);
+      return withCORS(env, request, coerceResponse(result));
     } catch (e) {
-      console.error("[worker] Unhandled exception:", e);
-      const errRes = new Response(JSON.stringify({
-        error: "Internal error",
-        detail: String(e?.message || e)
-      }), {
+      return withCORS(env, request, new Response(JSON.stringify({ error: "Internal error", detail: String(e?.message || e) }), {
         status: 500,
         headers: { "content-type": "application/json; charset=utf-8" }
-      });
-      return withCORS(env, request, errRes);
+      }));
     }
   }
 };

--- a/public/css/consent-forms.css
+++ b/public/css/consent-forms.css
@@ -1,0 +1,140 @@
+/* ==========================================================================
+   ResearchOps UI • Consent forms
+   Service:    Home Office Biometrics — ResearchOps
+   ========================================================================== */
+
+.consent-layout {
+	display: grid;
+	gap: 20px;
+	grid-template-columns: 1fr;
+	}
+
+.consent-list-panel,
+.consent-editor-panel {
+	padding: 16px;
+	border: 1px solid #b1b4b6;
+	background: #ffffff;
+	}
+
+.consent-form-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	}
+
+.consent-form-list li {
+	margin: 0 0 8px 0;
+	}
+
+.consent-form-list__button {
+	display: block;
+	width: 100%;
+	padding: 12px;
+	border: 1px solid #b1b4b6;
+	background: #ffffff;
+	color: #0b0c0c;
+	text-align: left;
+	cursor: pointer;
+	}
+
+.consent-form-list__button:hover,
+.consent-form-list__button:focus {
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	}
+
+.consent-form-list__button[aria-current="true"] {
+	border-color: #1d70b8;
+	box-shadow: inset 4px 0 0 #1d70b8;
+	}
+
+.consent-form-list__button span {
+	display: block;
+	margin-top: 4px;
+	color: #505a5f;
+	}
+
+.consent-form-list__empty {
+	padding: 12px;
+	border: 1px solid #b1b4b6;
+	background: #f8f8f8;
+	}
+
+.consent-editor-grid {
+	display: grid;
+	gap: 8px;
+	grid-template-columns: 1fr;
+	margin-bottom: 16px;
+	}
+
+.consent-editor-split {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
+	margin-bottom: 16px;
+	}
+
+.consent-editor-split--metadata {
+	margin-top: 16px;
+	}
+
+.consent-source {
+	font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+	}
+
+.consent-preview-wrap {
+	min-height: 320px;
+	}
+
+.consent-preview {
+	min-height: 320px;
+	max-height: 720px;
+	overflow: auto;
+	padding: 16px;
+	border: 1px solid #b1b4b6;
+	background: #f8f8f8;
+	}
+
+.consent-preview h2,
+.consent-preview h3,
+.consent-preview h4,
+.consent-preview p,
+.consent-preview ul {
+	max-width: 42em;
+	}
+
+.consent-details {
+	margin: 0 0 16px 0;
+	padding: 12px;
+	border: 1px solid #b1b4b6;
+	background: #ffffff;
+	}
+
+.consent-details summary {
+	cursor: pointer;
+	font-weight: 700;
+	}
+
+.govuk-error-message {
+	margin: 4px 0 0 0;
+	color: #d4351c;
+	font-weight: 700;
+	}
+
+@media (min-width: 980px) {
+	.consent-layout {
+		grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+		align-items: start;
+		}
+
+	.consent-list-panel {
+		position: sticky;
+		top: 16px;
+		}
+
+	.consent-editor-split {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+		}
+	}
+
+/* transparency begins in the cascade */

--- a/public/js/consent-forms-page.js
+++ b/public/js/consent-forms-page.js
@@ -1,0 +1,443 @@
+/**
+ * @file public/js/consent-forms-page.js
+ * @module consent-forms-page
+ * @summary Study consent form authoring with Markdown, Mustache-style variables and Airtable-backed persistence.
+ */
+
+const API_ORIGIN =
+	document.documentElement?.dataset?.apiOrigin ||
+	window.API_ORIGIN ||
+	window.RESEARCHOPS_API_ORIGIN ||
+	(location.hostname.endsWith("pages.dev") ?
+		"https://rops-api.digikev-kevin-rapley.workers.dev" :
+		location.origin);
+
+const DEFAULT_VARIABLES = {
+	studyTitle: "Study title",
+	organisation: "Home Office Biometrics",
+	researcherName: "Researcher name",
+	researcherEmail: "research@example.gov.uk",
+	sessionFormat: "remote research session",
+	recordingSummary: "The session may be audio or video recorded if you agree.",
+	withdrawalPeriod: "14 days after your session"
+};
+
+const DEFAULT_CONSENT_ITEMS = [
+	{
+		id: "participation",
+		label: "I understand what taking part involves and I agree to take part in this research.",
+		required: true
+	},
+	{
+		id: "voluntary",
+		label: "I understand that taking part is voluntary and that I can stop the session at any time.",
+		required: true
+	},
+	{
+		id: "data-use",
+		label: "I understand how my information will be used for this research.",
+		required: true
+	},
+	{
+		id: "recording",
+		label: "I agree to the session being recorded if recording is being used for this study.",
+		required: false
+	}
+];
+
+const DEFAULT_SOURCE = `# {{studyTitle}} participant information and consent form
+
+## About this research
+
+We are doing research for {{organisation}}. The session will help us understand how people use or experience this service.
+
+## What taking part involves
+
+You will take part in a {{sessionFormat}} with a researcher. You can choose not to answer any question. You can stop the session at any time.
+
+## Recording and observers
+
+{{recordingSummary}}
+
+## How your information will be used
+
+We will use what we learn to improve the service. Research notes and outputs should not identify you directly.
+
+## Withdrawal
+
+You can ask for your contribution to be withdrawn up to {{withdrawalPeriod}}, where this is possible.
+
+## Consent statements
+
+{{#consentItems}}
+- {{label}}
+{{/consentItems}}
+
+## Contact
+
+If you have questions, contact {{researcherName}} at {{researcherEmail}}.
+`;
+
+const state = {
+	pid: "",
+	sid: "",
+	forms: [],
+	selectedId: ""
+};
+
+const $ = (selector, root = document) => root.querySelector(selector);
+
+function apiUrl(path) {
+	const p = String(path || "");
+	return `${API_ORIGIN}${p.startsWith("/") ? p : "/" + p}`;
+}
+
+function route(path, params) {
+	const url = new URL(path, window.location.origin);
+	for (const [key, value] of Object.entries(params)) {
+		if (value) url.searchParams.set(key, value);
+	}
+	return `${url.pathname}${url.search}`;
+}
+
+function setText(selector, value) {
+	const el = $(selector);
+	if (el) el.textContent = value || "";
+}
+
+function showError(message) {
+	const panel = $("#consent-error");
+	const messageEl = $("#consent-error-message");
+	if (!panel || !messageEl) return;
+	panel.hidden = false;
+	panel.removeAttribute("aria-hidden");
+	messageEl.textContent = message;
+	panel.focus();
+}
+
+function hideError() {
+	const panel = $("#consent-error");
+	if (!panel) return;
+	panel.hidden = true;
+	panel.setAttribute("aria-hidden", "true");
+}
+
+function setStatus(message) {
+	setText("#consent-save-status", message);
+}
+
+function clearInlineError(selector) {
+	const el = $(selector);
+	if (!el) return;
+	el.hidden = true;
+	el.textContent = "";
+}
+
+function showInlineError(selector, message) {
+	const el = $(selector);
+	if (!el) return;
+	el.hidden = false;
+	el.textContent = message;
+}
+
+async function jsonFetch(url, options = {}) {
+	const response = await fetch(url, {
+		cache: "no-store",
+		...options,
+		headers: {
+			"content-type": "application/json",
+			...(options.headers || {})
+		}
+	});
+	const text = await response.text();
+	const body = text ? JSON.parse(text) : {};
+	if (!response.ok) throw new Error(body?.detail || body?.error || `Request failed (${response.status})`);
+	return body;
+}
+
+function escapeHtml(value) {
+	return String(value ?? "")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function inlineMarkdown(text) {
+	return escapeHtml(text)
+		.replace(/`([^`]+)`/g, "<code>$1</code>")
+		.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+		.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+}
+
+function renderMarkdown(markdown) {
+	const lines = String(markdown || "").replace(/\r\n?/g, "\n").split("\n");
+	const html = [];
+	let listOpen = false;
+	let paragraph = [];
+
+	const flushParagraph = () => {
+		if (!paragraph.length) return;
+		html.push(`<p>${inlineMarkdown(paragraph.join(" "))}</p>`);
+		paragraph = [];
+	};
+
+	const closeList = () => {
+		if (!listOpen) return;
+		html.push("</ul>");
+		listOpen = false;
+	};
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed) {
+			flushParagraph();
+			closeList();
+			continue;
+		}
+
+		const heading = trimmed.match(/^(#{1,6})\s+(.+)$/);
+		if (heading) {
+			flushParagraph();
+			closeList();
+			const level = Math.min(6, heading[1].length + 1);
+			html.push(`<h${level}>${inlineMarkdown(heading[2])}</h${level}>`);
+			continue;
+		}
+
+		const bullet = trimmed.match(/^[-*]\s+(.+)$/);
+		if (bullet) {
+			flushParagraph();
+			if (!listOpen) {
+				html.push("<ul>");
+				listOpen = true;
+			}
+			html.push(`<li>${inlineMarkdown(bullet[1])}</li>`);
+			continue;
+		}
+
+		paragraph.push(trimmed);
+	}
+
+	flushParagraph();
+	closeList();
+	return html.join("\n");
+}
+
+function parseJson(selector, errorSelector, fallback) {
+	const raw = $(selector)?.value || "";
+	clearInlineError(errorSelector);
+	try {
+		return raw.trim() ? JSON.parse(raw) : fallback;
+	} catch (error) {
+		showInlineError(errorSelector, "Enter valid JSON before saving or previewing.");
+		throw error;
+	}
+}
+
+function lookupValue(context, key) {
+	return key.split(".").reduce((value, part) => {
+		if (value == null) return "";
+		return value[part];
+	}, context);
+}
+
+function renderMustache(template, context) {
+	let output = String(template || "");
+	output = output.replace(/{{#([\w.]+)}}([\s\S]*?){{\/\1}}/g, (_match, key, block) => {
+		const value = lookupValue(context, key);
+		if (!Array.isArray(value)) return "";
+		return value.map(item => renderMustache(block, { ...context, ...item })).join("");
+	});
+	return output.replace(/{{\s*([\w.]+)\s*}}/g, (_match, key) => {
+		const value = lookupValue(context, key.trim());
+		return value == null ? "" : String(value);
+	});
+}
+
+function currentPayload() {
+	const variables = parseJson("#consent-variables", "#consent-variables-error", {});
+	const consentItems = parseJson("#consent-items", "#consent-items-error", []);
+	return {
+		title: $("#consent-title")?.value.trim() || "Participant information and consent form",
+		formType: $("#consent-form-type")?.value || "Consent form",
+		status: $("#consent-status")?.value || "Draft",
+		sourceMarkdown: $("#consent-source")?.value || "",
+		variables,
+		consentItems,
+		plainEnglishSummary: $("#consent-summary")?.value || "",
+		accessibilityNotes: $("#consent-accessibility-notes")?.value || "",
+		reviewNotes: $("#consent-review-notes")?.value || ""
+	};
+}
+
+function renderPreview() {
+	try {
+		const payload = currentPayload();
+		const context = { ...payload.variables, consentItems: payload.consentItems };
+		const rendered = renderMustache(payload.sourceMarkdown, context);
+		const preview = $("#consent-preview");
+		if (preview) preview.innerHTML = renderMarkdown(rendered);
+	} catch {
+		const preview = $("#consent-preview");
+		if (preview) preview.innerHTML = "<p>Preview unavailable until JSON errors are fixed.</p>";
+	}
+}
+
+function defaultDraft() {
+	return {
+		id: "",
+		title: "Participant information and consent form",
+		formType: "Consent form",
+		status: "Draft",
+		version: 1,
+		sourceMarkdown: DEFAULT_SOURCE,
+		variables: DEFAULT_VARIABLES,
+		consentItems: DEFAULT_CONSENT_ITEMS,
+		plainEnglishSummary: "Participant-facing consent material for this study.",
+		accessibilityNotes: "",
+		reviewNotes: ""
+	};
+}
+
+function setEditor(form) {
+	$("#consent-form-id").value = form.id || "";
+	$("#consent-title").value = form.title || "Participant information and consent form";
+	$("#consent-form-type").value = form.formType || "Consent form";
+	$("#consent-status").value = form.status || "Draft";
+	$("#consent-source").value = form.sourceMarkdown || DEFAULT_SOURCE;
+	$("#consent-variables").value = JSON.stringify(form.variables || DEFAULT_VARIABLES, null, 2);
+	$("#consent-items").value = JSON.stringify(form.consentItems || DEFAULT_CONSENT_ITEMS, null, 2);
+	$("#consent-summary").value = form.plainEnglishSummary || "";
+	$("#consent-accessibility-notes").value = form.accessibilityNotes || "";
+	$("#consent-review-notes").value = form.reviewNotes || "";
+	state.selectedId = form.id || "";
+	renderList();
+	renderPreview();
+	setStatus(form.id ? `Editing ${form.title}` : "New draft not saved yet.");
+}
+
+function renderList() {
+	const list = $("#consent-form-list");
+	if (!list) return;
+	list.innerHTML = "";
+
+	if (!state.forms.length) {
+		const li = document.createElement("li");
+		li.className = "consent-form-list__empty";
+		li.textContent = "No consent forms have been saved for this study yet.";
+		list.append(li);
+		setText("#consent-list-status", "No saved consent forms.");
+		return;
+	}
+
+	setText("#consent-list-status", `${state.forms.length} saved consent form${state.forms.length === 1 ? "" : "s"}.`);
+	for (const form of state.forms) {
+		const li = document.createElement("li");
+		const button = document.createElement("button");
+		button.type = "button";
+		button.className = "consent-form-list__button";
+		if (form.id === state.selectedId) button.setAttribute("aria-current", "true");
+		button.innerHTML = `<strong>${escapeHtml(form.title || "Untitled")}</strong><span>${escapeHtml(form.formType || "Consent form")} · ${escapeHtml(form.status || "Draft")}</span>`;
+		button.addEventListener("click", () => setEditor(form));
+		li.append(button);
+		list.append(li);
+	}
+}
+
+async function loadConsentForms() {
+	const url = new URL(apiUrl("/api/consent-forms"));
+	url.searchParams.set("study", state.sid);
+	const body = await jsonFetch(url.toString());
+	state.forms = Array.isArray(body?.consentForms) ? body.consentForms : [];
+	renderList();
+	setEditor(state.forms[0] || defaultDraft());
+}
+
+async function loadStudyContext() {
+	try {
+		const studiesUrl = new URL(apiUrl("/api/studies"));
+		studiesUrl.searchParams.set("project", state.pid);
+		const body = await jsonFetch(studiesUrl.toString());
+		const study = (body.studies || []).find(item => item.id === state.sid);
+		setText("#breadcrumb-study", study?.title || study?.method || "Study");
+	} catch (error) {
+		console.warn("[consent-forms] study context lookup failed", error);
+	}
+}
+
+async function saveForm(event) {
+	event.preventDefault();
+	try {
+		setStatus("Saving…");
+		const id = $("#consent-form-id").value;
+		const payload = { ...currentPayload(), study_airtable_id: state.sid };
+		const body = await jsonFetch(id ? apiUrl(`/api/consent-forms/${encodeURIComponent(id)}`) : apiUrl("/api/consent-forms"), {
+			method: id ? "PATCH" : "POST",
+			body: JSON.stringify(payload)
+		});
+		if (body.id && !id) $("#consent-form-id").value = body.id;
+		setStatus("Saved.");
+		await loadConsentForms();
+		const nextId = body.id || id;
+		const saved = state.forms.find(form => form.id === nextId);
+		if (saved) setEditor(saved);
+	} catch (error) {
+		console.error("[consent-forms] save failed", error);
+		setStatus("Could not save. Check the fields and try again.");
+	}
+}
+
+async function publishForm() {
+	const id = $("#consent-form-id").value;
+	if (!id) {
+		setStatus("Save the draft before publishing.");
+		return;
+	}
+	try {
+		setStatus("Publishing…");
+		await jsonFetch(apiUrl(`/api/consent-forms/${encodeURIComponent(id)}/publish`), { method: "POST" });
+		setStatus("Published.");
+		await loadConsentForms();
+		const published = state.forms.find(form => form.id === id);
+		if (published) setEditor(published);
+	} catch (error) {
+		console.error("[consent-forms] publish failed", error);
+		setStatus("Could not publish. Try again.");
+	}
+}
+
+function bindEvents() {
+	$("#new-consent-form")?.addEventListener("click", () => setEditor(defaultDraft()));
+	$("#consent-form-editor")?.addEventListener("submit", saveForm);
+	$("#publish-consent-form")?.addEventListener("click", publishForm);
+	for (const selector of ["#consent-source", "#consent-variables", "#consent-items"]) {
+		$(selector)?.addEventListener("input", renderPreview);
+	}
+}
+
+async function init() {
+	hideError();
+	const params = new URLSearchParams(window.location.search);
+	state.pid = params.get("pid") || "";
+	state.sid = params.get("sid") || "";
+	if (!state.pid || !state.sid) {
+		showError("The consent forms page needs a project ID and study ID in the URL.");
+		return;
+	}
+
+	$("#back-to-study").href = route("/pages/study/", { pid: state.pid, sid: state.sid });
+	$("#breadcrumb-project").href = route("/pages/project-dashboard/", { id: state.pid });
+	$("#breadcrumb-study").href = route("/pages/study/", { pid: state.pid, sid: state.sid });
+	bindEvents();
+
+	try {
+		await Promise.all([loadStudyContext(), loadConsentForms()]);
+	} catch (error) {
+		console.error("[consent-forms] init failed", error);
+		showError("Could not load consent forms. Check the study link and try again.");
+	}
+}
+
+init();

--- a/public/js/study-page.js
+++ b/public/js/study-page.js
@@ -119,7 +119,7 @@ function renderReadiness(study) {
 	setReadinessItem("status", status ? "Set" : "Needs attention", `Study status is ${status}.`);
 	setReadinessItem("participants", "Action needed", "Add or review participants for this study.");
 	setReadinessItem("guide", "Action needed", "Create or review the discussion guide before running a session.");
-	setReadinessItem("consent", "Action needed", "Confirm consent materials and participant consent.");
+	setReadinessItem("consent", "Action needed", "Create or review consent forms, then confirm participant consent.");
 	setReadinessItem("session", "Available", "Open the session workspace when the study setup is ready.");
 }
 
@@ -127,6 +127,7 @@ function renderRoutes(projectId, studyId) {
 	const params = { pid: projectId, sid: studyId };
 	enableLink("#back-to-project", route("/pages/project-dashboard/", { id: projectId }));
 	enableLink("#breadcrumb-project", route("/pages/project-dashboard/", { id: projectId }));
+	enableLink("#link-consent-forms", route("/pages/study/consent-forms/", params));
 	enableLink("#link-guides", route("/pages/study/guides/", params));
 	enableLink("#link-participants", route("/pages/study/participants/", params));
 	enableLink("#link-session", route("/pages/study/session/", params));

--- a/public/pages/study/consent-forms/index.html
+++ b/public/pages/study/consent-forms/index.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Consent forms — ResearchOps</title>
+
+	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/consent-forms.css" media="screen" />
+
+	<script type="module" src="/components/layout.js"></script>
+	<script type="module" src="/js/consent-forms-page.js" defer></script>
+</head>
+
+<body>
+	<x-include src="/partials/debug-boot.html" debug-only></x-include>
+
+	<x-include src="/partials/header.html" vars='{
+    "active":"Projects",
+    "subtitle":"Consent forms"
+  }'></x-include>
+
+	<main id="main" class="container govuk-body" role="main">
+		<nav class="breadcrumbs" aria-label="Breadcrumb">
+			<ol>
+				<li><a href="/pages/projects/">Projects</a></li>
+				<li><a id="breadcrumb-project" href="#">Project</a></li>
+				<li><a id="breadcrumb-study" href="#">Study</a></li>
+				<li aria-current="page">Consent forms</li>
+			</ol>
+		</nav>
+
+		<div id="consent-error" class="panel" role="alert" tabindex="-1" hidden aria-hidden="true">
+			<h2 class="govuk-heading-s">There is a problem loading consent forms</h2>
+			<p id="consent-error-message" class="govuk-body">Could not load consent forms.</p>
+		</div>
+
+		<div class="actions-bar">
+			<a id="back-to-study" href="/pages/study/" class="btn btn--secondary">← Back to Study</a>
+			<button id="new-consent-form" type="button" class="btn">New consent form</button>
+		</div>
+
+		<header class="dashboard-hero">
+			<p class="project-org">Study materials</p>
+			<h1 class="govuk-heading-l">Consent forms</h1>
+			<p class="govuk-body">Create participant-facing consent materials using Markdown and Mustache variables. Participant consent responses are managed separately.</p>
+		</header>
+
+		<section class="consent-layout" aria-label="Consent form editor">
+			<aside class="consent-list-panel" aria-labelledby="consent-list-title">
+				<h2 id="consent-list-title" class="govuk-heading-m">Forms for this study</h2>
+				<p id="consent-list-status" class="govuk-body-s" aria-live="polite">Loading consent forms.</p>
+				<ul id="consent-form-list" class="consent-form-list"></ul>
+			</aside>
+
+			<section class="consent-editor-panel" aria-labelledby="consent-editor-title">
+				<h2 id="consent-editor-title" class="govuk-heading-m">Editor</h2>
+
+				<form id="consent-form-editor">
+					<input id="consent-form-id" type="hidden" />
+
+					<div class="consent-editor-grid">
+						<label class="govuk-label" for="consent-title">Title</label>
+						<input id="consent-title" class="govuk-input" type="text" autocomplete="off" />
+
+						<label class="govuk-label" for="consent-form-type">Form type</label>
+						<select id="consent-form-type" class="govuk-select">
+							<option>Participant information sheet</option>
+							<option selected>Consent form</option>
+							<option>Privacy notice</option>
+							<option>Debrief sheet</option>
+							<option>Screening consent</option>
+							<option>Other</option>
+						</select>
+
+						<label class="govuk-label" for="consent-status">Status</label>
+						<select id="consent-status" class="govuk-select">
+							<option selected>Draft</option>
+							<option>In review</option>
+							<option>Published</option>
+							<option>Archived</option>
+						</select>
+					</div>
+
+					<div class="consent-editor-split">
+						<div>
+							<label class="govuk-label" for="consent-source">Source Markdown</label>
+							<textarea id="consent-source" class="govuk-textarea consent-source" rows="22" spellcheck="true"></textarea>
+						</div>
+
+						<div class="consent-preview-wrap">
+							<h3 class="govuk-heading-s">Preview</h3>
+							<div id="consent-preview" class="consent-preview" aria-live="polite"></div>
+						</div>
+					</div>
+
+					<details class="consent-details" open>
+						<summary>Variables and consent statements</summary>
+						<div class="consent-editor-split consent-editor-split--metadata">
+							<div>
+								<label class="govuk-label" for="consent-variables">Variables JSON</label>
+								<textarea id="consent-variables" class="govuk-textarea" rows="12" spellcheck="false"></textarea>
+								<p id="consent-variables-error" class="govuk-error-message" hidden></p>
+							</div>
+							<div>
+								<label class="govuk-label" for="consent-items">Consent Items JSON</label>
+								<textarea id="consent-items" class="govuk-textarea" rows="12" spellcheck="false"></textarea>
+								<p id="consent-items-error" class="govuk-error-message" hidden></p>
+							</div>
+						</div>
+					</details>
+
+					<div class="consent-editor-grid">
+						<label class="govuk-label" for="consent-summary">Plain English summary</label>
+						<textarea id="consent-summary" class="govuk-textarea" rows="4"></textarea>
+
+						<label class="govuk-label" for="consent-accessibility-notes">Accessibility notes</label>
+						<textarea id="consent-accessibility-notes" class="govuk-textarea" rows="4"></textarea>
+
+						<label class="govuk-label" for="consent-review-notes">Review notes</label>
+						<textarea id="consent-review-notes" class="govuk-textarea" rows="4"></textarea>
+					</div>
+
+					<div class="actions-bar">
+						<button id="save-consent-form" type="submit" class="btn">Save draft</button>
+						<button id="publish-consent-form" type="button" class="btn btn--secondary">Publish</button>
+						<span id="consent-save-status" class="govuk-body-s" aria-live="polite"></span>
+					</div>
+				</form>
+			</section>
+		</section>
+	</main>
+
+	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
+</body>
+
+</html>

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -119,7 +119,7 @@
 						</li>
 						<li class="readiness-item" data-readiness-item="consent">
 							<div class="readiness-item__header"><strong>Consent</strong> <span class="readiness-item__status">Action needed</span></div>
-							<p class="readiness-item__body">Confirm consent materials and participant consent.</p>
+							<p class="readiness-item__body">Create or review consent forms, then confirm participant consent.</p>
 						</li>
 						<li class="readiness-item" data-readiness-item="session">
 							<div class="readiness-item__header"><strong>Session workspace</strong> <span class="readiness-item__status">Available</span></div>
@@ -139,10 +139,10 @@
 			</header>
 			<div class="section__body">
 				<ul class="study-task-list">
-					<li class="study-task-card study-task-card--unavailable">
-						<h3 class="study-task-card__title">Create consent forms</h3>
-						<p class="study-task-card__status">Not available yet</p>
-						<p class="study-task-card__body">Consent form generation has not been connected yet.</p>
+					<li class="study-task-card">
+						<h3 class="study-task-card__title"><a id="link-consent-forms" href="#">Create consent forms</a></h3>
+						<p class="study-task-card__status">Action needed</p>
+						<p class="study-task-card__body">Create or review Markdown and Mustache consent form templates for this study.</p>
 					</li>
 					<li class="study-task-card study-task-card--unavailable">
 						<h3 class="study-task-card__title">Manage participant consent</h3>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -40,6 +40,7 @@ require_file "tests/journal-tabs-resilience-route-state.test.js"
 require_file "tests/journal-secondary-actions-route-state.test.js"
 require_file "tests/mural-journal-sync-route-state.test.js"
 require_file "tests/study-page-route-state.test.js"
+require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -165,5 +166,8 @@ node tests/mural-journal-sync-route-state.test.js
 
 info "checking Study page route-state contract"
 node tests/study-page-route-state.test.js
+
+info "checking Consent Forms route-state contract"
+node tests/consent-forms-route-state.test.js
 
 info "validation passed"

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -36,7 +36,7 @@ includes(consentPageSource, "id=\"consent-source\"", "consent forms page");
 includes(consentPageSource, "id=\"consent-preview\"", "consent forms page");
 includes(consentPageSource, "id=\"consent-variables\"", "consent forms page");
 includes(consentPageSource, "id=\"consent-items\"", "consent forms page");
-includes(consentPageSource, "participant consent responses are managed separately", "consent forms page");
+includes(consentPageSource, "Participant consent responses are managed separately", "consent forms page");
 
 includes(consentControllerSource, "const API_ORIGIN", "consent forms controller");
 includes(consentControllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "consent forms controller");

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -68,7 +68,6 @@ includes(serviceSource, "export async function publishConsentForm", "consent for
 includes(serviceSource, "AIRTABLE_TABLE_CONSENT_FORMS", "consent forms service");
 includes(serviceSource, "CONSENT_FORM_LINK_FIELD_CANDIDATES", "consent forms service");
 includes(serviceSource, "CONSENT_FORM_FIELD_NAMES", "consent forms service");
-includes(serviceSource, "Consent Items (JSON)", "consent forms service");
 
 includes(serviceIndexSource, "./consent-forms.js", "service index");
 includes(serviceIndexSource, "listConsentForms", "service index");
@@ -76,3 +75,4 @@ includes(serviceIndexSource, "publishConsentForm", "service index");
 
 includes(fieldsSource, "CONSENT_FORM_LINK_FIELD_CANDIDATES", "fields");
 includes(fieldsSource, "CONSENT_FORM_FIELD_NAMES", "fields");
+includes(fieldsSource, "Consent Items (JSON)", "fields");

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const studyPageSource = fs.readFileSync("public/pages/study/index.html", "utf8");
+const studyControllerSource = fs.readFileSync("public/js/study-page.js", "utf8");
+const consentPageSource = fs.readFileSync("public/pages/study/consent-forms/index.html", "utf8");
+const consentControllerSource = fs.readFileSync("public/js/consent-forms-page.js", "utf8");
+const consentCssSource = fs.readFileSync("public/css/consent-forms.css", "utf8");
+const workerSource = fs.readFileSync("infra/cloudflare/src/worker.js", "utf8");
+const serviceSource = fs.readFileSync("infra/cloudflare/src/service/consent-forms.js", "utf8");
+const serviceIndexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
+const fieldsSource = fs.readFileSync("infra/cloudflare/src/core/fields.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(studyPageSource, "id=\"link-consent-forms\"", "study page");
+includes(studyPageSource, "Create consent forms", "study page");
+includes(studyPageSource, "Markdown and Mustache", "study page");
+includes(studyControllerSource, "#link-consent-forms", "study page controller");
+includes(studyControllerSource, "route(\"/pages/study/consent-forms/\", params)", "study page controller");
+
+includes(consentPageSource, "/js/consent-forms-page.js", "consent forms page");
+includes(consentPageSource, "/css/consent-forms.css", "consent forms page");
+includes(consentPageSource, "id=\"consent-error\"", "consent forms page");
+includes(consentPageSource, "role=\"alert\"", "consent forms page");
+includes(consentPageSource, "id=\"new-consent-form\"", "consent forms page");
+includes(consentPageSource, "id=\"consent-form-list\"", "consent forms page");
+includes(consentPageSource, "id=\"consent-form-editor\"", "consent forms page");
+includes(consentPageSource, "id=\"consent-source\"", "consent forms page");
+includes(consentPageSource, "id=\"consent-preview\"", "consent forms page");
+includes(consentPageSource, "id=\"consent-variables\"", "consent forms page");
+includes(consentPageSource, "id=\"consent-items\"", "consent forms page");
+includes(consentPageSource, "participant consent responses are managed separately", "consent forms page");
+
+includes(consentControllerSource, "const API_ORIGIN", "consent forms controller");
+includes(consentControllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "consent forms controller");
+includes(consentControllerSource, "function renderMustache", "consent forms controller");
+includes(consentControllerSource, "function renderMarkdown", "consent forms controller");
+includes(consentControllerSource, "consentItems", "consent forms controller");
+includes(consentControllerSource, "study_airtable_id", "consent forms controller");
+includes(consentControllerSource, "apiUrl(\"/api/consent-forms\")", "consent forms controller");
+includes(consentControllerSource, "/api/consent-forms/${encodeURIComponent(id)}/publish", "consent forms controller");
+includes(consentControllerSource, "Enter valid JSON", "consent forms controller");
+excludes(consentControllerSource, "alert(", "consent forms controller");
+
+includes(consentCssSource, ".consent-layout", "consent forms css");
+includes(consentCssSource, ".consent-form-list__button", "consent forms css");
+includes(consentCssSource, ".consent-preview", "consent forms css");
+includes(consentCssSource, "/* transparency begins in the cascade */", "consent forms css");
+
+includes(workerSource, "handleConsentForms", "worker");
+includes(workerSource, "/api/consent-forms", "worker");
+includes(workerSource, "service.listConsentForms", "worker");
+includes(workerSource, "service.createConsentForm", "worker");
+includes(workerSource, "service.publishConsentForm", "worker");
+
+includes(serviceSource, "export async function listConsentForms", "consent forms service");
+includes(serviceSource, "export async function createConsentForm", "consent forms service");
+includes(serviceSource, "export async function readConsentForm", "consent forms service");
+includes(serviceSource, "export async function updateConsentForm", "consent forms service");
+includes(serviceSource, "export async function publishConsentForm", "consent forms service");
+includes(serviceSource, "AIRTABLE_TABLE_CONSENT_FORMS", "consent forms service");
+includes(serviceSource, "CONSENT_FORM_LINK_FIELD_CANDIDATES", "consent forms service");
+includes(serviceSource, "CONSENT_FORM_FIELD_NAMES", "consent forms service");
+includes(serviceSource, "Consent Items (JSON)", "consent forms service");
+
+includes(serviceIndexSource, "./consent-forms.js", "service index");
+includes(serviceIndexSource, "listConsentForms", "service index");
+includes(serviceIndexSource, "publishConsentForm", "service index");
+
+includes(fieldsSource, "CONSENT_FORM_LINK_FIELD_CANDIDATES", "fields");
+includes(fieldsSource, "CONSENT_FORM_FIELD_NAMES", "fields");

--- a/tmp-consent-route-note.txt
+++ b/tmp-consent-route-note.txt
@@ -1,1 +1,0 @@
-Consent Forms route note

--- a/tmp-consent-route-note.txt
+++ b/tmp-consent-route-note.txt
@@ -1,0 +1,1 @@
+Consent Forms route note


### PR DESCRIPTION
## Summary
- build the Study > Create consent forms route at `/pages/study/consent-forms/?pid=<projectId>&sid=<studyId>`
- wire the Study page task card to the new route while preserving `pid` and `sid`
- add a consent forms authoring UI with Markdown source, Mustache-style variables, consent item JSON, live preview, save, and publish actions
- add `/api/consent-forms` Worker handling for list, create, read, update, and publish
- add an Airtable-backed Consent Forms service using the new `Consent Forms` table
- add flexible Airtable field candidates for Consent Forms
- add route-state and implementation regression coverage

## Airtable context
The Airtable table has already been created in the ResearchOps base:

- table: `Consent Forms`
- table ID: `tblmVEkrazgR3wWAN`

The service falls back to `Consent Forms`, but production should ideally set:

`AIRTABLE_TABLE_CONSENT_FORMS=Consent Forms`

## Scope boundary
This route manages study-level consent materials and templates only. It does not yet manage participant-level consent responses. That remains the separate Manage participant consent workflow.

## Testing
Not run locally through this connector. Expected CI: `npm run validate`.