### PR TITLE
Extract Guides page context module

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -100,6 +100,29 @@ Why this helps:
 - It makes the intended non-blocking behaviour explicit.
 - It aligns shared entry points with the Projects page pattern.
 
+## Follow-up changes completed after the initial audit
+
+### Performance inventory tooling
+
+`npm run audit:performance` and `npm run audit:performance:write` now provide a repeatable inventory for large files, inline scripts, rough gzip estimates, and possible unused CSS selector tokens.
+
+Why this helps:
+
+- Future route extraction and CSS splitting work can be based on measured file and script weight.
+- CSS review starts from an evidence queue rather than manual guessing.
+
+### Discussion Guides context extraction
+
+The Discussion Guides route no longer carries its page-context bootstrap inline in `public/pages/study/guides/index.html`.
+
+That code now lives in `public/js/study-guides-context.js` and is loaded with `rel="modulepreload"`.
+
+Why this helps:
+
+- The Guides HTML document is smaller and easier to review.
+- The page-context bootstrap becomes independently cacheable.
+- A route-state test now prevents the page from regressing to inline module scripts.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
@@ -132,38 +155,31 @@ The codebase still contains other pages with large inline module scripts.
 The highest-priority follow-up candidates are:
 
 1. `public/pages/project-dashboard/index.html`
-2. `public/pages/study/index.html`
-3. `public/pages/study/guides/index.html`
-4. `public/pages/study/session/index.html`
-5. `public/pages/projects/journals/index.html`
+2. `public/pages/study/session/index.html`
+3. `public/pages/projects/journals/index.html`
 
-Those should be extracted into route-specific modules in separate PRs. The dashboard page is large enough that a careful extraction should be treated as its own behavioural refactor, with route-state tests attached.
+The Study route and Discussion Guides route now use external route modules.
+
+The dashboard page is large enough that a careful extraction should be treated as its own behavioural refactor, with route-state tests attached.
 
 ## Validation checklist
 
-Before merging this branch:
+Before merging performance branches:
 
 - Run `npm run validate`.
 - Run `npm run lint`.
-- Open `/pages/projects/` and confirm the list loads from Airtable.
-- Temporarily fail `/api/projects` and confirm the CSV fallback still renders.
-- Open the browser network panel and verify repeat navigation uses cached `/components/layout.js`, `/partials/header.html`, `/partials/footer.html`, `/css/*`, and `/js/projects-page.js` where appropriate.
+- Open the changed route and confirm its visible state still loads correctly.
+- Open the browser network panel and verify external route modules are loaded and cached where appropriate.
 
 ## PR recommendation
 
-This branch is now suitable for a normal pull request focused on first-pass initial-load improvements.
+Performance PRs should stay route-scoped where possible.
 
-The PR should not claim to complete full CSS splitting or complete inline-script extraction across the entire application.
+The PR should not claim to complete full CSS splitting or complete inline-script extraction across the entire application unless every affected route has validation coverage.
 
-Suggested PR title:
+Suggested PR summary pattern:
 
-`Improve initial page load performance`
-
-Suggested PR summary:
-
-- Extract Projects page JavaScript into a cacheable module.
-- Add module preload for the Projects route.
-- Add Cloudflare Pages cache headers for static assets and partials.
-- Improve include caching and avoid unnecessary script re-execution.
-- Defer shared layout module loading on common entry points.
-- Document remaining CSS and inline-script follow-up work.
+- Extract one route script into a cacheable module.
+- Add module preload for the changed route.
+- Add or update route-state tests.
+- Document remaining route and CSS follow-up work.

--- a/public/js/study-guides-context.js
+++ b/public/js/study-guides-context.js
@@ -1,0 +1,85 @@
+/**
+ * @file public/js/study-guides-context.js
+ * @module StudyGuidesContext
+ * @summary Loads project and study context for the Discussion Guides page.
+ */
+
+const $ = (selector, root = document) => root.querySelector(selector);
+
+function fallbackTitle(study = {}) {
+  const method = (study.method || "Study").trim();
+  const date = study.createdAt ? new Date(study.createdAt) : new Date();
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${method} — ${year}-${month}-${day}`;
+}
+
+function pickTitle(study = {}) {
+  return (study.title || study.Title || "").trim() || fallbackTitle(study);
+}
+
+async function loadStudies(projectId) {
+  const url = `/api/studies?project=${encodeURIComponent(projectId)}`;
+  const response = await fetch(url, { cache: "no-store" });
+  const data = await response.json().catch(() => ({}));
+
+  if (!response.ok || data?.ok !== true || !Array.isArray(data.studies)) {
+    throw new Error(data?.error || `Studies fetch failed (${response.status})`);
+  }
+
+  return data.studies;
+}
+
+async function loadProject(projectId) {
+  const response = await fetch(`/api/projects/${encodeURIComponent(projectId)}`, {
+    cache: "no-store"
+  });
+
+  if (!response.ok) return {};
+  return response.json().catch(() => ({}));
+}
+
+function bindContext({ projectId, studyId, project, study }) {
+  const projectBreadcrumb = $("#breadcrumb-project");
+  const studyBreadcrumb = $("#breadcrumb-study");
+  const studyTitle = $("#study-title");
+  const backToStudy = $("#back-to-study");
+
+  if (projectBreadcrumb) {
+    projectBreadcrumb.href = `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
+    projectBreadcrumb.textContent = project?.name || "Project";
+  }
+
+  if (studyBreadcrumb) {
+    studyBreadcrumb.href = `/pages/study/?pid=${encodeURIComponent(projectId)}&sid=${encodeURIComponent(studyId)}`;
+    studyBreadcrumb.textContent = pickTitle(study);
+  }
+
+  if (studyTitle) studyTitle.textContent = pickTitle(study);
+  if (backToStudy) backToStudy.href = `/pages/study/?pid=${encodeURIComponent(projectId)}&sid=${encodeURIComponent(studyId)}`;
+
+  window.__guideCtx = { project, study };
+}
+
+async function init() {
+  try {
+    const params = new URLSearchParams(location.search);
+    const projectId = params.get("pid") || "";
+    const studyId = params.get("sid") || "";
+
+    if (!projectId || !studyId) throw new Error("Missing pid or sid in URL");
+
+    const [project, studies] = await Promise.all([loadProject(projectId), loadStudies(projectId)]);
+    const study = studies.find((candidate) => candidate.id === studyId) || {};
+
+    bindContext({ projectId, studyId, project, study });
+  } catch (error) {
+    console.error("[guides] init error:", error);
+    alert("Could not load study or project context.");
+  }
+}
+
+init();
+
+export { fallbackTitle, pickTitle };

--- a/public/pages/study/guides/index.html
+++ b/public/pages/study/guides/index.html
@@ -11,12 +11,15 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	
+
 	<!-- Page styles -->
 	<link rel="stylesheet" href="/css/guides.css" media="screen" />
 
+	<link rel="modulepreload" href="/js/study-guides-context.js" />
+
 	<!-- Components/layout first -->
-	<script type="module" src="/components/layout.js"></script>
+	<script type="module" src="/components/layout.js" defer></script>
+	<script type="module" src="/js/study-guides-context.js" defer></script>
 	<script type="module" src="/components/guides/guides-page.js" defer></script>
 </head>
 
@@ -178,74 +181,6 @@
 	</main>
 
 	<x-include src="/partials/footer.html"></x-include>
-
-	<script type="module">
-		/**
-		 * @file /pages/study/guides/index.html
-		 * @module GuidesPage
-		 * @summary Fetches project + study data, ensuring a valid title is always shown.
-		 * @description
-		 * - Title uses `study.title || study.Title || Method — YYYY-MM-DD`.
-		 * - Binds study name into breadcrumb and header subtitle.
-		 * - Routes “Back to Study” to `/pages/study/?pid=…&sid=…`.
-		 * - Exposes context for /components/guides/guides-page.js.
-		 */
-
-		const $ = (s, r = document) => r.querySelector(s);
-
-		function fallbackTitle(s = {}) {
-			const method = (s.method || "Study").trim();
-			const d = s.createdAt ? new Date(s.createdAt) : new Date();
-			const yyyy = d.getUTCFullYear();
-			const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-			const dd = String(d.getUTCDate()).padStart(2, "0");
-			return `${method} — ${yyyy}-${mm}-${dd}`;
-		}
-
-		function pickTitle(s = {}) {
-			return (s.title || s.Title || "").trim() || fallbackTitle(s);
-		}
-
-		async function loadStudies(projectId) {
-			const url = `/api/studies?project=${encodeURIComponent(projectId)}`;
-			const res = await fetch(url, { cache: "no-store" });
-			const js = await res.json().catch(() => ({}));
-			if (!res.ok || js?.ok !== true || !Array.isArray(js.studies)) {
-				throw new Error(js?.error || `Studies fetch failed (${res.status})`);
-			}
-			return js.studies;
-		}
-
-		/* ── Bootstrap ───────────────────────────────────────────────────── */
-		(async function init() {
-			try {
-				const usp = new URLSearchParams(location.search);
-				const pid = usp.get("pid") || "";
-				const sid = usp.get("sid") || "";
-				if (!pid || !sid) throw new Error("Missing pid or sid in URL");
-
-				const [projRes, studies] = await Promise.all([
-					fetch(`/api/projects/${encodeURIComponent(pid)}`, { cache: "no-store" }),
-					loadStudies(pid)
-				]);
-				const project = projRes.ok ? await projRes.json() : {};
-				const study = studies.find(s => s.id === sid) || {};
-
-				$("#breadcrumb-project").href = `/pages/project-dashboard/?id=${encodeURIComponent(pid)}`;
-				$("#breadcrumb-project").textContent = project?.name || "Project";
-				$("#breadcrumb-study").href = `/pages/study/?pid=${encodeURIComponent(pid)}&sid=${encodeURIComponent(sid)}`;
-				$("#breadcrumb-study").textContent = pickTitle(study);
-
-				$("#study-title").textContent = pickTitle(study);
-				$("#back-to-study").href = `/pages/study/?pid=${encodeURIComponent(pid)}&sid=${encodeURIComponent(sid)}`;
-
-				window.__guideCtx = { project, study };
-			} catch (err) {
-				console.error("[guides] init error:", err);
-				alert("Could not load study or project context.");
-			}
-		})();
-	</script>
 </body>
 
 </html>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -44,6 +44,7 @@ require_file "tests/journal-tabs-resilience-route-state.test.js"
 require_file "tests/journal-secondary-actions-route-state.test.js"
 require_file "tests/mural-journal-sync-route-state.test.js"
 require_file "tests/study-page-route-state.test.js"
+require_file "tests/study-guides-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
@@ -181,6 +182,9 @@ node tests/mural-journal-sync-route-state.test.js
 
 info "checking Study page route-state contract"
 node tests/study-page-route-state.test.js
+
+info "checking Study guides route-state contract"
+node tests/study-guides-route-state.test.js
 
 info "checking Consent Forms route-state contract"
 node tests/consent-forms-route-state.test.js

--- a/tests/study-guides-route-state.test.js
+++ b/tests/study-guides-route-state.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/study/guides/index.html", "utf8");
+const contextSource = fs.readFileSync("public/js/study-guides-context.js", "utf8");
+const guidesPageSource = fs.readFileSync("public/components/guides/guides-page.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "/js/study-guides-context.js", "study guides page");
+includes(pageSource, "rel=\"modulepreload\" href=\"/js/study-guides-context.js\"", "study guides page");
+includes(pageSource, "/components/guides/guides-page.js", "study guides page");
+includes(pageSource, "id=\"guides-tbody\"", "study guides page");
+includes(pageSource, "id=\"editor-section\"", "study guides page");
+includes(pageSource, "id=\"drawer-patterns\"", "study guides page");
+includes(pageSource, "id=\"drawer-variables\"", "study guides page");
+includes(pageSource, "id=\"back-to-study\"", "study guides page");
+excludes(pageSource, "<script type=\"module\">", "study guides page");
+
+includes(contextSource, "function fallbackTitle", "study guides context module");
+includes(contextSource, "function pickTitle", "study guides context module");
+includes(contextSource, "async function loadStudies", "study guides context module");
+includes(contextSource, "async function loadProject", "study guides context module");
+includes(contextSource, "function bindContext", "study guides context module");
+includes(contextSource, "window.__guideCtx", "study guides context module");
+includes(contextSource, "Missing pid or sid in URL", "study guides context module");
+includes(contextSource, "export { fallbackTitle, pickTitle };", "study guides context module");
+
+includes(guidesPageSource, "hydrateCrumbs", "guides component module");
+includes(guidesPageSource, "loadGuides", "guides component module");


### PR DESCRIPTION
## Summary

Extracts the Discussion Guides page context bootstrap from inline HTML into a cacheable route module.

## Changes

- Add `public/js/study-guides-context.js`.
- Load the new module from `public/pages/study/guides/index.html`.
- Add `rel="modulepreload"` for the Guides context module.
- Remove the inline `type="module"` bootstrap script from the Guides page.
- Add `tests/study-guides-route-state.test.js` to prevent inline module regression.
- Wire the new route-state test into `scripts/validate.sh`.
- Update the performance audit follow-up status.

## Why

The initial-load audit identified route inline scripts as a follow-up performance issue. This keeps the behavioural change route-scoped and makes the Guides page context bootstrap independently cacheable.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/study/guides/?pid=<project-id>&sid=<study-id>`.
- Confirm project and study breadcrumbs hydrate correctly.
- Confirm the Guides table still loads.
- Confirm the Back to Study link points to `/pages/study/?pid=...&sid=...`.