### PR TITLE
Preload Session and Journals route modules

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -123,6 +123,29 @@ Why this helps:
 - The page-context bootstrap becomes independently cacheable.
 - A route-state test now prevents the page from regressing to inline module scripts.
 
+### Project Dashboard route extraction
+
+Project Dashboard inline module has been extracted to:
+`public/js/project-dashboard.js`
+
+Why this helps:
+
+- The dashboard HTML document is smaller.
+- The dashboard route behaviour is independently cacheable.
+- A route-state test prevents the page from regressing to inline module scripts.
+
+### Study Session and Journals module preload coverage
+
+The Study Session and Journals routes already use external route modules.
+
+They now include `rel="modulepreload"` hints for their route controllers, and route-state tests enforce that these modules remain external and discoverable.
+
+Why this helps:
+
+- The browser can discover key route modules earlier.
+- The routes align with the loading pattern used by Projects, Project Dashboard, and Guides.
+- Validation now covers Session and Journals module loading contracts.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
@@ -150,17 +173,14 @@ Recommended next step:
 
 ## Known remaining work
 
-The codebase still contains other pages with large inline module scripts.
+The highest-value remaining work is now CSS splitting and route-specific CSS coverage.
 
-The highest-priority follow-up candidates are:
+Recommended next slices:
 
-1. `public/pages/study/session/index.html`
-2. `public/pages/projects/journals/index.html`
-
-The Study route and Discussion Guides route now use external route modules.
-
-Project Dashboard inline module has been extracted to:
-`public/js/project-dashboard.js`
+1. Use `npm run audit:performance:write` to generate the latest inventory.
+2. Start page-level CSS splitting with the highest-traffic covered routes: Projects, Project Dashboard, Study, and Guides.
+3. Keep `screen.css` as the base layer until each route has browser and route-state coverage.
+4. Continue extracting smaller legacy inline module pages, such as Search, Notes, Consent, Sessions, and Synthesize, in separate route-scoped PRs.
 
 ## Validation checklist
 

--- a/public/pages/projects/journals/index.html
+++ b/public/pages/projects/journals/index.html
@@ -19,6 +19,10 @@
 	<link rel="stylesheet" href="/css/journals.css?v=1.0.1" media="screen" />
 	<link rel="stylesheet" href="/css/journal-mural-sync.css" media="screen" />
 
+	<link rel="modulepreload" href="/js/journal-tabs.js" />
+	<link rel="modulepreload" href="/js/journal-mural-sync-compact.js" />
+	<link rel="modulepreload" href="/components/journal-excerpts.js" />
+
 	<!-- Components/layout first -->
 	<script type="module" src="/components/layout.js" defer></script>
 </head>

--- a/public/pages/study/session/index.html
+++ b/public/pages/study/session/index.html
@@ -18,7 +18,9 @@
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/session.css" media="screen" />
 
-	<script type="module" src="/components/layout.js"></script>
+	<link rel="modulepreload" href="/components/session-controller.js" />
+
+	<script type="module" src="/components/layout.js" defer></script>
 	<script type="module" src="/components/session-controller.js" defer></script>
 </head>
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -39,6 +39,7 @@ require_file "tests/projects-route-contract.test.js"
 require_file "tests/project-dashboard-route-state.test.js"
 require_file "tests/mural-ui-route-state.test.js"
 require_file "tests/journals-project-route-contract.test.js"
+require_file "tests/journals-route-state.test.js"
 require_file "tests/journal-tabs-api-origin-route-state.test.js"
 require_file "tests/journal-tabs-filter-state-route-state.test.js"
 require_file "tests/journal-tabs-resilience-route-state.test.js"
@@ -46,6 +47,7 @@ require_file "tests/journal-secondary-actions-route-state.test.js"
 require_file "tests/mural-journal-sync-route-state.test.js"
 require_file "tests/study-page-route-state.test.js"
 require_file "tests/study-guides-route-state.test.js"
+require_file "tests/study-session-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
@@ -169,6 +171,9 @@ node tests/mural-ui-route-state.test.js
 info "checking Journals project route contract"
 node tests/journals-project-route-contract.test.js
 
+info "checking Journals route-state contract"
+node tests/journals-route-state.test.js
+
 info "checking Journal tabs API origin route-state contract"
 node tests/journal-tabs-api-origin-route-state.test.js
 
@@ -189,6 +194,9 @@ node tests/study-page-route-state.test.js
 
 info "checking Study guides route-state contract"
 node tests/study-guides-route-state.test.js
+
+info "checking Study session route-state contract"
+node tests/study-session-route-state.test.js
 
 info "checking Consent Forms route-state contract"
 node tests/consent-forms-route-state.test.js

--- a/tests/journals-route-state.test.js
+++ b/tests/journals-route-state.test.js
@@ -27,6 +27,10 @@ includes(pageSource, "id=\"analysis\"", "journals page");
 includes(pageSource, "id=\"coding-panel\"", "journals page");
 excludes(pageSource, "<script type=\"module\">", "journals page");
 
-includes(tabsSource, "journal", "journal tabs module");
+includes(tabsSource, "tab:shown", "journal tabs module");
 includes(muralSyncSource, "mural", "journal mural sync module");
-includes(excerptsSource, "customElements", "journal excerpts module");
+includes(excerptsSource, "function renderEntries", "journal excerpts module");
+includes(excerptsSource, "function loadEntries", "journal excerpts module");
+includes(excerptsSource, "/api/journal-entries", "journal excerpts module");
+includes(excerptsSource, "journal:entry:delete", "journal excerpts module");
+includes(excerptsSource, "document.addEventListener(\"DOMContentLoaded\", setup)", "journal excerpts module");

--- a/tests/journals-route-state.test.js
+++ b/tests/journals-route-state.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/projects/journals/index.html", "utf8");
+const tabsSource = fs.readFileSync("public/js/journal-tabs.js", "utf8");
+const muralSyncSource = fs.readFileSync("public/js/journal-mural-sync-compact.js", "utf8");
+const excerptsSource = fs.readFileSync("public/components/journal-excerpts.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "rel=\"modulepreload\" href=\"/js/journal-tabs.js\"", "journals page");
+includes(pageSource, "rel=\"modulepreload\" href=\"/js/journal-mural-sync-compact.js\"", "journals page");
+includes(pageSource, "rel=\"modulepreload\" href=\"/components/journal-excerpts.js\"", "journals page");
+includes(pageSource, "src=\"/js/journal-tabs.js\"", "journals page");
+includes(pageSource, "src=\"/js/journal-mural-sync-compact.js\"", "journals page");
+includes(pageSource, "src=\"/components/journal-excerpts.js\"", "journals page");
+includes(pageSource, "id=\"journal-entries\"", "journals page");
+includes(pageSource, "id=\"codes\"", "journals page");
+includes(pageSource, "id=\"memos\"", "journals page");
+includes(pageSource, "id=\"analysis\"", "journals page");
+includes(pageSource, "id=\"coding-panel\"", "journals page");
+excludes(pageSource, "<script type=\"module\">", "journals page");
+
+includes(tabsSource, "journal", "journal tabs module");
+includes(muralSyncSource, "mural", "journal mural sync module");
+includes(excerptsSource, "customElements", "journal excerpts module");

--- a/tests/study-session-route-state.test.js
+++ b/tests/study-session-route-state.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/study/session/index.html", "utf8");
+const controllerSource = fs.readFileSync("public/components/session-controller.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "rel=\"modulepreload\" href=\"/components/session-controller.js\"", "study session page");
+includes(pageSource, "src=\"/components/session-controller.js\"", "study session page");
+includes(pageSource, "src=\"/components/layout.js\" defer", "study session page");
+includes(pageSource, "id=\"participant-select\"", "study session page");
+includes(pageSource, "id=\"btn-start\"", "study session page");
+includes(pageSource, "id=\"btn-pause\"", "study session page");
+includes(pageSource, "id=\"btn-stop\"", "study session page");
+includes(pageSource, "id=\"note-editor\"", "study session page");
+includes(pageSource, "id=\"notes-list\"", "study session page");
+excludes(pageSource, "<script type=\"module\">", "study session page");
+
+includes(controllerSource, "participant-select", "session controller");
+includes(controllerSource, "timer-display", "session controller");
+includes(controllerSource, "btn-save-note", "session controller");
+includes(controllerSource, "note-editor", "session controller");


### PR DESCRIPTION
## Summary

Adds module preload coverage and route-state validation for the Study Session and Journals routes.

## Changes

- Add `rel="modulepreload"` for `/components/session-controller.js`.
- Make the Study Session layout module explicitly deferred.
- Add `rel="modulepreload"` for Journals route modules:
  - `/js/journal-tabs.js`
  - `/js/journal-mural-sync-compact.js`
  - `/components/journal-excerpts.js`
- Add `tests/study-session-route-state.test.js`.
- Add `tests/journals-route-state.test.js`.
- Wire both new route-state tests into `scripts/validate.sh`.
- Update `docs/performance/initial-load-audit.md` to reflect the current performance follow-up status.

## Why

The remaining audit candidates already use external route modules. This PR makes those modules discoverable earlier by the browser and adds validation coverage so they do not regress to inline module scripts.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/study/session/?pid=<project-id>&sid=<study-id>` and confirm the session page controls still initialise.
- Open `/pages/projects/journals/?id=<project-id>` and confirm tabs, Mural sync status, and journal panels still initialise.