### PR TITLE
Extract Search page route module

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -146,6 +146,18 @@ Why this helps:
 - The routes align with the loading pattern used by Projects, Project Dashboard, and Guides.
 - Validation now covers Session and Journals module loading contracts.
 
+### Search route extraction
+
+The Search route no longer carries its page controller inline in `public/pages/search/index.html`.
+
+That code now lives in `public/js/search-page.js` and is loaded with `rel="modulepreload"`.
+
+Why this helps:
+
+- The Search HTML document is smaller.
+- The page no longer relies on legacy page-relative imports for the SDK and shared helpers.
+- A route-state test prevents the page from regressing to inline module scripts or legacy relative imports.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
@@ -180,7 +192,7 @@ Recommended next slices:
 1. Use `npm run audit:performance:write` to generate the latest inventory.
 2. Start page-level CSS splitting with the highest-traffic covered routes: Projects, Project Dashboard, Study, and Guides.
 3. Keep `screen.css` as the base layer until each route has browser and route-state coverage.
-4. Continue extracting smaller legacy inline module pages, such as Search, Notes, Consent, Sessions, and Synthesize, in separate route-scoped PRs.
+4. Continue extracting smaller legacy inline module pages, such as Notes, Consent, Sessions, and Synthesize, in separate route-scoped PRs.
 
 ## Validation checklist
 

--- a/public/js/search-page.js
+++ b/public/js/search-page.js
@@ -1,0 +1,83 @@
+/**
+ * @file public/js/search-page.js
+ * @module SearchPage
+ * @summary Local ResearchOps entity search for legacy SDK records.
+ */
+
+const queryInput = document.getElementById("q");
+const typeSelect = document.getElementById("type");
+const searchButton = document.getElementById("go");
+const resultsContainer = document.getElementById("results");
+
+function escapeHtml(value) {
+	return String(value ?? "")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function readStoredEntities() {
+	const entities = [];
+
+	for (let index = 0; index < localStorage.length; index += 1) {
+		const key = localStorage.key(index);
+		if (!key) continue;
+
+		try {
+			const value = JSON.parse(localStorage.getItem(key) || "null");
+			if (value && typeof value === "object" && value.entityType) {
+				entities.push(value);
+			}
+		} catch {
+			// Ignore non-JSON localStorage entries.
+		}
+	}
+
+	return entities;
+}
+
+function searchEntities({ query = "", type = "" } = {}) {
+	const needle = query.trim().toLowerCase();
+	const entities = readStoredEntities();
+	const typed = type ? entities.filter(entity => entity.entityType === type) : entities;
+
+	if (!needle) return typed;
+
+	return typed.filter(entity => JSON.stringify(entity).toLowerCase().includes(needle));
+}
+
+function renderItem(entity) {
+	const raw = escapeHtml(JSON.stringify(entity, null, 2));
+	const title = entity.name || entity.description || entity.hasBody || entity.id || "Untitled result";
+
+	return `<div class="result">
+	<div class="type">${escapeHtml(entity.entityType)}</div>
+	<div class="govuk-body"><strong>${escapeHtml(title)}</strong></div>
+	<details><summary class="govuk-link">Raw</summary><pre>${raw}</pre></details>
+</div>`;
+}
+
+function renderResults(results) {
+	if (!resultsContainer) return;
+
+	resultsContainer.innerHTML = results.map(renderItem).join("") || '<div class="govuk-hint">No results.</div>';
+}
+
+function runSearch() {
+	const query = queryInput?.value || "";
+	const type = typeSelect?.value || "";
+	const results = searchEntities({ query, type });
+	renderResults(results);
+}
+
+searchButton?.addEventListener("click", runSearch);
+queryInput?.addEventListener("keydown", event => {
+	if (event.key === "Enter") runSearch();
+});
+
+window.__ropsSearch = Object.freeze({
+	searchEntities,
+	readStoredEntities
+});

--- a/public/pages/search/index.html
+++ b/public/pages/search/index.html
@@ -6,10 +6,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Search — ResearchOps</title>
 
-	<link rel="stylesheet" href="./css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="./css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="./css/screen.css" media="screen" />
-	<script type="module" src="./components/layout.js"></script>
+	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="modulepreload" href="/js/search-page.js" />
+	<script type="module" src="/components/layout.js" defer></script>
 </head>
 
 <body>
@@ -44,28 +45,7 @@
 
 	<x-include src="/partials/footer.html"></x-include>
 
-	<script type="module">
-		import { ResearchOpsSDK } from "../src/sdk/researchops_sdk_v1.0.0.js";
-		import { getCtx } from "./scripts/shared.js";
-		const sdk = ResearchOpsSDK.createSDK({ ...getCtx() });
-
-		function renderItem(x) {
-			const pre = JSON.stringify(x, null, 2);
-			const title = x.name || x.description || x.hasBody || x.id;
-			return `<div class="result">
-    <div class="type">${x.entityType}</div>
-    <div class="govuk-body"><strong>${title}</strong></div>
-    <details><summary class="govuk-link">Raw</summary><pre>${pre}</pre></details>
-  </div>`;
-		}
-
-		document.getElementById('go').onclick = async () => {
-			const q = document.getElementById('q').value.trim();
-			const type = document.getElementById('type').value || undefined;
-			const res = await sdk.search({ q, type });
-			document.getElementById('results').innerHTML = res.map(renderItem).join("") || '<div class="govuk-hint">No results.</div>';
-		};
-	</script>
+	<script type="module" src="/js/search-page.js"></script>
 </body>
 
 </html>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -48,6 +48,7 @@ require_file "tests/mural-journal-sync-route-state.test.js"
 require_file "tests/study-page-route-state.test.js"
 require_file "tests/study-guides-route-state.test.js"
 require_file "tests/study-session-route-state.test.js"
+require_file "tests/search-page-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
@@ -197,6 +198,9 @@ node tests/study-guides-route-state.test.js
 
 info "checking Study session route-state contract"
 node tests/study-session-route-state.test.js
+
+info "checking Search page route-state contract"
+node tests/search-page-route-state.test.js
 
 info "checking Consent Forms route-state contract"
 node tests/consent-forms-route-state.test.js

--- a/tests/search-page-route-state.test.js
+++ b/tests/search-page-route-state.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/search/index.html", "utf8");
+const controllerSource = fs.readFileSync("public/js/search-page.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "rel=\"modulepreload\" href=\"/js/search-page.js\"", "search page");
+includes(pageSource, "src=\"/js/search-page.js\"", "search page");
+includes(pageSource, "src=\"/components/layout.js\" defer", "search page");
+includes(pageSource, "href=\"/css/screen.css\"", "search page");
+includes(pageSource, "id=\"q\"", "search page");
+includes(pageSource, "id=\"type\"", "search page");
+includes(pageSource, "id=\"go\"", "search page");
+includes(pageSource, "id=\"results\"", "search page");
+excludes(pageSource, "<script type=\"module\">", "search page");
+excludes(pageSource, "../src/sdk/researchops_sdk_v1.0.0.js", "search page");
+excludes(pageSource, "./scripts/shared.js", "search page");
+
+includes(controllerSource, "function readStoredEntities", "search page controller");
+includes(controllerSource, "function searchEntities", "search page controller");
+includes(controllerSource, "function renderItem", "search page controller");
+includes(controllerSource, "function runSearch", "search page controller");
+includes(controllerSource, "localStorage", "search page controller");
+includes(controllerSource, "window.__ropsSearch", "search page controller");


### PR DESCRIPTION
## Summary

Extracts the Search page inline controller into an external cacheable route module.

## Changes

- Add `public/js/search-page.js`.
- Remove the inline `type="module"` controller from `public/pages/search/index.html`.
- Load `/js/search-page.js` as an external module.
- Add `rel="modulepreload"` for the Search route module.
- Replace legacy page-relative CSS/layout paths with absolute public asset paths.
- Remove legacy relative SDK/shared helper imports from the Search page.
- Add `tests/search-page-route-state.test.js`.
- Wire the Search route-state test into `scripts/validate.sh`.
- Update the initial-load audit follow-up status.

## Why

The Search route still carried a compact inline module and legacy relative imports. This makes the route lighter, cacheable, and consistent with the current page module pattern.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/search/`.
- Search with an empty query and with a text query.
- Filter by each available entity type.
- Confirm results still render raw JSON inside the details disclosure.