### PR TITLE
Extract Notes page route module

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -158,6 +158,19 @@ Why this helps:
 - The page no longer relies on legacy page-relative imports for the SDK and shared helpers.
 - A route-state test prevents the page from regressing to inline module scripts or legacy relative imports.
 
+### Notes route extraction
+
+The Notes route no longer carries its page controller inline in `public/pages/notes/index.html`.
+
+That code now lives in `public/js/notes-page.js` and is loaded with `rel="modulepreload"`.
+
+Why this helps:
+
+- The Notes HTML document is smaller.
+- The page no longer relies on legacy page-relative imports for the SDK and shared helpers.
+- Rendered note and tag content is escaped before being inserted into the DOM.
+- A route-state test prevents the page from regressing to inline module scripts or legacy relative imports.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
@@ -192,7 +205,7 @@ Recommended next slices:
 1. Use `npm run audit:performance:write` to generate the latest inventory.
 2. Start page-level CSS splitting with the highest-traffic covered routes: Projects, Project Dashboard, Study, and Guides.
 3. Keep `screen.css` as the base layer until each route has browser and route-state coverage.
-4. Continue extracting smaller legacy inline module pages, such as Notes, Consent, Sessions, and Synthesize, in separate route-scoped PRs.
+4. Continue extracting smaller legacy inline module pages, such as Consent, Sessions, and Synthesize, in separate route-scoped PRs.
 
 ## Validation checklist
 

--- a/public/js/notes-page.js
+++ b/public/js/notes-page.js
@@ -1,0 +1,195 @@
+/**
+ * @file public/js/notes-page.js
+ * @module NotesPage
+ * @summary Local ResearchOps notes UI for legacy SDK records.
+ */
+
+const sessionSelect = document.getElementById("session");
+const noteText = document.getElementById("text");
+const tagsInput = document.getElementById("tags");
+const saveButton = document.getElementById("save");
+const statusMessage = document.getElementById("status");
+const notesContainer = document.getElementById("notes");
+
+function escapeHtml(value) {
+	return String(value ?? "")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function formatDate(iso) {
+	try {
+		return new Date(iso).toLocaleString();
+	} catch {
+		return iso || "";
+	}
+}
+
+function uid(prefix) {
+	return `${prefix}_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+}
+
+function getCtx() {
+	return {
+		org: localStorage.getItem("rops.org") || "home-office-biometrics",
+		project: localStorage.getItem("rops.project") || "demo",
+		study: localStorage.getItem("rops.study") || "demo",
+		user: localStorage.getItem("rops.user") || "you@homeoffice.gov.uk"
+	};
+}
+
+function readStoredEntities() {
+	const entities = [];
+
+	for (let index = 0; index < localStorage.length; index += 1) {
+		const key = localStorage.key(index);
+		if (!key) continue;
+
+		try {
+			const value = JSON.parse(localStorage.getItem(key) || "null");
+			if (value && typeof value === "object" && value.entityType) {
+				entities.push(value);
+			}
+		} catch {
+			// Ignore non-JSON localStorage entries.
+		}
+	}
+
+	return entities;
+}
+
+function searchEntities({ type = "" } = {}) {
+	const entities = readStoredEntities();
+	return type ? entities.filter(entity => entity.entityType === type) : entities;
+}
+
+function envelope(entityType, body) {
+	const ctx = getCtx();
+
+	return {
+		id: body.id || uid(entityType.toLowerCase()),
+		type: entityType,
+		entityType,
+		created: new Date().toISOString(),
+		creator: ctx.user,
+		scope: {
+			org: ctx.org,
+			project: ctx.project,
+			study: ctx.study
+		},
+		...body
+	};
+}
+
+function saveEntity(collection, entity) {
+	localStorage.setItem(`${collection}:${entity.id}`, JSON.stringify(entity));
+	return entity;
+}
+
+function addTag(targetId, label) {
+	const ctx = getCtx();
+	const tag = envelope("Tag", {
+		name: label,
+		inScheme: `${ctx.org}::${ctx.project}::taxonomy`,
+		hasTarget: targetId
+	});
+
+	return saveEntity("tag", tag);
+}
+
+function addNote(sessionId, { text, tags = [] }) {
+	const note = envelope("Note", {
+		hasTarget: sessionId,
+		hasBody: text
+	});
+
+	saveEntity("note", note);
+
+	for (const tag of tags) {
+		addTag(note.id, tag);
+	}
+
+	return note;
+}
+
+async function populateSessions() {
+	if (!sessionSelect) return null;
+
+	const sessions = searchEntities({ type: "ResearchSession" })
+		.sort((a, b) => String(b.created || "").localeCompare(String(a.created || "")));
+
+	sessionSelect.innerHTML = "";
+
+	for (const session of sessions) {
+		const option = document.createElement("option");
+		option.value = session.id;
+		option.textContent = `${session.name || "(Untitled)"} — ${formatDate(session["schema:startDate"] || session.created)}`;
+		sessionSelect.appendChild(option);
+	}
+
+	return sessionSelect.value || null;
+}
+
+async function loadNotes(sessionId) {
+	if (!notesContainer) return;
+
+	const allNotes = searchEntities({ type: "Note" });
+	const allTags = searchEntities({ type: "Tag" });
+	const filtered = allNotes.filter(note => note.hasTarget === sessionId);
+
+	notesContainer.innerHTML = filtered.map(note => {
+		const tags = allTags.filter(tag => tag.hasTarget === note.id);
+		const tagsHtml = tags.map(tag => `<span class="tag">${escapeHtml(tag.name)}</span>`).join("");
+
+		return `<div class="item">
+	<strong>${escapeHtml(formatDate(note.created))}</strong>
+	<div class="govuk-body">${escapeHtml(note.hasBody)}</div>
+	<div>${tagsHtml || '<span class="govuk-hint">No tags</span>'}</div>
+</div>`;
+	}).join("") || '<div class="govuk-hint">No notes yet.</div>';
+}
+
+async function saveNote() {
+	const sessionId = sessionSelect?.value || "";
+	if (!sessionId) {
+		alert("Create/select a session first.");
+		return;
+	}
+
+	const text = noteText?.value.trim() || "";
+	if (!text) {
+		alert("Enter a note.");
+		return;
+	}
+
+	const tags = (tagsInput?.value || "")
+		.split(",")
+		.map(tag => tag.trim())
+		.filter(Boolean);
+
+	const note = addNote(sessionId, { text, tags });
+	if (statusMessage) statusMessage.textContent = `Saved note ${note.id}`;
+
+	await loadNotes(sessionId);
+	if (noteText) noteText.value = "";
+	if (tagsInput) tagsInput.value = "";
+}
+
+sessionSelect?.addEventListener("change", async event => {
+	await loadNotes(event.target.value);
+});
+
+saveButton?.addEventListener("click", saveNote);
+
+const firstSessionId = await populateSessions();
+if (firstSessionId) await loadNotes(firstSessionId);
+
+window.__ropsNotes = Object.freeze({
+	addNote,
+	addTag,
+	readStoredEntities,
+	searchEntities
+});

--- a/public/pages/notes/index.html
+++ b/public/pages/notes/index.html
@@ -6,10 +6,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Notes — ResearchOps</title>
 	
-	<link rel="stylesheet" href="./css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="./css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="./css/screen.css" media="screen" />
-	<script type="module" src="./components/layout.js"></script>
+	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="modulepreload" href="/js/notes-page.js" />
+	<script type="module" src="/components/layout.js" defer></script>
 </head>
 
 <body>
@@ -39,61 +40,7 @@
 	
 	<x-include src="/partials/footer.html"></x-include>
 
-	<script type="module">
-		import { ResearchOpsSDK } from "../src/sdk/researchops_sdk_v1.0.0.js";
-		import { getCtx, formatDate } from "./scripts/shared.js";
-		const sdk = ResearchOpsSDK.createSDK({ ...getCtx() });
-
-		async function populateSessions() {
-			const list = await sdk.search({ type: "ResearchSession" });
-			const sel = document.getElementById('session');
-			sel.innerHTML = "";
-			list.forEach(s => {
-				const opt = document.createElement('option');
-				opt.value = s.id;
-				opt.textContent = `${s.name || "(Untitled)"} — ${formatDate(s["schema:startDate"]||s.created)}`;
-				sel.appendChild(opt);
-			});
-			return sel.value || null;
-		}
-
-		async function loadNotes(sessionId) {
-			const allNotes = await sdk.search({ type: "Note" });
-			const allTags = await sdk.search({ type: "Tag" }); // fetch once
-
-			const div = document.getElementById('notes');
-			const filtered = allNotes.filter(n => n.hasTarget === sessionId);
-
-			div.innerHTML = filtered.map(n => {
-				const tags = allTags.filter(t => t.hasTarget === n.id);
-				const tagsHtml = tags.map(t => `<span class="tag">${t.name}</span>`).join("");
-				return `<div class="item">
-      <strong>${formatDate(n.created)}</strong>
-      <div class="govuk-body">${n.hasBody}</div>
-      <div>${tagsHtml || '<span class="govuk-hint">No tags</span>'}</div>
-    </div>`;
-			}).join("") || '<div class="govuk-hint">No notes yet.</div>';
-		}
-
-		document.getElementById('session').onchange = async e => {
-			await loadNotes(e.target.value);
-		};
-		document.getElementById('save').onclick = async () => {
-			const sid = document.getElementById('session').value;
-			if (!sid) return alert("Create/select a session first.");
-			const text = document.getElementById('text').value.trim();
-			if (!text) return alert("Enter a note.");
-			const tags = document.getElementById('tags').value.split(',').map(t => t.trim()).filter(Boolean);
-			const n = await sdk.addNote(sid, { text, tags });
-			document.getElementById('status').textContent = `Saved note ${n.id}`;
-			await loadNotes(sid);
-			document.getElementById('text').value = "";
-			document.getElementById('tags').value = "";
-		};
-
-		const first = await populateSessions();
-		if (first) await loadNotes(first);
-	</script>
+	<script type="module" src="/js/notes-page.js"></script>
 </body>
 
 </html>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -49,6 +49,7 @@ require_file "tests/study-page-route-state.test.js"
 require_file "tests/study-guides-route-state.test.js"
 require_file "tests/study-session-route-state.test.js"
 require_file "tests/search-page-route-state.test.js"
+require_file "tests/notes-page-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
@@ -201,6 +202,9 @@ node tests/study-session-route-state.test.js
 
 info "checking Search page route-state contract"
 node tests/search-page-route-state.test.js
+
+info "checking Notes page route-state contract"
+node tests/notes-page-route-state.test.js
 
 info "checking Consent Forms route-state contract"
 node tests/consent-forms-route-state.test.js

--- a/tests/notes-page-route-state.test.js
+++ b/tests/notes-page-route-state.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/notes/index.html", "utf8");
+const controllerSource = fs.readFileSync("public/js/notes-page.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "rel=\"modulepreload\" href=\"/js/notes-page.js\"", "notes page");
+includes(pageSource, "src=\"/js/notes-page.js\"", "notes page");
+includes(pageSource, "src=\"/components/layout.js\" defer", "notes page");
+includes(pageSource, "href=\"/css/screen.css\"", "notes page");
+includes(pageSource, "id=\"session\"", "notes page");
+includes(pageSource, "id=\"text\"", "notes page");
+includes(pageSource, "id=\"tags\"", "notes page");
+includes(pageSource, "id=\"save\"", "notes page");
+includes(pageSource, "id=\"notes\"", "notes page");
+excludes(pageSource, "<script type=\"module\">", "notes page");
+excludes(pageSource, "../src/sdk/researchops_sdk_v1.0.0.js", "notes page");
+excludes(pageSource, "./scripts/shared.js", "notes page");
+
+includes(controllerSource, "function readStoredEntities", "notes page controller");
+includes(controllerSource, "function searchEntities", "notes page controller");
+includes(controllerSource, "function addNote", "notes page controller");
+includes(controllerSource, "function addTag", "notes page controller");
+includes(controllerSource, "async function populateSessions", "notes page controller");
+includes(controllerSource, "async function loadNotes", "notes page controller");
+includes(controllerSource, "function saveNote", "notes page controller");
+includes(controllerSource, "localStorage", "notes page controller");
+includes(controllerSource, "window.__ropsNotes", "notes page controller");


### PR DESCRIPTION
## Summary

Extracts the Notes page inline controller into an external cacheable route module.

## Changes

- Add `public/js/notes-page.js`.
- Remove the inline `type="module"` controller from `public/pages/notes/index.html`.
- Load `/js/notes-page.js` as an external module.
- Add `rel="modulepreload"` for the Notes route module.
- Replace legacy page-relative CSS/layout paths with absolute public asset paths.
- Remove legacy relative SDK/shared helper imports from the Notes page.
- Escape rendered note and tag content before inserting it into the DOM.
- Add `tests/notes-page-route-state.test.js`.
- Wire the Notes route-state test into `scripts/validate.sh`.
- Update the initial-load audit follow-up status.

## Why

The Notes route still carried a legacy inline module and page-relative imports. This makes the route lighter, cacheable, and consistent with the current page module pattern.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/notes/`.
- Confirm sessions populate from local ResearchOps session records.
- Add a note with comma-separated tags.
- Confirm the note and tags render under the selected session.
- Switch sessions and confirm the note list updates.