### PR TITLE
Extract Sessions page route module

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -184,6 +184,19 @@ Why this helps:
 - Rendered consent values are escaped before being inserted into the DOM.
 - The existing consent route-state test now covers the legacy Consent page module contract.
 
+### Sessions route extraction
+
+The legacy Sessions route no longer carries its page controller inline in `public/pages/sessions/index.html`.
+
+That code now lives in `public/js/sessions-page.js` and is loaded with `rel="modulepreload"`.
+
+Why this helps:
+
+- The Sessions HTML document is smaller.
+- The page no longer relies on legacy page-relative imports for the SDK and shared helpers.
+- Rendered session values are escaped before being inserted into the DOM.
+- The existing session route-state test now covers the legacy Sessions page module contract.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
@@ -218,7 +231,7 @@ Recommended next slices:
 1. Use `npm run audit:performance:write` to generate the latest inventory.
 2. Start page-level CSS splitting with the highest-traffic covered routes: Projects, Project Dashboard, Study, and Guides.
 3. Keep `screen.css` as the base layer until each route has browser and route-state coverage.
-4. Continue extracting smaller legacy inline module pages, such as Sessions and Synthesize, in separate route-scoped PRs.
+4. Continue extracting smaller legacy inline module pages, such as Synthesize, in a separate route-scoped PR.
 
 ## Validation checklist
 

--- a/public/js/sessions-page.js
+++ b/public/js/sessions-page.js
@@ -1,0 +1,154 @@
+/**
+ * @file public/js/sessions-page.js
+ * @module SessionsPage
+ * @summary Local ResearchOps sessions UI for legacy SDK records.
+ */
+
+const titleInput = document.getElementById("title");
+const whenInput = document.getElementById("when");
+const participantsInput = document.getElementById("participants");
+const createButton = document.getElementById("create");
+const statusMessage = document.getElementById("status");
+const sessionsContainer = document.getElementById("sessions");
+
+function escapeHtml(value) {
+	return String(value ?? "")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function formatDate(iso) {
+	try {
+		return new Date(iso).toLocaleString();
+	} catch {
+		return iso || "";
+	}
+}
+
+function uid(prefix) {
+	return `${prefix}_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+}
+
+function getCtx() {
+	return {
+		org: localStorage.getItem("rops.org") || "home-office-biometrics",
+		project: localStorage.getItem("rops.project") || "demo",
+		study: localStorage.getItem("rops.study") || "demo",
+		user: localStorage.getItem("rops.user") || "you@homeoffice.gov.uk"
+	};
+}
+
+function readStoredEntities() {
+	const entities = [];
+
+	for (let index = 0; index < localStorage.length; index += 1) {
+		const key = localStorage.key(index);
+		if (!key) continue;
+
+		try {
+			const value = JSON.parse(localStorage.getItem(key) || "null");
+			if (value && typeof value === "object" && value.entityType) {
+				entities.push(value);
+			}
+		} catch {
+			// Ignore non-JSON localStorage entries.
+		}
+	}
+
+	return entities;
+}
+
+function searchEntities({ type = "" } = {}) {
+	const entities = readStoredEntities();
+	return type ? entities.filter(entity => entity.entityType === type) : entities;
+}
+
+function envelope(entityType, body) {
+	const ctx = getCtx();
+
+	return {
+		id: body.id || uid(entityType.toLowerCase()),
+		type: entityType,
+		entityType,
+		created: new Date().toISOString(),
+		creator: ctx.user,
+		scope: {
+			org: ctx.org,
+			project: ctx.project,
+			study: ctx.study
+		},
+		...body
+	};
+}
+
+function saveEntity(collection, entity) {
+	localStorage.setItem(`${collection}:${entity.id}`, JSON.stringify(entity));
+	return entity;
+}
+
+function createSession({ title, when, participants = [], id } = {}) {
+	const session = envelope("ResearchSession", {
+		id,
+		name: title || "Untitled session",
+		"schema:startDate": when || new Date().toISOString(),
+		participants
+	});
+
+	return saveEntity("session", session);
+}
+
+function renderSession(session) {
+	const element = document.createElement("div");
+	element.className = "item govuk-body";
+	element.innerHTML = `<strong>${escapeHtml(session.name || "(Untitled)")}</strong>
+<div class="govuk-hint">${escapeHtml(formatDate(session["schema:startDate"] || session.created))} — ${escapeHtml(session.id)}</div>
+<div class="govuk-hint">Participants: ${escapeHtml((session.participants || []).join(", ") || "—")}</div>`;
+	return element;
+}
+
+async function loadSessions() {
+	if (!sessionsContainer) return;
+
+	const sessions = searchEntities({ type: "ResearchSession" })
+		.sort((first, second) => String(second.created || "").localeCompare(String(first.created || "")));
+
+	sessionsContainer.innerHTML = "";
+
+	if (!sessions.length) {
+		sessionsContainer.innerHTML = '<div class="govuk-hint">No sessions yet.</div>';
+		return;
+	}
+
+	for (const session of sessions) {
+		sessionsContainer.appendChild(renderSession(session));
+	}
+}
+
+async function handleCreateSession() {
+	const participants = (participantsInput?.value || "")
+		.split(",")
+		.map(participant => participant.trim())
+		.filter(Boolean);
+
+	const session = createSession({
+		title: titleInput?.value || "Untitled session",
+		when: whenInput?.value || new Date().toISOString(),
+		participants
+	});
+
+	if (statusMessage) statusMessage.textContent = `Created ${session.id}`;
+	await loadSessions();
+}
+
+createButton?.addEventListener("click", handleCreateSession);
+
+await loadSessions();
+
+window.__ropsSessions = Object.freeze({
+	createSession,
+	readStoredEntities,
+	searchEntities
+});

--- a/public/pages/sessions/index.html
+++ b/public/pages/sessions/index.html
@@ -6,10 +6,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Sessions — ResearchOps</title>
 
-	<link rel="stylesheet" href="./css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="./css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="./css/screen.css" media="screen" />
-	<script type="module" src="./components/layout.js"></script>
+	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="modulepreload" href="/js/sessions-page.js" />
+	<script type="module" src="/components/layout.js" defer></script>
 </head>
 
 <body>
@@ -39,37 +40,7 @@
 
 	<x-include src="/partials/footer.html"></x-include>
 
-	<script type="module">
-		import { ResearchOpsSDK } from "../src/sdk/researchops_sdk_v1.0.0.js";
-		import { getCtx, formatDate } from "./scripts/shared.js";
-
-		const ctx = getCtx();
-		const sdk = ResearchOpsSDK.createSDK({ ...ctx });
-
-		async function load() {
-			const all = await sdk.search({ type: "ResearchSession" });
-			const list = document.getElementById('sessions');
-			list.innerHTML = "";
-			all.sort((a, b) => (a.created > b.created ? -1 : 1)).forEach(s => {
-				const el = document.createElement('div');
-				el.className = "item govuk-body";
-				el.innerHTML = `<strong>${s.name || "(Untitled)"}</strong>
-      <div class="govuk-hint">${formatDate(s["schema:startDate"] || s.created)} — ${s.id}</div>
-      <div class="govuk-hint">Participants: ${(s.participants||[]).join(", ") || "—"}</div>`;
-				list.appendChild(el);
-			});
-		}
-		document.getElementById('create').onclick = async () => {
-			const title = document.getElementById('title').value || "Untitled session";
-			const when = document.getElementById('when').value || new Date().toISOString();
-			const participants = (document.getElementById('participants').value || "")
-				.split(",").map(x => x.trim()).filter(Boolean);
-			const s = await sdk.createSession({ title, when, participants });
-			document.getElementById('status').textContent = `Created ${s.id}`;
-			await load();
-		};
-		load();
-	</script>
+	<script type="module" src="/js/sessions-page.js"></script>
 </body>
 
 </html>

--- a/tests/study-session-route-state.test.js
+++ b/tests/study-session-route-state.test.js
@@ -3,6 +3,8 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/study/session/index.html", "utf8");
 const controllerSource = fs.readFileSync("public/components/session-controller.js", "utf8");
+const legacySessionsPageSource = fs.readFileSync("public/pages/sessions/index.html", "utf8");
+const legacySessionsControllerSource = fs.readFileSync("public/js/sessions-page.js", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -27,3 +29,26 @@ includes(controllerSource, "participant-select", "session controller");
 includes(controllerSource, "timer-display", "session controller");
 includes(controllerSource, "btn-save-note", "session controller");
 includes(controllerSource, "note-editor", "session controller");
+
+includes(legacySessionsPageSource, "rel=\"modulepreload\" href=\"/js/sessions-page.js\"", "legacy sessions page");
+includes(legacySessionsPageSource, "src=\"/js/sessions-page.js\"", "legacy sessions page");
+includes(legacySessionsPageSource, "src=\"/components/layout.js\" defer", "legacy sessions page");
+includes(legacySessionsPageSource, "href=\"/css/screen.css\"", "legacy sessions page");
+includes(legacySessionsPageSource, "id=\"title\"", "legacy sessions page");
+includes(legacySessionsPageSource, "id=\"when\"", "legacy sessions page");
+includes(legacySessionsPageSource, "id=\"participants\"", "legacy sessions page");
+includes(legacySessionsPageSource, "id=\"create\"", "legacy sessions page");
+includes(legacySessionsPageSource, "id=\"status\"", "legacy sessions page");
+includes(legacySessionsPageSource, "id=\"sessions\"", "legacy sessions page");
+excludes(legacySessionsPageSource, "<script type=\"module\">", "legacy sessions page");
+excludes(legacySessionsPageSource, "../src/sdk/researchops_sdk_v1.0.0.js", "legacy sessions page");
+excludes(legacySessionsPageSource, "./scripts/shared.js", "legacy sessions page");
+
+includes(legacySessionsControllerSource, "function readStoredEntities", "legacy sessions controller");
+includes(legacySessionsControllerSource, "function searchEntities", "legacy sessions controller");
+includes(legacySessionsControllerSource, "function createSession", "legacy sessions controller");
+includes(legacySessionsControllerSource, "function renderSession", "legacy sessions controller");
+includes(legacySessionsControllerSource, "async function loadSessions", "legacy sessions controller");
+includes(legacySessionsControllerSource, "async function handleCreateSession", "legacy sessions controller");
+includes(legacySessionsControllerSource, "localStorage", "legacy sessions controller");
+includes(legacySessionsControllerSource, "window.__ropsSessions", "legacy sessions controller");


### PR DESCRIPTION
## Summary

Extracts the legacy Sessions page inline controller into an external cacheable route module.

## Changes

- Add `public/js/sessions-page.js`.
- Remove the inline `type="module"` controller from `public/pages/sessions/index.html`.
- Load `/js/sessions-page.js` as an external module.
- Add `rel="modulepreload"` for the Sessions route module.
- Replace legacy page-relative CSS/layout paths with absolute public asset paths.
- Remove legacy relative SDK/shared helper imports from the Sessions page.
- Escape rendered session values before inserting them into the DOM.
- Extend `tests/study-session-route-state.test.js` to cover the legacy Sessions page module contract.
- Update the initial-load audit follow-up status.

## Why

The legacy Sessions route still carried an inline module and page-relative imports. This makes the route lighter, cacheable, and consistent with the current page module pattern.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/sessions/`.
- Create a session with a title, ISO date, and comma-separated participants.
- Confirm the new session appears in the Your sessions list.
- Refresh and confirm the session remains available from local ResearchOps records.