### PR TITLE
Extract Synthesize page route module

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -197,6 +197,19 @@ Why this helps:
 - Rendered session values are escaped before being inserted into the DOM.
 - The existing session route-state test now covers the legacy Sessions page module contract.
 
+### Synthesize route extraction
+
+The legacy Synthesize route no longer carries its page controller inline in `public/pages/synthesize/index.html`.
+
+That code now lives in `public/js/synthesize-page.js` and is loaded with `rel="modulepreload"`.
+
+Why this helps:
+
+- The Synthesize HTML document is smaller.
+- The page no longer relies on legacy page-relative imports for the SDK and shared helpers.
+- Rendered evidence, tag, cluster, and theme values are escaped before being inserted into the DOM.
+- A route-state test prevents the page from regressing to inline module scripts or legacy relative imports.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
@@ -231,7 +244,7 @@ Recommended next slices:
 1. Use `npm run audit:performance:write` to generate the latest inventory.
 2. Start page-level CSS splitting with the highest-traffic covered routes: Projects, Project Dashboard, Study, and Guides.
 3. Keep `screen.css` as the base layer until each route has browser and route-state coverage.
-4. Continue extracting smaller legacy inline module pages, such as Synthesize, in a separate route-scoped PR.
+4. Continue checking legacy pages for smaller inline module cleanups, but the named inline-module follow-up list from this audit is now complete.
 
 ## Validation checklist
 

--- a/public/js/synthesize-page.js
+++ b/public/js/synthesize-page.js
@@ -1,0 +1,247 @@
+/**
+ * @file public/js/synthesize-page.js
+ * @module SynthesizePage
+ * @summary Local ResearchOps synthesis UI for legacy SDK records.
+ */
+
+const filterInput = document.getElementById("filter");
+const evidenceContainer = document.getElementById("evidence");
+const clustersContainer = document.getElementById("clusters");
+const newClusterInput = document.getElementById("newCluster");
+const addClusterButton = document.getElementById("addCluster");
+const clusterSelect = document.getElementById("clusterSelect");
+const themeLabelInput = document.getElementById("themeLabel");
+const themeDescriptionInput = document.getElementById("themeDesc");
+const publishButton = document.getElementById("publish");
+const statusMessage = document.getElementById("status");
+
+function escapeHtml(value) {
+	return String(value ?? "")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function uid(prefix) {
+	return `${prefix}_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+}
+
+function getCtx() {
+	return {
+		org: localStorage.getItem("rops.org") || "home-office-biometrics",
+		project: localStorage.getItem("rops.project") || "demo",
+		study: localStorage.getItem("rops.study") || "demo",
+		user: localStorage.getItem("rops.user") || "you@homeoffice.gov.uk"
+	};
+}
+
+function readStoredEntities() {
+	const entities = [];
+
+	for (let index = 0; index < localStorage.length; index += 1) {
+		const key = localStorage.key(index);
+		if (!key) continue;
+
+		try {
+			const value = JSON.parse(localStorage.getItem(key) || "null");
+			if (value && typeof value === "object" && value.entityType) {
+				entities.push(value);
+			}
+		} catch {
+			// Ignore non-JSON localStorage entries.
+		}
+	}
+
+	return entities;
+}
+
+function searchEntities({ type = "" } = {}) {
+	const entities = readStoredEntities();
+	return type ? entities.filter(entity => entity.entityType === type) : entities;
+}
+
+function envelope(entityType, body) {
+	const ctx = getCtx();
+
+	return {
+		id: body.id || uid(entityType.toLowerCase()),
+		type: entityType,
+		entityType,
+		created: new Date().toISOString(),
+		creator: ctx.user,
+		scope: {
+			org: ctx.org,
+			project: ctx.project,
+			study: ctx.study
+		},
+		...body
+	};
+}
+
+function saveEntity(collection, entity) {
+	localStorage.setItem(`${collection}:${entity.id}`, JSON.stringify(entity));
+	return entity;
+}
+
+function createCluster({ label, members = [], id } = {}) {
+	const cluster = envelope("Cluster", {
+		id,
+		name: label || "Untitled cluster",
+		members
+	});
+
+	return saveEntity("cluster", cluster);
+}
+
+function publishTheme({ label, description = "", evidenceIds = [] } = {}) {
+	const theme = envelope("Theme", {
+		name: label,
+		description,
+		evidenceIds
+	});
+
+	return saveEntity("theme", theme);
+}
+
+function makeElement(html) {
+	const wrapper = document.createElement("div");
+	wrapper.innerHTML = html.trim();
+	return wrapper.firstElementChild;
+}
+
+async function loadEvidence(tagFilter = "") {
+	if (!evidenceContainer) return;
+
+	const notes = searchEntities({ type: "Note" });
+	const tags = searchEntities({ type: "Tag" });
+	const tagsByNote = new Map();
+
+	for (const tag of tags) {
+		const existing = tagsByNote.get(tag.hasTarget) || [];
+		existing.push(tag);
+		tagsByNote.set(tag.hasTarget, existing);
+	}
+
+	evidenceContainer.innerHTML = "";
+
+	for (const note of notes) {
+		const noteTags = tagsByNote.get(note.id) || [];
+		const filter = tagFilter.trim().toLowerCase();
+
+		if (filter && !noteTags.some(tag => String(tag.name || "").toLowerCase().includes(filter))) {
+			continue;
+		}
+
+		const tagHtml = noteTags
+			.map(tag => `<span class="tag">${escapeHtml(tag.name)}</span>`)
+			.join("");
+
+		const card = makeElement(`<div class="note" draggable="true" data-id="${escapeHtml(note.id)}">
+	<div><strong>${escapeHtml(new Date(note.created).toLocaleString())}</strong></div>
+	<div>${escapeHtml(note.hasBody)}</div>
+	<div>${tagHtml}</div>
+</div>`);
+
+		card.addEventListener("dragstart", event => {
+			event.dataTransfer.setData("text/plain", note.id);
+		});
+
+		evidenceContainer.appendChild(card);
+	}
+
+	if (!evidenceContainer.children.length) {
+		evidenceContainer.innerHTML = '<div class="govuk-hint">No evidence found.</div>';
+	}
+}
+
+async function loadClusters() {
+	if (!clustersContainer || !clusterSelect) return;
+
+	const clusters = searchEntities({ type: "Cluster" });
+
+	clustersContainer.innerHTML = "";
+	clusterSelect.innerHTML = "";
+
+	for (const cluster of clusters) {
+		const box = makeElement(`<div class="cluster" data-id="${escapeHtml(cluster.id)}">
+	<div><strong>${escapeHtml(cluster.name)}</strong> <span class="govuk-hint">(${escapeHtml((cluster.members || []).length)} items)</span></div>
+	<div class="bin"></div>
+</div>`);
+
+		box.addEventListener("dragover", event => event.preventDefault());
+		box.addEventListener("drop", async event => {
+			const noteId = event.dataTransfer.getData("text/plain");
+			const fresh = searchEntities({ type: "Cluster" }).find(item => item.id === cluster.id) || cluster;
+			const members = new Set([...(fresh.members || []), noteId]);
+
+			createCluster({
+				label: cluster.name,
+				members: Array.from(members),
+				id: cluster.id
+			});
+
+			await loadClusters();
+		});
+
+		clustersContainer.appendChild(box);
+
+		const option = document.createElement("option");
+		option.value = cluster.id;
+		option.textContent = cluster.name;
+		clusterSelect.appendChild(option);
+	}
+
+	if (!clusters.length) {
+		clustersContainer.innerHTML = '<div class="govuk-hint">No clusters yet.</div>';
+	}
+}
+
+async function addCluster() {
+	const label = newClusterInput?.value.trim() || "";
+	if (!label) return;
+
+	createCluster({ label, members: [] });
+	if (newClusterInput) newClusterInput.value = "";
+	await loadClusters();
+}
+
+async function handlePublishTheme() {
+	const clusterId = clusterSelect?.value || "";
+	if (!clusterId) {
+		alert("Create/select a cluster.");
+		return;
+	}
+
+	const cluster = searchEntities({ type: "Cluster" }).find(item => item.id === clusterId);
+	const label = themeLabelInput?.value.trim() || "";
+	const description = themeDescriptionInput?.value.trim() || "";
+
+	if (!label) {
+		alert("Theme label required.");
+		return;
+	}
+
+	const theme = publishTheme({
+		label,
+		description,
+		evidenceIds: cluster?.members || []
+	});
+
+	if (statusMessage) statusMessage.textContent = `Published theme ${theme.id}`;
+}
+
+addClusterButton?.addEventListener("click", addCluster);
+publishButton?.addEventListener("click", handlePublishTheme);
+filterInput?.addEventListener("input", event => loadEvidence(event.target.value));
+
+await loadEvidence("");
+await loadClusters();
+
+window.__ropsSynthesize = Object.freeze({
+	createCluster,
+	publishTheme,
+	readStoredEntities,
+	searchEntities
+});

--- a/public/pages/synthesize/index.html
+++ b/public/pages/synthesize/index.html
@@ -6,10 +6,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Synthesis — ResearchOps</title>
 
-	<link rel="stylesheet" href="./css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="./css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="./css/screen.css" media="screen" />
-	<script type="module" src="./components/layout.js"></script>
+	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="modulepreload" href="/js/synthesize-page.js" />
+	<script type="module" src="/components/layout.js" defer></script>
 </head>
 
 <body>
@@ -43,98 +44,7 @@
 
 	<x-include src="/partials/footer.html"></x-include>
 
-	<script type="module">
-		import { ResearchOpsSDK } from "../src/sdk/researchops_sdk_v1.0.0.js";
-		import { getCtx } from "./scripts/shared.js";
-		const sdk = ResearchOpsSDK.createSDK({ ...getCtx() });
-
-		function el(html) {
-			const d = document.createElement('div');
-			d.innerHTML = html.trim();
-			return d.firstChild;
-		}
-
-		async function loadEvidence(tagFilter) {
-			const notes = await sdk.search({ type: "Note" });
-			const tags = await sdk.search({ type: "Tag" });
-			const byNote = new Map();
-			tags.forEach(t => {
-				const arr = byNote.get(t.hasTarget) || [];
-				arr.push(t);
-				byNote.set(t.hasTarget, arr);
-			});
-			const wrap = document.getElementById('evidence');
-			wrap.innerHTML = "";
-			notes.forEach(n => {
-				const noteTags = byNote.get(n.id) || [];
-				if (tagFilter && !noteTags.some(t => t.name.toLowerCase().includes(tagFilter.toLowerCase()))) return;
-				const tagHtml = noteTags.map(t => `<span class="tag">${t.name}</span>`).join("");
-				const card = el(`<div class="note" draggable="true" data-id="${n.id}">
-        <div><strong>${new Date(n.created).toLocaleString()}</strong></div>
-        <div>${n.hasBody}</div>
-        <div>${tagHtml}</div>
-    </div>`);
-				card.addEventListener('dragstart', e => {
-					e.dataTransfer.setData('text/plain', n.id);
-				});
-				wrap.appendChild(card);
-			});
-		}
-
-		async function loadClusters() {
-			const clusters = await sdk.search({ type: "Cluster" });
-			const wrap = document.getElementById('clusters');
-			const sel = document.getElementById('clusterSelect');
-			wrap.innerHTML = "";
-			sel.innerHTML = "";
-			clusters.forEach(c => {
-				const box = el(`<div class="cluster" data-id="${c.id}">
-        <div><strong>${c.name}</strong> <span class="govuk-hint">(${(c.members||[]).length} items)</span></div>
-        <div class="bin"></div>
-    </div>`);
-				box.addEventListener('dragover', e => e.preventDefault());
-				box.addEventListener('drop', async e => {
-					const id = e.dataTransfer.getData('text/plain');
-					const fresh = (await sdk.search({ type: "Cluster" })).find(x => x.id === c.id);
-					const members = new Set([...(fresh.members || []), id]);
-					// “update” by saving a new cluster object (simple demo approach)
-					await sdk.createCluster({ label: c.name, members: Array.from(members), id: c.id });
-					await loadClusters();
-				});
-				wrap.appendChild(box);
-
-				const opt = document.createElement('option');
-				opt.value = c.id;
-				opt.textContent = c.name;
-				sel.appendChild(opt);
-			});
-		}
-
-		document.getElementById('addCluster').onclick = async () => {
-			const label = document.getElementById('newCluster').value.trim();
-			if (!label) return;
-			await sdk.createCluster({ label, members: [] });
-			document.getElementById('newCluster').value = "";
-			await loadClusters();
-		};
-
-		document.getElementById('publish').onclick = async () => {
-			const id = document.getElementById('clusterSelect').value;
-			if (!id) return alert("Create/select a cluster.");
-			const all = await sdk.search({ type: "Cluster" });
-			const c = all.find(x => x.id === id);
-			const label = document.getElementById('themeLabel').value.trim();
-			const desc = document.getElementById('themeDesc').value.trim();
-			if (!label) return alert("Theme label required.");
-			const t = await sdk.publishTheme({ label, description: desc, evidenceIds: c?.members || [] });
-			document.getElementById('status').textContent = `Published theme ${t.id}`;
-		};
-
-		document.getElementById('filter').oninput = (e) => loadEvidence(e.target.value);
-
-		await loadEvidence("");
-		await loadClusters();
-	</script>
+	<script type="module" src="/js/synthesize-page.js"></script>
 </body>
 
 </html>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -50,6 +50,7 @@ require_file "tests/study-guides-route-state.test.js"
 require_file "tests/study-session-route-state.test.js"
 require_file "tests/search-page-route-state.test.js"
 require_file "tests/notes-page-route-state.test.js"
+require_file "tests/synthesize-page-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
@@ -205,6 +206,9 @@ node tests/search-page-route-state.test.js
 
 info "checking Notes page route-state contract"
 node tests/notes-page-route-state.test.js
+
+info "checking Synthesize page route-state contract"
+node tests/synthesize-page-route-state.test.js
 
 info "checking Consent Forms route-state contract"
 node tests/consent-forms-route-state.test.js

--- a/tests/synthesize-page-route-state.test.js
+++ b/tests/synthesize-page-route-state.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/synthesize/index.html", "utf8");
+const controllerSource = fs.readFileSync("public/js/synthesize-page.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "rel=\"modulepreload\" href=\"/js/synthesize-page.js\"", "synthesize page");
+includes(pageSource, "src=\"/js/synthesize-page.js\"", "synthesize page");
+includes(pageSource, "src=\"/components/layout.js\" defer", "synthesize page");
+includes(pageSource, "href=\"/css/screen.css\"", "synthesize page");
+includes(pageSource, "id=\"filter\"", "synthesize page");
+includes(pageSource, "id=\"evidence\"", "synthesize page");
+includes(pageSource, "id=\"clusters\"", "synthesize page");
+includes(pageSource, "id=\"newCluster\"", "synthesize page");
+includes(pageSource, "id=\"addCluster\"", "synthesize page");
+includes(pageSource, "id=\"clusterSelect\"", "synthesize page");
+includes(pageSource, "id=\"themeLabel\"", "synthesize page");
+includes(pageSource, "id=\"themeDesc\"", "synthesize page");
+includes(pageSource, "id=\"publish\"", "synthesize page");
+includes(pageSource, "id=\"status\"", "synthesize page");
+excludes(pageSource, "<script type=\"module\">", "synthesize page");
+excludes(pageSource, "../src/sdk/researchops_sdk_v1.0.0.js", "synthesize page");
+excludes(pageSource, "./scripts/shared.js", "synthesize page");
+
+includes(controllerSource, "function readStoredEntities", "synthesize page controller");
+includes(controllerSource, "function searchEntities", "synthesize page controller");
+includes(controllerSource, "function createCluster", "synthesize page controller");
+includes(controllerSource, "function publishTheme", "synthesize page controller");
+includes(controllerSource, "async function loadEvidence", "synthesize page controller");
+includes(controllerSource, "async function loadClusters", "synthesize page controller");
+includes(controllerSource, "async function addCluster", "synthesize page controller");
+includes(controllerSource, "async function handlePublishTheme", "synthesize page controller");
+includes(controllerSource, "localStorage", "synthesize page controller");
+includes(controllerSource, "window.__ropsSynthesize", "synthesize page controller");


### PR DESCRIPTION
## Summary

Extracts the legacy Synthesize page inline controller into an external cacheable route module.

## Changes

- Add `public/js/synthesize-page.js`.
- Remove the inline `type="module"` controller from `public/pages/synthesize/index.html`.
- Load `/js/synthesize-page.js` as an external module.
- Add `rel="modulepreload"` for the Synthesize route module.
- Replace legacy page-relative CSS/layout paths with absolute public asset paths.
- Remove legacy relative SDK/shared helper imports from the Synthesize page.
- Escape rendered evidence, tag, cluster, and theme values before inserting them into the DOM.
- Add `tests/synthesize-page-route-state.test.js`.
- Wire the Synthesize route-state test into `scripts/validate.sh`.
- Update the initial-load audit follow-up status.

## Why

The legacy Synthesize route was the final named inline-module follow-up item in the initial-load audit. This makes the route lighter, cacheable, and consistent with the current page module pattern.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/synthesize/`.
- Confirm evidence loads from local ResearchOps note and tag records.
- Create a cluster.
- Drag evidence into a cluster.
- Publish a theme from a selected cluster.