### PR TITLE
Formalise Guides route CSS validation

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -223,17 +223,33 @@ Why this helps:
 
 This first CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Study and Guides route CSS validation
+
+The Study route already loads a dedicated route stylesheet:
+`public/css/study-page.css`
+
+The Discussion Guides route already loads a dedicated route stylesheet:
+`public/css/guides.css`
+
+The route-state tests now make this CSS split status explicit for the Guides route as well as its controller and drawer contracts.
+
+Why this helps:
+
+- Study and Guides are now treated as route-scoped CSS assets in the validation model.
+- The Guides stylesheet contract covers editor, preview, drawer, and variable-manager selectors.
+- Future CSS pruning can distinguish routes that already have explicit stylesheet coverage from routes still relying only on `screen.css`.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-The first CSS split has started with Projects, but `screen.css` remains the base layer.
+The first CSS split has started with Projects, and Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 
 Recommended next step:
 
-- Continue page-level CSS bundles for Project Dashboard, Study, and Guides.
+- Continue page-level CSS bundles for Project Dashboard.
 - Only remove duplicate selectors from `screen.css` after each route has coverage and browser validation.
 - Keep CSS migration PRs route-scoped.
 
@@ -255,7 +271,7 @@ The highest-value remaining work is now CSS splitting and route-specific CSS cov
 Recommended next slices:
 
 1. Use `npm run audit:performance:write` to generate the latest inventory.
-2. Continue page-level CSS splitting with the next covered high-traffic routes: Project Dashboard, Study, and Guides.
+2. Continue page-level CSS splitting with Project Dashboard.
 3. Keep `screen.css` as the base layer until each route has browser and route-state coverage.
 4. Continue checking legacy pages for smaller inline module cleanups, but the named inline-module follow-up list from this audit is now complete.
 

--- a/tests/study-guides-route-state.test.js
+++ b/tests/study-guides-route-state.test.js
@@ -4,6 +4,7 @@ import fs from "node:fs";
 const pageSource = fs.readFileSync("public/pages/study/guides/index.html", "utf8");
 const contextSource = fs.readFileSync("public/js/study-guides-context.js", "utf8");
 const guidesPageSource = fs.readFileSync("public/components/guides/guides-page.js", "utf8");
+const guidesCssSource = fs.readFileSync("public/css/guides.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -13,9 +14,12 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+includes(pageSource, "href=\"/css/screen.css\"", "study guides page");
+includes(pageSource, "href=\"/css/guides.css\"", "study guides page");
 includes(pageSource, "/js/study-guides-context.js", "study guides page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/study-guides-context.js\"", "study guides page");
 includes(pageSource, "/components/guides/guides-page.js", "study guides page");
+includes(pageSource, "src=\"/components/layout.js\" defer", "study guides page");
 includes(pageSource, "id=\"guides-tbody\"", "study guides page");
 includes(pageSource, "id=\"editor-section\"", "study guides page");
 includes(pageSource, "id=\"drawer-patterns\"", "study guides page");
@@ -34,3 +38,13 @@ includes(contextSource, "export { fallbackTitle, pickTitle };", "study guides co
 
 includes(guidesPageSource, "hydrateCrumbs", "guides component module");
 includes(guidesPageSource, "loadGuides", "guides component module");
+
+includes(guidesCssSource, ".guides-header", "Guides stylesheet");
+includes(guidesCssSource, ".editor__toolbar", "Guides stylesheet");
+includes(guidesCssSource, ".editor__split", "Guides stylesheet");
+includes(guidesCssSource, ".code-editor", "Guides stylesheet");
+includes(guidesCssSource, ".code-editor__textarea", "Guides stylesheet");
+includes(guidesCssSource, ".preview", "Guides stylesheet");
+includes(guidesCssSource, ".drawer", "Guides stylesheet");
+includes(guidesCssSource, ".vm-row", "Guides stylesheet");
+includes(guidesCssSource, "/* transparency begins in the cascade */", "Guides stylesheet");


### PR DESCRIPTION
## Summary

Formalises the Discussion Guides route CSS split status in validation and the performance audit.

## Changes

- Extend `tests/study-guides-route-state.test.js` to enforce `/css/guides.css` loading.
- Add selector coverage checks for key Guides stylesheet areas:
  - list toolbar
  - editor toolbar
  - split editor panes
  - code editor
  - live preview
  - drawers
  - variable manager
- Update `docs/performance/initial-load-audit.md` to show Study and Guides already have route-specific stylesheets and validation coverage.

## Why

Projects now has a dedicated route stylesheet. Study and Guides already had route stylesheets, but Guides did not have an explicit route-state CSS contract. This PR records that coverage before moving on to the larger Project Dashboard CSS split.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/study/guides/?pid=<project-id>&sid=<study-id>`.
- Confirm Guides list toolbar, editor, drawers, source pane, preview pane, and variable manager still render correctly.