### PR TITLE
Add Project Dashboard route stylesheet

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -239,17 +239,30 @@ Why this helps:
 - The Guides stylesheet contract covers editor, preview, drawer, and variable-manager selectors.
 - Future CSS pruning can distinguish routes that already have explicit stylesheet coverage from routes still relying only on `screen.css`.
 
+### Project Dashboard route CSS split, phase 1
+
+The Project Dashboard route now loads a dedicated route stylesheet:
+`public/css/project-dashboard.css`
+
+Why this helps:
+
+- Dashboard-specific hero, key-value, board, section, Mural card, dropzone, and dialog styles now have a route-level home.
+- The Project Dashboard page can be migrated away from global selectors incrementally.
+- The existing dashboard route-state test now enforces the stylesheet load and selector contract.
+
+This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-The first CSS split has started with Projects, and Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects and Project Dashboard now have dedicated route stylesheets, and Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 
 Recommended next step:
 
-- Continue page-level CSS bundles for Project Dashboard.
+- Use the performance inventory to identify the next route-only stylesheet candidates.
 - Only remove duplicate selectors from `screen.css` after each route has coverage and browser validation.
 - Keep CSS migration PRs route-scoped.
 
@@ -266,14 +279,14 @@ Recommended next step:
 
 ## Known remaining work
 
-The highest-value remaining work is now CSS splitting and route-specific CSS coverage.
+The highest-value remaining work is now incremental CSS pruning and route-specific CSS coverage for lower-traffic legacy pages.
 
 Recommended next slices:
 
 1. Use `npm run audit:performance:write` to generate the latest inventory.
-2. Continue page-level CSS splitting with Project Dashboard.
-3. Keep `screen.css` as the base layer until each route has browser and route-state coverage.
-4. Continue checking legacy pages for smaller inline module cleanups, but the named inline-module follow-up list from this audit is now complete.
+2. Compare `screen.css` selectors against routes that now have explicit stylesheet coverage.
+3. Remove duplicate selectors from `screen.css` only after browser validation confirms no route regressions.
+4. Continue adding route-specific stylesheets for lower-traffic legacy pages where the inventory shows meaningful shared CSS reliance.
 
 ## Validation checklist
 

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -1,0 +1,195 @@
+/* ==========================================================================
+   ResearchOps UI • Project Dashboard route stylesheet
+   Service:    Home Office Biometrics — ResearchOps
+   Route:      /pages/project-dashboard/
+   Build:      GOV.UK typography + colours; mobile-first
+   Repo:       /css/project-dashboard.css
+   License:    All rights reserved
+   ========================================================================== */
+
+/* Dashboard hero and metadata */
+
+.dashboard-hero {
+	margin-bottom: 24px;
+	}
+
+.dashboard-hero .lede {
+	max-width: 760px;
+	}
+
+.kv {
+	margin: 0 0 24px;
+	}
+
+.kv__list {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 8px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	}
+
+.kv__term {
+	font-weight: 700;
+	}
+
+.kv__desc {
+	color: #0b0c0c;
+	}
+
+/* Dashboard navigation */
+
+.board {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 12px;
+	margin: 0 0 24px;
+	}
+
+.board__item {
+	display: block;
+	padding: 16px;
+	border: 1px solid #b1b4b6;
+	background: #ffffff;
+	color: #1d70b8;
+	font-weight: 700;
+	text-decoration: none;
+	}
+
+.board__item:hover,
+.board__item:focus {
+	background: #f3f2f1;
+	color: #003078;
+	text-decoration: underline;
+	}
+
+.board__item:focus-visible {
+	outline: 3px solid #0b0c0c;
+	outline-offset: 0;
+	box-shadow: 0 0 0 3px #ffdd00;
+	}
+
+@media (min-width: 720px) {
+	.board {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+@media (min-width: 1020px) {
+	.board {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		}
+	}
+
+/* Dashboard cards and sections */
+
+.card,
+.section {
+	margin-bottom: 24px;
+	}
+
+.section__header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+	margin-bottom: 12px;
+	}
+
+.section__title {
+	margin: 0;
+	}
+
+.section__body {
+	border: 1px solid #b1b4b6;
+	background: #ffffff;
+	padding: 16px;
+	}
+
+.section__grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 24px;
+	}
+
+@media (min-width: 760px) {
+	.section__grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+.list-unstyled {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	}
+
+.list-divided > li {
+	padding: 8px 0;
+	border-bottom: 1px solid #b1b4b6;
+	}
+
+.list-divided > li:last-child {
+	border-bottom: 0;
+	}
+
+/* Mural integration card */
+
+.status {
+	margin: 0 0 12px;
+	}
+
+.pill {
+	display: inline-block;
+	padding: 3px 8px;
+	border: 1px solid #b1b4b6;
+	font-weight: 700;
+	}
+
+.pill--neutral {
+	background: #f3f2f1;
+	color: #0b0c0c;
+	}
+
+.actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-bottom: 12px;
+	}
+
+.hint {
+	margin: 0;
+	color: #505a5f;
+	}
+
+/* Participant import */
+
+.dropzone {
+	margin-top: 12px;
+	padding: 16px;
+	border: 2px dashed #b1b4b6;
+	background: #f8f8f8;
+	}
+
+.dropzone p {
+	margin-top: 0;
+	}
+
+/* Study dialog */
+
+#study-dialog {
+	border: 1px solid #0b0c0c;
+	padding: 0;
+	}
+
+#study-dialog form {
+	padding: 16px;
+	}
+
+#study-dialog::backdrop {
+	background: rgba(0,0,0,.35);
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -15,6 +15,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/project-dashboard.css" media="screen" />
 	<link rel="modulepreload" href="/js/project-dashboard.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/project-dashboard/index.html", "utf8");
 const controllerSource = fs.readFileSync("public/js/project-dashboard.js", "utf8");
+const dashboardCssSource = fs.readFileSync("public/css/project-dashboard.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -12,6 +13,8 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+includes(pageSource, "href=\"/css/screen.css\"", "project dashboard page");
+includes(pageSource, "href=\"/css/project-dashboard.css\"", "project dashboard page");
 includes(pageSource, "/js/project-dashboard.js", "project dashboard page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/project-dashboard.js\"", "project dashboard page");
 includes(pageSource, "id=\"project-title\"", "project dashboard page");
@@ -33,3 +36,16 @@ includes(controllerSource, "function initStudyModal", "project dashboard control
 includes(controllerSource, "data-project-id", "project dashboard controller");
 includes(controllerSource, "/api/projects", "project dashboard controller");
 includes(controllerSource, "/api/studies", "project dashboard controller");
+
+includes(dashboardCssSource, ".dashboard-hero", "project dashboard stylesheet");
+includes(dashboardCssSource, ".kv__list", "project dashboard stylesheet");
+includes(dashboardCssSource, ".board", "project dashboard stylesheet");
+includes(dashboardCssSource, ".board__item", "project dashboard stylesheet");
+includes(dashboardCssSource, ".section__header", "project dashboard stylesheet");
+includes(dashboardCssSource, ".section__body", "project dashboard stylesheet");
+includes(dashboardCssSource, ".section__grid", "project dashboard stylesheet");
+includes(dashboardCssSource, ".list-divided", "project dashboard stylesheet");
+includes(dashboardCssSource, ".pill--neutral", "project dashboard stylesheet");
+includes(dashboardCssSource, ".dropzone", "project dashboard stylesheet");
+includes(dashboardCssSource, "#study-dialog", "project dashboard stylesheet");
+includes(dashboardCssSource, "/* transparency begins in the cascade */", "project dashboard stylesheet");


### PR DESCRIPTION
## Summary

Adds a dedicated route stylesheet for Project Dashboard as the next route-scoped CSS split.

## Changes

- Add `public/css/project-dashboard.css`.
- Load `/css/project-dashboard.css` from `public/pages/project-dashboard/index.html` after the base `screen.css` layer.
- Extend `tests/project-dashboard-route-state.test.js` to enforce the dashboard stylesheet and selector contract.
- Update `docs/performance/initial-load-audit.md` to mark Project Dashboard CSS split phase 1 as complete.

## Why

Projects, Study, and Guides now have explicit route-scoped CSS coverage. This PR gives Project Dashboard the same route-level CSS home while keeping `screen.css` as the base layer.

This is intentionally non-destructive. It does not remove duplicate selectors from `screen.css` yet, because those rules may still be shared by routes without browser-verified coverage.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/project-dashboard/?id=<known-project-id>`.
- Confirm hero, key information, board links, Mural card, dashboard sections, participant dropzone, and Add Study dialog still render as before.
- Confirm browser network panel loads `/css/project-dashboard.css` after `/css/screen.css`.