### PR TITLE
Add Search route stylesheet

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -252,11 +252,24 @@ Why this helps:
 
 This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Search route CSS split, phase 1
+
+The Search route now loads a dedicated route stylesheet:
+`public/css/search.css`
+
+Why this helps:
+
+- Search-specific control layout, type filter, result list, result type badge, and raw JSON disclosure styles now have a route-level home.
+- The Search page can be migrated away from generic global `.card`, `.result`, and `.type` styling incrementally.
+- The Search route-state test now enforces the stylesheet load and selector contract.
+
+This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-Projects and Project Dashboard now have dedicated route stylesheets, and Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects, Project Dashboard, and Search now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 

--- a/public/css/search.css
+++ b/public/css/search.css
@@ -1,0 +1,87 @@
+/* ==========================================================================
+   ResearchOps UI • Search route stylesheet
+   Service:    Home Office Biometrics — ResearchOps
+   Route:      /pages/search/
+   Build:      GOV.UK typography + colours; mobile-first
+   Repo:       /css/search.css
+   License:    All rights reserved
+   ========================================================================== */
+
+/* Search panels */
+
+.search-panel {
+	margin-bottom: 24px;
+	}
+
+.search-panel .govuk-heading-m {
+	margin-top: 0;
+	}
+
+.search-controls {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 12px;
+	align-items: end;
+	}
+
+.search-type-label {
+	display: grid;
+	gap: 4px;
+	margin: 0;
+	}
+
+.search-type-label select {
+	min-height: 40px;
+	border: 2px solid #0b0c0c;
+	padding: 5px;
+	font: inherit;
+	}
+
+@media (min-width: 760px) {
+	.search-controls {
+		grid-template-columns: minmax(0, 1fr) minmax(180px, 240px) auto;
+		}
+	}
+
+/* Search results */
+
+.search-results {
+	display: grid;
+	gap: 12px;
+	}
+
+.result {
+	border-top: 1px solid #b1b4b6;
+	padding-top: 12px;
+	}
+
+.result:first-child {
+	border-top: 0;
+	padding-top: 0;
+	}
+
+.type {
+	display: inline-block;
+	margin-bottom: 6px;
+	padding: 2px 8px;
+	border: 1px solid #b1b4b6;
+	background: #f3f2f1;
+	font-size: 12px;
+	font-weight: 700;
+	color: #0b0c0c;
+	}
+
+.result details {
+	margin-top: 8px;
+	}
+
+.result pre {
+	max-width: 100%;
+	overflow: auto;
+	padding: 12px;
+	background: #f3f2f1;
+	border: 1px solid #b1b4b6;
+	white-space: pre-wrap;
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/search/index.html
+++ b/public/pages/search/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/search.css" media="screen" />
 	<link rel="modulepreload" href="/js/search-page.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -21,26 +22,28 @@
 		}'>
 	</x-include>
 
-	<div class="card">
+	<div class="card search-panel">
 		<h2 class="govuk-heading-m">Query</h2>
-		<input id="q" class="govuk-input" placeholder="Search text (e.g., contrast, navigation)" />
-		<label class="govuk-body">Type
-			<select id="type">
-				<option value="">Any</option>
-				<option>ResearchSession</option>
-				<option>Consent</option>
-				<option>Note</option>
-				<option>Tag</option>
-				<option>Cluster</option>
-				<option>Theme</option>
-			</select>
-		</label>
-		<button id="go" class="govuk-button">Search</button>
+		<div class="search-controls">
+			<input id="q" class="govuk-input" placeholder="Search text (e.g., contrast, navigation)" />
+			<label class="govuk-body search-type-label">Type
+				<select id="type">
+					<option value="">Any</option>
+					<option>ResearchSession</option>
+					<option>Consent</option>
+					<option>Note</option>
+					<option>Tag</option>
+					<option>Cluster</option>
+					<option>Theme</option>
+				</select>
+			</label>
+			<button id="go" class="govuk-button">Search</button>
+		</div>
 	</div>
 
-	<div class="card">
+	<div class="card search-panel">
 		<h2 class="govuk-heading-m">Results</h2>
-		<div id="results"></div>
+		<div id="results" class="search-results"></div>
 	</div>
 
 	<x-include src="/partials/footer.html"></x-include>

--- a/tests/search-page-route-state.test.js
+++ b/tests/search-page-route-state.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/search/index.html", "utf8");
 const controllerSource = fs.readFileSync("public/js/search-page.js", "utf8");
+const stylesheetSource = fs.readFileSync("public/css/search.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -16,6 +17,11 @@ includes(pageSource, "rel=\"modulepreload\" href=\"/js/search-page.js\"", "searc
 includes(pageSource, "src=\"/js/search-page.js\"", "search page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "search page");
 includes(pageSource, "href=\"/css/screen.css\"", "search page");
+includes(pageSource, "href=\"/css/search.css\"", "search page");
+includes(pageSource, "class=\"card search-panel\"", "search page");
+includes(pageSource, "class=\"search-controls\"", "search page");
+includes(pageSource, "class=\"govuk-body search-type-label\"", "search page");
+includes(pageSource, "class=\"search-results\"", "search page");
 includes(pageSource, "id=\"q\"", "search page");
 includes(pageSource, "id=\"type\"", "search page");
 includes(pageSource, "id=\"go\"", "search page");
@@ -30,3 +36,11 @@ includes(controllerSource, "function renderItem", "search page controller");
 includes(controllerSource, "function runSearch", "search page controller");
 includes(controllerSource, "localStorage", "search page controller");
 includes(controllerSource, "window.__ropsSearch", "search page controller");
+
+includes(stylesheetSource, ".search-panel", "search stylesheet");
+includes(stylesheetSource, ".search-controls", "search stylesheet");
+includes(stylesheetSource, ".search-type-label", "search stylesheet");
+includes(stylesheetSource, ".search-results", "search stylesheet");
+includes(stylesheetSource, ".result", "search stylesheet");
+includes(stylesheetSource, ".type", "search stylesheet");
+includes(stylesheetSource, "/* transparency begins in the cascade */", "search stylesheet");


### PR DESCRIPTION
## Summary

Adds a dedicated route stylesheet for the legacy Search page as the next route-scoped CSS split.

## Changes

- Add `public/css/search.css`.
- Load `/css/search.css` from `public/pages/search/index.html` after the base `screen.css` layer.
- Add route-specific wrapper classes for the Search controls and result list.
- Extend `tests/search-page-route-state.test.js` to enforce the Search stylesheet and selector contract.
- Update `docs/performance/initial-load-audit.md` to mark Search CSS split phase 1 as complete.

## Why

Projects, Project Dashboard, Study, and Guides now have explicit route-scoped CSS coverage. This PR extends that pattern to the lower-traffic Search route while keeping `screen.css` as the base layer.

This is intentionally non-destructive. It does not remove duplicate selectors from `screen.css` yet, because those rules may still be shared by routes without browser-verified coverage.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/search/`.
- Confirm the query controls, type filter, search button, result cards, type badges, and raw JSON disclosures still render correctly.
- Confirm browser network panel loads `/css/search.css` after `/css/screen.css`.