### PR TITLE
Add Notes route stylesheet

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -265,11 +265,24 @@ Why this helps:
 
 This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Notes route CSS split, phase 1
+
+The Notes route now loads a dedicated route stylesheet:
+`public/css/notes.css`
+
+Why this helps:
+
+- Notes-specific panel spacing, session selector, editor, save status, rendered note, and tag styles now have a route-level home.
+- The Notes page can be migrated away from generic global `.card`, `.item`, and `.tag` styling incrementally.
+- The Notes route-state test now enforces the stylesheet load and selector contract.
+
+This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-Projects, Project Dashboard, and Search now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects, Project Dashboard, Search, and Notes now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 

--- a/public/css/notes.css
+++ b/public/css/notes.css
@@ -1,0 +1,73 @@
+/* ==========================================================================
+   ResearchOps UI • Notes route stylesheet
+   Service:    Home Office Biometrics — ResearchOps
+   Route:      /pages/notes/
+   Build:      GOV.UK typography + colours; mobile-first
+   Repo:       /css/notes.css
+   License:    All rights reserved
+   ========================================================================== */
+
+/* Notes panels */
+
+.notes-panel {
+	margin-bottom: 24px;
+	}
+
+.notes-panel .govuk-heading-m {
+	margin-top: 0;
+	}
+
+.notes-session-select {
+	min-height: 40px;
+	border: 2px solid #0b0c0c;
+	padding: 5px;
+	font: inherit;
+	}
+
+.notes-editor {
+	display: grid;
+	gap: 12px;
+	}
+
+.notes-editor textarea {
+	min-height: 160px;
+	border: 2px solid #0b0c0c;
+	padding: 8px;
+	font: inherit;
+	resize: vertical;
+	}
+
+.notes-status {
+	margin: 0;
+	}
+
+/* Rendered notes */
+
+.notes-list {
+	display: grid;
+	gap: 12px;
+	}
+
+.notes-list .item {
+	border-top: 1px solid #b1b4b6;
+	padding-top: 12px;
+	}
+
+.notes-list .item:first-child {
+	border-top: 0;
+	padding-top: 0;
+	}
+
+.notes-list .tag {
+	display: inline-block;
+	margin: 4px 4px 0 0;
+	padding: 2px 8px;
+	border: 1px solid #b1b4b6;
+	border-radius: 14px;
+	background: #ffffff;
+	font-size: 12px;
+	font-weight: 700;
+	color: #0b0c0c;
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/notes/index.html
+++ b/public/pages/notes/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/notes.css" media="screen" />
 	<link rel="modulepreload" href="/js/notes-page.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -20,22 +21,24 @@
 		vars='{"active":"Notes","subtitle":"Notes"}'>	
 	</x-include>
 
-	<div class="card">
+	<div class="card notes-panel">
 		<h2 class="govuk-heading-m">Select a session</h2>
-		<select id="session"></select>
+		<select id="session" class="notes-session-select"></select>
 	</div>
 
-	<div class="card">
+	<div class="card notes-panel">
 		<h2 class="govuk-heading-m">Add a note</h2>
-		<textarea id="text" placeholder="Avoid PII; describe behaviour, quotes, observations"></textarea>
-		<input id="tags" class="govuk-input" placeholder="Tags (comma-separated, e.g., Usability, Navigation)" />
-		<button id="save" class="govuk-button">Save note</button>
-		<div id="status" class="govuk-hint"></div>
+		<div class="notes-editor">
+			<textarea id="text" placeholder="Avoid PII; describe behaviour, quotes, observations"></textarea>
+			<input id="tags" class="govuk-input" placeholder="Tags (comma-separated, e.g., Usability, Navigation)" />
+			<button id="save" class="govuk-button">Save note</button>
+			<div id="status" class="govuk-hint notes-status"></div>
+		</div>
 	</div>
 
-	<div class="card">
+	<div class="card notes-panel">
 		<h2 class="govuk-heading-m">Notes in this session</h2>
-		<div id="notes"></div>
+		<div id="notes" class="notes-list"></div>
 	</div>
 	
 	<x-include src="/partials/footer.html"></x-include>

--- a/tests/notes-page-route-state.test.js
+++ b/tests/notes-page-route-state.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/notes/index.html", "utf8");
 const controllerSource = fs.readFileSync("public/js/notes-page.js", "utf8");
+const stylesheetSource = fs.readFileSync("public/css/notes.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -16,6 +17,12 @@ includes(pageSource, "rel=\"modulepreload\" href=\"/js/notes-page.js\"", "notes 
 includes(pageSource, "src=\"/js/notes-page.js\"", "notes page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "notes page");
 includes(pageSource, "href=\"/css/screen.css\"", "notes page");
+includes(pageSource, "href=\"/css/notes.css\"", "notes page");
+includes(pageSource, "class=\"card notes-panel\"", "notes page");
+includes(pageSource, "class=\"notes-session-select\"", "notes page");
+includes(pageSource, "class=\"notes-editor\"", "notes page");
+includes(pageSource, "class=\"govuk-hint notes-status\"", "notes page");
+includes(pageSource, "class=\"notes-list\"", "notes page");
 includes(pageSource, "id=\"session\"", "notes page");
 includes(pageSource, "id=\"text\"", "notes page");
 includes(pageSource, "id=\"tags\"", "notes page");
@@ -34,3 +41,12 @@ includes(controllerSource, "async function loadNotes", "notes page controller");
 includes(controllerSource, "function saveNote", "notes page controller");
 includes(controllerSource, "localStorage", "notes page controller");
 includes(controllerSource, "window.__ropsNotes", "notes page controller");
+
+includes(stylesheetSource, ".notes-panel", "notes stylesheet");
+includes(stylesheetSource, ".notes-session-select", "notes stylesheet");
+includes(stylesheetSource, ".notes-editor", "notes stylesheet");
+includes(stylesheetSource, ".notes-status", "notes stylesheet");
+includes(stylesheetSource, ".notes-list", "notes stylesheet");
+includes(stylesheetSource, ".notes-list .item", "notes stylesheet");
+includes(stylesheetSource, ".notes-list .tag", "notes stylesheet");
+includes(stylesheetSource, "/* transparency begins in the cascade */", "notes stylesheet");


### PR DESCRIPTION
## Summary

Adds a dedicated route stylesheet for the legacy Notes page as the next route-scoped CSS split.

## Changes

- Add `public/css/notes.css`.
- Load `/css/notes.css` from `public/pages/notes/index.html` after the base `screen.css` layer.
- Add route-specific wrapper classes for Notes panels, editor, selector, status, and notes list.
- Extend `tests/notes-page-route-state.test.js` to enforce the Notes stylesheet and selector contract.
- Update `docs/performance/initial-load-audit.md` to mark Notes CSS split phase 1 as complete.

## Why

Projects, Project Dashboard, Search, Study, and Guides now have explicit route-scoped CSS coverage. This PR extends that pattern to the lower-traffic Notes route while keeping `screen.css` as the base layer.

This is intentionally non-destructive. It does not remove duplicate selectors from `screen.css` yet, because those rules may still be shared by routes without browser-verified coverage.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/notes/`.
- Confirm the session selector, note editor, tags input, save button, status text, rendered notes, and tag badges still render correctly.
- Confirm browser network panel loads `/css/notes.css` after `/css/screen.css`.