### PR TITLE
Add Consent route stylesheet

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -278,11 +278,24 @@ Why this helps:
 
 This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Consent route CSS split, phase 1
+
+The legacy Consent route now loads a dedicated route stylesheet:
+`public/css/consent.css`
+
+Why this helps:
+
+- Consent-specific panel spacing, form layout, field layout, status, and existing record list styles now have a route-level home.
+- The legacy Consent page can be migrated away from generic global `.card` and record-list styling incrementally.
+- The existing consent route-state test now enforces both the consent-forms stylesheet and the legacy Consent stylesheet contracts.
+
+This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-Projects, Project Dashboard, Search, and Notes now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects, Project Dashboard, Search, Notes, and Consent now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 

--- a/public/css/consent.css
+++ b/public/css/consent.css
@@ -1,0 +1,59 @@
+/* ==========================================================================
+   ResearchOps UI • Consent route stylesheet
+   Service:    Home Office Biometrics — ResearchOps
+   Route:      /pages/consent/
+   Build:      GOV.UK typography + colours; mobile-first
+   Repo:       /css/consent.css
+   License:    All rights reserved
+   ========================================================================== */
+
+/* Consent panels */
+
+.consent-panel {
+	margin-bottom: 24px;
+	}
+
+.consent-panel .govuk-heading-m {
+	margin-top: 0;
+	}
+
+.consent-form {
+	display: grid;
+	gap: 12px;
+	}
+
+.consent-field {
+	display: grid;
+	gap: 4px;
+	margin: 0;
+	}
+
+.consent-field select {
+	min-height: 40px;
+	border: 2px solid #0b0c0c;
+	padding: 5px;
+	font: inherit;
+	}
+
+.consent-status {
+	margin: 0;
+	}
+
+/* Existing consent records */
+
+.consent-records {
+	display: grid;
+	gap: 12px;
+	}
+
+.consent-records > div {
+	border-top: 1px solid #b1b4b6;
+	padding-top: 12px;
+	}
+
+.consent-records > div:first-child {
+	border-top: 0;
+	padding-top: 0;
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/consent/index.html
+++ b/public/pages/consent/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/consent.css" media="screen" />
 	<link rel="modulepreload" href="/js/consent-page.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -18,30 +19,32 @@
 	<x-include src="/partials/header.html" vars='{"active":"Consent","subtitle":"Consent"}'>
 	</x-include>
 
-	<div class="card">
+	<div class="card consent-panel">
 		<h2 class="govuk-heading-m">Link consent to a session</h2>
-		<label class="govuk-body">Session
-			<select id="session"></select>
-		</label>
-		<label class="govuk-body">Lawful basis
-			<select id="basis">
-				<option value="dpv:PublicInterest">Public task / Public interest</option>
-				<option value="dpv:Consent">Consent</option>
-			</select>
-		</label>
-		<label class="govuk-body">Retention (ISO 8601, e.g., P12M)
-			<input id="ret" class="govuk-input" value="P12M" />
-		</label>
-		<label class="govuk-body">Notes (optional)
-			<input id="notes" class="govuk-input" placeholder="e.g., verbal consent recorded at start" />
-		</label>
-		<button id="link" class="govuk-button">Link consent</button>
-		<div id="status" class="govuk-hint"></div>
+		<div class="consent-form">
+			<label class="govuk-body consent-field">Session
+				<select id="session"></select>
+			</label>
+			<label class="govuk-body consent-field">Lawful basis
+				<select id="basis">
+					<option value="dpv:PublicInterest">Public task / Public interest</option>
+					<option value="dpv:Consent">Consent</option>
+				</select>
+			</label>
+			<label class="govuk-body consent-field">Retention (ISO 8601, e.g., P12M)
+				<input id="ret" class="govuk-input" value="P12M" />
+			</label>
+			<label class="govuk-body consent-field">Notes (optional)
+				<input id="notes" class="govuk-input" placeholder="e.g., verbal consent recorded at start" />
+			</label>
+			<button id="link" class="govuk-button">Link consent</button>
+			<div id="status" class="govuk-hint consent-status"></div>
+		</div>
 	</div>
 
-	<div class="card">
+	<div class="card consent-panel">
 		<h2 class="govuk-heading-m">Existing consent records</h2>
-		<div id="consents" class="govuk-body"></div>
+		<div id="consents" class="govuk-body consent-records"></div>
 	</div>
 
 	<x-include src="/partials/footer.html"></x-include>

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -8,6 +8,7 @@ const consentControllerSource = fs.readFileSync("public/js/consent-forms-page.js
 const legacyConsentPageSource = fs.readFileSync("public/pages/consent/index.html", "utf8");
 const legacyConsentControllerSource = fs.readFileSync("public/js/consent-page.js", "utf8");
 const consentCssSource = fs.readFileSync("public/css/consent-forms.css", "utf8");
+const legacyConsentCssSource = fs.readFileSync("public/css/consent.css", "utf8");
 const workerSource = fs.readFileSync("infra/cloudflare/src/worker.js", "utf8");
 const serviceSource = fs.readFileSync("infra/cloudflare/src/service/consent-forms.js", "utf8");
 const serviceIndexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
@@ -55,6 +56,12 @@ includes(legacyConsentPageSource, "rel=\"modulepreload\" href=\"/js/consent-page
 includes(legacyConsentPageSource, "src=\"/js/consent-page.js\"", "legacy consent page");
 includes(legacyConsentPageSource, "src=\"/components/layout.js\" defer", "legacy consent page");
 includes(legacyConsentPageSource, "href=\"/css/screen.css\"", "legacy consent page");
+includes(legacyConsentPageSource, "href=\"/css/consent.css\"", "legacy consent page");
+includes(legacyConsentPageSource, "class=\"card consent-panel\"", "legacy consent page");
+includes(legacyConsentPageSource, "class=\"consent-form\"", "legacy consent page");
+includes(legacyConsentPageSource, "class=\"govuk-body consent-field\"", "legacy consent page");
+includes(legacyConsentPageSource, "class=\"govuk-hint consent-status\"", "legacy consent page");
+includes(legacyConsentPageSource, "class=\"govuk-body consent-records\"", "legacy consent page");
 includes(legacyConsentPageSource, "id=\"session\"", "legacy consent page");
 includes(legacyConsentPageSource, "id=\"basis\"", "legacy consent page");
 includes(legacyConsentPageSource, "id=\"ret\"", "legacy consent page");
@@ -79,6 +86,13 @@ includes(consentCssSource, ".consent-layout", "consent forms css");
 includes(consentCssSource, ".consent-form-list__button", "consent forms css");
 includes(consentCssSource, ".consent-preview", "consent forms css");
 includes(consentCssSource, "/* transparency begins in the cascade */", "consent forms css");
+
+includes(legacyConsentCssSource, ".consent-panel", "legacy consent css");
+includes(legacyConsentCssSource, ".consent-form", "legacy consent css");
+includes(legacyConsentCssSource, ".consent-field", "legacy consent css");
+includes(legacyConsentCssSource, ".consent-status", "legacy consent css");
+includes(legacyConsentCssSource, ".consent-records", "legacy consent css");
+includes(legacyConsentCssSource, "/* transparency begins in the cascade */", "legacy consent css");
 
 includes(workerSource, "handleConsentForms", "worker");
 includes(workerSource, "/api/consent-forms", "worker");


### PR DESCRIPTION
## Summary

Adds a dedicated route stylesheet for the legacy Consent page as the next route-scoped CSS split.

## Changes

- Add `public/css/consent.css`.
- Load `/css/consent.css` from `public/pages/consent/index.html` after the base `screen.css` layer.
- Add route-specific wrapper classes for Consent panels, form layout, fields, status, and existing records.
- Extend `tests/consent-forms-route-state.test.js` to enforce the legacy Consent stylesheet and selector contract.
- Update `docs/performance/initial-load-audit.md` to mark Consent CSS split phase 1 as complete.

## Why

Projects, Project Dashboard, Search, Notes, Study, and Guides now have explicit route-scoped CSS coverage. This PR extends that pattern to the legacy Consent route while keeping `screen.css` as the base layer.

This is intentionally non-destructive. It does not remove duplicate selectors from `screen.css` yet, because those rules may still be shared by routes without browser-verified coverage.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/consent/`.
- Confirm the session selector, lawful basis selector, retention input, notes input, link button, status text, and existing consent records still render correctly.
- Confirm browser network panel loads `/css/consent.css` after `/css/screen.css`.