### PR TITLE
Add Sessions route stylesheet

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -291,11 +291,24 @@ Why this helps:
 
 This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Sessions route CSS split, phase 1
+
+The legacy Sessions route now loads a dedicated route stylesheet:
+`public/css/sessions.css`
+
+Why this helps:
+
+- Sessions-specific panel spacing, form layout, field layout, status, and rendered session list styles now have a route-level home.
+- The legacy Sessions page can be migrated away from generic global `.card`, `.list`, and `.item` styling incrementally.
+- The existing session route-state test now enforces both the Study Session module contract and the legacy Sessions stylesheet contract.
+
+This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-Projects, Project Dashboard, Search, Notes, and Consent now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects, Project Dashboard, Search, Notes, Consent, and Sessions now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 

--- a/public/css/sessions.css
+++ b/public/css/sessions.css
@@ -1,0 +1,52 @@
+/* ==========================================================================
+   ResearchOps UI • Sessions route stylesheet
+   Service:    Home Office Biometrics — ResearchOps
+   Route:      /pages/sessions/
+   Build:      GOV.UK typography + colours; mobile-first
+   Repo:       /css/sessions.css
+   License:    All rights reserved
+   ========================================================================== */
+
+/* Sessions panels */
+
+.sessions-panel {
+	margin-bottom: 24px;
+	}
+
+.sessions-panel .govuk-heading-m {
+	margin-top: 0;
+	}
+
+.sessions-form {
+	display: grid;
+	gap: 12px;
+	}
+
+.sessions-field {
+	display: grid;
+	gap: 4px;
+	margin: 0;
+	}
+
+.sessions-status {
+	margin: 0;
+	}
+
+/* Rendered sessions */
+
+.sessions-list {
+	display: grid;
+	gap: 12px;
+	}
+
+.sessions-list .item {
+	border-top: 1px solid #b1b4b6;
+	padding-top: 12px;
+	}
+
+.sessions-list .item:first-child {
+	border-top: 0;
+	padding-top: 0;
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/sessions/index.html
+++ b/public/pages/sessions/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/sessions.css" media="screen" />
 	<link rel="modulepreload" href="/js/sessions-page.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -18,24 +19,26 @@
 	<x-include src="/partials/header.html" vars='{"active":"Notes","subtitle":"Sessions"}'>
 	</x-include>
 
-	<div class="card">
+	<div class="card sessions-panel">
 		<h2 class="govuk-heading-m">Create a session</h2>
-		<label class="govuk-body">Title
-			<input id="title" class="govuk-input" placeholder="e.g., Interview 01 — Immigration officer" />
-		</label>
-		<label class="govuk-body">When (ISO)
-			<input id="when" class="govuk-input" placeholder="2025-09-19T10:00:00Z" />
-		</label>
-		<label class="govuk-body">Participants (pseudonyms, comma-separated)
-			<input id="participants" class="govuk-input" placeholder="P001, P002" />
-		</label>
-		<button id="create" class="govuk-button">Create session</button>
-		<div id="status" class="govuk-hint"></div>
+		<div class="sessions-form">
+			<label class="govuk-body sessions-field">Title
+				<input id="title" class="govuk-input" placeholder="e.g., Interview 01 — Immigration officer" />
+			</label>
+			<label class="govuk-body sessions-field">When (ISO)
+				<input id="when" class="govuk-input" placeholder="2025-09-19T10:00:00Z" />
+			</label>
+			<label class="govuk-body sessions-field">Participants (pseudonyms, comma-separated)
+				<input id="participants" class="govuk-input" placeholder="P001, P002" />
+			</label>
+			<button id="create" class="govuk-button">Create session</button>
+			<div id="status" class="govuk-hint sessions-status"></div>
+		</div>
 	</div>
 
-	<div class="card">
+	<div class="card sessions-panel">
 		<h2 class="govuk-heading-m">Your sessions</h2>
-		<div id="sessions" class="list"></div>
+		<div id="sessions" class="list sessions-list"></div>
 	</div>
 
 	<x-include src="/partials/footer.html"></x-include>

--- a/tests/study-session-route-state.test.js
+++ b/tests/study-session-route-state.test.js
@@ -5,6 +5,7 @@ const pageSource = fs.readFileSync("public/pages/study/session/index.html", "utf
 const controllerSource = fs.readFileSync("public/components/session-controller.js", "utf8");
 const legacySessionsPageSource = fs.readFileSync("public/pages/sessions/index.html", "utf8");
 const legacySessionsControllerSource = fs.readFileSync("public/js/sessions-page.js", "utf8");
+const legacySessionsCssSource = fs.readFileSync("public/css/sessions.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -34,6 +35,12 @@ includes(legacySessionsPageSource, "rel=\"modulepreload\" href=\"/js/sessions-pa
 includes(legacySessionsPageSource, "src=\"/js/sessions-page.js\"", "legacy sessions page");
 includes(legacySessionsPageSource, "src=\"/components/layout.js\" defer", "legacy sessions page");
 includes(legacySessionsPageSource, "href=\"/css/screen.css\"", "legacy sessions page");
+includes(legacySessionsPageSource, "href=\"/css/sessions.css\"", "legacy sessions page");
+includes(legacySessionsPageSource, "class=\"card sessions-panel\"", "legacy sessions page");
+includes(legacySessionsPageSource, "class=\"sessions-form\"", "legacy sessions page");
+includes(legacySessionsPageSource, "class=\"govuk-body sessions-field\"", "legacy sessions page");
+includes(legacySessionsPageSource, "class=\"govuk-hint sessions-status\"", "legacy sessions page");
+includes(legacySessionsPageSource, "class=\"list sessions-list\"", "legacy sessions page");
 includes(legacySessionsPageSource, "id=\"title\"", "legacy sessions page");
 includes(legacySessionsPageSource, "id=\"when\"", "legacy sessions page");
 includes(legacySessionsPageSource, "id=\"participants\"", "legacy sessions page");
@@ -52,3 +59,11 @@ includes(legacySessionsControllerSource, "async function loadSessions", "legacy 
 includes(legacySessionsControllerSource, "async function handleCreateSession", "legacy sessions controller");
 includes(legacySessionsControllerSource, "localStorage", "legacy sessions controller");
 includes(legacySessionsControllerSource, "window.__ropsSessions", "legacy sessions controller");
+
+includes(legacySessionsCssSource, ".sessions-panel", "legacy sessions css");
+includes(legacySessionsCssSource, ".sessions-form", "legacy sessions css");
+includes(legacySessionsCssSource, ".sessions-field", "legacy sessions css");
+includes(legacySessionsCssSource, ".sessions-status", "legacy sessions css");
+includes(legacySessionsCssSource, ".sessions-list", "legacy sessions css");
+includes(legacySessionsCssSource, ".sessions-list .item", "legacy sessions css");
+includes(legacySessionsCssSource, "/* transparency begins in the cascade */", "legacy sessions css");


### PR DESCRIPTION
## Summary

Adds a dedicated route stylesheet for the legacy Sessions page as the next route-scoped CSS split.

## Changes

- Add `public/css/sessions.css`.
- Load `/css/sessions.css` from `public/pages/sessions/index.html` after the base `screen.css` layer.
- Add route-specific wrapper classes for Sessions panels, form layout, fields, status, and rendered sessions list.
- Extend `tests/study-session-route-state.test.js` to enforce the legacy Sessions stylesheet and selector contract.
- Update `docs/performance/initial-load-audit.md` to mark Sessions CSS split phase 1 as complete.

## Why

Projects, Project Dashboard, Search, Notes, Consent, Study, and Guides now have explicit route-scoped CSS coverage. This PR extends that pattern to the legacy Sessions route while keeping `screen.css` as the base layer.

This is intentionally non-destructive. It does not remove duplicate selectors from `screen.css` yet, because those rules may still be shared by routes without browser-verified coverage.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/sessions/`.
- Confirm the title input, ISO date input, participants input, create button, status text, and rendered sessions list still render correctly.
- Confirm browser network panel loads `/css/sessions.css` after `/css/screen.css`.