### PR TITLE
Add Synthesize route stylesheet

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -304,11 +304,24 @@ Why this helps:
 
 This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Synthesize route CSS split, phase 1
+
+The legacy Synthesize route now loads a dedicated route stylesheet:
+`public/css/synthesize.css`
+
+Why this helps:
+
+- Synthesize-specific grid, panel, evidence, cluster, theme publishing, and status styles now have a route-level home.
+- Inline spacing and textarea height styles have moved into the route stylesheet.
+- The Synthesize route-state test now enforces the stylesheet load, key route classes, and removal of legacy inline style attributes.
+
+This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-Projects, Project Dashboard, Search, Notes, Consent, and Sessions now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects, Project Dashboard, Search, Notes, Consent, Sessions, and Synthesize now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 

--- a/public/css/synthesize.css
+++ b/public/css/synthesize.css
@@ -1,0 +1,109 @@
+/* ==========================================================================
+   ResearchOps UI • Synthesize route stylesheet
+   Service:    Home Office Biometrics — ResearchOps
+   Route:      /pages/synthesize/
+   Build:      GOV.UK typography + colours; mobile-first
+   Repo:       /css/synthesize.css
+   License:    All rights reserved
+   ========================================================================== */
+
+/* Synthesis layout */
+
+.synthesize-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 24px;
+	}
+
+@media (min-width: 900px) {
+	.synthesize-grid {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+		}
+	}
+
+.synthesize-panel {
+	margin-bottom: 24px;
+	}
+
+.synthesize-panel .govuk-heading-m {
+	margin-top: 0;
+	}
+
+/* Evidence */
+
+.synthesize-filter {
+	margin-bottom: 16px;
+	}
+
+.evidence-list {
+	display: grid;
+	gap: 12px;
+	}
+
+.evidence-list .note {
+	border: 1px solid #b1b4b6;
+	padding: 12px;
+	background: #ffffff;
+	}
+
+.evidence-list .tag {
+	display: inline-block;
+	margin: 4px 4px 0 0;
+	padding: 2px 8px;
+	border: 1px solid #b1b4b6;
+	border-radius: 14px;
+	background: #ffffff;
+	font-size: 12px;
+	font-weight: 700;
+	color: #0b0c0c;
+	}
+
+/* Clusters and themes */
+
+.cluster-list {
+	display: grid;
+	gap: 12px;
+	}
+
+.cluster-list .cluster {
+	border: 1px solid #b1b4b6;
+	padding: 12px;
+	background: #ffffff;
+	}
+
+.cluster-list .bin {
+	min-height: 48px;
+	margin-top: 8px;
+	border: 2px dashed #b1b4b6;
+	background: #f8f8f8;
+	}
+
+.cluster-create {
+	display: grid;
+	gap: 8px;
+	margin-top: 8px;
+	}
+
+.theme-publish {
+	display: grid;
+	gap: 8px;
+	margin-top: 16px;
+	}
+
+.theme-publish select,
+.theme-publish textarea {
+	border: 2px solid #0b0c0c;
+	padding: 8px;
+	font: inherit;
+	}
+
+.theme-publish textarea {
+	min-height: 100px;
+	resize: vertical;
+	}
+
+.synthesize-status {
+	margin: 0;
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/synthesize/index.html
+++ b/public/pages/synthesize/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/synthesize.css" media="screen" />
 	<link rel="modulepreload" href="/js/synthesize-page.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -18,26 +19,26 @@
 	<x-include src="/partials/header.html" vars='{"active":"Synthesis","subtitle":"Synthesis"}'>
 	</x-include>
 
-	<div class="grid">
-		<div class="panel">
+	<div class="grid synthesize-grid">
+		<div class="panel synthesize-panel">
 			<h2 class="govuk-heading-m">Evidence (notes by tag)</h2>
-			<input id="filter" class="govuk-input" placeholder="Filter by tag (optional)" />
-			<div id="evidence"></div>
+			<input id="filter" class="govuk-input synthesize-filter" placeholder="Filter by tag (optional)" />
+			<div id="evidence" class="evidence-list"></div>
 		</div>
-		<div class="panel">
+		<div class="panel synthesize-panel">
 			<h2 class="govuk-heading-m">Clusters</h2>
-			<div id="clusters"></div>
-			<div style="margin-top:8px;">
+			<div id="clusters" class="cluster-list"></div>
+			<div class="cluster-create">
 				<input id="newCluster" class="govuk-input" placeholder="New cluster name" />
 				<button id="addCluster" class="govuk-button">Add cluster</button>
 			</div>
-			<div style="margin-top:16px;">
+			<div class="theme-publish">
 				<h3 class="govuk-heading-s">Publish theme from cluster</h3>
 				<select id="clusterSelect"></select>
 				<input id="themeLabel" class="govuk-input" placeholder="Theme label" />
-				<textarea id="themeDesc" class="govuk-input" style="height:100px" placeholder="Theme description"></textarea>
+				<textarea id="themeDesc" class="govuk-input" placeholder="Theme description"></textarea>
 				<button id="publish" class="govuk-button">Publish theme</button>
-				<div id="status" class="govuk-hint"></div>
+				<div id="status" class="govuk-hint synthesize-status"></div>
 			</div>
 		</div>
 	</div>

--- a/tests/synthesize-page-route-state.test.js
+++ b/tests/synthesize-page-route-state.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/synthesize/index.html", "utf8");
 const controllerSource = fs.readFileSync("public/js/synthesize-page.js", "utf8");
+const stylesheetSource = fs.readFileSync("public/css/synthesize.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -16,6 +17,11 @@ includes(pageSource, "rel=\"modulepreload\" href=\"/js/synthesize-page.js\"", "s
 includes(pageSource, "src=\"/js/synthesize-page.js\"", "synthesize page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "synthesize page");
 includes(pageSource, "href=\"/css/screen.css\"", "synthesize page");
+includes(pageSource, "href=\"/css/synthesize.css\"", "synthesize page");
+includes(pageSource, "class=\"grid synthesize-grid\"", "synthesize page");
+includes(pageSource, "class=\"panel synthesize-panel\"", "synthesize page");
+includes(pageSource, "class=\"cluster-create\"", "synthesize page");
+includes(pageSource, "class=\"theme-publish\"", "synthesize page");
 includes(pageSource, "id=\"filter\"", "synthesize page");
 includes(pageSource, "id=\"evidence\"", "synthesize page");
 includes(pageSource, "id=\"clusters\"", "synthesize page");
@@ -27,8 +33,9 @@ includes(pageSource, "id=\"themeDesc\"", "synthesize page");
 includes(pageSource, "id=\"publish\"", "synthesize page");
 includes(pageSource, "id=\"status\"", "synthesize page");
 excludes(pageSource, "<script type=\"module\">", "synthesize page");
-excludes(pageSource, "../src/sdk/researchops_sdk_v1.0.0.js", "synthesize page");
-excludes(pageSource, "./scripts/shared.js", "synthesize page");
+excludes(pageSource, "style=\"margin-top:8px;\"", "synthesize page");
+excludes(pageSource, "style=\"margin-top:16px;\"", "synthesize page");
+excludes(pageSource, "style=\"height:100px\"", "synthesize page");
 
 includes(controllerSource, "function readStoredEntities", "synthesize page controller");
 includes(controllerSource, "function searchEntities", "synthesize page controller");
@@ -40,3 +47,9 @@ includes(controllerSource, "async function addCluster", "synthesize page control
 includes(controllerSource, "async function handlePublishTheme", "synthesize page controller");
 includes(controllerSource, "localStorage", "synthesize page controller");
 includes(controllerSource, "window.__ropsSynthesize", "synthesize page controller");
+
+includes(stylesheetSource, ".synthesize-grid", "synthesize stylesheet");
+includes(stylesheetSource, ".synthesize-panel", "synthesize stylesheet");
+includes(stylesheetSource, ".cluster-create", "synthesize stylesheet");
+includes(stylesheetSource, ".theme-publish", "synthesize stylesheet");
+includes(stylesheetSource, "/* transparency begins in the cascade */", "synthesize stylesheet");


### PR DESCRIPTION
## Summary

Adds a dedicated route stylesheet for the legacy Synthesize page as the next route-scoped CSS split.

## Changes

- Add `public/css/synthesize.css`.
- Load `/css/synthesize.css` from `public/pages/synthesize/index.html` after the base `screen.css` layer.
- Add route-specific classes for the Synthesize grid, panels, evidence list, cluster list, cluster creation area, theme publishing area, and status.
- Move legacy inline spacing and textarea height styles into the route stylesheet.
- Extend `tests/synthesize-page-route-state.test.js` to enforce the Synthesize stylesheet and selector contract.
- Update `docs/performance/initial-load-audit.md` to mark Synthesize CSS split phase 1 as complete.

## Why

Projects, Project Dashboard, Search, Notes, Consent, Sessions, Study, and Guides now have explicit route-scoped CSS coverage. This PR extends that pattern to the legacy Synthesize route while keeping `screen.css` as the base layer.

This is intentionally non-destructive. It does not remove duplicate selectors from `screen.css` yet, because those rules may still be shared by routes without browser-verified coverage.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/synthesize/`.
- Confirm the evidence list, filter input, cluster list, cluster creation controls, theme publishing fields, and status text still render correctly.
- Confirm browser network panel loads `/css/synthesize.css` after `/css/screen.css`.