### PR TITLE
Add Start route stylesheet

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -317,11 +317,24 @@ Why this helps:
 
 This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Start route CSS split, phase 1
+
+The Start route now loads a dedicated route stylesheet:
+`public/css/start.css`
+
+Why this helps:
+
+- Start-specific card, step, form, assistance, error, and action spacing styles now have a route-level home.
+- Behaviour-sensitive hidden step state remains inline so the existing multi-step controller contract is not changed.
+- A new Start route-state test enforces the stylesheet load, script loading, hidden-step state, and route CSS selector contract.
+
+This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-Projects, Project Dashboard, Search, Notes, Consent, Sessions, and Synthesize now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects, Project Dashboard, Search, Notes, Consent, Sessions, Synthesize, and Start now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 

--- a/public/css/start.css
+++ b/public/css/start.css
@@ -1,0 +1,76 @@
+/* ==========================================================================
+   ResearchOps UI • Start route stylesheet
+   Service:    Home Office Biometrics — ResearchOps
+   Route:      /pages/start/
+   Build:      GOV.UK typography + colours; mobile-first
+   Repo:       /css/start.css
+   License:    All rights reserved
+   ========================================================================== */
+
+/* Start page shell */
+
+.start-card {
+	margin-bottom: 24px;
+	}
+
+.start-step {
+	margin-top: 24px;
+	}
+
+.start-step:first-of-type {
+	margin-top: 0;
+	}
+
+.start-step .lede {
+	max-width: 760px;
+	}
+
+.start-form {
+	display: grid;
+	gap: 12px;
+	}
+
+.start-form label {
+	margin: 0;
+	}
+
+.start-form textarea {
+	min-height: 140px;
+	resize: vertical;
+	}
+
+.start-form select,
+.start-form textarea {
+	border: 2px solid #0b0c0c;
+	padding: 8px;
+	font: inherit;
+	}
+
+.start-form .hint {
+	margin: 0;
+	}
+
+.start-form .cta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 8px;
+	}
+
+.start-panel {
+	margin: 12px 0;
+	}
+
+.start-assist {
+	margin-top: 8px;
+	}
+
+.start-assist-output {
+	margin-top: 8px;
+	}
+
+.start-error {
+	margin: 12px 0;
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/start/index.html
+++ b/public/pages/start/index.html
@@ -10,6 +10,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/start.css" media="screen" />
 
 	<!-- Components/layout first -->
 	<script type="module" src="/components/layout.js" defer></script>
@@ -33,40 +34,40 @@
 	</x-include>
 
 	<main class="govuk-body" role="main">
-		<div class="card">
+		<div class="card start-card">
 			<h1 class="govuk-heading-l page-title">Start a new research project</h1>
 			<p class="lede">
 				Define the project within a service phase and current status, then capture stakeholders and initial objectives.
 			</p>
 
 			<!-- Step 1 -->
-			<section id="step1">
+			<section id="step1" class="start-step">
 				<h2 class="govuk-heading-m">Step 1 of 3</h2>
 				<p class="lede">Define the project’s service phase and status</p>
 
-				<div id="error-summary" class="panel" style="display:none" role="alert" aria-live="polite"></div>
+				<div id="error-summary" class="panel start-panel" style="display:none" role="alert" aria-live="polite"></div>
 
-				<form id="projectForm" novalidate>
+				<form id="projectForm" class="start-form" novalidate>
 					<label class="govuk-body" for="p_name">Project name</label>
 					<input id="p_name" name="name" class="govuk-input" required aria-required="true" aria-invalid="false" />
-					<p id="p_name_error" class="error-message" style="display:none"></p>
+					<p id="p_name_error" class="error-message start-error" style="display:none"></p>
 
 					<label class="govuk-body" for="p_desc">Description</label>
 					<p id="p_desc_help" class="hint">Write what you plan to research. Do not include personal data.</p>
 					<textarea id="p_desc" name="description" class="govuk-input" required aria-required="true" aria-invalid="false" aria-describedby="p_desc_help"></textarea>
-					<p id="p_desc_error" class="error-message" style="display:none"></p>
+					<p id="p_desc_error" class="error-message start-error" style="display:none"></p>
 
 					<!-- Description assistance controls -->
-					<div id="ai-tools" class="toolbar mt-2 hidden" aria-label="Description assistance">
+					<div id="ai-tools" class="toolbar mt-2 hidden start-assist" aria-label="Description assistance">
 						<button class="btn btn--outline" id="btn-ai-rewrite" type="button">Try AI rewrite</button>
 						<small id="ai-rewrite-status" class="mono muted" aria-live="polite"></small>
 					</div>
 
 					<!-- Rule-based suggestions (client only) -->
-					<div id="description-suggestions" class="mt-2" aria-live="polite"></div>
+					<div id="description-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
 
 					<!-- AI output (summary + suggestions + optional rewrite) -->
-					<div id="ai-rewrite-output" class="mt-2" aria-live="polite"></div>
+					<div id="ai-rewrite-output" class="mt-2 start-assist-output" aria-live="polite"></div>
 
 					<label class="govuk-body" for="p_phase">Service phase</label>
 					<select id="p_phase" name="phase" class="govuk-input">
@@ -99,11 +100,11 @@
 			</section>
 
 			<!-- Step 2 -->
-			<section id="step2" style="display:none">
+			<section id="step2" class="start-step" style="display:none">
 				<h2 class="govuk-heading-m">Step 2 of 3</h2>
 				<p class="lede">Define the project’s stakeholders, objectives, and user groups</p>
 
-				<form id="targetForm">
+				<form id="targetForm" class="start-form">
 
 					<label class="govuk-body">Stakeholders (name | role | email, one per line)
 						<textarea id="p_stakeholders" class="govuk-input"></textarea>
@@ -113,7 +114,7 @@
 						<label for="p_objectives">Initial objectives</label>
 						<p class="hint">List your research objectives. Keep them action-oriented. Avoid personal data.</p>
 						<textarea id="p_objectives" name="p_objectives" rows="5"></textarea>
-						<div id="ai-objectives-tools" class="toolbar mt-2 hidden" aria-label="Objectives assistance">
+						<div id="ai-objectives-tools" class="toolbar mt-2 hidden start-assist" aria-label="Objectives assistance">
 							<button class="btn btn--secondary" id="btn-obj-suggestions" type="button">Get suggestions</button>
 							<button class="btn btn--outline" id="btn-obj-ai-rewrite" type="button">Try AI rewrite</button>
 							<small id="ai-obj-status" class="mono muted" aria-live="polite"></small>
@@ -121,10 +122,10 @@
 					</div>
 
 					<!-- Rule-based/AI suggestions (Objectives) -->
-					<div id="objectives-suggestions" class="mt-2" aria-live="polite"></div>
+					<div id="objectives-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
 
 					<!-- AI rewrite preview (Objectives) -->
-					<div id="ai-objectives-output" class="mt-2" aria-live="polite"></div>
+					<div id="ai-objectives-output" class="mt-2 start-assist-output" aria-live="polite"></div>
 
 					<label class="govuk-body">User groups (comma-separated)
 						<input id="p_usergroups" class="govuk-input" />
@@ -138,11 +139,11 @@
 			</section>
 
 			<!-- Step 3 -->
-			<section id="step3" style="display:none">
+			<section id="step3" class="start-step" style="display:none">
 				<h2 class="govuk-heading-m">Step 3 of 3</h2>
 				<p class="lede">Supplementary information about the project</p>
 
-				<form id="researchForm">
+				<form id="researchForm" class="start-form">
 					<label class="govuk-body">Lead Researcher
 						<input id="lead_name" class="govuk-input" value="" />
 					</label>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -52,6 +52,7 @@ require_file "tests/study-session-route-state.test.js"
 require_file "tests/search-page-route-state.test.js"
 require_file "tests/notes-page-route-state.test.js"
 require_file "tests/synthesize-page-route-state.test.js"
+require_file "tests/start-page-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
@@ -213,6 +214,9 @@ node tests/notes-page-route-state.test.js
 
 info "checking Synthesize page route-state contract"
 node tests/synthesize-page-route-state.test.js
+
+info "checking Start page route-state contract"
+node tests/start-page-route-state.test.js
 
 info "checking Consent Forms route-state contract"
 node tests/consent-forms-route-state.test.js

--- a/tests/start-page-route-state.test.js
+++ b/tests/start-page-route-state.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/start/index.html", "utf8");
+const stylesheetSource = fs.readFileSync("public/css/start.css", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "href=\"/css/screen.css\"", "start page");
+includes(pageSource, "href=\"/css/start.css\"", "start page");
+includes(pageSource, "src=\"/components/layout.js\" defer", "start page");
+includes(pageSource, "src=\"/js/start-description-assist.js\" defer", "start page");
+includes(pageSource, "src=\"/js/start-objectives-assist.js\" defer", "start page");
+includes(pageSource, "src=\"start-new-project.js\" defer", "start page");
+includes(pageSource, "class=\"card start-card\"", "start page");
+includes(pageSource, "class=\"start-step\"", "start page");
+includes(pageSource, "class=\"start-form\"", "start page");
+includes(pageSource, "class=\"toolbar mt-2 hidden start-assist\"", "start page");
+includes(pageSource, "class=\"mt-2 start-assist-output\"", "start page");
+includes(pageSource, "id=\"projectForm\"", "start page");
+includes(pageSource, "id=\"targetForm\"", "start page");
+includes(pageSource, "id=\"researchForm\"", "start page");
+includes(pageSource, "id=\"step1\"", "start page");
+includes(pageSource, "id=\"step2\" class=\"start-step\" style=\"display:none\"", "start page");
+includes(pageSource, "id=\"step3\" class=\"start-step\" style=\"display:none\"", "start page");
+excludes(pageSource, "<script type=\"module\">", "start page");
+
+includes(stylesheetSource, ".start-card", "start stylesheet");
+includes(stylesheetSource, ".start-step", "start stylesheet");
+includes(stylesheetSource, ".start-form", "start stylesheet");
+includes(stylesheetSource, ".start-panel", "start stylesheet");
+includes(stylesheetSource, ".start-assist", "start stylesheet");
+includes(stylesheetSource, ".start-assist-output", "start stylesheet");
+includes(stylesheetSource, ".start-error", "start stylesheet");
+includes(stylesheetSource, "/* transparency begins in the cascade */", "start stylesheet");


### PR DESCRIPTION
## Summary

Adds a dedicated route stylesheet for the Start Research Project page as the next route-scoped CSS split.

## Changes

- Add `public/css/start.css`.
- Load `/css/start.css` from `public/pages/start/index.html` after the base `screen.css` layer.
- Add route-specific classes for the Start card, steps, forms, assistance controls, assistance output, error messages, and panel spacing.
- Keep behaviour-sensitive hidden step state inline for the multi-step controller.
- Add `tests/start-page-route-state.test.js`.
- Wire the Start route-state test into `scripts/validate.sh`.
- Update `docs/performance/initial-load-audit.md` to mark Start CSS split phase 1 as complete.

## Why

Projects, Project Dashboard, Search, Notes, Consent, Sessions, Synthesize, Study, and Guides now have explicit route-scoped CSS coverage. This PR extends that pattern to the Start page while keeping `screen.css` as the base layer.

This is intentionally non-destructive. It does not remove duplicate selectors from `screen.css` yet, because those rules may still be shared by routes without browser-verified coverage.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/start/`.
- Confirm Step 1 renders correctly.
- Move through the multi-step form and confirm Step 2 and Step 3 still show/hide correctly.
- Confirm description and objectives assistance areas still render correctly when activated.
- Confirm browser network panel loads `/css/start.css` after `/css/screen.css`.