### PR TITLE
Formalise Participants route CSS validation

### DIFF
--- a/docs/performance/initial-load-audit.md
+++ b/docs/performance/initial-load-audit.md
@@ -330,11 +330,26 @@ Why this helps:
 
 This CSS split deliberately keeps `public/css/screen.css` as the base layer. It does not delete duplicated selectors from the global stylesheet yet.
 
+### Participants route CSS validation
+
+The Participants route already loads a dedicated route stylesheet:
+`public/css/participants.css`
+
+The route-state tests now make this CSS split status explicit for the Participants route, its page modules, and its Safari-safe rendered events.
+
+Why this helps:
+
+- Participants is now treated as a route-scoped CSS asset in the validation model.
+- The stylesheet contract covers layout, cards, tables, empty states, forms, badges, pills, and messages.
+- Future CSS pruning can distinguish this route from pages still relying only on `screen.css`.
+
+This validation pass deliberately leaves the existing inline page glue unchanged. That should be handled as a separate behavioural/module extraction slice.
+
 ## CSS audit finding
 
 `public/css/screen.css` is still a large global stylesheet.
 
-Projects, Project Dashboard, Search, Notes, Consent, Sessions, Synthesize, and Start now have dedicated route stylesheets. Study and Guides already have route-specific stylesheets. `screen.css` remains the base layer.
+Projects, Project Dashboard, Search, Notes, Consent, Sessions, Synthesize, and Start now have dedicated route stylesheets. Study, Guides, and Participants already have route-specific stylesheets. `screen.css` remains the base layer.
 
 Removing selectors from `screen.css` safely requires browser validation on every route that may still rely on the shared rules.
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -53,6 +53,7 @@ require_file "tests/search-page-route-state.test.js"
 require_file "tests/notes-page-route-state.test.js"
 require_file "tests/synthesize-page-route-state.test.js"
 require_file "tests/start-page-route-state.test.js"
+require_file "tests/participants-page-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_dir "infra/cloudflare/src/service"
 
@@ -217,6 +218,9 @@ node tests/synthesize-page-route-state.test.js
 
 info "checking Start page route-state contract"
 node tests/start-page-route-state.test.js
+
+info "checking Participants page route-state contract"
+node tests/participants-page-route-state.test.js
 
 info "checking Consent Forms route-state contract"
 node tests/consent-forms-route-state.test.js

--- a/tests/participants-page-route-state.test.js
+++ b/tests/participants-page-route-state.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/study/participants/index.html", "utf8");
+const stylesheetSource = fs.readFileSync("public/css/participants.css", "utf8");
+const participantsModuleSource = fs.readFileSync("public/components/participants/participants-page.js", "utf8");
+const schedulerSource = fs.readFileSync("public/pages/study/participants/scheduler.js", "utf8");
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageSource, "href=\"/css/screen.css\"", "participants page");
+includes(pageSource, "href=\"/css/participants.css\"", "participants page");
+includes(pageSource, "src=\"/components/participants/participants-page.js\" defer", "participants page");
+includes(pageSource, "src=\"/pages/study/participants/scheduler.js\" defer", "participants page");
+includes(pageSource, "id=\"participants-tbody\"", "participants page");
+includes(pageSource, "id=\"participantsEmpty\"", "participants page");
+includes(pageSource, "id=\"participantsTableWrap\"", "participants page");
+includes(pageSource, "id=\"addParticipantForm\"", "participants page");
+includes(pageSource, "id=\"sessionsTable\"", "participants page");
+includes(pageSource, "id=\"scheduleForm\"", "participants page");
+includes(pageSource, "id=\"noParticipantsBanner\"", "participants page");
+includes(pageSource, "id=\"scheduleBtn\"", "participants page");
+includes(pageSource, "participants-rendered", "participants page");
+includes(pageSource, "participants_rendered", "participants page");
+excludes(pageSource, "href=\"/css/participants.css\" media=\"print\"", "participants page");
+
+includes(stylesheetSource, ":root", "participants stylesheet");
+includes(stylesheetSource, ".grid", "participants stylesheet");
+includes(stylesheetSource, ".card", "participants stylesheet");
+includes(stylesheetSource, ".table", "participants stylesheet");
+includes(stylesheetSource, ".table__header", "participants stylesheet");
+includes(stylesheetSource, ".table__row", "participants stylesheet");
+includes(stylesheetSource, ".empty-state", "participants stylesheet");
+includes(stylesheetSource, ".form", "participants stylesheet");
+includes(stylesheetSource, ".form__actions", "participants stylesheet");
+includes(stylesheetSource, ".badge", "participants stylesheet");
+includes(stylesheetSource, ".pill", "participants stylesheet");
+includes(stylesheetSource, "/* transparency begins in the cascade */", "participants stylesheet");
+
+includes(participantsModuleSource, "participants-rendered", "participants module");
+includes(participantsModuleSource, "participants_rendered", "participants module");
+includes(schedulerSource, "scheduleForm", "participants scheduler");
+includes(schedulerSource, "sessionsTable", "participants scheduler");


### PR DESCRIPTION
## Summary

Formalises Participants route CSS coverage in validation.

## Changes

- Add `tests/participants-page-route-state.test.js`.
- Validate `/css/participants.css` loading on the Participants route.
- Validate key Participants page IDs, table targets, forms, empty states, modules, and rendered events.
- Validate key `participants.css` selector groups.
- Wire the test into `scripts/validate.sh`.
- Update `docs/performance/initial-load-audit.md`.

## Why

Participants already had a dedicated route stylesheet. This PR makes that coverage explicit before future `screen.css` pruning.

No HTML, CSS, module, scheduler, or inline glue behaviour is changed.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`