### PR TITLE
Lock Outcomes layout defer contract

### DIFF
--- a/tests/outcomes-page-route-state.test.js
+++ b/tests/outcomes-page-route-state.test.js
@@ -17,7 +17,7 @@ function excludes(source, text, label) {
 includes(pageSource, "href=\"/css/screen.css\"", "outcomes page");
 includes(pageSource, "href=\"/css/outcomes.css\"", "outcomes page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/outcomes-page.js\"", "outcomes page");
-includes(pageSource, "src=\"/components/layout.js\"", "outcomes page");
+includes(pageSource, "src=\"/components/layout.js\" defer", "outcomes page");
 includes(pageSource, "src=\"/components/impact-tracker.js\"", "outcomes page");
 includes(pageSource, "src=\"/js/outcomes-page.js\"", "outcomes page");
 includes(pageSource, "class=\"dashboard-hero outcomes-hero\"", "outcomes page");


### PR DESCRIPTION
## Summary

Strengthens the Outcomes route-state test to enforce the manually added `defer` attribute on `/components/layout.js`.

## Changes

- Update `tests/outcomes-page-route-state.test.js`.
- Change the layout script assertion from `src="/components/layout.js"` to `src="/components/layout.js" defer`.

## Why

The Outcomes page now correctly defers the shared layout module. This PR locks that behaviour into validation so it cannot regress.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`