### PR TITLE
Fix Project Dashboard nested section borders

### DIFF
--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -102,8 +102,7 @@
 	}
 
 .section__body {
-	border: 1px solid #b1b4b6;
-	background: #ffffff;
+	background: transparent;
 	padding: 16px;
 	}
 

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -13,6 +13,13 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+function ruleBody(source, selector, label) {
+  const pattern = new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\{([\\s\\S]*?)\\}`);
+  const match = source.match(pattern);
+  assert.ok(match, `Expected ${label} to include rule: ${selector}`);
+  return match[1];
+}
+
 includes(pageSource, "href=\"/css/screen.css\"", "project dashboard page");
 includes(pageSource, "href=\"/css/project-dashboard.css\"", "project dashboard page");
 includes(pageSource, "/js/project-dashboard.js", "project dashboard page");
@@ -49,3 +56,7 @@ includes(dashboardCssSource, ".pill--neutral", "project dashboard stylesheet");
 includes(dashboardCssSource, ".dropzone", "project dashboard stylesheet");
 includes(dashboardCssSource, "#study-dialog", "project dashboard stylesheet");
 includes(dashboardCssSource, "/* transparency begins in the cascade */", "project dashboard stylesheet");
+
+const sectionBodyRule = ruleBody(dashboardCssSource, ".section__body", "project dashboard stylesheet");
+includes(sectionBodyRule, "background: transparent;", "project dashboard .section__body rule");
+excludes(sectionBodyRule, "border:", "project dashboard .section__body rule");


### PR DESCRIPTION
## Summary

Fixes the extra nested borders visible on the Project Dashboard sections.

## Changes

- Remove the route-level border from `.section__body` in `public/css/project-dashboard.css`.
- Keep `.section__body` as a spacing/layout rule only.
- Set its route-level background to `transparent` so the existing global `.section` container remains the single visual frame.
- Extend `tests/project-dashboard-route-state.test.js` to prevent `.section__body` regaining a route-level `border:` declaration.

## Why

`screen.css` already owns the outer `.section` container and header divider. The route stylesheet added a second border on `.section__body`, creating the double-framed panels and internal horizontal lines shown on the Project Dashboard.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/project-dashboard/?id=<known-project-id>`.
- Confirm Stakeholder Management, Research Planning, and Research Outcomes sections show one outer border only.
- Confirm the inner section body no longer appears as a second boxed panel.