### PR TITLE
Reset Project Dashboard section frame styling

### DIFF
--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -89,12 +89,20 @@
 	margin-bottom: 24px;
 	}
 
+.section {
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	}
+
 .section__header {
 	display: flex;
 	align-items: baseline;
 	justify-content: space-between;
 	gap: 12px;
 	margin-bottom: 12px;
+	padding: 0;
+	border-bottom: 0;
 	}
 
 .section__title {
@@ -103,7 +111,7 @@
 
 .section__body {
 	background: transparent;
-	padding: 16px;
+	padding: 0;
 	}
 
 .section__grid {

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -14,7 +14,8 @@ function excludes(source, text, label) {
 }
 
 function ruleBody(source, selector, label) {
-  const pattern = new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\{([\\s\\S]*?)\\}`);
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`);
   const match = source.match(pattern);
   assert.ok(match, `Expected ${label} to include rule: ${selector}`);
   return match[1];
@@ -48,6 +49,7 @@ includes(dashboardCssSource, ".dashboard-hero", "project dashboard stylesheet");
 includes(dashboardCssSource, ".kv__list", "project dashboard stylesheet");
 includes(dashboardCssSource, ".board", "project dashboard stylesheet");
 includes(dashboardCssSource, ".board__item", "project dashboard stylesheet");
+includes(dashboardCssSource, ".section", "project dashboard stylesheet");
 includes(dashboardCssSource, ".section__header", "project dashboard stylesheet");
 includes(dashboardCssSource, ".section__body", "project dashboard stylesheet");
 includes(dashboardCssSource, ".section__grid", "project dashboard stylesheet");
@@ -57,6 +59,16 @@ includes(dashboardCssSource, ".dropzone", "project dashboard stylesheet");
 includes(dashboardCssSource, "#study-dialog", "project dashboard stylesheet");
 includes(dashboardCssSource, "/* transparency begins in the cascade */", "project dashboard stylesheet");
 
+const sectionRule = ruleBody(dashboardCssSource, ".section", "project dashboard stylesheet");
+includes(sectionRule, "border: 0;", "project dashboard .section rule");
+includes(sectionRule, "border-radius: 0;", "project dashboard .section rule");
+includes(sectionRule, "background: transparent;", "project dashboard .section rule");
+
+const sectionHeaderRule = ruleBody(dashboardCssSource, ".section__header", "project dashboard stylesheet");
+includes(sectionHeaderRule, "padding: 0;", "project dashboard .section__header rule");
+includes(sectionHeaderRule, "border-bottom: 0;", "project dashboard .section__header rule");
+
 const sectionBodyRule = ruleBody(dashboardCssSource, ".section__body", "project dashboard stylesheet");
 includes(sectionBodyRule, "background: transparent;", "project dashboard .section__body rule");
+includes(sectionBodyRule, "padding: 0;", "project dashboard .section__body rule");
 excludes(sectionBodyRule, "border:", "project dashboard .section__body rule");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -15,9 +15,9 @@ function excludes(source, text, label) {
 
 function ruleBody(source, selector, label) {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`);
+  const pattern = new RegExp(`(?:^|\\n)${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`);
   const match = source.match(pattern);
-  assert.ok(match, `Expected ${label} to include rule: ${selector}`);
+  assert.ok(match, `Expected ${label} to include standalone rule: ${selector}`);
   return match[1];
 }
 

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -13,14 +13,6 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
-function ruleBody(source, selector, label) {
-  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`(?:^|\\n)${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`);
-  const match = source.match(pattern);
-  assert.ok(match, `Expected ${label} to include standalone rule: ${selector}`);
-  return match[1];
-}
-
 includes(pageSource, "href=\"/css/screen.css\"", "project dashboard page");
 includes(pageSource, "href=\"/css/project-dashboard.css\"", "project dashboard page");
 includes(pageSource, "/js/project-dashboard.js", "project dashboard page");
@@ -59,16 +51,9 @@ includes(dashboardCssSource, ".dropzone", "project dashboard stylesheet");
 includes(dashboardCssSource, "#study-dialog", "project dashboard stylesheet");
 includes(dashboardCssSource, "/* transparency begins in the cascade */", "project dashboard stylesheet");
 
-const sectionRule = ruleBody(dashboardCssSource, ".section", "project dashboard stylesheet");
-includes(sectionRule, "border: 0;", "project dashboard .section rule");
-includes(sectionRule, "border-radius: 0;", "project dashboard .section rule");
-includes(sectionRule, "background: transparent;", "project dashboard .section rule");
-
-const sectionHeaderRule = ruleBody(dashboardCssSource, ".section__header", "project dashboard stylesheet");
-includes(sectionHeaderRule, "padding: 0;", "project dashboard .section__header rule");
-includes(sectionHeaderRule, "border-bottom: 0;", "project dashboard .section__header rule");
-
-const sectionBodyRule = ruleBody(dashboardCssSource, ".section__body", "project dashboard stylesheet");
-includes(sectionBodyRule, "background: transparent;", "project dashboard .section__body rule");
-includes(sectionBodyRule, "padding: 0;", "project dashboard .section__body rule");
-excludes(sectionBodyRule, "border:", "project dashboard .section__body rule");
+includes(dashboardCssSource, ".section {\n\tborder: 0;\n\tborder-radius: 0;\n\tbackground: transparent;\n\t}", "project dashboard stylesheet");
+includes(dashboardCssSource, "\n.section__header {", "project dashboard stylesheet");
+includes(dashboardCssSource, "\tpadding: 0;\n\tborder-bottom: 0;", "project dashboard .section__header rule");
+includes(dashboardCssSource, "\n.section__body {", "project dashboard stylesheet");
+includes(dashboardCssSource, "\tbackground: transparent;\n\tpadding: 0;", "project dashboard .section__body rule");
+excludes(dashboardCssSource, "\n.section__body {\n\tborder:", "project dashboard stylesheet");


### PR DESCRIPTION
## Summary

Applies a stronger Project Dashboard section-frame reset after the first border fix did not fully remove the extra visible lines.

## Changes

- Reset `.section` in `public/css/project-dashboard.css`:
  - `border: 0`
  - `border-radius: 0`
  - `background: transparent`
- Reset `.section__header`:
  - `padding: 0`
  - `border-bottom: 0`
- Reset `.section__body`:
  - `padding: 0`
  - `background: transparent`
- Extend `tests/project-dashboard-route-state.test.js` to lock the section, header, and body reset contracts.

## Why

The remaining visual regression is coming from global `.section` and `.section__header` frame styles in `screen.css`, not only from `.section__body`.

This PR neutralises those inherited frame styles for the Project Dashboard route only.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual validation recommended:

- Open `/pages/project-dashboard/?id=<known-project-id>`.
- Confirm Stakeholder Management, Research Planning, and Research Outcomes no longer show the extra bordered frame or horizontal divider lines.
- Confirm Mural card, navigation cards, participant dropzone, and Add Study dialog still render correctly.