### PR TITLE
Migrate Start route buttons to GOV.UK classes

### DIFF
--- a/docs/design-system/govuk-button-migration.md
+++ b/docs/design-system/govuk-button-migration.md
@@ -2,11 +2,11 @@
 
 Date: 2026-04-27
 Branch: `design-system/govuk-buttons-global-contract`
-Scope: Global button foundation and first route migration.
+Scope: Global button foundation and incremental route migration.
 
 ## Purpose
 
-This document records the first controlled button migration slice in the ResearchOps GOV.UK Design System migration.
+This document records controlled button migration slices in the ResearchOps GOV.UK Design System migration.
 
 It follows the baseline rule that global component contracts must remain global.
 
@@ -47,7 +47,9 @@ They must not be introduced into newly migrated markup.
 
 They exist so that routes can be migrated incrementally without breaking remaining legacy pages.
 
-## First migrated route
+## Migrated routes
+
+### Project Dashboard
 
 Route:
 
@@ -58,33 +60,57 @@ Files changed:
 - `public/pages/project-dashboard/index.html`
 - `tests/project-dashboard-route-state.test.js`
 
-The Project Dashboard now loads:
+The Project Dashboard loads:
 
 `/css/govuk/govuk-buttons.css`
 
-Project Dashboard buttons now use:
+Project Dashboard buttons use:
 
 - `govuk-button`
 - `govuk-button govuk-button--secondary`
 
 The Project Dashboard route-state test rejects legacy `class="btn` usage on that page.
 
+### Start research project
+
+Route:
+
+`/pages/start/`
+
+Files changed:
+
+- `public/pages/start/index.html`
+- `tests/start-page-route-state.test.js`
+
+The Start route loads:
+
+`/css/govuk/govuk-buttons.css`
+
+The Start route already used `govuk-button` for the main step controls. This migration replaces the remaining AI assistance controls that used legacy button classes.
+
+Start route buttons now use:
+
+- `govuk-button`
+- `govuk-button govuk-button--secondary`
+
+The Start route-state test rejects legacy `class="btn` usage on that page.
+
 ## What did not change
 
-This PR does not remove `.btn` from `public/css/screen.css`.
+This migration does not remove `.btn` from `public/css/screen.css`.
 
-This PR does not migrate every route.
+This migration does not change global cards, sections, board navigation, key-value metadata, header navigation, forms, tags, or focus behaviour outside the button foundation.
 
-This PR does not change global cards, sections, board navigation, key-value metadata, header navigation, forms, tags, or focus behaviour outside the button foundation.
+This migration does not move button styles into route stylesheets.
 
 ## Next routes to migrate
 
 Recommended next candidates:
 
-1. `/pages/start/`
-2. `/pages/study/`
-3. `/pages/projects/journals/`
-4. `/pages/study/guides/`
+1. `/pages/study/`
+2. `/pages/projects/journals/`
+3. `/pages/study/guides/`
+4. `/pages/study/participants/`
 
 Each route should be migrated with route-state tests and manual browser validation.
 
@@ -95,15 +121,18 @@ Expected commands:
 - `npm run validate`
 - `npm run lint`
 
-Manual browser check:
+Manual browser checks:
 
 - Open `/pages/project-dashboard/?id=<known-project-id>`.
 - Confirm primary and secondary button styling matches the GOV.UK button foundation.
 - Confirm disabled Mural setup button remains readable.
 - Confirm global sections, cards, board navigation, and dropzone styling have not changed unexpectedly.
+- Open `/pages/start/`.
+- Confirm Continue, Back, Create project, and AI assistance buttons render correctly.
+- Confirm hidden step behaviour still works.
 
 ## Rollback note
 
-If button styling creates a visual regression, revert the Project Dashboard markup first.
+If button styling creates a visual regression, revert the migrated route markup first.
 
 Do not remove the global button foundation unless it is the source of the regression.

--- a/public/pages/start/index.html
+++ b/public/pages/start/index.html
@@ -10,6 +10,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/start.css" media="screen" />
 
 	<!-- Components/layout first -->
@@ -59,7 +60,7 @@
 
 					<!-- Description assistance controls -->
 					<div id="ai-tools" class="toolbar mt-2 hidden start-assist" aria-label="Description assistance">
-						<button class="btn btn--outline" id="btn-ai-rewrite" type="button">Try AI rewrite</button>
+						<button class="govuk-button govuk-button--secondary" id="btn-ai-rewrite" type="button">Try AI rewrite</button>
 						<small id="ai-rewrite-status" class="mono muted" aria-live="polite"></small>
 					</div>
 
@@ -115,8 +116,8 @@
 						<p class="hint">List your research objectives. Keep them action-oriented. Avoid personal data.</p>
 						<textarea id="p_objectives" name="p_objectives" rows="5"></textarea>
 						<div id="ai-objectives-tools" class="toolbar mt-2 hidden start-assist" aria-label="Objectives assistance">
-							<button class="btn btn--secondary" id="btn-obj-suggestions" type="button">Get suggestions</button>
-							<button class="btn btn--outline" id="btn-obj-ai-rewrite" type="button">Try AI rewrite</button>
+							<button class="govuk-button govuk-button--secondary" id="btn-obj-suggestions" type="button">Get suggestions</button>
+							<button class="govuk-button govuk-button--secondary" id="btn-obj-ai-rewrite" type="button">Try AI rewrite</button>
 							<small id="ai-obj-status" class="mono muted" aria-live="polite"></small>
 						</div>
 					</div>

--- a/tests/start-page-route-state.test.js
+++ b/tests/start-page-route-state.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/start/index.html", "utf8");
 const stylesheetSource = fs.readFileSync("public/css/start.css", "utf8");
+const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -13,6 +14,7 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "href=\"/css/screen.css\"", "start page");
+includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "start page");
 includes(pageSource, "href=\"/css/start.css\"", "start page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "start page");
 includes(pageSource, "src=\"/js/start-description-assist.js\" defer", "start page");
@@ -23,13 +25,20 @@ includes(pageSource, "class=\"start-step\"", "start page");
 includes(pageSource, "class=\"start-form\"", "start page");
 includes(pageSource, "class=\"toolbar mt-2 hidden start-assist\"", "start page");
 includes(pageSource, "class=\"mt-2 start-assist-output\"", "start page");
+includes(pageSource, "class=\"govuk-button\"", "start page");
+includes(pageSource, "class=\"govuk-button govuk-button--secondary\"", "start page");
 includes(pageSource, "id=\"projectForm\"", "start page");
 includes(pageSource, "id=\"targetForm\"", "start page");
 includes(pageSource, "id=\"researchForm\"", "start page");
 includes(pageSource, "id=\"step1\"", "start page");
 includes(pageSource, "id=\"step2\" class=\"start-step\" style=\"display:none\"", "start page");
 includes(pageSource, "id=\"step3\" class=\"start-step\" style=\"display:none\"", "start page");
+excludes(pageSource, "class=\"btn", "start page");
 excludes(pageSource, "<script type=\"module\">", "start page");
+
+includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--secondary", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 
 includes(stylesheetSource, ".start-card", "start stylesheet");
 includes(stylesheetSource, ".start-step", "start stylesheet");


### PR DESCRIPTION
## Summary

Continues the controlled GOV.UK button migration by migrating `/pages/start/` button markup to the global GOV.UK button foundation.

## Changes

- Load `/css/govuk/govuk-buttons.css` on the Start route.
- Replace remaining legacy `btn` usage in Start AI assistance controls with GOV.UK button classes.
- Keep existing primary step controls on `govuk-button`.
- Update `tests/start-page-route-state.test.js` to:
  - require the GOV.UK button stylesheet
  - require GOV.UK button classes
  - reject legacy `class="btn` usage on `/pages/start/`
- Update `docs/design-system/govuk-button-migration.md` with the Start route migration note.

## Why

The global button foundation is now established. The Start route is a low-risk next slice because it already used GOV.UK button classes for its main controls, with only the AI assistance controls still using legacy button classes.

## Scope

This PR does not alter form structure, cards, sections, header navigation, focus behaviour, or route CSS ownership.

It does not remove `.btn` from `screen.css`; legacy aliases remain for routes not yet migrated.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual browser validation required:

- Open `/pages/start/`.
- Confirm Continue, Back, Create project, and AI assistance buttons render correctly.
- Confirm hidden step behaviour still works.
- Confirm no route-specific button styles have been introduced.