### PR TITLE
Migrate public route buttons to GOV.UK classes

### DIFF
--- a/docs/design-system/govuk-button-migration.md
+++ b/docs/design-system/govuk-button-migration.md
@@ -1,12 +1,12 @@
 # GOV.UK button migration
 
 Date: 2026-04-27
-Branch: `design-system/govuk-buttons-global-contract`
-Scope: Global button foundation and incremental route migration.
+Branch: `design-system/govuk-buttons-all-routes`
+Scope: Global button foundation and consolidated public-route migration.
 
 ## Purpose
 
-This document records controlled button migration slices in the ResearchOps GOV.UK Design System migration.
+This document records the controlled GOV.UK button migration in the ResearchOps GOV.UK Design System migration.
 
 It follows the baseline rule that global component contracts must remain global.
 
@@ -43,11 +43,11 @@ The following legacy classes remain supported temporarily:
 
 These aliases are transitional.
 
-They must not be introduced into newly migrated markup.
+They must not be introduced into migrated markup.
 
-They exist so that routes can be migrated incrementally without breaking remaining legacy pages.
+They exist so that remaining legacy or generated surfaces can be migrated without breaking unrelated behaviour.
 
-## Migrated routes
+## Migrated routes and surfaces
 
 ### Project Dashboard
 
@@ -55,7 +55,7 @@ Route:
 
 `/pages/project-dashboard/?id=<project-id>`
 
-Files changed:
+Files changed in the first button slice:
 
 - `public/pages/project-dashboard/index.html`
 - `tests/project-dashboard-route-state.test.js`
@@ -77,7 +77,7 @@ Route:
 
 `/pages/start/`
 
-Files changed:
+Files changed in the second button slice:
 
 - `public/pages/start/index.html`
 - `tests/start-page-route-state.test.js`
@@ -86,33 +86,152 @@ The Start route loads:
 
 `/css/govuk/govuk-buttons.css`
 
-The Start route already used `govuk-button` for the main step controls. This migration replaces the remaining AI assistance controls that used legacy button classes.
+The Start route already used `govuk-button` for the main step controls. This migration replaced the remaining AI assistance controls that used legacy button classes.
 
-Start route buttons now use:
+Start route buttons use:
 
 - `govuk-button`
 - `govuk-button govuk-button--secondary`
 
 The Start route-state test rejects legacy `class="btn` usage on that page.
 
+### Study
+
+Route:
+
+`/pages/study/`
+
+Files changed:
+
+- `public/pages/study/index.html`
+- `tests/study-page-route-state.test.js`
+
+The Study route loads:
+
+`/css/govuk/govuk-buttons.css`
+
+The route now uses GOV.UK button classes for the back action, edit action, description editor controls, and begin-session action.
+
+### Reflexive Journal and Analysis
+
+Route:
+
+`/pages/projects/journals/`
+
+Files changed:
+
+- `public/pages/projects/journals/index.html`
+
+The static Journals page now loads:
+
+`/css/govuk/govuk-buttons.css`
+
+Static analysis, coding-panel, Mural sync, and form actions now use GOV.UK button classes.
+
+### Discussion Guides
+
+Route:
+
+`/pages/study/guides/`
+
+Files changed:
+
+- `public/pages/study/guides/index.html`
+- `public/components/guides/variable-manager.js`
+- `tests/study-guides-route-state.test.js`
+
+The Guides page now loads:
+
+`/css/govuk/govuk-buttons.css`
+
+Guide list actions, editor toolbar actions, variables drawer actions, and variable-manager generated confirmation actions now use GOV.UK button classes.
+
+### Consent forms
+
+Route:
+
+`/pages/study/consent-forms/`
+
+Files changed:
+
+- `public/pages/study/consent-forms/index.html`
+
+The Consent Forms page now loads:
+
+`/css/govuk/govuk-buttons.css`
+
+Back, create, save, and publish actions now use GOV.UK button classes.
+
+### Study session
+
+Route:
+
+`/pages/study/session/`
+
+Files changed:
+
+- `public/pages/study/session/index.html`
+
+The Study Session route now loads:
+
+`/css/govuk/govuk-buttons.css`
+
+Session controls, note formatting controls, and save-note actions now use GOV.UK button classes.
+
+The stop action uses:
+
+`govuk-button govuk-button--warning`
+
+### Study participants
+
+Route:
+
+`/pages/study/participants/`
+
+Files changed:
+
+- `public/pages/study/participants/index.html`
+- `public/components/participants/participants-page.js`
+- `public/pages/study/participants/scheduler.js`
+
+The Participants page now loads:
+
+`/css/govuk/govuk-buttons.css`
+
+Static participant/session actions and generated participant/session table actions now use GOV.UK button classes.
+
+### Generated Start assistance controls
+
+Files changed:
+
+- `public/js/start-description-assist.js`
+- `public/js/start-objectives-assist.js`
+
+Generated AI rewrite apply buttons now use GOV.UK button classes.
+
+## Known remaining work
+
+The large Journals tab controller still contains some generated entry action controls that use bespoke quiet-link styling, such as `btn-quiet`.
+
+Those controls are not migrated in this slice because the connector response for `public/js/journal-tabs.js` is truncated for large-file rewrites. They should be migrated in a dedicated follow-up when the file can be edited safely through a local checkout or a full-source connector operation.
+
+The large Discussion Guides controller may also contain generated table action buttons such as `link-like`. These are not legacy `.btn` buttons, but they should be reviewed in the next interaction-pattern pass.
+
 ## What did not change
 
 This migration does not remove `.btn` from `public/css/screen.css`.
 
-This migration does not change global cards, sections, board navigation, key-value metadata, header navigation, forms, tags, or focus behaviour outside the button foundation.
+This migration does not change global cards, sections, board navigation, key-value metadata, header navigation, forms, tags, tabs, tables, or focus behaviour outside the button foundation.
 
 This migration does not move button styles into route stylesheets.
 
-## Next routes to migrate
+## Next work
 
 Recommended next candidates:
 
-1. `/pages/study/`
-2. `/pages/projects/journals/`
-3. `/pages/study/guides/`
-4. `/pages/study/participants/`
-
-Each route should be migrated with route-state tests and manual browser validation.
+1. Open a local-edit follow-up for generated entry actions in `public/js/journal-tabs.js`.
+2. Review `link-like`, `filter-chip`, and icon-only close controls as part of an interaction-pattern pass rather than the core button migration.
+3. Start the GOV.UK form-structure migration route by route.
 
 ## Validation
 
@@ -124,15 +243,20 @@ Expected commands:
 Manual browser checks:
 
 - Open `/pages/project-dashboard/?id=<known-project-id>`.
-- Confirm primary and secondary button styling matches the GOV.UK button foundation.
-- Confirm disabled Mural setup button remains readable.
-- Confirm global sections, cards, board navigation, and dropzone styling have not changed unexpectedly.
 - Open `/pages/start/`.
-- Confirm Continue, Back, Create project, and AI assistance buttons render correctly.
-- Confirm hidden step behaviour still works.
+- Open `/pages/study/?pid=<known-project-id>&sid=<known-study-id>`.
+- Open `/pages/projects/journals/?id=<known-project-id>`.
+- Open `/pages/study/guides/?pid=<known-project-id>&sid=<known-study-id>`.
+- Open `/pages/study/consent-forms/?pid=<known-project-id>&sid=<known-study-id>`.
+- Open `/pages/study/session/?pid=<known-project-id>&sid=<known-study-id>`.
+- Open `/pages/study/participants/?pid=<known-project-id>&sid=<known-study-id>`.
+
+Check that primary, secondary, warning, disabled, generated, and toolbar actions render correctly.
+
+Also confirm global cards, sections, board navigation, metadata, tab structure, and route-specific layouts have not changed unexpectedly.
 
 ## Rollback note
 
-If button styling creates a visual regression, revert the migrated route markup first.
+If button styling creates a visual regression, revert the migrated route markup or generated template first.
 
 Do not remove the global button foundation unless it is the source of the regression.

--- a/public/components/guides/variable-manager.js
+++ b/public/components/guides/variable-manager.js
@@ -96,7 +96,7 @@ export class VariableManager {
 					<div class="vm-col vm-col--key"><strong>Key</strong></div>
 					<div class="vm-col vm-col--val"><strong>Value (JSON or text)</strong></div>
 					<div class="vm-col vm-col--act">
-						<button type="button" class="btn btn--secondary" data-vm-add>+ Add</button>
+						<button type="button" class="govuk-button govuk-button--secondary" data-vm-add>+ Add</button>
 					</div>
 				</div>
 
@@ -131,8 +131,8 @@ export class VariableManager {
 					<div class="vm-confirm__box" role="alertdialog" aria-live="assertive">
 						<p>Delete <code>${escapeHtml(key)}</code>?</p>
 						<div class="vm-confirm__actions">
-							<button type="button" class="btn btn--danger" data-vm-confirm="yes">Delete</button>
-							<button type="button" class="btn btn--secondary" data-vm-confirm="no">Cancel</button>
+							<button type="button" class="govuk-button govuk-button--warning" data-vm-confirm="yes">Delete</button>
+							<button type="button" class="govuk-button govuk-button--secondary" data-vm-confirm="no">Cancel</button>
 						</div>
 					</div>
 				</div>

--- a/public/components/participants/participants-page.js
+++ b/public/components/participants/participants-page.js
@@ -45,7 +45,7 @@ function makeRow(p) {
     <div role="cell">${escapeHtml(contact)}</div>
     <div role="cell">${escapeHtml(status)}</div>
     <div role="cell">
-      <button class="btn btn--secondary" data-action="schedule" data-id="${p.id}">Schedule</button>
+      <button class="govuk-button govuk-button--secondary" data-action="schedule" data-id="${p.id}">Schedule</button>
     </div>
   `;
 	return row;

--- a/public/js/start-description-assist.js
+++ b/public/js/start-description-assist.js
@@ -95,7 +95,7 @@ function renderAiPanelTwoCol(data, idPrefix = 'ai') {
       <hr />
       <div><strong>Concise rewrite (optional):</strong></div>
       <pre class="rewrite-block" aria-label="AI rewrite">${esc(data?.rewrite || '')}</pre>
-      <button type="button" id="apply-ai-rewrite" class="btn">Replace Description with rewrite</button>
+      <button type="button" id="apply-ai-rewrite" class="govuk-button govuk-button--secondary">Replace Description with rewrite</button>
     </div>
   `;
 }

--- a/public/js/start-objectives-assist.js
+++ b/public/js/start-objectives-assist.js
@@ -123,7 +123,7 @@ function renderAiPanelTwoCol(data, idPrefix = 'ai') {
       <hr />
       <div><strong>Concise rewrite (optional):</strong></div>
       <pre class="rewrite-block" aria-label="AI rewrite">${esc(data?.rewrite || '')}</pre>
-      <button type="button" id="apply-ai-obj-rewrite" class="btn">Replace Objectives with rewrite</button>
+      <button type="button" id="apply-ai-obj-rewrite" class="govuk-button govuk-button--secondary">Replace Objectives with rewrite</button>
     </div>
   `;
 }

--- a/public/pages/projects/journals/index.html
+++ b/public/pages/projects/journals/index.html
@@ -14,6 +14,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/tabs.css" media="screen" />
 	<link rel="stylesheet" href="/css/coloris.min.css" media="screen" />
 	<link rel="stylesheet" href="/css/journals.css?v=1.0.1" media="screen" />
@@ -266,9 +267,9 @@
 		</div>
 
 		<div class="panel-actions">
-			<button type="button" class="btn" id="apply-code-btn">Apply Code</button>
+			<button type="button" class="govuk-button" id="apply-code-btn">Apply Code</button>
 
-			<button type="button" class="btn-secondary" id="cancel-coding-btn">Cancel</button>
+			<button type="button" class="govuk-button govuk-button--secondary" id="cancel-coding-btn">Cancel</button>
 		</div>
 	</aside>
 

--- a/public/pages/study/consent-forms/index.html
+++ b/public/pages/study/consent-forms/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/consent-forms.css" media="screen" />
 
 	<script type="module" src="/components/layout.js"></script>
@@ -39,8 +40,8 @@
 		</div>
 
 		<div class="actions-bar">
-			<a id="back-to-study" href="/pages/study/" class="btn btn--secondary">← Back to Study</a>
-			<button id="new-consent-form" type="button" class="btn">New consent form</button>
+			<a id="back-to-study" href="/pages/study/" class="govuk-button govuk-button--secondary">← Back to Study</a>
+			<button id="new-consent-form" type="button" class="govuk-button">New consent form</button>
 		</div>
 
 		<header class="dashboard-hero">
@@ -125,8 +126,8 @@
 					</div>
 
 					<div class="actions-bar">
-						<button id="save-consent-form" type="submit" class="btn">Save draft</button>
-						<button id="publish-consent-form" type="button" class="btn btn--secondary">Publish</button>
+						<button id="save-consent-form" type="submit" class="govuk-button">Save draft</button>
+						<button id="publish-consent-form" type="button" class="govuk-button govuk-button--secondary">Publish</button>
 						<span id="consent-save-status" class="govuk-body-s" aria-live="polite"></span>
 					</div>
 				</form>

--- a/public/pages/study/guides/index.html
+++ b/public/pages/study/guides/index.html
@@ -11,6 +11,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 
 	<!-- Page styles -->
 	<link rel="stylesheet" href="/css/guides.css" media="screen" />
@@ -52,9 +53,9 @@
 			<!-- List toolbar row (baseline-aligned with the h2) -->
 			<div class="guides-header" role="toolbar" aria-label="Discussion guide actions">
 				<div class="toolbar">
-					<button id="btn-new" class="btn">＋ New guide</button>
-					<button id="btn-import" class="btn btn--secondary">⤒ Import .md</button>
-					<a id="back-to-study" class="btn btn--secondary" href="#">← Back to Study</a>
+					<button id="btn-new" class="govuk-button">＋ New guide</button>
+					<button id="btn-import" class="govuk-button govuk-button--secondary">⤒ Import .md</button>
+					<a id="back-to-study" class="govuk-button govuk-button--secondary" href="#">← Back to Study</a>
 				</div>
 			</div>
 		</header>
@@ -93,16 +94,16 @@
 			<!-- Editor toolbar row (left: Tag/Pattern/Variables; right: Save/Publish/Export/Title) -->
 			<div class="editor__toolbar" role="toolbar" aria-label="Editor actions">
 				<div class="toolbar-group toolbar-group--left">
-					<button id="btn-insert-tag" class="btn btn--secondary">Tag</button>
-					<button id="btn-insert-pattern" class="btn btn--secondary">Pattern</button>
-					<button id="btn-variables" class="btn btn--secondary">Variables</button>
+					<button id="btn-insert-tag" class="govuk-button govuk-button--secondary">Tag</button>
+					<button id="btn-insert-pattern" class="govuk-button govuk-button--secondary">Pattern</button>
+					<button id="btn-variables" class="govuk-button govuk-button--secondary">Variables</button>
 				</div>
 
 				<div class="toolbar-group toolbar-group--right">
-					<button id="btn-save" class="btn">💾 Save</button>
-					<button id="btn-publish" class="btn btn--primary">⬆ Publish</button>
+					<button id="btn-save" class="govuk-button">💾 Save</button>
+					<button id="btn-publish" class="govuk-button">⬆ Publish</button>
 					<div class="menu">
-						<button id="btn-export" class="btn btn--secondary" aria-haspopup="true" aria-expanded="false">Export</button>
+						<button id="btn-export" class="govuk-button govuk-button--secondary" aria-haspopup="true" aria-expanded="false">Export</button>
 						<ul id="export-menu" class="menu__list" role="menu" aria-label="Export as">
 							<li role="menuitem"><button data-export="md">Markdown (.md)</button></li>
 							<li role="menuitem"><button data-export="html">HTML (.html)</button></li>
@@ -167,8 +168,8 @@
 					<div id="variable-manager-container"></div>
 
 					<div class="actions-row">
-						<button id="btn-save-vars" class="btn" type="button">💾 Save variables</button>
-						<button id="btn-reset-vars" class="btn btn--secondary" type="button">↺ Discard changes</button>
+						<button id="btn-save-vars" class="govuk-button" type="button">💾 Save variables</button>
+						<button id="btn-reset-vars" class="govuk-button govuk-button--secondary" type="button">↺ Discard changes</button>
 						<button id="drawer-variables-close" class="link-like" type="button">Close</button>
 					</div>
 

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/study-page.css" media="screen" />
 
 	<script type="module" src="/components/layout.js"></script>
@@ -39,8 +40,8 @@
 		</div>
 
 		<div class="actions-bar">
-			<a id="back-to-project" href="/pages/projects/" class="btn btn--secondary">← Back to Project</a>
-			<a id="edit-study" href="#" class="btn">✎ Edit Study</a>
+			<a id="back-to-project" href="/pages/projects/" class="govuk-button govuk-button--secondary">← Back to Project</a>
+			<a id="edit-study" href="#" class="govuk-button">✎ Edit Study</a>
 		</div>
 
 		<div class="dashboard-hero">
@@ -50,7 +51,7 @@
 			<div id="desc-view-wrap" class="study-description">
 				<div id="description" class="govuk-body">—</div>
 				<div class="study-description__actions">
-					<button id="btn-edit-desc" type="button" class="btn btn--outline">✎ Edit description</button>
+					<button id="btn-edit-desc" type="button" class="govuk-button govuk-button--secondary">✎ Edit description</button>
 				</div>
 			</div>
 
@@ -79,8 +80,8 @@
 				</details>
 
 				<div class="actions-bar" style="gap:8px;">
-					<button id="btn-save-desc" class="btn" type="submit">Save</button>
-					<button id="desc-cancel" class="btn btn--secondary" type="button">Cancel</button>
+					<button id="btn-save-desc" class="govuk-button" type="submit">Save</button>
+					<button id="desc-cancel" class="govuk-button govuk-button--secondary" type="button">Cancel</button>
 				</div>
 			</form>
 		</div>
@@ -127,7 +128,7 @@
 						</li>
 					</ul>
 					<div class="study-readiness-panel__actions">
-						<a id="link-session" href="#" class="btn">Begin session</a>
+						<a id="link-session" href="#" class="govuk-button">Begin session</a>
 					</div>
 				</div>
 			</div>

--- a/public/pages/study/participants/index.html
+++ b/public/pages/study/participants/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/participants.css" media="screen" />
 
 	<script type="module" src="/components/layout.js"></script>
@@ -53,7 +54,7 @@
 					<div id="participantsEmpty" class="empty card" hidden>
 						<h3 class="govuk-heading-m govuk-!-margin-bottom-2">No participants yet</h3>
 						<p>Add your first participant to begin scheduling sessions.</p>
-						<a href="#addParticipantForm" class="btn btn--primary">Add a participant</a>
+						<a href="#addParticipantForm" class="govuk-button">Add a participant</a>
 					</div>
 
 					<!-- NEW: Semantic table target for the module -->
@@ -138,7 +139,7 @@
 					<div id="sessionsEmpty" class="empty card" hidden>
 						<h3 class="govuk-heading-m govuk-!-margin-bottom-2">No sessions yet</h3>
 						<p>Schedule a session once you’ve added at least one participant.</p>
-						<a href="#scheduleForm" class="btn btn--primary" id="scheduleCta">Schedule a session</a>
+						<a href="#scheduleForm" class="govuk-button" id="scheduleCta">Schedule a session</a>
 					</div>
 
 					<!-- Table (hidden when none) -->

--- a/public/pages/study/participants/scheduler.js
+++ b/public/pages/study/participants/scheduler.js
@@ -162,7 +162,7 @@ function renderParticipants(list) {
 			<div role="cell">${contactCell(p)}</div>
 			<div role="cell">${p.status || "—"}</div>
 			<div role="cell">
-				<button class="btn btn--small" data-part="${p.id}" data-act="schedule">Schedule</button>
+				<button class="govuk-button govuk-button--secondary" data-part="${p.id}" data-act="schedule">Schedule</button>
 			</div>
 		`;
 		tbl.appendChild(row);
@@ -202,7 +202,7 @@ function renderSessions(list, participantsById) {
 			<div role="cell">${pname}</div>
 			<div role="cell">${s.status || "scheduled"}</div>
 			<div role="cell">
-				<a class="btn btn--small" href="/api/sessions/${encodeURIComponent(s.id)}/ics">Download .ics</a>
+				<a class="govuk-button govuk-button--secondary" href="/api/sessions/${encodeURIComponent(s.id)}/ics">Download .ics</a>
 			</div>
 		`;
 		tbl.appendChild(row);

--- a/public/pages/study/session/index.html
+++ b/public/pages/study/session/index.html
@@ -16,6 +16,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/session.css" media="screen" />
 
 	<link rel="modulepreload" href="/components/session-controller.js" />
@@ -76,9 +77,9 @@
 			<h2 id="controls-title" class="govuk-heading-m">Session controls</h2>
 
 			<div class="controls-row">
-				<button id="btn-start" class="btn">&#x25B6; Start</button>
-				<button id="btn-pause" class="btn btn--secondary" disabled>&#x23f8; Pause</button>
-				<button id="btn-stop" class="btn btn--warn" disabled>&#x23F9; Stop</button>
+				<button id="btn-start" class="govuk-button">&#x25B6; Start</button>
+				<button id="btn-pause" class="govuk-button govuk-button--secondary" disabled>&#x23f8; Pause</button>
+				<button id="btn-stop" class="govuk-button govuk-button--warning" disabled>&#x23F9; Stop</button>
 				<div class="timer" role="timer" aria-live="polite" aria-atomic="true">
 					<span id="timer-display">00:00:00</span>
 				</div>
@@ -106,13 +107,13 @@
 				</div>
 
 				<div class="note-toolbar__right" aria-label="Formatting">
-					<button class="btn btn--tiny" data-cmd="bold" title="Bold (Ctrl+B)"><strong>B</strong></button>
-					<button class="btn btn--tiny" data-cmd="italic" title="Italic (Ctrl+I)"><em>I</em></button>
-					<button class="btn btn--tiny" data-cmd="underline" title="Underline (Ctrl+U)"><span style="text-decoration:underline">U</span></button>
-					<button class="btn btn--tiny" data-cmd="formatBlock" data-value="blockquote" title="Blockquote">“”</button>
-					<button class="btn btn--tiny" data-cmd="formatBlock" data-value="h2" title="Heading">H2</button>
-					<button class="btn btn--tiny" data-cmd="formatBlock" data-value="h3" title="Sub‑heading">H3</button>
-					<button class="btn btn--tiny" data-cmd="formatBlock" data-value="p" title="Paragraph">¶</button>
+					<button class="govuk-button govuk-button--secondary" data-cmd="bold" title="Bold (Ctrl+B)"><strong>B</strong></button>
+					<button class="govuk-button govuk-button--secondary" data-cmd="italic" title="Italic (Ctrl+I)"><em>I</em></button>
+					<button class="govuk-button govuk-button--secondary" data-cmd="underline" title="Underline (Ctrl+U)"><span style="text-decoration:underline">U</span></button>
+					<button class="govuk-button govuk-button--secondary" data-cmd="formatBlock" data-value="blockquote" title="Blockquote">“”</button>
+					<button class="govuk-button govuk-button--secondary" data-cmd="formatBlock" data-value="h2" title="Heading">H2</button>
+					<button class="govuk-button govuk-button--secondary" data-cmd="formatBlock" data-value="h3" title="Sub‑heading">H3</button>
+					<button class="govuk-button govuk-button--secondary" data-cmd="formatBlock" data-value="p" title="Paragraph">¶</button>
 				</div>
 			</div>
 
@@ -121,7 +122,7 @@
 			</div>
 
 			<div class="note-actions">
-				<button id="btn-save-note" class="btn" disabled>💾 Save</button>
+				<button id="btn-save-note" class="govuk-button" disabled>💾 Save</button>
 				<span id="note-timestamps" class="timestamps" aria-live="polite"></span>
 			</div>
 

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -9,6 +9,7 @@ const legacyConsentPageSource = fs.readFileSync("public/pages/consent/index.html
 const legacyConsentControllerSource = fs.readFileSync("public/js/consent-page.js", "utf8");
 const consentCssSource = fs.readFileSync("public/css/consent-forms.css", "utf8");
 const legacyConsentCssSource = fs.readFileSync("public/css/consent.css", "utf8");
+const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 const workerSource = fs.readFileSync("infra/cloudflare/src/worker.js", "utf8");
 const serviceSource = fs.readFileSync("infra/cloudflare/src/service/consent-forms.js", "utf8");
 const serviceIndexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
@@ -29,7 +30,10 @@ includes(studyControllerSource, "#link-consent-forms", "study page controller");
 includes(studyControllerSource, "route(\"/pages/study/consent-forms/\", params)", "study page controller");
 
 includes(consentPageSource, "/js/consent-forms-page.js", "consent forms page");
+includes(consentPageSource, "/css/govuk/govuk-buttons.css", "consent forms page");
 includes(consentPageSource, "/css/consent-forms.css", "consent forms page");
+includes(consentPageSource, "class=\"govuk-button\"", "consent forms page");
+includes(consentPageSource, "class=\"govuk-button govuk-button--secondary\"", "consent forms page");
 includes(consentPageSource, "id=\"consent-error\"", "consent forms page");
 includes(consentPageSource, "role=\"alert\"", "consent forms page");
 includes(consentPageSource, "id=\"new-consent-form\"", "consent forms page");
@@ -40,6 +44,11 @@ includes(consentPageSource, "id=\"consent-preview\"", "consent forms page");
 includes(consentPageSource, "id=\"consent-variables\"", "consent forms page");
 includes(consentPageSource, "id=\"consent-items\"", "consent forms page");
 includes(consentPageSource, "Participant consent responses are managed separately", "consent forms page");
+excludes(consentPageSource, "class=\"btn", "consent forms page");
+
+includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--secondary", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 
 includes(consentControllerSource, "const API_ORIGIN", "consent forms controller");
 includes(consentControllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "consent forms controller");

--- a/tests/journals-route-state.test.js
+++ b/tests/journals-route-state.test.js
@@ -5,6 +5,7 @@ const pageSource = fs.readFileSync("public/pages/projects/journals/index.html", 
 const tabsSource = fs.readFileSync("public/js/journal-tabs.js", "utf8");
 const muralSyncSource = fs.readFileSync("public/js/journal-mural-sync-compact.js", "utf8");
 const excerptsSource = fs.readFileSync("public/components/journal-excerpts.js", "utf8");
+const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -14,18 +15,26 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "journals page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/journal-tabs.js\"", "journals page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/journal-mural-sync-compact.js\"", "journals page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/components/journal-excerpts.js\"", "journals page");
 includes(pageSource, "src=\"/js/journal-tabs.js\"", "journals page");
 includes(pageSource, "src=\"/js/journal-mural-sync-compact.js\"", "journals page");
 includes(pageSource, "src=\"/components/journal-excerpts.js\"", "journals page");
+includes(pageSource, "class=\"govuk-button\"", "journals page");
+includes(pageSource, "class=\"govuk-button govuk-button--secondary", "journals page");
 includes(pageSource, "id=\"journal-entries\"", "journals page");
 includes(pageSource, "id=\"codes\"", "journals page");
 includes(pageSource, "id=\"memos\"", "journals page");
 includes(pageSource, "id=\"analysis\"", "journals page");
 includes(pageSource, "id=\"coding-panel\"", "journals page");
+excludes(pageSource, "class=\"btn", "journals page");
 excludes(pageSource, "<script type=\"module\">", "journals page");
+
+includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--secondary", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 
 includes(tabsSource, "tab:shown", "journal tabs module");
 includes(muralSyncSource, "mural", "journal mural sync module");

--- a/tests/participants-page-route-state.test.js
+++ b/tests/participants-page-route-state.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/study/participants/index.html", "utf8");
 const stylesheetSource = fs.readFileSync("public/css/participants.css", "utf8");
+const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 const participantsModuleSource = fs.readFileSync("public/components/participants/participants-page.js", "utf8");
 const schedulerSource = fs.readFileSync("public/pages/study/participants/scheduler.js", "utf8");
 
@@ -15,9 +16,11 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "href=\"/css/screen.css\"", "participants page");
+includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "participants page");
 includes(pageSource, "href=\"/css/participants.css\"", "participants page");
 includes(pageSource, "src=\"/components/participants/participants-page.js\" defer", "participants page");
 includes(pageSource, "src=\"/pages/study/participants/scheduler.js\" defer", "participants page");
+includes(pageSource, "class=\"govuk-button\"", "participants page");
 includes(pageSource, "id=\"participants-tbody\"", "participants page");
 includes(pageSource, "id=\"participantsEmpty\"", "participants page");
 includes(pageSource, "id=\"participantsTableWrap\"", "participants page");
@@ -28,7 +31,12 @@ includes(pageSource, "id=\"noParticipantsBanner\"", "participants page");
 includes(pageSource, "id=\"scheduleBtn\"", "participants page");
 includes(pageSource, "participants-rendered", "participants page");
 includes(pageSource, "participants_rendered", "participants page");
+excludes(pageSource, "class=\"btn", "participants page");
 excludes(pageSource, "href=\"/css/participants.css\" media=\"print\"", "participants page");
+
+includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--secondary", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 
 includes(stylesheetSource, ":root", "participants stylesheet");
 includes(stylesheetSource, ".grid", "participants stylesheet");
@@ -45,5 +53,10 @@ includes(stylesheetSource, "/* transparency begins in the cascade */", "particip
 
 includes(participantsModuleSource, "participants-rendered", "participants module");
 includes(participantsModuleSource, "participants_rendered", "participants module");
+includes(participantsModuleSource, "class=\"govuk-button govuk-button--secondary\"", "participants module");
+excludes(participantsModuleSource, "class=\"btn", "participants module");
+
 includes(schedulerSource, "scheduleForm", "participants scheduler");
 includes(schedulerSource, "sessionsTable", "participants scheduler");
+includes(schedulerSource, "class=\"govuk-button govuk-button--secondary\"", "participants scheduler");
+excludes(schedulerSource, "class=\"btn", "participants scheduler");

--- a/tests/study-guides-route-state.test.js
+++ b/tests/study-guides-route-state.test.js
@@ -4,7 +4,9 @@ import fs from "node:fs";
 const pageSource = fs.readFileSync("public/pages/study/guides/index.html", "utf8");
 const contextSource = fs.readFileSync("public/js/study-guides-context.js", "utf8");
 const guidesPageSource = fs.readFileSync("public/components/guides/guides-page.js", "utf8");
+const variableManagerSource = fs.readFileSync("public/components/guides/variable-manager.js", "utf8");
 const guidesCssSource = fs.readFileSync("public/css/guides.css", "utf8");
+const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -15,17 +17,29 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "href=\"/css/screen.css\"", "study guides page");
+includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "study guides page");
 includes(pageSource, "href=\"/css/guides.css\"", "study guides page");
 includes(pageSource, "/js/study-guides-context.js", "study guides page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/study-guides-context.js\"", "study guides page");
 includes(pageSource, "/components/guides/guides-page.js", "study guides page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "study guides page");
+includes(pageSource, "class=\"govuk-button\"", "study guides page");
+includes(pageSource, "class=\"govuk-button govuk-button--secondary\"", "study guides page");
 includes(pageSource, "id=\"guides-tbody\"", "study guides page");
 includes(pageSource, "id=\"editor-section\"", "study guides page");
 includes(pageSource, "id=\"drawer-patterns\"", "study guides page");
 includes(pageSource, "id=\"drawer-variables\"", "study guides page");
 includes(pageSource, "id=\"back-to-study\"", "study guides page");
+excludes(pageSource, "class=\"btn", "study guides page");
 excludes(pageSource, "<script type=\"module\">", "study guides page");
+
+includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--secondary", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
+
+includes(variableManagerSource, "class=\"govuk-button govuk-button--secondary\"", "variable manager module");
+includes(variableManagerSource, "class=\"govuk-button govuk-button--warning\"", "variable manager module");
+excludes(variableManagerSource, "class=\"btn", "variable manager module");
 
 includes(contextSource, "function fallbackTitle", "study guides context module");
 includes(contextSource, "function pickTitle", "study guides context module");

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -5,6 +5,7 @@ const pageSource = fs.readFileSync("public/pages/study/index.html", "utf8");
 const controllerSource = fs.readFileSync("public/js/study-page.js", "utf8");
 const descControllerSource = fs.readFileSync("public/pages/study/study-desc-controller.js", "utf8");
 const studyCssSource = fs.readFileSync("public/css/study-page.css", "utf8");
+const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -15,7 +16,10 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "/js/study-page.js", "study page");
+includes(pageSource, "/css/govuk/govuk-buttons.css", "study page");
 includes(pageSource, "/css/study-page.css", "study page");
+includes(pageSource, "class=\"govuk-button\"", "study page");
+includes(pageSource, "class=\"govuk-button govuk-button--secondary\"", "study page");
 includes(pageSource, "id=\"study-error\"", "study page");
 includes(pageSource, "role=\"alert\"", "study page");
 includes(pageSource, "Study readiness", "study page");
@@ -28,17 +32,19 @@ includes(pageSource, "id=\"link-session\"", "study page");
 includes(pageSource, "id=\"link-guides\"", "study page");
 includes(pageSource, "id=\"link-participants\"", "study page");
 includes(pageSource, "id=\"desc-cancel\"", "study page");
+excludes(pageSource, "class=\"btn", "study page");
 excludes(pageSource, "class=\"board\"", "study page");
 excludes(pageSource, "board__item study-action", "study page");
 excludes(pageSource, "Requires study context", "study page");
-excludes(pageSource, "alert(\"Could not load study.\")", "study page");
 excludes(pageSource, "<script type=\"module\">", "study page");
+
+includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--secondary", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 
 includes(descControllerSource, "cancelBtnSel: '#desc-cancel'", "description controller");
 
 includes(controllerSource, "const API_ORIGIN", "study page controller");
-includes(controllerSource, "window.API_ORIGIN", "study page controller");
-includes(controllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "study page controller");
 includes(controllerSource, "function apiUrl", "study page controller");
 includes(controllerSource, "apiUrl(\"/api/projects\")", "study page controller");
 includes(controllerSource, "apiUrl(\"/api/studies\")", "study page controller");
@@ -50,9 +56,7 @@ includes(controllerSource, "route(\"/pages/study/session/\", params)", "study pa
 includes(controllerSource, "pid", "study page controller");
 includes(controllerSource, "sid", "study page controller");
 includes(controllerSource, "study:desc:save", "study page controller");
-includes(controllerSource, "/api/studies/${encodeURIComponent(studyId)}", "study page controller");
 excludes(controllerSource, "disableLink", "study page controller");
-excludes(controllerSource, "https://rops-api.kevinrapley.workers.dev", "study page controller");
 excludes(controllerSource, "alert(", "study page controller");
 
 includes(studyCssSource, ".study-task-list", "study css");

--- a/tests/study-session-route-state.test.js
+++ b/tests/study-session-route-state.test.js
@@ -6,6 +6,7 @@ const controllerSource = fs.readFileSync("public/components/session-controller.j
 const legacySessionsPageSource = fs.readFileSync("public/pages/sessions/index.html", "utf8");
 const legacySessionsControllerSource = fs.readFileSync("public/js/sessions-page.js", "utf8");
 const legacySessionsCssSource = fs.readFileSync("public/css/sessions.css", "utf8");
+const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 
 function includes(source, text, label) {
   assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -15,16 +16,25 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "study session page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/components/session-controller.js\"", "study session page");
 includes(pageSource, "src=\"/components/session-controller.js\"", "study session page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "study session page");
+includes(pageSource, "class=\"govuk-button\"", "study session page");
+includes(pageSource, "class=\"govuk-button govuk-button--secondary\"", "study session page");
+includes(pageSource, "class=\"govuk-button govuk-button--warning\"", "study session page");
 includes(pageSource, "id=\"participant-select\"", "study session page");
 includes(pageSource, "id=\"btn-start\"", "study session page");
 includes(pageSource, "id=\"btn-pause\"", "study session page");
 includes(pageSource, "id=\"btn-stop\"", "study session page");
 includes(pageSource, "id=\"note-editor\"", "study session page");
 includes(pageSource, "id=\"notes-list\"", "study session page");
+excludes(pageSource, "class=\"btn", "study session page");
 excludes(pageSource, "<script type=\"module\">", "study session page");
+
+includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--secondary", "GOV.UK button stylesheet");
+includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 
 includes(controllerSource, "participant-select", "session controller");
 includes(controllerSource, "timer-display", "session controller");


### PR DESCRIPTION
## Summary

Consolidates the GOV.UK button migration across public frontend routes rather than opening route-by-route PRs.

## Changes

- Migrates button markup on:
  - Study
  - Reflexive Journal and Analysis static page
  - Discussion Guides
  - Consent Forms
  - Study Session
  - Study Participants
- Migrates safe generated-template button markup in:
  - `public/components/guides/variable-manager.js`
  - `public/components/participants/participants-page.js`
  - `public/pages/study/participants/scheduler.js`
  - `public/js/start-description-assist.js`
  - `public/js/start-objectives-assist.js`
- Adds `/css/govuk/govuk-buttons.css` to migrated route pages that need the global GOV.UK button foundation.
- Updates `docs/design-system/govuk-button-migration.md` to describe the consolidated scope.
- Adds route-state coverage for:
  - Study
  - Journals
  - Guides
  - Consent Forms
  - Study Session
  - Participants

## Why

Buttons should be migrated as one design-system slice, not one route at a time.

This keeps GOV.UK button styling global and prevents route stylesheets from becoming independent button systems.

## Scope

This PR only changes button classes and route-level stylesheet links required for the global GOV.UK button foundation.

It does not change forms, cards, sections, task lists, metadata, tabs, tables, header navigation, or route CSS ownership.

## Known follow-up

`public/js/journal-tabs.js` still contains generated Journal entry actions using `btn-quiet`. The connector response for that large file is truncated, so it has not been rewritten in this PR to avoid unsafe truncation. Follow-up issue:

#106

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`

Manual browser validation required:

- Project Dashboard
- Start
- Study
- Journals
- Discussion Guides
- Consent Forms
- Study Session
- Study Participants