### PR TITLE
Migrate shared page chrome and navigation to GOV.UK patterns

### DIFF
--- a/docs/design-system/govuk-page-chrome-navigation-migration.md
+++ b/docs/design-system/govuk-page-chrome-navigation-migration.md
@@ -1,0 +1,151 @@
+# GOV.UK page chrome and navigation migration
+
+Date: 2026-04-27
+Branch: `design-system/govuk-page-chrome-navigation-all-routes`
+Scope: Shared page chrome, service navigation, skip link, phase banner, footer and main-content targeting.
+
+## Purpose
+
+This document records the GOV.UK page chrome and navigation migration for ResearchOps.
+
+Page chrome is a shared service frame. It must remain global. Route stylesheets may lay out route content, but they must not define independent header, footer, skip-link or service-navigation systems.
+
+## Component classification
+
+### Skip link
+
+Target classification: GOV.UK global.
+
+Implemented in:
+
+- `public/partials/header.html`
+- `public/css/govuk/govuk-page-chrome.css`
+
+The skip link points to `#main-content`.
+
+The shared header helper preserves existing route-facing main IDs. If a page already has a main ID such as `main` or `content`, the helper inserts a small `#main-content` target before the main landmark. If a page has an unnamed main landmark, it assigns `id="main-content"` to that landmark.
+
+### Header
+
+Target classification: GOV.UK global.
+
+Implemented in:
+
+- `public/partials/header.html`
+- `public/css/govuk/govuk-page-chrome.css`
+
+The shared header now uses GOV.UK-style service header classes:
+
+- `govuk-header`
+- `govuk-header__container`
+- `govuk-header__service-name`
+- `govuk-header__link`
+- `govuk-header__service-description`
+
+### Service navigation
+
+Target classification: GOV.UK global.
+
+Implemented in:
+
+- `public/partials/header.html`
+- `public/css/govuk/govuk-page-chrome.css`
+
+The shared service navigation now uses GOV.UK-style service navigation classes:
+
+- `govuk-service-navigation`
+- `govuk-service-navigation__container`
+- `govuk-service-navigation__list`
+- `govuk-service-navigation__item`
+- `govuk-service-navigation__link`
+
+The existing `data-active` and `data-nav` contract is preserved so `layout.js` continues to set active navigation state.
+
+### Phase banner
+
+Target classification: GOV.UK global.
+
+Implemented in:
+
+- `public/partials/header.html`
+- `public/css/govuk/govuk-page-chrome.css`
+
+ResearchOps remains a prototype, so a shared phase banner is included under the service navigation.
+
+The banner warns users not to enter real participant personal data.
+
+### Footer
+
+Target classification: GOV.UK global.
+
+Implemented in:
+
+- `public/partials/footer.html`
+- `public/css/govuk/govuk-page-chrome.css`
+
+The shared footer now uses GOV.UK-style footer classes:
+
+- `govuk-footer`
+- `govuk-footer__container`
+- `govuk-footer__meta`
+
+## CSS ownership
+
+Base page chrome styling lives in:
+
+`public/css/govuk/govuk-page-chrome.css`
+
+Route stylesheets must not recreate shared header, service navigation, skip-link, phase banner or footer behaviour.
+
+## What changed
+
+Changed files:
+
+- `public/css/govuk/govuk-page-chrome.css`
+- `public/partials/header.html`
+- `public/partials/footer.html`
+- `docs/design-system/govuk-page-chrome-navigation-migration.md`
+- `tests/govuk-page-chrome-navigation-route-state.test.js`
+- `scripts/validate.sh`
+
+## What did not change
+
+This migration does not rewrite route content.
+
+This migration does not change page controllers, API payloads, Airtable payloads, or dynamic breadcrumb IDs.
+
+This migration does not rename existing route-facing main IDs such as `main` or `content`.
+
+## Manual checks
+
+Check these routes after merge:
+
+- `/`
+- `/pages/start/`
+- `/pages/projects/`
+- `/pages/project-dashboard/?id=<project-id>`
+- `/pages/study/?pid=<project-id>&sid=<study-id>`
+- `/pages/study/guides/?pid=<project-id>&sid=<study-id>`
+- `/pages/study/participants/?pid=<project-id>&sid=<study-id>`
+- `/pages/projects/outcomes/?id=<project-id>`
+
+Confirm:
+
+- skip link appears on keyboard focus
+- skip link moves focus to main content
+- header and footer are visually consistent
+- active service navigation state remains correct
+- phase banner appears once
+- route-specific breadcrumbs and dynamic IDs still work
+- no route stylesheet owns shared page chrome styling
+
+## Validation
+
+Expected commands:
+
+- `npm run validate`
+- `npm run lint`
+
+The application-level route-state test is:
+
+`tests/govuk-page-chrome-navigation-route-state.test.js`

--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -1,21 +1,31 @@
 /* GOV.UK page chrome foundation */
 
 .govuk-skip-link {
-	position: absolute;
-	z-index: 9999;
-	top: 0;
-	left: 0;
 	display: block;
-	padding: 8px 15px;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
 	background: #ffdd00;
 	color: #0b0c0c;
 	font-weight: 700;
 	text-decoration: none;
-	transform: translateY(-120%);
 	}
 
 .govuk-skip-link:focus {
-	transform: translateY(0);
+	width: auto;
+	height: auto;
+	margin: 0;
+	padding: 8px 15px;
+	overflow: visible;
+	clip: auto;
+	clip-path: none;
+	white-space: inherit;
 	outline: 3px solid #0b0c0c;
 	outline-offset: 0;
 	box-shadow: none;

--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -1,0 +1,253 @@
+/* GOV.UK page chrome foundation */
+
+.govuk-skip-link {
+	position: absolute;
+	z-index: 9999;
+	top: 0;
+	left: 0;
+	display: block;
+	padding: 8px 15px;
+	background: #ffdd00;
+	color: #0b0c0c;
+	font-weight: 700;
+	text-decoration: none;
+	transform: translateY(-120%);
+	}
+
+.govuk-skip-link:focus {
+	transform: translateY(0);
+	outline: 3px solid #0b0c0c;
+	outline-offset: 0;
+	box-shadow: none;
+	}
+
+.govuk-main-wrapper {
+	outline: none;
+	}
+
+.govuk-header {
+	margin: -24px -24px 24px;
+	border-bottom: 10px solid #1d70b8;
+	background: #0b0c0c;
+	color: #ffffff;
+	}
+
+.govuk-header__container {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 12px 24px;
+	}
+
+.govuk-header__link {
+	color: #ffffff;
+	font-weight: 700;
+	text-decoration: none;
+	}
+
+.govuk-header__link:hover {
+	text-decoration: underline;
+	text-decoration-thickness: 3px;
+	text-underline-offset: 0.1em;
+	}
+
+.govuk-header__link:focus {
+	background-color: #ffdd00;
+	color: #0b0c0c;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 0 0 4px #0b0c0c;
+	}
+
+.govuk-header__service-name {
+	margin: 0;
+	font-size: 30px;
+	line-height: 1.11111;
+	}
+
+.govuk-header__service-description {
+	margin: 6px 0 0;
+	color: #ffffff;
+	font-size: 19px;
+	line-height: 1.31579;
+	}
+
+.govuk-service-navigation {
+	background: #f3f2f1;
+	border-bottom: 1px solid #b1b4b6;
+	}
+
+.govuk-service-navigation__container {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 24px;
+	}
+
+.govuk-service-navigation__list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0 24px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	}
+
+.govuk-service-navigation__item {
+	margin: 0;
+	padding: 0;
+	}
+
+.govuk-service-navigation__link {
+	display: inline-block;
+	padding: 15px 0 12px;
+	border-bottom: 3px solid transparent;
+	color: #1d70b8;
+	text-decoration: none;
+	}
+
+.govuk-service-navigation__link:hover {
+	text-decoration: underline;
+	text-decoration-thickness: 3px;
+	text-underline-offset: 0.1em;
+	}
+
+.govuk-service-navigation__link:focus {
+	background-color: #ffdd00;
+	color: #0b0c0c;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+	text-decoration: none;
+	}
+
+.govuk-service-navigation__link[aria-current="page"],
+.govuk-service-navigation__link.active {
+	border-bottom-color: #1d70b8;
+	color: #0b0c0c;
+	font-weight: 700;
+	}
+
+.govuk-phase-banner {
+	max-width: 1200px;
+	margin: 0 auto 24px;
+	padding: 10px 24px;
+	border-bottom: 1px solid #b1b4b6;
+	}
+
+.govuk-phase-banner__content {
+	display: flex;
+	gap: 10px;
+	align-items: baseline;
+	margin: 0;
+	}
+
+.govuk-tag {
+	display: inline-block;
+	padding: 2px 8px 1px;
+	background: #1d70b8;
+	color: #ffffff;
+	font-size: 16px;
+	font-weight: 700;
+	line-height: 1.25;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	}
+
+.govuk-breadcrumbs,
+.breadcrumbs {
+	margin: 8px 0 20px;
+	font-size: 16px;
+	line-height: 1.25;
+	}
+
+.govuk-breadcrumbs__list,
+.breadcrumbs ol {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	}
+
+.govuk-breadcrumbs__list-item,
+.breadcrumbs li {
+	margin: 0;
+	padding: 0;
+	}
+
+.govuk-breadcrumbs__list-item + .govuk-breadcrumbs__list-item::before,
+.breadcrumbs li + li::before {
+	content: "›";
+	display: inline-block;
+	margin: 0 8px;
+	color: #505a5f;
+	}
+
+.govuk-back-link {
+	display: inline-block;
+	margin-top: 15px;
+	margin-bottom: 15px;
+	color: #0b0c0c;
+	font-size: 16px;
+	line-height: 1.25;
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.1em;
+	}
+
+.govuk-back-link::before {
+	content: "‹";
+	display: inline-block;
+	margin-right: 5px;
+	}
+
+.govuk-footer {
+	margin: 48px -24px -24px;
+	padding: 32px 24px;
+	border-top: 1px solid #b1b4b6;
+	background: #f3f2f1;
+	color: #0b0c0c;
+	}
+
+.govuk-footer__container {
+	max-width: 1200px;
+	margin: 0 auto;
+	}
+
+.govuk-footer__meta {
+	margin: 0;
+	color: #505a5f;
+	font-size: 16px;
+	line-height: 1.25;
+	}
+
+@media (max-width: 640px) {
+	.govuk-header,
+	.govuk-footer {
+		margin-right: -16px;
+		margin-left: -16px;
+		}
+
+	.govuk-header__container,
+	.govuk-service-navigation__container,
+	.govuk-phase-banner,
+	.govuk-footer {
+		padding-right: 16px;
+		padding-left: 16px;
+		}
+
+	.govuk-header__service-name {
+		font-size: 24px;
+		}
+
+	.govuk-phase-banner__content {
+		display: block;
+		}
+
+	.govuk-phase-banner__text {
+		display: block;
+		margin-top: 8px;
+		}
+	}
+
+/* transparency begins in the cascade */

--- a/public/pages/consent/index.html
+++ b/public/pages/consent/index.html
@@ -21,40 +21,42 @@
 	<x-include src="/partials/header.html" vars='{"active":"Consent","subtitle":"Consent"}'>
 	</x-include>
 
-	<div class="card consent-panel">
-		<h2 class="govuk-heading-m">Link consent to a session</h2>
-		<div class="consent-form">
-			<div class="govuk-form-group consent-field">
-				<label class="govuk-label" for="session">Session</label>
-				<select id="session" class="govuk-select"></select>
+	<main id="main-content" class="govuk-body" role="main" tabindex="-1">
+		<div class="card consent-panel">
+			<h2 class="govuk-heading-m">Link consent to a session</h2>
+			<div class="consent-form">
+				<div class="govuk-form-group consent-field">
+					<label class="govuk-label" for="session">Session</label>
+					<select id="session" class="govuk-select"></select>
+				</div>
+				<div class="govuk-form-group consent-field">
+					<label class="govuk-label" for="basis">Lawful basis</label>
+					<select id="basis" class="govuk-select">
+						<option value="dpv:PublicInterest">Public task / Public interest</option>
+						<option value="dpv:Consent">Consent</option>
+					</select>
+				</div>
+				<div class="govuk-form-group consent-field">
+					<label class="govuk-label" for="ret">Retention</label>
+					<div id="ret-hint" class="govuk-hint">Use ISO 8601 duration format, for example P12M.</div>
+					<input id="ret" class="govuk-input" value="P12M" aria-describedby="ret-hint" />
+				</div>
+				<div class="govuk-form-group consent-field">
+					<label class="govuk-label" for="notes">Notes</label>
+					<input id="notes" class="govuk-input" placeholder="e.g., verbal consent recorded at start" />
+				</div>
+				<div class="govuk-button-group">
+					<button id="link" class="govuk-button">Link consent</button>
+				</div>
+				<div id="status" class="govuk-hint consent-status"></div>
 			</div>
-			<div class="govuk-form-group consent-field">
-				<label class="govuk-label" for="basis">Lawful basis</label>
-				<select id="basis" class="govuk-select">
-					<option value="dpv:PublicInterest">Public task / Public interest</option>
-					<option value="dpv:Consent">Consent</option>
-				</select>
-			</div>
-			<div class="govuk-form-group consent-field">
-				<label class="govuk-label" for="ret">Retention</label>
-				<div id="ret-hint" class="govuk-hint">Use ISO 8601 duration format, for example P12M.</div>
-				<input id="ret" class="govuk-input" value="P12M" aria-describedby="ret-hint" />
-			</div>
-			<div class="govuk-form-group consent-field">
-				<label class="govuk-label" for="notes">Notes</label>
-				<input id="notes" class="govuk-input" placeholder="e.g., verbal consent recorded at start" />
-			</div>
-			<div class="govuk-button-group">
-				<button id="link" class="govuk-button">Link consent</button>
-			</div>
-			<div id="status" class="govuk-hint consent-status"></div>
 		</div>
-	</div>
 
-	<div class="card consent-panel">
-		<h2 class="govuk-heading-m">Existing consent records</h2>
-		<div id="consents" class="govuk-body consent-records"></div>
-	</div>
+		<div class="card consent-panel">
+			<h2 class="govuk-heading-m">Existing consent records</h2>
+			<div id="consents" class="govuk-body consent-records"></div>
+		</div>
+	</main>
 
 	<x-include src="/partials/footer.html"></x-include>
 

--- a/public/pages/notes/index.html
+++ b/public/pages/notes/index.html
@@ -23,36 +23,38 @@
 		vars='{"active":"Notes","subtitle":"Notes"}'>	
 	</x-include>
 
-	<div class="card notes-panel">
-		<h2 class="govuk-heading-m">Select a session</h2>
-		<div class="govuk-form-group">
-			<label class="govuk-label" for="session">Session</label>
-			<select id="session" class="govuk-select notes-session-select"></select>
-		</div>
-	</div>
-
-	<div class="card notes-panel">
-		<h2 class="govuk-heading-m">Add a note</h2>
-		<div class="notes-editor">
+	<main id="main-content" class="govuk-body" role="main" tabindex="-1">
+		<div class="card notes-panel">
+			<h2 class="govuk-heading-m">Select a session</h2>
 			<div class="govuk-form-group">
-				<label class="govuk-label" for="text">Note</label>
-				<textarea id="text" class="govuk-textarea" placeholder="Avoid PII; describe behaviour, quotes, observations"></textarea>
+				<label class="govuk-label" for="session">Session</label>
+				<select id="session" class="govuk-select notes-session-select"></select>
 			</div>
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="tags">Tags</label>
-				<input id="tags" class="govuk-input" placeholder="Tags (comma-separated, e.g., Usability, Navigation)" />
-			</div>
-			<div class="govuk-button-group">
-				<button id="save" class="govuk-button">Save note</button>
-			</div>
-			<div id="status" class="govuk-hint notes-status"></div>
 		</div>
-	</div>
 
-	<div class="card notes-panel">
-		<h2 class="govuk-heading-m">Notes in this session</h2>
-		<div id="notes" class="notes-list"></div>
-	</div>
+		<div class="card notes-panel">
+			<h2 class="govuk-heading-m">Add a note</h2>
+			<div class="notes-editor">
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="text">Note</label>
+					<textarea id="text" class="govuk-textarea" placeholder="Avoid PII; describe behaviour, quotes, observations"></textarea>
+				</div>
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="tags">Tags</label>
+					<input id="tags" class="govuk-input" placeholder="Tags (comma-separated, e.g., Usability, Navigation)" />
+				</div>
+				<div class="govuk-button-group">
+					<button id="save" class="govuk-button">Save note</button>
+				</div>
+				<div id="status" class="govuk-hint notes-status"></div>
+			</div>
+		</div>
+
+		<div class="card notes-panel">
+			<h2 class="govuk-heading-m">Notes in this session</h2>
+			<div id="notes" class="notes-list"></div>
+		</div>
+	</main>
 	
 	<x-include src="/partials/footer.html"></x-include>
 

--- a/public/pages/search/index.html
+++ b/public/pages/search/index.html
@@ -24,35 +24,37 @@
 		}'>
 	</x-include>
 
-	<div class="card search-panel">
-		<h2 class="govuk-heading-m">Query</h2>
-		<div class="search-controls">
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="q">Search text</label>
-				<input id="q" class="govuk-input" placeholder="Search text (e.g., contrast, navigation)" />
-			</div>
-			<div class="govuk-form-group">
-				<label class="govuk-label search-type-label" for="type">Type</label>
-				<select id="type" class="govuk-select">
-					<option value="">Any</option>
-					<option>ResearchSession</option>
-					<option>Consent</option>
-					<option>Note</option>
-					<option>Tag</option>
-					<option>Cluster</option>
-					<option>Theme</option>
-				</select>
-			</div>
-			<div class="govuk-button-group">
-				<button id="go" class="govuk-button">Search</button>
+	<main id="main-content" class="govuk-body" role="main" tabindex="-1">
+		<div class="card search-panel">
+			<h2 class="govuk-heading-m">Query</h2>
+			<div class="search-controls">
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="q">Search text</label>
+					<input id="q" class="govuk-input" placeholder="Search text (e.g., contrast, navigation)" />
+				</div>
+				<div class="govuk-form-group">
+					<label class="govuk-label search-type-label" for="type">Type</label>
+					<select id="type" class="govuk-select">
+						<option value="">Any</option>
+						<option>ResearchSession</option>
+						<option>Consent</option>
+						<option>Note</option>
+						<option>Tag</option>
+						<option>Cluster</option>
+						<option>Theme</option>
+					</select>
+				</div>
+				<div class="govuk-button-group">
+					<button id="go" class="govuk-button">Search</button>
+				</div>
 			</div>
 		</div>
-	</div>
 
-	<div class="card search-panel">
-		<h2 class="govuk-heading-m">Results</h2>
-		<div id="results" class="search-results"></div>
-	</div>
+		<div class="card search-panel">
+			<h2 class="govuk-heading-m">Results</h2>
+			<div id="results" class="search-results"></div>
+		</div>
+	</main>
 
 	<x-include src="/partials/footer.html"></x-include>
 

--- a/public/pages/sessions/index.html
+++ b/public/pages/sessions/index.html
@@ -21,34 +21,36 @@
 	<x-include src="/partials/header.html" vars='{"active":"Notes","subtitle":"Sessions"}'>
 	</x-include>
 
-	<div class="card sessions-panel">
-		<h2 class="govuk-heading-m">Create a session</h2>
-		<div class="sessions-form">
-			<div class="govuk-form-group sessions-field">
-				<label class="govuk-label" for="title">Title</label>
-				<input id="title" class="govuk-input" placeholder="e.g., Interview 01 — Immigration officer" />
+	<main id="main-content" class="govuk-body" role="main" tabindex="-1">
+		<div class="card sessions-panel">
+			<h2 class="govuk-heading-m">Create a session</h2>
+			<div class="sessions-form">
+				<div class="govuk-form-group sessions-field">
+					<label class="govuk-label" for="title">Title</label>
+					<input id="title" class="govuk-input" placeholder="e.g., Interview 01 — Immigration officer" />
+				</div>
+				<div class="govuk-form-group sessions-field">
+					<label class="govuk-label" for="when">When</label>
+					<div id="when-hint" class="govuk-hint">Use an ISO timestamp, for example 2025-09-19T10:00:00Z.</div>
+					<input id="when" class="govuk-input" placeholder="2025-09-19T10:00:00Z" aria-describedby="when-hint" />
+				</div>
+				<div class="govuk-form-group sessions-field">
+					<label class="govuk-label" for="participants">Participants</label>
+					<div id="participants-hint" class="govuk-hint">Enter pseudonyms as a comma-separated list.</div>
+					<input id="participants" class="govuk-input" placeholder="P001, P002" aria-describedby="participants-hint" />
+				</div>
+				<div class="govuk-button-group">
+					<button id="create" class="govuk-button">Create session</button>
+				</div>
+				<div id="status" class="govuk-hint sessions-status"></div>
 			</div>
-			<div class="govuk-form-group sessions-field">
-				<label class="govuk-label" for="when">When</label>
-				<div id="when-hint" class="govuk-hint">Use an ISO timestamp, for example 2025-09-19T10:00:00Z.</div>
-				<input id="when" class="govuk-input" placeholder="2025-09-19T10:00:00Z" aria-describedby="when-hint" />
-			</div>
-			<div class="govuk-form-group sessions-field">
-				<label class="govuk-label" for="participants">Participants</label>
-				<div id="participants-hint" class="govuk-hint">Enter pseudonyms as a comma-separated list.</div>
-				<input id="participants" class="govuk-input" placeholder="P001, P002" aria-describedby="participants-hint" />
-			</div>
-			<div class="govuk-button-group">
-				<button id="create" class="govuk-button">Create session</button>
-			</div>
-			<div id="status" class="govuk-hint sessions-status"></div>
 		</div>
-	</div>
 
-	<div class="card sessions-panel">
-		<h2 class="govuk-heading-m">Your sessions</h2>
-		<div id="sessions" class="list sessions-list"></div>
-	</div>
+		<div class="card sessions-panel">
+			<h2 class="govuk-heading-m">Your sessions</h2>
+			<div id="sessions" class="list sessions-list"></div>
+		</div>
+	</main>
 
 	<x-include src="/partials/footer.html"></x-include>
 

--- a/public/pages/synthesize/index.html
+++ b/public/pages/synthesize/index.html
@@ -21,48 +21,50 @@
 	<x-include src="/partials/header.html" vars='{"active":"Synthesis","subtitle":"Synthesis"}'>
 	</x-include>
 
-	<div class="grid synthesize-grid">
-		<div class="panel synthesize-panel">
-			<h2 class="govuk-heading-m">Evidence (notes by tag)</h2>
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="filter">Filter by tag</label>
-				<input id="filter" class="govuk-input synthesize-filter" placeholder="Filter by tag (optional)" />
+	<main id="main-content" class="govuk-body" role="main" tabindex="-1">
+		<div class="grid synthesize-grid">
+			<div class="panel synthesize-panel">
+				<h2 class="govuk-heading-m">Evidence (notes by tag)</h2>
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="filter">Filter by tag</label>
+					<input id="filter" class="govuk-input synthesize-filter" placeholder="Filter by tag (optional)" />
+				</div>
+				<div id="evidence" class="evidence-list"></div>
 			</div>
-			<div id="evidence" class="evidence-list"></div>
+			<div class="panel synthesize-panel">
+				<h2 class="govuk-heading-m">Clusters</h2>
+				<div id="clusters" class="cluster-list"></div>
+				<div class="cluster-create">
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="newCluster">New cluster name</label>
+						<input id="newCluster" class="govuk-input" placeholder="New cluster name" />
+					</div>
+					<div class="govuk-button-group">
+						<button id="addCluster" class="govuk-button">Add cluster</button>
+					</div>
+				</div>
+				<div class="theme-publish">
+					<h3 class="govuk-heading-s">Publish theme from cluster</h3>
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="clusterSelect">Cluster</label>
+						<select id="clusterSelect" class="govuk-select"></select>
+					</div>
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="themeLabel">Theme label</label>
+						<input id="themeLabel" class="govuk-input" placeholder="Theme label" />
+					</div>
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="themeDesc">Theme description</label>
+						<textarea id="themeDesc" class="govuk-textarea" placeholder="Theme description"></textarea>
+					</div>
+					<div class="govuk-button-group">
+						<button id="publish" class="govuk-button">Publish theme</button>
+					</div>
+					<div id="status" class="govuk-hint synthesize-status"></div>
+				</div>
+			</div>
 		</div>
-		<div class="panel synthesize-panel">
-			<h2 class="govuk-heading-m">Clusters</h2>
-			<div id="clusters" class="cluster-list"></div>
-			<div class="cluster-create">
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="newCluster">New cluster name</label>
-					<input id="newCluster" class="govuk-input" placeholder="New cluster name" />
-				</div>
-				<div class="govuk-button-group">
-					<button id="addCluster" class="govuk-button">Add cluster</button>
-				</div>
-			</div>
-			<div class="theme-publish">
-				<h3 class="govuk-heading-s">Publish theme from cluster</h3>
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="clusterSelect">Cluster</label>
-					<select id="clusterSelect" class="govuk-select"></select>
-				</div>
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="themeLabel">Theme label</label>
-					<input id="themeLabel" class="govuk-input" placeholder="Theme label" />
-				</div>
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="themeDesc">Theme description</label>
-					<textarea id="themeDesc" class="govuk-textarea" placeholder="Theme description"></textarea>
-				</div>
-				<div class="govuk-button-group">
-					<button id="publish" class="govuk-button">Publish theme</button>
-				</div>
-				<div id="status" class="govuk-hint synthesize-status"></div>
-			</div>
-		</div>
-	</div>
+	</main>
 
 	<x-include src="/partials/footer.html"></x-include>
 

--- a/public/partials/footer.html
+++ b/public/partials/footer.html
@@ -1,5 +1,6 @@
 <!-- public/partials/footer.html -->
-<footer class="govuk-body" role="contentinfo">
-	<hr />
-	<div class="muted">© {{year}} {{org}} · {{build}}</div>
+<footer class="govuk-footer" role="contentinfo">
+	<div class="govuk-footer__container">
+		<p class="govuk-footer__meta">© {{year}} {{org}} · {{build}}</p>
+	</div>
 </footer>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -72,7 +72,6 @@
 			target.id = "main-content";
 			target.className = "govuk-main-wrapper__target";
 			target.setAttribute("tabindex", "-1");
-			target.setAttribute("aria-hidden", "true");
 			main.parentNode.insertBefore(target, main);
 		}
 

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -39,6 +39,18 @@
 
 <script>
 	(function () {
+		function ensurePageChromeStylesheet() {
+			var href = "/css/govuk/govuk-page-chrome.css";
+			var selector = "link[href='" + href + "']";
+			if (document.querySelector(selector)) return;
+
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href = href;
+			link.media = "screen";
+			document.head.appendChild(link);
+		}
+
 		function ensureMainContentTarget() {
 			var existing = document.getElementById("main-content");
 			if (existing) return;
@@ -46,17 +58,33 @@
 			var main = document.querySelector("main");
 			if (!main) return;
 
-			main.setAttribute("id", "main-content");
 			main.classList.add("govuk-main-wrapper");
-			if (!main.hasAttribute("tabindex")) {
-				main.setAttribute("tabindex", "-1");
+
+			if (!main.id) {
+				main.id = "main-content";
+				if (!main.hasAttribute("tabindex")) {
+					main.setAttribute("tabindex", "-1");
+				}
+				return;
 			}
+
+			var target = document.createElement("div");
+			target.id = "main-content";
+			target.className = "govuk-main-wrapper__target";
+			target.setAttribute("tabindex", "-1");
+			target.setAttribute("aria-hidden", "true");
+			main.parentNode.insertBefore(target, main);
+		}
+
+		function init() {
+			ensurePageChromeStylesheet();
+			ensureMainContentTarget();
 		}
 
 		if (document.readyState === "loading") {
-			document.addEventListener("DOMContentLoaded", ensureMainContentTarget, { once: true });
+			document.addEventListener("DOMContentLoaded", init, { once: true });
 		} else {
-			ensureMainContentTarget();
+			init();
 		}
 	})();
 </script>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,21 +1,62 @@
 <!-- public/partials/header.html -->
-<header class="rops-header" role="banner">
-	<div class="rops-header__title">
-		{{#title}}
-			<p class="govuk-heading-l rops-header__title-text">{{title}}</p>
-		{{/title}}
-		{{^title}}
-			<p class="govuk-heading-l rops-header__title-text">ResearchOps Demo Suite</p>
-		{{/title}}
+<a class="govuk-skip-link" href="#main-content">Skip to main content</a>
+
+<header class="govuk-header" role="banner">
+	<div class="govuk-header__container">
+		<div class="govuk-header__service-name">
+			<a class="govuk-header__link" href="/">
+				{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
+			</a>
+		</div>
+		{{#subtitle}}
+			<p class="govuk-header__service-description">{{subtitle}}</p>
+		{{/subtitle}}
 	</div>
-	{{#subtitle}}
-		<p class="govuk-heading-m rops-header__subtitle">{{subtitle}}</p>
-	{{/subtitle}}
-	<nav class="nav govuk-body" data-active="{{active}}" aria-label="Primary navigation">
-		<ul class="nav__list">
-			<li><a class="govuk-link" href="/" data-nav="Home">Home</a></li>
-			<li><a class="govuk-link" href="/pages/start/" data-nav="Start Research Project">Start Research Project</a></li>
-			<li><a class="govuk-link" href="/pages/projects/" data-nav="Projects">Projects</a></li>
-		</ul>
-	</nav>
 </header>
+
+<nav class="govuk-service-navigation" data-active="{{active}}" aria-label="Service navigation">
+	<div class="govuk-service-navigation__container">
+		<ul class="govuk-service-navigation__list">
+			<li class="govuk-service-navigation__item">
+				<a class="govuk-service-navigation__link" href="/" data-nav="Home">Home</a>
+			</li>
+			<li class="govuk-service-navigation__item">
+				<a class="govuk-service-navigation__link" href="/pages/start/" data-nav="Start Research Project">Start research project</a>
+			</li>
+			<li class="govuk-service-navigation__item">
+				<a class="govuk-service-navigation__link" href="/pages/projects/" data-nav="Projects">Projects</a>
+			</li>
+		</ul>
+	</div>
+</nav>
+
+<div class="govuk-phase-banner" role="note" aria-label="Service phase">
+	<p class="govuk-phase-banner__content">
+		<strong class="govuk-tag">Prototype</strong>
+		<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant personal data.</span>
+	</p>
+</div>
+
+<script>
+	(function () {
+		function ensureMainContentTarget() {
+			var existing = document.getElementById("main-content");
+			if (existing) return;
+
+			var main = document.querySelector("main");
+			if (!main) return;
+
+			main.setAttribute("id", "main-content");
+			main.classList.add("govuk-main-wrapper");
+			if (!main.hasAttribute("tabindex")) {
+				main.setAttribute("tabindex", "-1");
+			}
+		}
+
+		if (document.readyState === "loading") {
+			document.addEventListener("DOMContentLoaded", ensureMainContentTarget, { once: true });
+		} else {
+			ensureMainContentTarget();
+		}
+	})();
+</script>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -30,12 +30,14 @@ require_file "public/_headers"
 require_file "public/css/govuk/govuk-buttons.css"
 require_file "public/css/govuk/govuk-forms.css"
 require_file "public/css/govuk/govuk-tables.css"
+require_file "public/css/govuk/govuk-page-chrome.css"
 require_file "docs/performance/initial-load-audit.md"
 require_file "docs/performance/performance-inventory-tooling.md"
 require_file "docs/design-system/govuk-compliance-audit.md"
 require_file "docs/design-system/govuk-button-migration.md"
 require_file "docs/design-system/govuk-form-migration.md"
 require_file "docs/design-system/govuk-table-summary-list-migration.md"
+require_file "docs/design-system/govuk-page-chrome-navigation-migration.md"
 require_file "docs/design-system/researchops-component-inventory.md"
 require_file "scripts/performance-audit.sh"
 require_file "infra/cloudflare/wrangler.toml"
@@ -46,6 +48,7 @@ require_file "infra/cloudflare/src/service/index.js"
 require_file "tests/govuk-design-system-baseline-route-state.test.js"
 require_file "tests/govuk-forms-application-route-state.test.js"
 require_file "tests/govuk-tables-summary-lists-application-route-state.test.js"
+require_file "tests/govuk-page-chrome-navigation-route-state.test.js"
 require_file "tests/projects-route-contract.test.js"
 require_file "tests/projects-page-route-state.test.js"
 require_file "tests/project-dashboard-route-state.test.js"
@@ -185,6 +188,9 @@ node tests/govuk-forms-application-route-state.test.js
 
 info "checking application GOV.UK tables and summary lists route-state contract"
 node tests/govuk-tables-summary-lists-application-route-state.test.js
+
+info "checking GOV.UK page chrome and navigation route-state contract"
+node tests/govuk-page-chrome-navigation-route-state.test.js
 
 info "checking Projects API route contract"
 node tests/projects-route-contract.test.js

--- a/tests/govuk-page-chrome-navigation-route-state.test.js
+++ b/tests/govuk-page-chrome-navigation-route-state.test.js
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageChromeCss = fs.readFileSync("public/css/govuk/govuk-page-chrome.css", "utf8");
+const headerPartial = fs.readFileSync("public/partials/header.html", "utf8");
+const footerPartial = fs.readFileSync("public/partials/footer.html", "utf8");
+const migrationDoc = fs.readFileSync(
+  "docs/design-system/govuk-page-chrome-navigation-migration.md",
+  "utf8"
+);
+
+const pagesUsingSharedChrome = [
+  "public/index.html",
+  "public/pages/start/index.html",
+  "public/pages/projects/index.html",
+  "public/pages/project-dashboard/index.html",
+  "public/pages/projects/outcomes/index.html",
+  "public/pages/projects/journals/index.html",
+  "public/pages/study/index.html",
+  "public/pages/study/guides/index.html",
+  "public/pages/study/participants/index.html",
+  "public/pages/study/session/index.html",
+  "public/pages/study/consent-forms/index.html",
+  "public/pages/search/index.html",
+  "public/pages/notes/index.html",
+  "public/pages/consent/index.html",
+  "public/pages/sessions/index.html",
+  "public/pages/synthesize/index.html"
+];
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageChromeCss, ".govuk-skip-link", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-header", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-header__container", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-header__service-name", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-service-navigation", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-service-navigation__link", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-phase-banner", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-back-link", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-footer", "page chrome stylesheet");
+includes(pageChromeCss, "/* transparency begins in the cascade */", "page chrome stylesheet");
+
+includes(headerPartial, "class=\"govuk-skip-link\" href=\"#main-content\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header\" role=\"banner\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header__container\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header__service-name\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header__link\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-service-navigation\"", "shared header partial");
+includes(headerPartial, "aria-label=\"Service navigation\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-service-navigation__list\"", "shared header partial");
+includes(headerPartial, "data-active=\"{{active}}\"", "shared header partial");
+includes(headerPartial, "data-nav=\"Home\"", "shared header partial");
+includes(headerPartial, "data-nav=\"Start Research Project\"", "shared header partial");
+includes(headerPartial, "data-nav=\"Projects\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-phase-banner\"", "shared header partial");
+includes(headerPartial, "Do not enter real participant personal data", "shared header partial");
+includes(headerPartial, "ensurePageChromeStylesheet", "shared header partial");
+includes(headerPartial, "ensureMainContentTarget", "shared header partial");
+includes(headerPartial, "main.classList.add(\"govuk-main-wrapper\")", "shared header partial");
+includes(headerPartial, "target.id = \"main-content\"", "shared header partial");
+excludes(headerPartial, "main.setAttribute(\"id\", \"main-content\")", "shared header partial");
+excludes(headerPartial, "aria-hidden", "shared header partial");
+excludes(headerPartial, "class=\"rops-header\"", "shared header partial");
+excludes(headerPartial, "class=\"nav govuk-body\"", "shared header partial");
+
+includes(footerPartial, "class=\"govuk-footer\" role=\"contentinfo\"", "shared footer partial");
+includes(footerPartial, "class=\"govuk-footer__container\"", "shared footer partial");
+includes(footerPartial, "class=\"govuk-footer__meta\"", "shared footer partial");
+excludes(footerPartial, "<hr", "shared footer partial");
+
+includes(migrationDoc, "# GOV.UK page chrome and navigation migration", "page chrome migration doc");
+includes(migrationDoc, "Skip link", "page chrome migration doc");
+includes(migrationDoc, "Service navigation", "page chrome migration doc");
+includes(migrationDoc, "Phase banner", "page chrome migration doc");
+includes(migrationDoc, "Footer", "page chrome migration doc");
+includes(migrationDoc, "Route stylesheets must not recreate shared header", "page chrome migration doc");
+
+for (const pagePath of pagesUsingSharedChrome) {
+  const source = fs.readFileSync(pagePath, "utf8");
+
+  includes(source, "src=\"/partials/header.html\"", pagePath);
+  includes(source, "src=\"/partials/footer.html\"", pagePath);
+  includes(source, "<main", pagePath);
+  excludes(source, "class=\"rops-header\"", pagePath);
+}


### PR DESCRIPTION
## Summary

Migrates the shared ResearchOps page chrome and navigation frame toward GOV.UK Design System patterns.

This is the next structural slice after buttons, forms, tables and summary lists. It treats page chrome as a shared service frame rather than a route-by-route styling concern.

## Changes

- Add `public/css/govuk/govuk-page-chrome.css` as the global page chrome foundation.
- Migrate `public/partials/header.html` to GOV.UK-style shared chrome:
  - skip link
  - GOV.UK-style header
  - GOV.UK-style service navigation
  - prototype phase banner
  - shared main-content target helper
- Migrate `public/partials/footer.html` to GOV.UK-style footer classes.
- Add `docs/design-system/govuk-page-chrome-navigation-migration.md`.
- Add `tests/govuk-page-chrome-navigation-route-state.test.js`.
- Wire the new route-state test into `scripts/validate.sh`.
- Add primary `<main>` landmarks to legacy utility routes that previously placed route content directly after the shared header:
  - Search
  - Notes
  - Consent
  - Sessions
  - Synthesize

## Behaviour preserved

The shared skip-link helper preserves route-facing main IDs.

If a page already has a controller-facing main ID such as `main` or `content`, the helper inserts a small `#main-content` target before the main landmark instead of renaming the existing element.

This avoids breaking route controllers and selectors while giving the skip link a consistent target.

## CSS ownership

Base page chrome styling is global in:

`public/css/govuk/govuk-page-chrome.css`

Route stylesheets must not recreate shared header, service navigation, skip-link, phase banner or footer behaviour.

## Scope boundaries

This PR does not rewrite route content, breadcrumbs, controller logic, API payloads or Airtable payloads.

Breadcrumb normalisation should be a separate follow-up slice because several project and study routes preserve dynamic breadcrumb IDs and controller-owned links.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`
- pa11y

Manual browser checks:

- `/`
- `/pages/start/`
- `/pages/projects/`
- `/pages/project-dashboard/?id=<project-id>`
- `/pages/study/?pid=<project-id>&sid=<study-id>`
- `/pages/study/guides/?pid=<project-id>&sid=<study-id>`
- `/pages/study/participants/?pid=<project-id>&sid=<study-id>`
- `/pages/projects/outcomes/?id=<project-id>`
- `/pages/search/`
- `/pages/notes/`
- `/pages/consent/`
- `/pages/sessions/`
- `/pages/synthesize/`

Check that the skip link appears on keyboard focus, service navigation active state still works, the phase banner appears once, footers are consistent, and route-specific content still renders correctly.