### PR TITLE
Migrate breadcrumbs and back links to GOV.UK patterns

### DIFF
--- a/docs/design-system/govuk-breadcrumb-back-link-migration.md
+++ b/docs/design-system/govuk-breadcrumb-back-link-migration.md
@@ -1,0 +1,166 @@
+# GOV.UK breadcrumb and back-link migration
+
+Date: 2026-04-27
+Branch: `design-system/govuk-breadcrumbs-back-links-all-routes`
+Scope: Route-level breadcrumbs, parent links and back-link styling.
+
+## Purpose
+
+This document records the GOV.UK breadcrumb and back-link migration for ResearchOps.
+
+Breadcrumbs and back links are orientation patterns. They must not be treated as decorative navigation. Breadcrumbs show hierarchy. Back links return to a parent or previous step.
+
+## Component classification
+
+### Breadcrumbs
+
+Target classification: GOV.UK global.
+
+Implemented through:
+
+- `public/css/govuk/govuk-page-chrome.css`
+- route-level `nav.govuk-breadcrumbs` markup
+
+The route-level breadcrumb contract uses:
+
+```html
+<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item" aria-current="page">Current page</li>
+  </ol>
+</nav>
+```
+
+Dynamic project and study links preserve their controller-owned IDs.
+
+Examples:
+
+- `breadcrumb-project`
+- `breadcrumb-study`
+- `project-link`
+
+### Back links and parent links
+
+Target classification: GOV.UK global for styling, route-owned for destination.
+
+Implemented through:
+
+- `public/css/govuk/govuk-page-chrome.css`
+- route-level links where a parent route is useful
+
+Visible arrow characters such as `←` must not be placed in link text. The global back-link style owns arrow presentation.
+
+Where the link is styled as a button for a route action toolbar, the visible label still avoids decorative arrow characters.
+
+## Routes covered
+
+### Project Dashboard
+
+Route:
+
+`/pages/project-dashboard/?id=<project-id>`
+
+The breadcrumb now uses `govuk-breadcrumbs` markup and preserves `breadcrumb-project`.
+
+### Research Outcomes
+
+Route:
+
+`/pages/projects/outcomes/?id=<project-id>`
+
+The breadcrumb now uses `govuk-breadcrumbs` markup and preserves `breadcrumb-project`.
+
+The parent link text is `Back to project dashboard` without a decorative arrow in the markup.
+
+### Journals
+
+Route:
+
+`/pages/projects/journals/?id=<project-id>`
+
+The breadcrumb now uses `govuk-breadcrumbs` markup and preserves `project-link`.
+
+### Study
+
+Route:
+
+`/pages/study/?pid=<project-id>&sid=<study-id>`
+
+The breadcrumb now uses `govuk-breadcrumbs` markup and preserves `breadcrumb-project`.
+
+The parent link text is `Back to Project` without a decorative arrow in the markup.
+
+### Discussion Guides
+
+Route:
+
+`/pages/study/guides/?pid=<project-id>&sid=<study-id>`
+
+The breadcrumb now uses `govuk-breadcrumbs` markup and preserves:
+
+- `breadcrumb-project`
+- `breadcrumb-study`
+
+The parent link text is `Back to Study` without a decorative arrow in the markup.
+
+### Consent Forms
+
+Route:
+
+`/pages/study/consent-forms/?pid=<project-id>&sid=<study-id>`
+
+The breadcrumb now uses `govuk-breadcrumbs` markup and preserves:
+
+- `breadcrumb-project`
+- `breadcrumb-study`
+
+The parent link text is `Back to Study` without a decorative arrow in the markup.
+
+### Participants
+
+Route:
+
+`/pages/study/participants/?pid=<project-id>&sid=<study-id>`
+
+The breadcrumb now uses `govuk-breadcrumbs` markup and preserves:
+
+- `breadcrumb-project`
+- `breadcrumb-study`
+
+## What did not change
+
+This migration does not rewrite route controllers.
+
+This migration does not change project, study, participant or outcome payloads.
+
+This migration does not remove controller-owned IDs.
+
+This migration does not replace workflow action buttons with back links unless doing so is safe for existing route behaviour.
+
+## Validation
+
+Expected commands:
+
+- `npm run validate`
+- `npm run lint`
+
+The route-state test is:
+
+`tests/govuk-breadcrumb-back-link-route-state.test.js`
+
+## Manual checks
+
+Check these routes after merge:
+
+- `/pages/project-dashboard/?id=<project-id>`
+- `/pages/projects/outcomes/?id=<project-id>`
+- `/pages/projects/journals/?id=<project-id>`
+- `/pages/study/?pid=<project-id>&sid=<study-id>`
+- `/pages/study/guides/?pid=<project-id>&sid=<study-id>`
+- `/pages/study/consent-forms/?pid=<project-id>&sid=<study-id>`
+- `/pages/study/participants/?pid=<project-id>&sid=<study-id>`
+
+Confirm that breadcrumbs render as a list, dynamic project and study links still populate, and no visible link text includes decorative arrows.

--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -162,35 +162,46 @@
 	text-transform: uppercase;
 	}
 
-.govuk-breadcrumbs,
-.breadcrumbs {
+.govuk-breadcrumbs {
 	margin: 8px 0 20px;
 	font-size: 16px;
 	line-height: 1.25;
 	}
 
-.govuk-breadcrumbs__list,
-.breadcrumbs ol {
+.govuk-breadcrumbs__list {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 0;
 	margin: 0;
 	padding: 0;
 	list-style: none;
 	}
 
-.govuk-breadcrumbs__list-item,
-.breadcrumbs li {
+.govuk-breadcrumbs__list-item {
 	margin: 0;
 	padding: 0;
 	}
 
-.govuk-breadcrumbs__list-item + .govuk-breadcrumbs__list-item::before,
-.breadcrumbs li + li::before {
+.govuk-breadcrumbs__list-item + .govuk-breadcrumbs__list-item::before {
 	content: "›";
 	display: inline-block;
 	margin: 0 8px;
 	color: #505a5f;
+	}
+
+.govuk-breadcrumbs__link {
+	color: #1d70b8;
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.1em;
+	}
+
+.govuk-breadcrumbs__link:focus {
+	background-color: #ffdd00;
+	color: #0b0c0c;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+	text-decoration: none;
 	}
 
 .govuk-back-link {
@@ -209,6 +220,15 @@
 	content: "‹";
 	display: inline-block;
 	margin-right: 5px;
+	}
+
+.govuk-back-link:focus {
+	background-color: #ffdd00;
+	color: #0b0c0c;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+	text-decoration: none;
 	}
 
 .govuk-footer {

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -41,21 +41,21 @@
 	<main class="govuk-body" role="main" data-project-name="" data-project-id="" typeof="schema:ResearchProject" resource="#project">
 
 		<!-- BREADCRUMBS -->
-		<nav class="breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-			<ol>
-				<li property="schema:itemListElement" typeof="schema:ListItem">
-					<a href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+					<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
 						<span property="schema:name">Projects</span>
 					</a>
 					<meta property="schema:position" content="1" />
 				</li>
-				<li property="schema:itemListElement" typeof="schema:ListItem">
-					<a id="breadcrumb-project" href="#" property="schema:item" typeof="schema:Thing">
+				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+					<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#" property="schema:item" typeof="schema:Thing">
 						<span property="schema:name">Project</span>
 					</a>
 					<meta property="schema:position" content="2" />
 				</li>
-				<li property="schema:itemListElement" typeof="schema:ListItem" aria-current="page">
+				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem" aria-current="page">
 					<span property="schema:name">Dashboard</span>
 					<meta property="schema:position" content="3" />
 				</li>

--- a/public/pages/projects/journals/index.html
+++ b/public/pages/projects/journals/index.html
@@ -36,10 +36,12 @@
 		"subtitle":"Research Analysis"
 	}'></x-include>
 
-	<nav class="breadcrumbs" aria-label="Breadcrumb">
-		<a href="/pages/projects/">Projects</a> &rarr;
-		<a href="#" id="project-link">Project Dashboard</a> &rarr;
-		<span>Journal &amp; Analysis</span>
+	<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+		<ol class="govuk-breadcrumbs__list">
+			<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
+			<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#" id="project-link">Project dashboard</a></li>
+			<li class="govuk-breadcrumbs__list-item" aria-current="page">Journal and analysis</li>
+		</ol>
 	</nav>
 
 	<header role="banner" class="journal-header">

--- a/public/pages/projects/outcomes/index.html
+++ b/public/pages/projects/outcomes/index.html
@@ -35,29 +35,26 @@
 	<main class="govuk-body" role="main" data-project-name="" data-project-id="" typeof="schema:ResearchProject" resource="#project">
 
 		<!-- BREADCRUMBS -->
-		<nav class="breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-			<ol>
-				<li property="schema:itemListElement" typeof="schema:ListItem">
-					<a href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+					<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
 						<span property="schema:name">Projects</span>
 					</a>
 					<meta property="schema:position" content="1" />
 				</li>
-				<li property="schema:itemListElement" typeof="schema:ListItem">
-					<a id="breadcrumb-project" href="#" property="schema:item" typeof="schema:Thing">
+				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+					<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#" property="schema:item" typeof="schema:Thing">
 						<span property="schema:name">Project</span>
 					</a>
 					<meta property="schema:position" content="2" />
 				</li>
-				<li property="schema:itemListElement" typeof="schema:ListItem" aria-current="page">
+				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem" aria-current="page">
 					<span property="schema:name">Impact &amp; ROI</span>
 					<meta property="schema:position" content="3" />
 				</li>
 			</ol>
 		</nav>
-
-		<!-- Back link to dashboard outcomes -->
-		<a id="back-link" class="govuk-back-link" href="#">Back to project dashboard</a>
 
 		<!-- HERO -->
 		<div class="dashboard-hero outcomes-hero">

--- a/public/pages/study/consent-forms/index.html
+++ b/public/pages/study/consent-forms/index.html
@@ -26,12 +26,12 @@
   }'></x-include>
 
 	<main id="main" class="container govuk-body" role="main">
-		<nav class="breadcrumbs" aria-label="Breadcrumb">
-			<ol>
-				<li><a href="/pages/projects/">Projects</a></li>
-				<li><a id="breadcrumb-project" href="#">Project</a></li>
-				<li><a id="breadcrumb-study" href="#">Study</a></li>
-				<li aria-current="page">Consent forms</li>
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
+				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
+				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
+				<li class="govuk-breadcrumbs__list-item" aria-current="page">Consent forms</li>
 			</ol>
 		</nav>
 
@@ -41,7 +41,7 @@
 		</div>
 
 		<div class="actions-bar">
-			<a id="back-to-study" href="/pages/study/" class="govuk-button govuk-button--secondary">← Back to Study</a>
+			<a id="back-to-study" href="/pages/study/" class="govuk-button govuk-button--secondary">Back to Study</a>
 			<button id="new-consent-form" type="button" class="govuk-button">New consent form</button>
 		</div>
 

--- a/public/pages/study/guides/index.html
+++ b/public/pages/study/guides/index.html
@@ -36,12 +36,12 @@
 
 	<main id="main" class="container govuk-body" role="main">
 		<!-- Breadcrumb -->
-		<nav class="breadcrumbs" aria-label="Breadcrumb">
-			<ol>
-				<li><a href="/pages/projects/">Projects</a></li>
-				<li><a id="breadcrumb-project" href="#">Project</a></li>
-				<li><a id="breadcrumb-study" href="#">Study</a></li>
-				<li aria-current="page">Guides</li>
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
+				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
+				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
+				<li class="govuk-breadcrumbs__list-item" aria-current="page">Guides</li>
 			</ol>
 		</nav>
 
@@ -57,7 +57,7 @@
 				<div class="toolbar">
 					<button id="btn-new" class="govuk-button">＋ New guide</button>
 					<button id="btn-import" class="govuk-button govuk-button--secondary">⤒ Import .md</button>
-					<a id="back-to-study" class="govuk-button govuk-button--secondary" href="#">← Back to Study</a>
+					<a id="back-to-study" class="govuk-button govuk-button--secondary" href="#">Back to Study</a>
 				</div>
 			</div>
 		</header>

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -28,11 +28,11 @@
   }'></x-include>
 
 	<main id="main" class="container govuk-body" role="main">
-		<nav class="breadcrumbs" aria-label="Breadcrumb">
-			<ol>
-				<li><a href="/pages/projects/">Projects</a></li>
-				<li><a id="breadcrumb-project" href="#">Project</a></li>
-				<li aria-current="page">Study</li>
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
+				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
+				<li class="govuk-breadcrumbs__list-item" aria-current="page">Study</li>
 			</ol>
 		</nav>
 
@@ -42,7 +42,7 @@
 		</div>
 
 		<div class="actions-bar">
-			<a id="back-to-project" href="/pages/projects/" class="govuk-button govuk-button--secondary">← Back to Project</a>
+			<a id="back-to-project" href="/pages/projects/" class="govuk-button govuk-button--secondary">Back to Project</a>
 			<a id="edit-study" href="#" class="govuk-button">✎ Edit Study</a>
 		</div>
 

--- a/public/pages/study/participants/index.html
+++ b/public/pages/study/participants/index.html
@@ -28,12 +28,12 @@
   }'></x-include>
 
 	<main id="main" class="container govuk-body" role="main">
-		<nav class="breadcrumbs" aria-label="Breadcrumb">
-			<ol>
-				<li><a href="/pages/projects/">Projects</a></li>
-				<li><a id="breadcrumb-project" href="#">Project</a></li>
-				<li><a id="breadcrumb-study" href="#">Study</a></li>
-				<li aria-current="page">Participants</li>
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
+				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
+				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
+				<li class="govuk-breadcrumbs__list-item" aria-current="page">Participants</li>
 			</ol>
 		</nav>
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -38,6 +38,7 @@ require_file "docs/design-system/govuk-button-migration.md"
 require_file "docs/design-system/govuk-form-migration.md"
 require_file "docs/design-system/govuk-table-summary-list-migration.md"
 require_file "docs/design-system/govuk-page-chrome-navigation-migration.md"
+require_file "docs/design-system/govuk-breadcrumb-back-link-migration.md"
 require_file "docs/design-system/researchops-component-inventory.md"
 require_file "scripts/performance-audit.sh"
 require_file "infra/cloudflare/wrangler.toml"
@@ -49,6 +50,7 @@ require_file "tests/govuk-design-system-baseline-route-state.test.js"
 require_file "tests/govuk-forms-application-route-state.test.js"
 require_file "tests/govuk-tables-summary-lists-application-route-state.test.js"
 require_file "tests/govuk-page-chrome-navigation-route-state.test.js"
+require_file "tests/govuk-breadcrumb-back-link-route-state.test.js"
 require_file "tests/projects-route-contract.test.js"
 require_file "tests/projects-page-route-state.test.js"
 require_file "tests/project-dashboard-route-state.test.js"
@@ -191,6 +193,9 @@ node tests/govuk-tables-summary-lists-application-route-state.test.js
 
 info "checking GOV.UK page chrome and navigation route-state contract"
 node tests/govuk-page-chrome-navigation-route-state.test.js
+
+info "checking GOV.UK breadcrumb and back-link route-state contract"
+node tests/govuk-breadcrumb-back-link-route-state.test.js
 
 info "checking Projects API route contract"
 node tests/projects-route-contract.test.js

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageChromeCss = fs.readFileSync("public/css/govuk/govuk-page-chrome.css", "utf8");
+const migrationDoc = fs.readFileSync(
+  "docs/design-system/govuk-breadcrumb-back-link-migration.md",
+  "utf8"
+);
+
+const breadcrumbPages = [
+  {
+    label: "Project Dashboard route",
+    path: "public/pages/project-dashboard/index.html",
+    requiredIds: ["breadcrumb-project"],
+    currentText: "Dashboard"
+  },
+  {
+    label: "Outcomes route",
+    path: "public/pages/projects/outcomes/index.html",
+    requiredIds: ["breadcrumb-project"],
+    currentText: "Impact &amp; ROI"
+  },
+  {
+    label: "Journals route",
+    path: "public/pages/projects/journals/index.html",
+    requiredIds: ["project-link"],
+    currentText: "Journal and analysis"
+  },
+  {
+    label: "Study route",
+    path: "public/pages/study/index.html",
+    requiredIds: ["breadcrumb-project"],
+    currentText: "Study"
+  },
+  {
+    label: "Guides route",
+    path: "public/pages/study/guides/index.html",
+    requiredIds: ["breadcrumb-project", "breadcrumb-study", "back-to-study"],
+    currentText: "Guides"
+  },
+  {
+    label: "Consent Forms route",
+    path: "public/pages/study/consent-forms/index.html",
+    requiredIds: ["breadcrumb-project", "breadcrumb-study", "back-to-study"],
+    currentText: "Consent forms"
+  },
+  {
+    label: "Participants route",
+    path: "public/pages/study/participants/index.html",
+    requiredIds: ["breadcrumb-project", "breadcrumb-study"],
+    currentText: "Participants"
+  }
+];
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pageChromeCss, ".govuk-breadcrumbs", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-breadcrumbs__list", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-breadcrumbs__list-item", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-breadcrumbs__link", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-back-link", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-back-link::before", "page chrome stylesheet");
+excludes(pageChromeCss, ".breadcrumbs", "page chrome stylesheet");
+
+includes(migrationDoc, "# GOV.UK breadcrumb and back-link migration", "breadcrumb migration doc");
+includes(migrationDoc, "Breadcrumbs show hierarchy", "breadcrumb migration doc");
+includes(migrationDoc, "Back links return to a parent or previous step", "breadcrumb migration doc");
+includes(migrationDoc, "Visible arrow characters", "breadcrumb migration doc");
+includes(migrationDoc, "tests/govuk-breadcrumb-back-link-route-state.test.js", "breadcrumb migration doc");
+
+for (const page of breadcrumbPages) {
+  const source = fs.readFileSync(page.path, "utf8");
+
+  includes(source, "class=\"govuk-breadcrumbs\"", page.label);
+  includes(source, "aria-label=\"Breadcrumb\"", page.label);
+  includes(source, "class=\"govuk-breadcrumbs__list\"", page.label);
+  includes(source, "class=\"govuk-breadcrumbs__list-item\"", page.label);
+  includes(source, "class=\"govuk-breadcrumbs__link\"", page.label);
+  includes(source, "aria-current=\"page\"", page.label);
+  includes(source, page.currentText, page.label);
+
+  for (const id of page.requiredIds) {
+    includes(source, `id=\"${id}\"`, page.label);
+  }
+
+  excludes(source, "class=\"breadcrumbs\"", page.label);
+  excludes(source, "&rarr;", page.label);
+  excludes(source, "← Back", page.label);
+  excludes(source, "Back ←", page.label);
+}
+
+const studyPage = fs.readFileSync("public/pages/study/index.html", "utf8");
+includes(studyPage, "id=\"back-to-project\"", "Study route");
+includes(studyPage, ">Back to Project</a>", "Study route");
+
+const guidesPage = fs.readFileSync("public/pages/study/guides/index.html", "utf8");
+includes(guidesPage, "id=\"back-to-study\"", "Guides route");
+includes(guidesPage, ">Back to Study</a>", "Guides route");
+
+const consentFormsPage = fs.readFileSync("public/pages/study/consent-forms/index.html", "utf8");
+includes(consentFormsPage, "id=\"back-to-study\"", "Consent Forms route");
+includes(consentFormsPage, ">Back to Study</a>", "Consent Forms route");


### PR DESCRIPTION
## Summary

Migrates route-level breadcrumbs and parent/back-link labels toward GOV.UK Design System patterns.

This follows the shared page chrome pass. It keeps route-owned breadcrumb logic intact while replacing bespoke breadcrumb markup with GOV.UK-style breadcrumb structures.

## Changes

- Extend `public/css/govuk/govuk-page-chrome.css` with focused `govuk-breadcrumbs` and `govuk-back-link` support.
- Add `docs/design-system/govuk-breadcrumb-back-link-migration.md`.
- Add `tests/govuk-breadcrumb-back-link-route-state.test.js`.
- Wire the breadcrumb/back-link route-state test into `scripts/validate.sh`.
- Migrate breadcrumbs to GOV.UK structure in:
  - Project Dashboard
  - Research Outcomes
  - Journals
  - Study
  - Discussion Guides
  - Consent Forms
  - Participants
- Remove decorative arrow characters from route parent-link labels where CSS/pattern ownership should handle arrow presentation.

## Dynamic IDs preserved

This PR preserves controller-owned dynamic breadcrumb and parent-link IDs, including:

- `breadcrumb-project`
- `breadcrumb-study`
- `project-link`
- `back-to-project`
- `back-to-study`

## Behaviour preserved

This PR does not change route controllers, API payloads, Airtable payloads, dynamic project/study lookup logic, or workflow actions.

## Breadcrumb/back-link rules

- Breadcrumbs show hierarchy.
- Back links return to a parent or previous step.
- Visible arrow characters such as `←` must not be embedded in link text.
- Route stylesheets must not recreate breadcrumb or back-link systems.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`
- pa11y

Manual browser checks:

- `/pages/project-dashboard/?id=<project-id>`
- `/pages/projects/outcomes/?id=<project-id>`
- `/pages/projects/journals/?id=<project-id>`
- `/pages/study/?pid=<project-id>&sid=<study-id>`
- `/pages/study/guides/?pid=<project-id>&sid=<study-id>`
- `/pages/study/consent-forms/?pid=<project-id>&sid=<study-id>`
- `/pages/study/participants/?pid=<project-id>&sid=<study-id>`

Confirm that breadcrumbs render as ordered lists, dynamic breadcrumb links still populate, parent-link labels have no decorative arrows, and page controllers still work.