### PR TITLE
Fix project breadcrumb hydration on Journals and Outcomes

### DIFF
--- a/public/js/project-context.js
+++ b/public/js/project-context.js
@@ -1,0 +1,82 @@
+/**
+ * @file /js/project-context.js
+ * @summary Hydrates project route breadcrumbs and parent links from the ?id= project context.
+ */
+
+const API_ORIGIN =
+	document.documentElement?.dataset?.apiOrigin ||
+	window.API_ORIGIN ||
+	(location.hostname.endsWith("pages.dev") ?
+		"https://rops-api.digikev-kevin-rapley.workers.dev" :
+		location.origin);
+
+function projectApiUrl(path) {
+	const value = String(path || "");
+	return `${API_ORIGIN}${value.startsWith("/") ? value : "/" + value}`;
+}
+
+function normaliseProject(project = {}) {
+	return {
+		id: project.id || project.LocalId || project.localId || "",
+		localId: project.LocalId || project.localId || "",
+		name: project.name || project.Name || ""
+	};
+}
+
+async function loadProjects() {
+	const response = await fetch(projectApiUrl(`/api/projects?ts=${Date.now()}`), { cache: "no-store" });
+	const data = await response.json().catch(() => null);
+
+	if (!response.ok) {
+		throw new Error(`Could not load projects: HTTP ${response.status}`);
+	}
+
+	const list = Array.isArray(data) ? data : Array.isArray(data?.projects) ? data.projects : [];
+	return list.map(normaliseProject);
+}
+
+function findProject(projects, projectId) {
+	return projects.find((project) => project.id === projectId || project.localId === projectId) || null;
+}
+
+function dashboardHref(projectId) {
+	return `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
+}
+
+function setProjectAnchor(anchor, project) {
+	if (!anchor || !project) return;
+
+	anchor.textContent = project.name || "Project";
+	anchor.href = dashboardHref(project.id || project.localId);
+}
+
+function setProjectParentLink(anchor, project) {
+	if (!anchor || !project) return;
+
+	anchor.textContent = "Back to Project";
+	anchor.href = dashboardHref(project.id || project.localId);
+}
+
+async function hydrateProjectRouteContext() {
+	const params = new URLSearchParams(window.location.search);
+	const projectId = params.get("id");
+	if (!projectId) return;
+
+	const projects = await loadProjects();
+	const project = findProject(projects, projectId);
+	if (!project) return;
+
+	setProjectAnchor(document.getElementById("breadcrumb-project"), project);
+	setProjectAnchor(document.getElementById("project-link"), project);
+	setProjectParentLink(document.getElementById("back-to-project"), project);
+
+	const main = document.querySelector("main");
+	if (main) {
+		main.dataset.projectId = project.id || projectId;
+		main.dataset.projectName = project.name || "";
+	}
+}
+
+hydrateProjectRouteContext().catch((error) => {
+	console.warn("[project-context] Could not hydrate project route context", error);
+});

--- a/public/pages/projects/journals/index.html
+++ b/public/pages/projects/journals/index.html
@@ -21,6 +21,7 @@
 	<link rel="stylesheet" href="/css/journals.css?v=1.0.1" media="screen" />
 	<link rel="stylesheet" href="/css/journal-mural-sync.css" media="screen" />
 
+	<link rel="modulepreload" href="/js/project-context.js" />
 	<link rel="modulepreload" href="/js/journal-tabs.js" />
 	<link rel="modulepreload" href="/js/journal-mural-sync-compact.js" />
 	<link rel="modulepreload" href="/components/journal-excerpts.js" />
@@ -39,10 +40,12 @@
 	<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
 		<ol class="govuk-breadcrumbs__list">
 			<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
-			<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#" id="project-link">Project dashboard</a></li>
+			<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#" id="project-link">Project</a></li>
 			<li class="govuk-breadcrumbs__list-item" aria-current="page">Journal and analysis</li>
 		</ol>
 	</nav>
+
+	<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to Project</a>
 
 	<header role="banner" class="journal-header">
 		<div>
@@ -280,6 +283,7 @@
 
 	<x-include src="/partials/footer.html"></x-include>
 
+	<script type="module" src="/js/project-context.js"></script>
 	<script src="/components/tabs.js"></script>
 	<script src="/lib/coloris.min.js"></script>
 	<script type="module" src="/js/journal-tabs.js"></script>

--- a/public/pages/projects/outcomes/index.html
+++ b/public/pages/projects/outcomes/index.html
@@ -14,6 +14,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
 	<link rel="stylesheet" href="/css/outcomes.css" media="screen" />
+	<link rel="modulepreload" href="/js/project-context.js" />
 	<link rel="modulepreload" href="/js/outcomes-page.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -55,6 +56,8 @@
 				</li>
 			</ol>
 		</nav>
+
+		<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to Project</a>
 
 		<!-- HERO -->
 		<div class="dashboard-hero outcomes-hero">
@@ -195,6 +198,7 @@
 
 	<x-include src="/partials/footer.html"></x-include>
 
+	<script type="module" src="/js/project-context.js"></script>
 	<script type="module" src="/components/impact-tracker.js"></script>
 	<script type="module" src="/js/outcomes-page.js"></script>
 </body>

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const pageChromeCss = fs.readFileSync("public/css/govuk/govuk-page-chrome.css", "utf8");
+const projectContextSource = fs.readFileSync("public/js/project-context.js", "utf8");
 const migrationDoc = fs.readFileSync(
   "docs/design-system/govuk-breadcrumb-back-link-migration.md",
   "utf8"
@@ -17,13 +18,13 @@ const breadcrumbPages = [
   {
     label: "Outcomes route",
     path: "public/pages/projects/outcomes/index.html",
-    requiredIds: ["breadcrumb-project"],
+    requiredIds: ["breadcrumb-project", "back-to-project"],
     currentText: "Impact &amp; ROI"
   },
   {
     label: "Journals route",
     path: "public/pages/projects/journals/index.html",
-    requiredIds: ["project-link"],
+    requiredIds: ["project-link", "back-to-project"],
     currentText: "Journal and analysis"
   },
   {
@@ -68,6 +69,14 @@ includes(pageChromeCss, ".govuk-back-link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-back-link::before", "page chrome stylesheet");
 excludes(pageChromeCss, ".breadcrumbs", "page chrome stylesheet");
 
+includes(projectContextSource, "function hydrateProjectRouteContext", "project context hydrator");
+includes(projectContextSource, "document.getElementById(\"breadcrumb-project\")", "project context hydrator");
+includes(projectContextSource, "document.getElementById(\"project-link\")", "project context hydrator");
+includes(projectContextSource, "document.getElementById(\"back-to-project\")", "project context hydrator");
+includes(projectContextSource, "anchor.textContent = project.name || \"Project\"", "project context hydrator");
+includes(projectContextSource, "anchor.href = dashboardHref(project.id || project.localId)", "project context hydrator");
+includes(projectContextSource, "anchor.textContent = \"Back to Project\"", "project context hydrator");
+
 includes(migrationDoc, "# GOV.UK breadcrumb and back-link migration", "breadcrumb migration doc");
 includes(migrationDoc, "Breadcrumbs show hierarchy", "breadcrumb migration doc");
 includes(migrationDoc, "Back links return to a parent or previous step", "breadcrumb migration doc");
@@ -98,6 +107,21 @@ for (const page of breadcrumbPages) {
 const studyPage = fs.readFileSync("public/pages/study/index.html", "utf8");
 includes(studyPage, "id=\"back-to-project\"", "Study route");
 includes(studyPage, ">Back to Project</a>", "Study route");
+
+const outcomesPage = fs.readFileSync("public/pages/projects/outcomes/index.html", "utf8");
+includes(outcomesPage, "rel=\"modulepreload\" href=\"/js/project-context.js\"", "Outcomes route");
+includes(outcomesPage, "src=\"/js/project-context.js\"", "Outcomes route");
+includes(outcomesPage, "id=\"breadcrumb-project\"", "Outcomes route");
+includes(outcomesPage, "id=\"back-to-project\"", "Outcomes route");
+includes(outcomesPage, ">Back to Project</a>", "Outcomes route");
+
+const journalsPage = fs.readFileSync("public/pages/projects/journals/index.html", "utf8");
+includes(journalsPage, "rel=\"modulepreload\" href=\"/js/project-context.js\"", "Journals route");
+includes(journalsPage, "src=\"/js/project-context.js\"", "Journals route");
+includes(journalsPage, "id=\"project-link\"", "Journals route");
+includes(journalsPage, "id=\"back-to-project\"", "Journals route");
+includes(journalsPage, ">Back to Project</a>", "Journals route");
+excludes(journalsPage, "Project dashboard", "Journals route");
 
 const guidesPage = fs.readFileSync("public/pages/study/guides/index.html", "utf8");
 includes(guidesPage, "id=\"back-to-study\"", "Guides route");


### PR DESCRIPTION
## Summary

Corrects the remaining project breadcrumb and back-link issues identified after the GOV.UK breadcrumb migration.

The bug was that Journals and Outcomes had GOV.UK breadcrumb markup, but did not consistently hydrate the project breadcrumb label and parent link from the `?id=` route context.

## Changes

- Add `public/js/project-context.js` as a shared project route context hydrator.
- Hydrate project breadcrumb labels and links from `/api/projects` for routes using `?id=<project-id>`.
- Wire `project-context.js` into:
  - `/pages/projects/journals/`
  - `/pages/projects/outcomes/`
- Add a `Back to Project` GOV.UK back link to Journals.
- Add a `Back to Project` GOV.UK back link to Outcomes.
- Tighten `tests/govuk-breadcrumb-back-link-route-state.test.js` so this regression is covered.

## Behaviour fixed

### Journals

Before:

`Projects > Project dashboard > Journal and analysis`

After hydration:

`Projects > <project name> > Journal and analysis`

The project breadcrumb links to:

`/pages/project-dashboard/?id=<project-id>`

The route now also has a `Back to Project` link to the same dashboard route.

### Outcomes

Before:

`Projects > Project > Impact & ROI`

After hydration:

`Projects > <project name> > Impact & ROI`

The project breadcrumb links to:

`/pages/project-dashboard/?id=<project-id>`

The route now also has a `Back to Project` link to the same dashboard route.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`
- pa11y

Manual browser checks:

- `/pages/projects/journals/?id=<project-id>`
- `/pages/projects/outcomes/?id=<project-id>`

Confirm that the second breadcrumb item uses the real project name, links to the project dashboard, and that `Back to Project` also returns to the dashboard.