### PR TITLE
Render project parent links as right-aligned action buttons

### DIFF
--- a/public/js/project-context.js
+++ b/public/js/project-context.js
@@ -73,6 +73,9 @@ function setProjectParentLink(anchor, project) {
 }
 
 async function hydrateProjectRouteContext() {
+	const parentLink = document.getElementById("back-to-project");
+	ensureProjectActionBar(parentLink);
+
 	const params = new URLSearchParams(window.location.search);
 	const projectId = params.get("id");
 	if (!projectId) return;
@@ -83,7 +86,7 @@ async function hydrateProjectRouteContext() {
 
 	setProjectAnchor(document.getElementById("breadcrumb-project"), project);
 	setProjectAnchor(document.getElementById("project-link"), project);
-	setProjectParentLink(document.getElementById("back-to-project"), project);
+	setProjectParentLink(parentLink, project);
 
 	const main = document.querySelector("main");
 	if (main) {

--- a/public/js/project-context.js
+++ b/public/js/project-context.js
@@ -50,11 +50,26 @@ function setProjectAnchor(anchor, project) {
 	anchor.href = dashboardHref(project.id || project.localId);
 }
 
+function ensureProjectActionBar(anchor) {
+	if (!anchor) return;
+
+	anchor.classList.remove("govuk-back-link");
+	anchor.classList.add("govuk-button", "govuk-button--secondary");
+
+	if (anchor.parentElement?.classList.contains("actions-bar")) return;
+
+	const actionsBar = document.createElement("div");
+	actionsBar.className = "actions-bar";
+	anchor.parentNode.insertBefore(actionsBar, anchor);
+	actionsBar.appendChild(anchor);
+}
+
 function setProjectParentLink(anchor, project) {
 	if (!anchor || !project) return;
 
 	anchor.textContent = "Back to Project";
 	anchor.href = dashboardHref(project.id || project.localId);
+	ensureProjectActionBar(anchor);
 }
 
 async function hydrateProjectRouteContext() {

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -70,12 +70,17 @@ includes(pageChromeCss, ".govuk-back-link::before", "page chrome stylesheet");
 excludes(pageChromeCss, ".breadcrumbs", "page chrome stylesheet");
 
 includes(projectContextSource, "function hydrateProjectRouteContext", "project context hydrator");
+includes(projectContextSource, "function ensureProjectActionBar", "project context hydrator");
 includes(projectContextSource, "document.getElementById(\"breadcrumb-project\")", "project context hydrator");
 includes(projectContextSource, "document.getElementById(\"project-link\")", "project context hydrator");
 includes(projectContextSource, "document.getElementById(\"back-to-project\")", "project context hydrator");
 includes(projectContextSource, "anchor.textContent = project.name || \"Project\"", "project context hydrator");
 includes(projectContextSource, "anchor.href = dashboardHref(project.id || project.localId)", "project context hydrator");
 includes(projectContextSource, "anchor.textContent = \"Back to Project\"", "project context hydrator");
+includes(projectContextSource, "anchor.classList.remove(\"govuk-back-link\")", "project context hydrator");
+includes(projectContextSource, "anchor.classList.add(\"govuk-button\", \"govuk-button--secondary\")", "project context hydrator");
+includes(projectContextSource, "actionsBar.className = \"actions-bar\"", "project context hydrator");
+includes(projectContextSource, "ensureProjectActionBar(parentLink)", "project context hydrator");
 
 includes(migrationDoc, "# GOV.UK breadcrumb and back-link migration", "breadcrumb migration doc");
 includes(migrationDoc, "Breadcrumbs show hierarchy", "breadcrumb migration doc");


### PR DESCRIPTION
## Summary

Corrects the visual pattern for project parent links on project-owned child routes.

After the breadcrumb hydration fix, Journals and Outcomes had the correct target but rendered `Back to Project` as a standalone GOV.UK back link. This PR updates the shared project context hydrator so those parent links use the same right-aligned secondary GOV.UK button pattern as the Study page action bar.

## Changes

- Update `public/js/project-context.js` so `#back-to-project` is normalised into an action button:
  - removes `govuk-back-link`
  - adds `govuk-button govuk-button--secondary`
  - wraps the link in an `actions-bar` if needed
- Apply the action-bar normalisation before project data resolves, so the visual pattern does not depend on the project API completing first.
- Tighten `tests/govuk-breadcrumb-back-link-route-state.test.js` to validate the action-button normalisation contract.

## Behaviour preserved

The href hydration still resolves to:

`/pages/project-dashboard/?id=<project-id>`

The link ID remains:

`back-to-project`

## Manual checks

Check:

- `/pages/projects/journals/?id=<project-id>`
- `/pages/projects/outcomes/?id=<project-id>`

Confirm:

- `Back to Project` appears as a right-aligned secondary GOV.UK button.
- The button returns to the project dashboard.
- The project breadcrumb still shows the project name and links to the same dashboard route.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`
- pa11y