### PR TITLE
Fix project parent link action button rendering

### DIFF
--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -231,6 +231,35 @@
 	text-decoration: none;
 	}
 
+#back-to-project.govuk-back-link {
+	display: block;
+	width: fit-content;
+	margin: 0 24px 24px auto;
+	padding: 8px 10px 7px;
+	border: 2px solid transparent;
+	background: #f3f2f1;
+	box-shadow: 0 2px 0 #929191;
+	color: #0b0c0c;
+	font-size: 19px;
+	line-height: 1;
+	text-align: center;
+	text-decoration: none;
+	}
+
+#back-to-project.govuk-back-link::before {
+	content: none;
+	}
+
+#back-to-project.govuk-back-link:hover {
+	background: #dbdad9;
+	}
+
+#back-to-project.govuk-back-link:focus {
+	background: #ffdd00;
+	box-shadow: 0 2px 0 #0b0c0c;
+	outline: 3px solid transparent;
+	}
+
 .govuk-footer {
 	margin: 48px -24px -24px;
 	padding: 32px 24px;

--- a/public/pages/projects/outcomes/index.html
+++ b/public/pages/projects/outcomes/index.html
@@ -57,7 +57,9 @@
 			</ol>
 		</nav>
 
-		<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to Project</a>
+		<div class="actions-bar">
+			<a id="back-to-project" class="govuk-button govuk-button--secondary" href="/pages/projects/">Back to Project</a>
+		</div>
 
 		<!-- HERO -->
 		<div class="dashboard-hero outcomes-hero">

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -67,6 +67,11 @@ includes(pageChromeCss, ".govuk-breadcrumbs__list-item", "page chrome stylesheet
 includes(pageChromeCss, ".govuk-breadcrumbs__link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-back-link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-back-link::before", "page chrome stylesheet");
+includes(pageChromeCss, "#back-to-project.govuk-back-link", "page chrome stylesheet");
+includes(pageChromeCss, "width: fit-content;", "page chrome stylesheet");
+includes(pageChromeCss, "margin: 0 24px 24px auto;", "page chrome stylesheet");
+includes(pageChromeCss, "#back-to-project.govuk-back-link::before", "page chrome stylesheet");
+includes(pageChromeCss, "content: none;", "page chrome stylesheet");
 excludes(pageChromeCss, ".breadcrumbs", "page chrome stylesheet");
 
 includes(projectContextSource, "function hydrateProjectRouteContext", "project context hydrator");
@@ -118,6 +123,7 @@ includes(outcomesPage, "rel=\"modulepreload\" href=\"/js/project-context.js\"", 
 includes(outcomesPage, "src=\"/js/project-context.js\"", "Outcomes route");
 includes(outcomesPage, "id=\"breadcrumb-project\"", "Outcomes route");
 includes(outcomesPage, "id=\"back-to-project\"", "Outcomes route");
+includes(outcomesPage, "class=\"govuk-button govuk-button--secondary\"", "Outcomes route");
 includes(outcomesPage, ">Back to Project</a>", "Outcomes route");
 
 const journalsPage = fs.readFileSync("public/pages/projects/journals/index.html", "utf8");


### PR DESCRIPTION
## Summary

Fixes the remaining visual regression where `Back to Project` could still appear as a simple text link on project-owned child routes.

The previous fix relied too heavily on client-side class normalisation. This PR makes the visual fallback deterministic through the shared page chrome CSS and updates the Outcomes route source markup to the expected action-bar pattern.

## Changes

- Update `public/pages/projects/outcomes/index.html` so `Back to Project` is shipped inside an `actions-bar` as a secondary GOV.UK button.
- Update `public/css/govuk/govuk-page-chrome.css` so any remaining static `#back-to-project.govuk-back-link` fallback is rendered visually as a right-aligned secondary action button.
- Suppress the decorative back-link chevron for `#back-to-project.govuk-back-link`.
- Tighten `tests/govuk-breadcrumb-back-link-route-state.test.js` to validate the fallback action-button rendering.

## Why CSS is included

Journals still ships a static `#back-to-project.govuk-back-link` before the shared hydrator runs. The global page chrome rule now treats that specific project-parent fallback as an action button immediately, rather than waiting for JavaScript to remove the class.

The selector is intentionally narrow:

`#back-to-project.govuk-back-link`

It does not change normal GOV.UK back links elsewhere.

## Manual checks

Check:

- `/pages/projects/outcomes/?id=recgdpwEI5hF07bUZ`
- `/pages/projects/journals/?id=recgdpwEI5hF07bUZ`

Confirm:

- `Back to Project` appears as a right-aligned secondary GOV.UK-style button.
- No left-facing chevron appears before the label.
- The link resolves to `/pages/project-dashboard/?id=recgdpwEI5hF07bUZ` after hydration.

## Validation

Expected checks:

- `npm run validate`
- `npm run lint`
- pa11y