### PR TITLE
Move GitHub governance files to standard locations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require at least one review from the core maintainers
+* @digikev @researchops-maintainers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What’s changing?
+<!-- Plain English. Link to issues. -->
+
+## Why?
+<!-- User need / outcome. -->
+
+## How tested?
+- [ ] Unit tests
+- [ ] Manual checks
+- [ ] Accessibility checks
+
+## Risk / rollout
+- [ ] Low  - no behavioural change
+- [ ] Medium
+- [ ] High - behind a feature flag


### PR DESCRIPTION
## Summary

Moves the existing ResearchOps GitHub governance files into standard GitHub-recognised locations:

- `.github/CODEOWNERS`
- `.github/pull_request_template.md`

The existing source files under `.github/workflows/` are preserved in this PR to avoid deleting historical or referenced files without a separate cleanup decision.

## Why

GitHub only applies CODEOWNERS and pull request templates from supported repository paths. This PR enables later branch protection settings such as code owner review and makes the pull request template appear automatically on new PRs.

## Validation

- Copied content from the existing `.github/workflows/CODEOWNERS.txt` file.
- Copied content from the existing `.github/workflows/pull_request_template.md` file.
- No application runtime files changed.

## Risk / rollout

Low. This is repository governance metadata only.