### PR TITLE
Normalize package scripts and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [20, 22]
 
     steps:
       - name: Checkout
@@ -45,10 +45,10 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npm run lint --if-present
+        run: npm run lint
 
       - name: Format check
-        run: npm run format --if-present -- -c
+        run: npm run format:check
 
       - name: Typecheck
         run: npm run typecheck --if-present
@@ -56,8 +56,8 @@ jobs:
       - name: Build (no deploy)
         run: npm run build --if-present
 
-      - name: Unit tests (CI mode)
-        run: npm test --if-present -- --ci --reporters=default --coverage
+      - name: Unit tests
+        run: npm test
 
       - name: Upload coverage
         if: always()

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "lint": "prettier -c . && eslint .",
     "format": "prettier -w .",
+    "format:check": "prettier -c .",
     "validate": "bash ./scripts/validate.sh",
     "audit:performance": "bash ./scripts/performance-audit.sh",
     "audit:performance:write": "bash ./scripts/performance-audit.sh --write docs/performance/performance-inventory.md",
+    "test": "node --test",
     "test:e2e": "playwright test",
     "qa:browsers": "playwright install --with-deps chromium",
     "qa:cucumber": "cucumber-js -p default"


### PR DESCRIPTION
## Summary

Normalizes package scripts and CI checks for ResearchOps:

- adds `format:check` as a pure Prettier check
- adds a default `test` script using Node's built-in test runner
- updates CI to run Node 20 and 22 instead of Node 18 and 20
- updates CI to call `npm run format:check`
- updates CI to run `npm test` without incompatible extra arguments

## Why

The repository declares `node >=20`, but CI still tested Node 18. CI also called the write-mode `format` script with check arguments. This PR makes the CI contract more deterministic and makes the package scripts clearer.

## Validation

Expected CI validation on this PR:

- `npm ci`
- `npm run lint`
- `npm run format:check`
- `npm test`
- optional typecheck/build steps where scripts are present

## Risk / rollout

Low to medium.

The main behaviour change is that `npm test` is now explicit and runs Node's built-in test runner. If no tests exist, this provides a clear baseline rather than silently skipping the unit-test step.