### PR TITLE
Remediate Pa11y absolute-position contrast warnings

### DIFF
--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -1,7 +1,20 @@
 /* GOV.UK page chrome foundation */
 
-.govuk-skip-link {
+.govuk-skip-link,
+.govuk-skip-link:link,
+.govuk-skip-link:visited {
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: 9999;
 	display: block;
+	background: #ffdd00;
+	color: #0b0c0c;
+	font-weight: 700;
+	text-decoration: none;
+	}
+
+.govuk-skip-link:not(:focus):not(:active) {
 	width: 1px;
 	height: 1px;
 	margin: -1px;
@@ -11,13 +24,10 @@
 	clip: rect(0 0 0 0);
 	clip-path: inset(50%);
 	white-space: nowrap;
-	background: #ffdd00;
-	color: #0b0c0c;
-	font-weight: 700;
-	text-decoration: none;
 	}
 
-.govuk-skip-link:focus {
+.govuk-skip-link:focus,
+.govuk-skip-link:active {
 	width: auto;
 	height: auto;
 	margin: 0;
@@ -29,6 +39,12 @@
 	outline: 3px solid #0b0c0c;
 	outline-offset: 0;
 	box-shadow: none;
+	}
+
+.govuk-visually-hidden,
+.visuallyhidden {
+	background: #ffffff;
+	color: #0b0c0c;
 	}
 
 .govuk-main-wrapper {


### PR DESCRIPTION
## Summary

Updates the GOV.UK page chrome stylesheet so the skip link and visually hidden utility styles have explicit foreground and background colours in both hidden and focusable states.

## Why

The accessibility workflow reported Pa11y contrast warnings for absolutely positioned elements on:

- `/`
- `/pages/start/`
- `/pages/projects/`

The warning stated that the element background colour could not be determined. This PR makes the relevant hidden/focusable chrome styles explicit rather than suppressing Pa11y.

## What changed

- Keeps the skip link absolutely positioned while hidden.
- Separates hidden and focusable skip-link states.
- Adds explicit `background` and `color` values for skip link states.
- Adds explicit colour/background defaults for visually hidden utility classes.

## Validation

Expected validation on this PR:

- Accessibility audit should rerun on the PR.
- Pa11y should no longer report the absolute-position contrast warnings for the shared page chrome.
- Release Gate should run and upload release-gate artefacts.

## Risk / rollout

Low.

This is a CSS-only accessibility remediation scoped to shared page chrome. It should not affect visible layout except when the skip link receives focus.