### PR TITLE
Add ResearchOps release evidence files

### DIFF
--- a/RECENT_LEARNINGS.md
+++ b/RECENT_LEARNINGS.md
@@ -1,0 +1,35 @@
+# Recent Learnings
+
+This file records repeatable repository-specific lessons for ResearchOps agents and maintainers. It is not a changelog.
+
+## 2026-04-29 — Do not remediate accessibility without a failing baseline
+
+Context: PR #120 attempted to remediate Pa11y absolute-position contrast warnings from a speculative CSS change.
+
+Learning: If `main` has a clean accessibility run, do not create a remediation PR. Treat clean `main` as the baseline. Accessibility fixes must be driven by a failing baseline or by a Pa11y artifact with a specific selector, HTML context, rule and page URL.
+
+Action: Before changing CSS for accessibility, inspect the Pa11y artifact and confirm the issue exists on the current base branch.
+
+## 2026-04-29 — Repository governance files must use GitHub-recognised paths
+
+Context: CODEOWNERS and the pull request template previously existed under `.github/workflows/`, which GitHub does not use for those functions.
+
+Learning: Governance metadata must live in supported GitHub locations.
+
+Action: Keep `.github/CODEOWNERS` and `.github/pull_request_template.md` as the authoritative files for branch-protection and PR-template behaviour.
+
+## 2026-04-29 — CI script names must distinguish write mode from check mode
+
+Context: The repository previously had a write-mode `format` script but CI needed a pure check.
+
+Learning: CI must never rely on write-mode formatting commands for validation.
+
+Action: Use `npm run format:check` in CI and reserve `npm run format` for local write-mode formatting.
+
+## 2026-04-29 — Release assurance should be joined into a single auditable gate
+
+Context: ResearchOps already had CI, validation, accessibility, security and QA workflows, but the release decision was spread across separate checks.
+
+Learning: A dedicated release gate makes the release decision auditable.
+
+Action: Use the `Release Gate` workflow as the central release-assurance check and keep its uploaded report artifacts as release evidence.

--- a/configuration-evidence.yaml
+++ b/configuration-evidence.yaml
@@ -1,0 +1,83 @@
+configuration:
+  repository: kevinrapley/ResearchOps
+  evidence_version: 1
+  prepared_at: 2026-04-29
+  runtime:
+    platform: Cloudflare Workers
+    worker_name: rops-api
+    worker_entrypoint: src/worker.js
+    compatibility_date: 2025-09-26
+    evidence:
+      - infra/cloudflare/wrangler.toml
+  static_assets:
+    binding: ASSETS
+    directory: ../../docs/devops/sourcebook
+    evidence:
+      - infra/cloudflare/wrangler.toml
+  ai:
+    provider: Cloudflare Workers AI
+    binding: AI
+    model: '@cf/meta/llama-3.1-8b-instruct'
+    evidence:
+      - infra/cloudflare/wrangler.toml
+  data_stores:
+    airtable_tables:
+      - Projects
+      - Project Details
+      - Mural Boards
+      - Journal Entries
+      - Project Studies
+      - Sessions
+      - Session Notes
+      - Discussion Guides
+      - Partials
+      - Codes
+      - Code Applications
+      - AI_Usage
+    d1:
+      binding: RESEARCHOPS_D1
+      database_name: researchops-d1
+    kv:
+      binding: SESSION_KV
+    evidence:
+      - infra/cloudflare/wrangler.toml
+  integrations:
+    github_csv:
+      owner: kevinrapley
+      repository: ResearchOps
+      branch: main
+      paths:
+        projects: data/projects.csv
+        details: data/project-details.csv
+        studies: data/studies.csv
+    mural:
+      api_base: https://app.mural.co/api/public/v1
+      company_id: homeofficegovuk
+      redirect_uri: https://rops-api.digikev-kevin-rapley.workers.dev/api/mural/callback
+      scopes:
+        - identity:read
+        - workspaces:read
+        - rooms:read
+        - rooms:write
+        - murals:read
+        - murals:write
+    evidence:
+      - infra/cloudflare/wrangler.toml
+  secrets:
+    required:
+      - CF_API_TOKEN
+      - CF_ACCOUNT_ID
+      - Airtable token or equivalent runtime secret
+      - Mural OAuth secret or equivalent runtime secret
+    note: Do not commit secret values. Verify presence and scope through GitHub and Cloudflare settings.
+  allowed_origins:
+    - https://researchops.pages.dev
+    - https://rops-api.digikev-kevin-rapley.workers.dev
+    - http://localhost:8080
+    - https://reops-sourcebook.pages.dev
+  observability:
+    logs_enabled: true
+    invocation_logs: true
+    persist: true
+    evidence:
+      - infra/cloudflare/wrangler.toml

--- a/configuration-evidence.yaml
+++ b/configuration-evidence.yaml
@@ -17,7 +17,7 @@ configuration:
   ai:
     provider: Cloudflare Workers AI
     binding: AI
-    model: '@cf/meta/llama-3.1-8b-instruct'
+    model: "@cf/meta/llama-3.1-8b-instruct"
     evidence:
       - infra/cloudflare/wrangler.toml
   data_stores:

--- a/conformance-matrix.yaml
+++ b/conformance-matrix.yaml
@@ -1,0 +1,61 @@
+records:
+  - id: github-governance-files
+    control: GitHub governance files use recognised repository paths.
+    evidence:
+      - .github/CODEOWNERS
+      - .github/pull_request_template.md
+      - PR #117
+    status: implemented
+    risk: low
+    owner: repository-maintainers
+
+  - id: package-ci-contract
+    control: Package scripts separate write-mode formatting from CI check-mode validation.
+    evidence:
+      - package.json
+      - .github/workflows/ci.yml
+      - PR #118
+    status: implemented
+    risk: low
+    owner: repository-maintainers
+
+  - id: release-gate-workflow
+    control: Repository release assurance is joined into a dedicated Release Gate workflow.
+    evidence:
+      - .github/workflows/release-gate.yml
+      - PR #119
+    status: implemented
+    risk: medium
+    owner: repository-maintainers
+
+  - id: accessibility-baseline
+    control: Accessibility remediation must be evidence-led and must not change clean baseline behaviour speculatively.
+    evidence:
+      - Accessibility audit on main
+      - PR #120 closed unmerged
+      - RECENT_LEARNINGS.md
+    status: implemented
+    risk: medium
+    owner: repository-maintainers
+
+  - id: cloudflare-worker-deployment
+    control: Cloudflare Worker deployment validates before deploy and uses repository secrets for account/token material.
+    evidence:
+      - .github/workflows/deploy-worker.yml
+      - infra/cloudflare/wrangler.toml
+    status: implemented
+    risk: medium
+    owner: repository-maintainers
+
+  - id: release-evidence-model
+    control: Repository has release evidence files for traceability and future branch-protection decisions.
+    evidence:
+      - RECENT_LEARNINGS.md
+      - conformance-matrix.yaml
+      - gap-register.yaml
+      - github-settings.yaml
+      - release-evidence.yaml
+      - configuration-evidence.yaml
+    status: proposed
+    risk: low
+    owner: repository-maintainers

--- a/gap-register.yaml
+++ b/gap-register.yaml
@@ -1,0 +1,53 @@
+gaps:
+  - id: branch-protection-release-gate-required
+    title: Require Release Gate before merge
+    status: open
+    severity: high
+    owner: repository-maintainers
+    context: ResearchOps now has a dedicated Release Gate workflow, but branch protection must be configured in GitHub settings to require it before merge.
+    mitigation: Enable branch protection for main and require the exact Release Gate status check after GitHub exposes the check name.
+    evidence:
+      - .github/workflows/release-gate.yml
+      - PR #119
+
+  - id: security-audit-release-blocking
+    title: Decide when high-severity dependency findings become blocking
+    status: open
+    severity: medium
+    owner: repository-maintainers
+    context: The Release Gate records npm audit findings as advisory to avoid suddenly blocking delivery while known findings are triaged.
+    mitigation: Triage current npm audit findings, document accepted risks, then make high/critical findings blocking for release mode.
+    evidence:
+      - .github/workflows/release-gate.yml
+      - .github/workflows/security.yml
+
+  - id: deployment-tool-pinning
+    title: Pin Wrangler deployment tooling
+    status: open
+    severity: medium
+    owner: repository-maintainers
+    context: The deploy workflow uses wrangler through npx with latest resolution, which is convenient but less deterministic than a pinned toolchain.
+    mitigation: Pin Wrangler to a known version and document upgrade cadence.
+    evidence:
+      - .github/workflows/deploy-worker.yml
+      - infra/cloudflare/wrangler.toml
+
+  - id: release-provenance-artifacts
+    title: Add signed or attested release artifacts
+    status: open
+    severity: medium
+    owner: repository-maintainers
+    context: The repository now has release-gate artifacts but does not yet publish signed or attested release artifacts for each tagged ResearchOps release.
+    mitigation: Add a release provenance workflow after the Release Gate is stable and branch protection is enabled.
+    evidence:
+      - .github/workflows/release-gate.yml
+
+  - id: live-github-settings-verification
+    title: Verify repository settings from GitHub's server state
+    status: open
+    severity: medium
+    owner: repository-maintainers
+    context: github-settings.yaml records intended repository policy, but live GitHub settings still need to be checked through the GitHub UI or API.
+    mitigation: Compare intended policy with live branch protection, required checks, CODEOWNERS enforcement, Actions permissions and security settings.
+    evidence:
+      - github-settings.yaml

--- a/github-settings.yaml
+++ b/github-settings.yaml
@@ -1,0 +1,41 @@
+default_branch: main
+branch_protection:
+  require_pull_request_reviews: true
+  required_reviews: 1
+  required_approving_review_count: 1
+  dismiss_stale_reviews: true
+  require_code_owner_reviews: true
+  require_status_checks: true
+  required_status_checks:
+    - CI
+    - Validate ResearchOps
+    - Release Gate
+    - Accessibility audit (pa11y-ci)
+  require_conversation_resolution: true
+  require_signed_commits: false
+  linear_history: true
+  allow_force_pushes: false
+  allow_deletions: false
+workflow_permissions: read
+actions_policy:
+  allowed_actions: github-and-selected
+  sha_pinning_required: false
+  oidc_for_deployments: false
+  default_workflow_permissions: read
+security_features:
+  dependabot: true
+  dependabot_updates: true
+  secret_scanning: true
+  push_protection: true
+  code_scanning: true
+  dependency_review: true
+  sbom_on_release: false
+repository_rulesets:
+  required: false
+environments:
+  deployment_protections_required: false
+verification_method: file
+notes:
+  - Intended repository settings for ResearchOps. Verify against GitHub server state before treating as live assurance evidence.
+  - Release Gate is present and should be made required after several clean runs.
+  - Accessibility audit should only be required while main remains clean and findings are triaged from artifacts rather than guessed at through speculative remediation.

--- a/release-evidence.yaml
+++ b/release-evidence.yaml
@@ -1,0 +1,55 @@
+release:
+  repository: kevinrapley/ResearchOps
+  release_profile: standard
+  evidence_version: 1
+  prepared_at: 2026-04-29
+  current_baseline:
+    branch: main
+    latest_known_commit: 30312b2fbdbdb3c30079f18c8a89a2eccf486c94
+    source: GitHub repository state at PR #119 merge
+  controls:
+    ci:
+      status: implemented
+      evidence:
+        - .github/workflows/ci.yml
+        - package.json
+        - PR #118
+    validation:
+      status: implemented
+      evidence:
+        - .github/workflows/validate.yml
+        - scripts/validate.sh
+    release_gate:
+      status: implemented
+      evidence:
+        - .github/workflows/release-gate.yml
+        - PR #119
+      artifacts:
+        - researchops-release-gate
+    accessibility:
+      status: implemented
+      evidence:
+        - .github/workflows/accessibility.yml
+      note: Main has a clean accessibility baseline. Future accessibility remediation must start from failing artifacts or a failing main baseline.
+    security:
+      status: partially-implemented
+      evidence:
+        - .github/workflows/security.yml
+      note: npm audit is currently advisory in the release gate pending dependency triage.
+    deployment:
+      status: implemented
+      evidence:
+        - .github/workflows/deploy-worker.yml
+        - infra/cloudflare/wrangler.toml
+    governance:
+      status: implemented
+      evidence:
+        - .github/CODEOWNERS
+        - .github/pull_request_template.md
+        - PR #117
+  required_manual_checks_before_release:
+    - Confirm Release Gate has passed on the release commit.
+    - Confirm Accessibility audit is clean on main.
+    - Confirm no unreviewed high-risk dependency issue is being promoted.
+    - Confirm Cloudflare deployment secrets are present and scoped appropriately.
+    - Confirm branch protection requires pull request review and required checks.


### PR DESCRIPTION
## Summary

Adds release evidence files for ResearchOps using the GitHub Diamond Standard Prompt Bundle v2.9.1 evidence model.

Added:

- `RECENT_LEARNINGS.md`
- `conformance-matrix.yaml`
- `gap-register.yaml`
- `github-settings.yaml`
- `release-evidence.yaml`
- `configuration-evidence.yaml`

## Why

ResearchOps now has governance metadata, normalized CI and a dedicated Release Gate workflow. This PR adds the evidence layer that explains what controls exist, what remains open, and which configuration and release facts should be checked before release.

## Scope

This PR is evidence-only. It does not alter runtime code, workflows, CSS, deployment configuration or application behaviour.

## Validation

Expected validation on this PR:

- CI should pass.
- Validate ResearchOps should pass.
- Release Gate should pass and upload release evidence artifacts.
- Accessibility audit should remain clean against `main` behaviour because no page code or CSS changed.

## Risk / rollout

Low.

The files document intended and observed controls. `github-settings.yaml` is marked as file-based intended state and must be checked against GitHub server state before being treated as live assurance evidence.