### PR TITLE
Fix release evidence and CODEOWNERS validity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Require at least one review from the core maintainers
-* @digikev @researchops-maintainers
+# Require at least one review from the repository owner.
+* @kevinrapley

--- a/RECENT_LEARNINGS.md
+++ b/RECENT_LEARNINGS.md
@@ -2,6 +2,14 @@
 
 This file records repeatable repository-specific lessons for ResearchOps agents and maintainers. It is not a changelog.
 
+## 2026-04-29 — Release evidence can become stale after merge
+
+Context: `release-evidence.yaml` can record a baseline commit that is correct when written but stale after subsequent PRs merge.
+
+Learning: Commit-specific evidence is useful for provenance, but it must be confirmed against the actual release commit before release decisions are made.
+
+Action: When preparing a release, confirm or regenerate any baseline SHA, release-gate run reference, accessibility baseline statement and deployment evidence before treating the file as authoritative.
+
 ## 2026-04-29 — Do not remediate accessibility without a failing baseline
 
 Context: PR #120 attempted to remediate Pa11y absolute-position contrast warnings from a speculative CSS change.

--- a/release-evidence.yaml
+++ b/release-evidence.yaml
@@ -5,8 +5,9 @@ release:
   prepared_at: 2026-04-29
   current_baseline:
     branch: main
-    latest_known_commit: 30312b2fbdbdb3c30079f18c8a89a2eccf486c94
-    source: GitHub repository state at PR #119 merge
+    latest_known_commit: 52bcb6065c3508aa5306c93bd32aa25e0fce8505
+    source: GitHub repository state after PR #121 merge
+    note: Confirm or regenerate this commit reference at release time before treating it as authoritative release evidence.
   controls:
     ci:
       status: implemented
@@ -47,9 +48,11 @@ release:
         - .github/CODEOWNERS
         - .github/pull_request_template.md
         - PR #117
+      note: CODEOWNERS should use GitHub users or teams that are resolvable in the repository owner context.
   required_manual_checks_before_release:
     - Confirm Release Gate has passed on the release commit.
     - Confirm Accessibility audit is clean on main.
     - Confirm no unreviewed high-risk dependency issue is being promoted.
     - Confirm Cloudflare deployment secrets are present and scoped appropriately.
     - Confirm branch protection requires pull request review and required checks.
+    - Confirm release evidence commit references match the release commit.


### PR DESCRIPTION
## Summary

Corrects the release evidence and CODEOWNERS validity issues found during the post-PR #121 reassessment.

Changes:

- replaces unresolved CODEOWNERS entries with the valid repository owner `@kevinrapley`
- updates `release-evidence.yaml` to reference the current post-PR #121 baseline commit
- adds an explicit release-time confirmation note for commit-specific evidence
- records a Recent Learning that release evidence can become stale after merges

## Why

The previous CODEOWNERS file referenced an uncertain user/team combination. For branch protection to enforce code-owner review reliably, CODEOWNERS should reference a resolvable GitHub user or team in the repository owner context.

The release evidence also referenced the PR #119 merge commit after PR #121 had already merged. This PR refreshes that baseline and documents the need to confirm or regenerate commit-specific evidence at release time.

## Scope

Evidence and governance metadata only.

No runtime code, CSS, deployment logic, application route, schema, data store or integration behaviour is changed.

## Validation

Expected validation on this PR:

- CI should pass.
- Validate ResearchOps should pass.
- Release Gate should pass.
- Accessibility should remain clean because no page code or CSS changed.

## Risk / rollout

Low.

This makes governance and evidence more accurate. It does not change application behaviour.