### PR TITLE
Add branch protection assurance evidence

### DIFF
--- a/branch-protection-evidence.yaml
+++ b/branch-protection-evidence.yaml
@@ -1,0 +1,43 @@
+branch_protection:
+  repository: kevinrapley/ResearchOps
+  branch: main
+  evidence_version: 1
+  status: pending-live-verification
+  prepared_at: 2026-04-29
+  intended_state_source:
+    - github-settings.yaml
+    - docs/release-assurance/branch-protection-verification.md
+  required_reviews:
+    expected: 1
+    observed: null
+  require_code_owner_reviews:
+    expected: true
+    observed: null
+  required_status_checks:
+    expected:
+      - CI
+      - Validate ResearchOps
+      - Release Gate
+      - Accessibility audit (pa11y-ci)
+    observed: []
+  require_conversation_resolution:
+    expected: true
+    observed: null
+  require_linear_history:
+    expected: true
+    observed: null
+  allow_force_pushes:
+    expected: false
+    observed: null
+  allow_deletions:
+    expected: false
+    observed: null
+  verification:
+    method: pending
+    verified_by: null
+    verified_at: null
+    evidence_references: []
+  notes:
+    - This file records intended and observed branch-protection evidence.
+    - Replace null observed values only after checking live GitHub repository settings.
+    - Do not treat pending-live-verification as an implemented control.

--- a/docs/release-assurance/branch-protection-verification.md
+++ b/docs/release-assurance/branch-protection-verification.md
@@ -1,0 +1,73 @@
+# Branch protection verification
+
+This document defines the ResearchOps branch-protection control for `main`.
+
+It is an operational checklist. The live GitHub repository settings remain the source of truth.
+
+## Target branch
+
+`main`
+
+## Required protection settings
+
+Enable these settings for `main`:
+
+- Require a pull request before merging.
+- Require at least 1 approving review.
+- Dismiss stale pull request approvals when new commits are pushed.
+- Require review from Code Owners.
+- Require status checks to pass before merging.
+- Require branches to be up to date before merging.
+- Require conversation resolution before merging.
+- Require linear history.
+- Block force pushes.
+- Block branch deletion.
+
+## Required status checks
+
+Use the exact check names shown by GitHub after successful pull-request runs.
+
+Expected checks:
+
+- `CI`
+- `Validate ResearchOps`
+- `Release gate`
+- `Accessibility audit (pa11y-ci)`
+
+If GitHub exposes a qualified check name such as `Release Gate / Release gate`, use the exact qualified value.
+
+## Verification evidence
+
+Record verification in `branch-protection-evidence.yaml` after the live settings are configured.
+
+Minimum evidence:
+
+- who configured the rule
+- when it was configured
+- source of verification: GitHub UI or GitHub API
+- required reviews
+- code owner review requirement
+- required status checks
+- conversation resolution requirement
+- linear history requirement
+- force-push and deletion settings
+- screenshots or API output references where available
+
+## Acceptance criteria
+
+Branch protection is not considered closed until:
+
+- the `main` branch rule exists in GitHub settings
+- pull requests are required before merge
+- at least one approval is required
+- code-owner review is required
+- the Release Gate check is required
+- CI and validation checks are required
+- accessibility remains a required check while the main baseline is clean
+- the final state is recorded in `branch-protection-evidence.yaml`
+
+## Notes for agents
+
+Do not mark branch protection as implemented from `github-settings.yaml` alone.
+
+`github-settings.yaml` is intended state. The live GitHub settings are authoritative.

--- a/gap-register.yaml
+++ b/gap-register.yaml
@@ -1,7 +1,7 @@
 gaps:
   - id: branch-protection-release-gate-required
     title: Require Release Gate before merge
-    status: open
+    status: in-progress
     severity: high
     owner: repository-maintainers
     context: ResearchOps now has a dedicated Release Gate workflow, but branch protection must be configured in GitHub settings to require it before merge.
@@ -9,6 +9,8 @@ gaps:
     evidence:
       - .github/workflows/release-gate.yml
       - PR #119
+      - docs/release-assurance/branch-protection-verification.md
+      - branch-protection-evidence.yaml
 
   - id: security-audit-release-blocking
     title: Decide when high-severity dependency findings become blocking
@@ -51,3 +53,4 @@ gaps:
     mitigation: Compare intended policy with live branch protection, required checks, CODEOWNERS enforcement, Actions permissions and security settings.
     evidence:
       - github-settings.yaml
+      - branch-protection-evidence.yaml

--- a/release-evidence.yaml
+++ b/release-evidence.yaml
@@ -5,8 +5,8 @@ release:
   prepared_at: 2026-04-29
   current_baseline:
     branch: main
-    latest_known_commit: 52bcb6065c3508aa5306c93bd32aa25e0fce8505
-    source: GitHub repository state after PR #121 merge
+    latest_known_commit: 9ebee3c38d5dd16492c651a9be47bb35fd66125f
+    source: GitHub repository state after PR #122 merge
     note: Confirm or regenerate this commit reference at release time before treating it as authoritative release evidence.
   controls:
     ci:
@@ -49,6 +49,13 @@ release:
         - .github/pull_request_template.md
         - PR #117
       note: CODEOWNERS should use GitHub users or teams that are resolvable in the repository owner context.
+    branch_protection:
+      status: pending-live-verification
+      evidence:
+        - github-settings.yaml
+        - branch-protection-evidence.yaml
+        - docs/release-assurance/branch-protection-verification.md
+      note: Branch protection must be verified from live GitHub settings before this control can be marked implemented.
   required_manual_checks_before_release:
     - Confirm Release Gate has passed on the release commit.
     - Confirm Accessibility audit is clean on main.


### PR DESCRIPTION
## Summary

Adds the PR 7 branch-protection assurance layer for ResearchOps.

Added:

- `docs/release-assurance/branch-protection-verification.md`
- `branch-protection-evidence.yaml`

Updated:

- `gap-register.yaml`
- `release-evidence.yaml`

## Why

ResearchOps now has governance metadata, normalized CI, a dedicated Release Gate and release evidence files. This PR defines the branch-protection acceptance criteria and adds a structured evidence file for recording observed GitHub branch-protection settings.

## Important note

This PR does not claim live branch protection has been configured.

`github-settings.yaml` is intended state. The live GitHub repository settings remain the source of truth. `branch-protection-evidence.yaml` is deliberately marked `pending-live-verification` until the settings are confirmed from GitHub UI or API.

## Scope

Evidence and release-assurance documentation only.

No runtime code, CSS, route behaviour, application data, integration logic or deployment logic is changed.

## Validation

Expected validation on this PR:

- CI should pass.
- Validate ResearchOps should pass.
- Release Gate should pass.
- Accessibility should remain clean because no page code or CSS changed.

## Risk / rollout

Low.

This adds an auditable checklist and placeholder evidence file so branch protection can be configured and verified without confusing intended state with observed server state.