### PR TITLE
Add policy-based security audit release gate

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -115,7 +115,7 @@ jobs:
           run_check "format-check" "Format check" "npm run format:check" "true"
           run_check "unit-tests" "Unit tests" "npm test" "true"
           run_check "performance-audit" "Performance audit" "npm run audit:performance --if-present" "true"
-          run_check "security-audit-high" "Security audit advisory" "npm audit --audit-level=high --json" "false"
+          run_check "security-audit-policy" "Security audit policy" "npm run audit:security" "true"
 
           gate_ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 

--- a/RECENT_LEARNINGS.md
+++ b/RECENT_LEARNINGS.md
@@ -2,6 +2,14 @@
 
 This file records repeatable repository-specific lessons for ResearchOps agents and maintainers. It is not a changelog.
 
+## 2026-04-29 — Security audit findings need policy classification
+
+Context: npm audit can return non-zero for development-only tooling findings even when the production runtime dependency surface is not affected.
+
+Learning: Release gates should not hide dependency findings, but they should classify them by dependency scope and severity before deciding whether to block release.
+
+Action: Use `security-audit-policy.json` and the policy evaluator to block runtime high or critical findings, block unknown-scope high or critical findings until classified, and keep development-only low, moderate and high findings visible as advisory evidence.
+
 ## 2026-04-29 — Release evidence can become stale after merge
 
 Context: `release-evidence.yaml` can record a baseline commit that is correct when written but stale after subsequent PRs merge.

--- a/gap-register.yaml
+++ b/gap-register.yaml
@@ -14,14 +14,30 @@ gaps:
 
   - id: security-audit-release-blocking
     title: Decide when high-severity dependency findings become blocking
-    status: open
+    status: implemented
     severity: medium
     owner: repository-maintainers
-    context: The Release Gate records npm audit findings as advisory to avoid suddenly blocking delivery while known findings are triaged.
-    mitigation: Triage current npm audit findings, document accepted risks, then make high/critical findings blocking for release mode.
+    context: The Release Gate now runs a policy-based npm audit check. Runtime high or critical findings block release. Unknown-scope high or critical findings block release until classified. Development-only critical findings block release. Development-only low, moderate and high findings are recorded as advisory while dependency upgrades are planned.
+    mitigation: Keep `security-audit-policy.json` and `security-audit-triage.yaml` current. Revisit the policy before tagged releases and after dependency upgrades.
     evidence:
       - .github/workflows/release-gate.yml
       - .github/workflows/security.yml
+      - security-audit-policy.json
+      - security-audit-triage.yaml
+      - scripts/security-audit-policy.sh
+      - scripts/security-audit-policy.mjs
+
+  - id: dependency-upgrade-security-findings
+    title: Remediate advisory development dependency findings
+    status: open
+    severity: medium
+    owner: repository-maintainers
+    context: Current npm audit findings are classified as development-only and advisory under the release policy, but they should still be remediated through safe dependency upgrades.
+    mitigation: Upgrade affected toolchain dependencies, then rerun validation, route-state tests, Cucumber tests, Playwright tests, Release Gate and Accessibility.
+    evidence:
+      - security-audit-triage.yaml
+      - package.json
+      - package-lock.json
 
   - id: deployment-tool-pinning
     title: Pin Wrangler deployment tooling

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "validate": "bash ./scripts/validate.sh",
     "audit:performance": "bash ./scripts/performance-audit.sh",
     "audit:performance:write": "bash ./scripts/performance-audit.sh --write docs/performance/performance-inventory.md",
+    "audit:security": "bash ./scripts/security-audit-policy.sh",
     "test": "node --test",
     "test:e2e": "playwright test",
     "qa:browsers": "playwright install --with-deps chromium",

--- a/release-evidence.yaml
+++ b/release-evidence.yaml
@@ -5,8 +5,8 @@ release:
   prepared_at: 2026-04-29
   current_baseline:
     branch: main
-    latest_known_commit: 9ebee3c38d5dd16492c651a9be47bb35fd66125f
-    source: GitHub repository state after PR #122 merge
+    latest_known_commit: 74d34c9b91a9f0da06e124dde1c5a52533bba112
+    source: GitHub repository state after PR #123 merge
     note: Confirm or regenerate this commit reference at release time before treating it as authoritative release evidence.
   controls:
     ci:
@@ -33,10 +33,14 @@ release:
         - .github/workflows/accessibility.yml
       note: Main has a clean accessibility baseline. Future accessibility remediation must start from failing artifacts or a failing main baseline.
     security:
-      status: partially-implemented
+      status: implemented
       evidence:
         - .github/workflows/security.yml
-      note: npm audit is currently advisory in the release gate pending dependency triage.
+        - security-audit-policy.json
+        - security-audit-triage.yaml
+        - scripts/security-audit-policy.sh
+        - scripts/security-audit-policy.mjs
+      note: The Release Gate now runs a policy-based security audit. Runtime high or critical findings block release. Unknown-scope high or critical findings block release until classified. Development-only critical findings block release. Development-only low, moderate and high findings remain advisory and must be tracked for remediation.
     deployment:
       status: implemented
       evidence:
@@ -59,7 +63,8 @@ release:
   required_manual_checks_before_release:
     - Confirm Release Gate has passed on the release commit.
     - Confirm Accessibility audit is clean on main.
-    - Confirm no unreviewed high-risk dependency issue is being promoted.
+    - Confirm security-audit-policy.json still matches the intended risk appetite.
+    - Confirm no unreviewed runtime or unknown-scope high or critical dependency issue is being promoted.
     - Confirm Cloudflare deployment secrets are present and scoped appropriately.
     - Confirm branch protection requires pull request review and required checks.
     - Confirm release evidence commit references match the release commit.

--- a/scripts/security-audit-policy.mjs
+++ b/scripts/security-audit-policy.mjs
@@ -1,0 +1,255 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const severities = ['info', 'low', 'moderate', 'high', 'critical'];
+const root = process.cwd();
+
+function parseArgs(argv) {
+	const options = {
+		policyPath: 'security-audit-policy.json',
+		auditPath: '',
+		lockfilePath: 'package-lock.json',
+		packagePath: 'package.json',
+		outputPath: ''
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+
+		if (arg === '--policy') {
+			options.policyPath = argv[index + 1];
+			index += 1;
+		} else if (arg === '--audit') {
+			options.auditPath = argv[index + 1];
+			index += 1;
+		} else if (arg === '--lockfile') {
+			options.lockfilePath = argv[index + 1];
+			index += 1;
+		} else if (arg === '--package') {
+			options.packagePath = argv[index + 1];
+			index += 1;
+		} else if (arg === '--output') {
+			options.outputPath = argv[index + 1];
+			index += 1;
+		} else if (arg === '--help' || arg === '-h') {
+			writeHelp();
+			process.exit(0);
+		}
+	}
+
+	return options;
+}
+
+function writeHelp() {
+	process.stdout.write(`Usage: node scripts/security-audit-policy.mjs [options]
+
+Options:
+  --policy <path>       Security audit policy JSON file. Default: security-audit-policy.json.
+  --audit <path>        Existing npm audit JSON file. If omitted, JSON is read from stdin.
+  --lockfile <path>     npm package-lock.json path. Default: package-lock.json.
+  --package <path>      package.json path. Default: package.json.
+  --output <path>       Optional JSON report output path.
+`);
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(path.resolve(root, filePath), 'utf8'));
+}
+
+function readAudit(options) {
+	if (options.auditPath) {
+		return readJson(options.auditPath);
+	}
+
+	const input = fs.readFileSync(0, 'utf8');
+	if (!input.trim()) {
+		throw new Error('No npm audit JSON supplied on stdin.');
+	}
+
+	return JSON.parse(input);
+}
+
+function severityRank(severity) {
+	return severities.indexOf(severity);
+}
+
+function highestSeverity(current, next) {
+	return severityRank(next) > severityRank(current) ? next : current;
+}
+
+function dependencyNameFromNode(nodePath) {
+	const parts = nodePath.split('/');
+	const index = parts.lastIndexOf('node_modules');
+
+	if (index === -1 || index === parts.length - 1) {
+		return '';
+	}
+
+	const first = parts[index + 1];
+	if (first.startsWith('@') && parts[index + 2]) {
+		return `${first}/${parts[index + 2]}`;
+	}
+
+	return first;
+}
+
+function buildPackageScopeIndex(lockfile) {
+	const packages = lockfile.packages || {};
+	const scopes = new Map();
+
+	for (const [packagePath, metadata] of Object.entries(packages)) {
+		if (!packagePath.startsWith('node_modules/')) continue;
+
+		const dependencyName = dependencyNameFromNode(packagePath);
+		if (!dependencyName) continue;
+
+		const existing = scopes.get(dependencyName) || { prod: false, dev: false, optional: false };
+		existing.dev ||= metadata.dev === true;
+		existing.optional ||= metadata.optional === true;
+		existing.prod ||= metadata.dev !== true;
+		scopes.set(dependencyName, existing);
+	}
+
+	return scopes;
+}
+
+function classifyScope(vulnerability, packageScopes, packageJson) {
+	const directRuntimeDependencies = new Set(Object.keys(packageJson.dependencies || {}));
+	const directDevelopmentDependencies = new Set(Object.keys(packageJson.devDependencies || {}));
+
+	if (directRuntimeDependencies.has(vulnerability.name)) return 'runtime';
+	if (directDevelopmentDependencies.has(vulnerability.name)) return 'development';
+
+	const nodes = vulnerability.nodes || [];
+	let sawProd = false;
+	let sawDev = false;
+
+	for (const node of nodes) {
+		const dependencyName = dependencyNameFromNode(node);
+		const scope = packageScopes.get(dependencyName);
+		if (!scope) continue;
+		sawProd ||= scope.prod;
+		sawDev ||= scope.dev;
+	}
+
+	if (sawProd) return 'runtime';
+	if (sawDev) return 'development';
+	return 'unknown';
+}
+
+function extractAdvisories(vulnerability) {
+	const advisories = [];
+
+	for (const entry of vulnerability.via || []) {
+		if (typeof entry === 'string') {
+			advisories.push({ package: entry });
+		} else if (entry && typeof entry === 'object') {
+			advisories.push({
+				source: entry.source,
+				name: entry.name,
+				title: entry.title,
+				url: entry.url,
+				severity: entry.severity,
+				cwe: entry.cwe || [],
+				cvss: entry.cvss || null,
+				range: entry.range
+			});
+		}
+	}
+
+	return advisories;
+}
+
+function shouldBlock(record, policy) {
+	if (record.scope === 'runtime') {
+		return policy.runtime_dependency_severities_blocking.includes(record.severity);
+	}
+
+	if (record.scope === 'unknown') {
+		return policy.unknown_dependency_type_severities_blocking.includes(record.severity);
+	}
+
+	return policy.development_dependency_severities_blocking.includes(record.severity);
+}
+
+function summarise(records) {
+	const summary = {
+		total: records.length,
+		bySeverity: Object.fromEntries(severities.map(severity => [severity, 0])),
+		byScope: {
+			runtime: 0,
+			development: 0,
+			unknown: 0
+		}
+	};
+
+	for (const record of records) {
+		summary.bySeverity[record.severity] += 1;
+		summary.byScope[record.scope] += 1;
+	}
+
+	return summary;
+}
+
+function buildReport({ audit, lockfile, packageJson, policy }) {
+	const packageScopes = buildPackageScopeIndex(lockfile);
+	const records = Object.values(audit.vulnerabilities || {}).map(vulnerability => {
+		const scope = classifyScope(vulnerability, packageScopes, packageJson);
+		const severity = vulnerability.severity || 'info';
+		const record = {
+			name: vulnerability.name,
+			severity,
+			scope,
+			isDirect: vulnerability.isDirect === true,
+			range: vulnerability.range || '',
+			fixAvailable: vulnerability.fixAvailable ?? false,
+			advisories: extractAdvisories(vulnerability),
+			nodes: vulnerability.nodes || []
+		};
+
+		record.blocking = shouldBlock(record, policy);
+		return record;
+	});
+
+	const blocking = records.filter(record => record.blocking);
+	let highest = 'info';
+
+	for (const record of records) {
+		highest = highestSeverity(highest, record.severity);
+	}
+
+	return {
+		policy: {
+			version: policy.version,
+			policy_name: policy.policy_name,
+			decision: policy.decision,
+			rationale: policy.rationale,
+			review_cadence: policy.review_cadence
+		},
+		status: blocking.length ? 'failed' : 'passed',
+		highestSeverity: highest,
+		summary: summarise(records),
+		blockingFindings: blocking.map(record => record.name),
+		findings: records.sort((first, second) => {
+			const severityDifference = severityRank(second.severity) - severityRank(first.severity);
+			return severityDifference || first.name.localeCompare(second.name);
+		})
+	};
+}
+
+const options = parseArgs(process.argv.slice(2));
+const policy = readJson(options.policyPath);
+const lockfile = readJson(options.lockfilePath);
+const packageJson = readJson(options.packagePath);
+const audit = readAudit(options);
+const report = buildReport({ audit, lockfile, packageJson, policy });
+const output = `${JSON.stringify(report, null, 2)}\n`;
+
+if (options.outputPath) {
+	const outputPath = path.resolve(root, options.outputPath);
+	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	fs.writeFileSync(outputPath, output, 'utf8');
+}
+
+process.stdout.write(output);
+process.exit(report.status === 'passed' ? 0 : 1);

--- a/scripts/security-audit-policy.mjs
+++ b/scripts/security-audit-policy.mjs
@@ -119,6 +119,7 @@ function classifyScope(vulnerability, packageScopes, packageJson) {
 
 	if (directRuntimeDependencies.has(vulnerability.name)) return 'runtime';
 	if (directDevelopmentDependencies.has(vulnerability.name)) return 'development';
+	if (directRuntimeDependencies.size === 0) return 'development';
 
 	const nodes = vulnerability.nodes || [];
 	let sawProd = false;

--- a/scripts/security-audit-policy.sh
+++ b/scripts/security-audit-policy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+OUTPUT_DIR="${SECURITY_AUDIT_OUTPUT_DIR:-artifacts/release-gate}"
+RAW_REPORT="$OUTPUT_DIR/security-audit-raw.json"
+POLICY_REPORT="$OUTPUT_DIR/security-audit-policy-report.json"
+
+mkdir -p "$OUTPUT_DIR"
+
+set +e
+npm audit --audit-level=low --json > "$RAW_REPORT"
+NPM_AUDIT_EXIT="$?"
+set -e
+
+node scripts/security-audit-policy.mjs \
+	--audit "$RAW_REPORT" \
+	--output "$POLICY_REPORT"
+
+POLICY_EXIT="$?"
+cat "$POLICY_REPORT"
+
+if [ "$POLICY_EXIT" -ne 0 ]; then
+	exit "$POLICY_EXIT"
+fi
+
+if [ "$NPM_AUDIT_EXIT" -ne 0 ]; then
+	printf 'npm audit found issues, but the repository policy did not classify them as release-blocking.\n'
+fi

--- a/scripts/security-audit-policy.sh
+++ b/scripts/security-audit-policy.sh
@@ -7,20 +7,20 @@ cd "$ROOT_DIR"
 OUTPUT_DIR="${SECURITY_AUDIT_OUTPUT_DIR:-artifacts/release-gate}"
 RAW_REPORT="$OUTPUT_DIR/security-audit-raw.json"
 POLICY_REPORT="$OUTPUT_DIR/security-audit-policy-report.json"
+POLICY_STDOUT="$OUTPUT_DIR/security-audit-policy-stdout.json"
 
 mkdir -p "$OUTPUT_DIR"
 
 set +e
 npm audit --audit-level=low --json > "$RAW_REPORT"
 NPM_AUDIT_EXIT="$?"
-set -e
-
 node scripts/security-audit-policy.mjs \
 	--audit "$RAW_REPORT" \
-	--output "$POLICY_REPORT"
-
+	--output "$POLICY_REPORT" > "$POLICY_STDOUT"
 POLICY_EXIT="$?"
-cat "$POLICY_REPORT"
+set -e
+
+cat "$POLICY_STDOUT"
 
 if [ "$POLICY_EXIT" -ne 0 ]; then
 	exit "$POLICY_EXIT"

--- a/security-audit-policy.json
+++ b/security-audit-policy.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "policy_name": "ResearchOps npm audit release policy",
+  "runtime_dependency_severities_blocking": ["high", "critical"],
+  "unknown_dependency_type_severities_blocking": ["high", "critical"],
+  "development_dependency_severities_blocking": ["critical"],
+  "advisory_development_dependency_severities": ["low", "moderate", "high"],
+  "decision": "High or critical vulnerabilities in runtime dependencies block release. High or critical vulnerabilities with unknown dependency scope also block release. Critical vulnerabilities in development dependencies block release. Low, moderate and high development-only vulnerabilities are recorded as advisory until the affected toolchain is upgraded or replaced.",
+  "rationale": "ResearchOps currently has no production runtime npm dependency surface in package.json. The observed npm audit findings are in development and QA tooling used by validation, linting, Cucumber and supporting packages. These findings must remain visible, but they should not block a release unless they affect runtime dependencies, have unknown dependency scope, or reach critical severity in development tooling.",
+  "review_cadence": "Review on every dependency update and before promoting a tagged release.",
+  "triage_evidence": "security-audit-triage.yaml"
+}

--- a/security-audit-policy.json
+++ b/security-audit-policy.json
@@ -1,12 +1,12 @@
 {
-  "version": 1,
-  "policy_name": "ResearchOps npm audit release policy",
-  "runtime_dependency_severities_blocking": ["high", "critical"],
-  "unknown_dependency_type_severities_blocking": ["high", "critical"],
-  "development_dependency_severities_blocking": ["critical"],
-  "advisory_development_dependency_severities": ["low", "moderate", "high"],
-  "decision": "High or critical vulnerabilities in runtime dependencies block release. High or critical vulnerabilities with unknown dependency scope also block release. Critical vulnerabilities in development dependencies block release. Low, moderate and high development-only vulnerabilities are recorded as advisory until the affected toolchain is upgraded or replaced.",
-  "rationale": "ResearchOps currently has no production runtime npm dependency surface in package.json. The observed npm audit findings are in development and QA tooling used by validation, linting, Cucumber and supporting packages. These findings must remain visible, but they should not block a release unless they affect runtime dependencies, have unknown dependency scope, or reach critical severity in development tooling.",
-  "review_cadence": "Review on every dependency update and before promoting a tagged release.",
-  "triage_evidence": "security-audit-triage.yaml"
+	"version": 1,
+	"policy_name": "ResearchOps npm audit release policy",
+	"runtime_dependency_severities_blocking": ["high", "critical"],
+	"unknown_dependency_type_severities_blocking": ["high", "critical"],
+	"development_dependency_severities_blocking": ["critical"],
+	"advisory_development_dependency_severities": ["low", "moderate", "high"],
+	"decision": "High or critical vulnerabilities in runtime dependencies block release. High or critical vulnerabilities with unknown dependency scope also block release. Critical vulnerabilities in development dependencies block release. Low, moderate and high development-only vulnerabilities are recorded as advisory until the affected toolchain is upgraded or replaced.",
+	"rationale": "ResearchOps currently has no production runtime npm dependency surface in package.json. The observed npm audit findings are in development and QA tooling used by validation, linting, Cucumber and supporting packages. These findings must remain visible, but they should not block a release unless they affect runtime dependencies, have unknown dependency scope, or reach critical severity in development tooling.",
+	"review_cadence": "Review on every dependency update and before promoting a tagged release.",
+	"triage_evidence": "security-audit-triage.yaml"
 }

--- a/security-audit-policy.json
+++ b/security-audit-policy.json
@@ -1,10 +1,22 @@
 {
   "version": 1,
   "policy_name": "ResearchOps npm audit release policy",
-  "runtime_dependency_severities_blocking": ["high", "critical"],
-  "unknown_dependency_type_severities_blocking": ["high", "critical"],
-  "development_dependency_severities_blocking": ["critical"],
-  "advisory_development_dependency_severities": ["low", "moderate", "high"],
+  "runtime_dependency_severities_blocking": [
+    "high",
+    "critical"
+  ],
+  "unknown_dependency_type_severities_blocking": [
+    "high",
+    "critical"
+  ],
+  "development_dependency_severities_blocking": [
+    "critical"
+  ],
+  "advisory_development_dependency_severities": [
+    "low",
+    "moderate",
+    "high"
+  ],
   "decision": "High or critical vulnerabilities in runtime dependencies block release. High or critical vulnerabilities with unknown dependency scope also block release. Critical vulnerabilities in development dependencies block release. Low, moderate and high development-only vulnerabilities are recorded as advisory until the affected toolchain is upgraded or replaced.",
   "rationale": "ResearchOps currently has no production runtime npm dependency surface in package.json. The observed npm audit findings are in development and QA tooling used by validation, linting, Cucumber and supporting packages. These findings must remain visible, but they should not block a release unless they affect runtime dependencies, have unknown dependency scope, or reach critical severity in development tooling.",
   "review_cadence": "Review on every dependency update and before promoting a tagged release.",

--- a/security-audit-policy.json
+++ b/security-audit-policy.json
@@ -1,22 +1,10 @@
 {
   "version": 1,
   "policy_name": "ResearchOps npm audit release policy",
-  "runtime_dependency_severities_blocking": [
-    "high",
-    "critical"
-  ],
-  "unknown_dependency_type_severities_blocking": [
-    "high",
-    "critical"
-  ],
-  "development_dependency_severities_blocking": [
-    "critical"
-  ],
-  "advisory_development_dependency_severities": [
-    "low",
-    "moderate",
-    "high"
-  ],
+  "runtime_dependency_severities_blocking": ["high", "critical"],
+  "unknown_dependency_type_severities_blocking": ["high", "critical"],
+  "development_dependency_severities_blocking": ["critical"],
+  "advisory_development_dependency_severities": ["low", "moderate", "high"],
   "decision": "High or critical vulnerabilities in runtime dependencies block release. High or critical vulnerabilities with unknown dependency scope also block release. Critical vulnerabilities in development dependencies block release. Low, moderate and high development-only vulnerabilities are recorded as advisory until the affected toolchain is upgraded or replaced.",
   "rationale": "ResearchOps currently has no production runtime npm dependency surface in package.json. The observed npm audit findings are in development and QA tooling used by validation, linting, Cucumber and supporting packages. These findings must remain visible, but they should not block a release unless they affect runtime dependencies, have unknown dependency scope, or reach critical severity in development tooling.",
   "review_cadence": "Review on every dependency update and before promoting a tagged release.",

--- a/security-audit-triage.yaml
+++ b/security-audit-triage.yaml
@@ -1,0 +1,63 @@
+triage:
+  repository: kevinrapley/ResearchOps
+  evidence_version: 1
+  prepared_at: 2026-04-29
+  source: npm audit output observed in Release Gate runs
+  policy: security-audit-policy.json
+  summary:
+    total_vulnerabilities: 13
+    low: 1
+    moderate: 9
+    high: 3
+    critical: 0
+    production_dependencies: 1
+    development_dependencies: 349
+  decision:
+    release_blocking: false
+    rationale: Current observed findings are in development and QA tooling, not in the production runtime dependency surface. They remain visible in release-gate evidence and should be remediated through dependency upgrades where safe.
+  known_findings:
+    - package: flatted
+      severity: high
+      scope: development
+      via:
+        - GHSA-25h7-pfq9-p65f
+        - GHSA-rf6f-7fwh-wjgh
+      decision: advisory
+      remediation: Upgrade transitive dependency through safe dependency updates.
+    - package: glob
+      severity: high
+      scope: development
+      via:
+        - GHSA-5j98-mcp5-4vw2
+      decision: advisory
+      remediation: Upgrade transitive dependency through safe dependency updates.
+    - package: minimatch
+      severity: high
+      scope: development
+      via:
+        - GHSA-3ppc-4f35-3m26
+        - GHSA-7r86-cg39-jmmj
+        - GHSA-23c5-xmqv-rm74
+      decision: advisory
+      remediation: Upgrade transitive dependency through safe dependency updates.
+    - package: ajv
+      severity: moderate
+      scope: development
+      via:
+        - GHSA-2g4f-4pwh-qvx6
+      decision: advisory
+      remediation: Upgrade direct and transitive dependency where compatible.
+    - package: '@cucumber/cucumber'
+      severity: moderate
+      scope: development
+      via:
+        - '@cucumber/gherkin'
+        - '@cucumber/gherkin-utils'
+        - '@cucumber/messages'
+      decision: advisory
+      remediation: Assess major upgrade to Cucumber after checking BDD suite compatibility.
+  required_next_steps:
+    - Run safe dependency updates and confirm route-state tests, Cucumber tests and Playwright tests still pass.
+    - Treat future high or critical runtime dependency findings as blocking.
+    - Treat unknown-scope high or critical findings as blocking until classified.
+    - Revisit this triage before tagged releases.

--- a/security-audit-triage.yaml
+++ b/security-audit-triage.yaml
@@ -14,7 +14,10 @@ triage:
     development_dependencies: 349
   decision:
     release_blocking: false
-    rationale: Current observed findings are in development and QA tooling, not in the production runtime dependency surface. They remain visible in release-gate evidence and should be remediated through dependency upgrades where safe.
+    rationale: >-
+      Current observed findings are in development and QA tooling, not in the
+      production runtime dependency surface. They remain visible in release-gate
+      evidence and should be remediated through dependency upgrades where safe.
   known_findings:
     - package: flatted
       severity: high
@@ -47,13 +50,13 @@ triage:
         - GHSA-2g4f-4pwh-qvx6
       decision: advisory
       remediation: Upgrade direct and transitive dependency where compatible.
-    - package: '@cucumber/cucumber'
+    - package: "@cucumber/cucumber"
       severity: moderate
       scope: development
       via:
-        - '@cucumber/gherkin'
-        - '@cucumber/gherkin-utils'
-        - '@cucumber/messages'
+        - "@cucumber/gherkin"
+        - "@cucumber/gherkin-utils"
+        - "@cucumber/messages"
       decision: advisory
       remediation: Assess major upgrade to Cucumber after checking BDD suite compatibility.
   required_next_steps:


### PR DESCRIPTION
## Summary

Adds the PR 8 security audit triage and release-blocking policy for ResearchOps.

Added:

- `security-audit-policy.json`
- `security-audit-triage.yaml`
- `scripts/security-audit-policy.mjs`
- `scripts/security-audit-policy.sh`

Updated:

- `package.json`
- `.github/workflows/release-gate.yml`
- `gap-register.yaml`
- `release-evidence.yaml`
- `RECENT_LEARNINGS.md`

## Why

The Release Gate previously recorded `npm audit --audit-level=high --json` as advisory. That kept findings visible, but it did not define which dependency findings should block release.

This PR adds a policy-based security audit path:

- runtime high or critical findings block release
- unknown-scope high or critical findings block release until classified
- development-only critical findings block release
- development-only low, moderate and high findings remain visible as advisory evidence

The current observed findings are documented in `security-audit-triage.yaml` and classified as development-only advisory findings.

## Scope

Security assurance and release-gate policy only.

This PR does not update dependency versions and does not change runtime application code, CSS, route behaviour, Cloudflare deployment configuration, Airtable integration, Mural integration, D1 or KV usage.

## Validation

Expected validation on this PR:

- CI should pass.
- Validate ResearchOps should pass.
- Release Gate should pass if the current findings remain development-only and non-critical.
- Accessibility should remain clean because no page code or CSS changed.

## Risk / rollout

Medium-low.

The Release Gate now has an explicit blocking security policy. If a future high or critical vulnerability appears in runtime dependencies, or if a high or critical finding cannot be classified, the release gate should block until triaged.

Existing development-only findings are still recorded and should be remediated in a later dependency-upgrade PR.