### PR TITLE
Pin Wrangler deployment tooling

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  WRANGLER_VERSION: "4.38.0"
+  WRANGLER_VERSION: "4.34.0"
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -10,6 +10,8 @@ on:
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/deploy-worker.yml"
+      - "deployment-toolchain.yaml"
+      - "docs/deployment/wrangler-toolchain.md"
   workflow_dispatch: {}
 
 permissions:
@@ -17,6 +19,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.38.0"
 
 jobs:
   deploy:
@@ -39,8 +42,11 @@ jobs:
       - name: Run validation contract
         run: npm run validate
 
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
       - name: Deploy Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        run: npx wrangler@latest deploy --config infra/cloudflare/wrangler.toml
+        run: npx --yes wrangler@${WRANGLER_VERSION} deploy --config infra/cloudflare/wrangler.toml

--- a/RECENT_LEARNINGS.md
+++ b/RECENT_LEARNINGS.md
@@ -2,6 +2,14 @@
 
 This file records repeatable repository-specific lessons for ResearchOps agents and maintainers. It is not a changelog.
 
+## 2026-04-30 — Deployment tools must be pinned
+
+Context: The Worker deployment workflow used `wrangler@latest`, which allowed the deployment toolchain to change without a repository change.
+
+Learning: Floating deployment tooling weakens release evidence because a clean validation run does not prove the same toolchain will be used later.
+
+Action: Pin Wrangler in `.github/workflows/deploy-worker.yml`, keep the pinned version aligned with `deployment-toolchain.yaml`, and record the Wrangler version in deployment logs.
+
 ## 2026-04-29 — Security audit findings need policy classification
 
 Context: npm audit can return non-zero for development-only tooling findings even when the production runtime dependency surface is not affected.

--- a/deployment-toolchain.yaml
+++ b/deployment-toolchain.yaml
@@ -1,0 +1,26 @@
+deployment_toolchain:
+  repository: kevinrapley/ResearchOps
+  evidence_version: 1
+  prepared_at: 2026-04-30
+  cloudflare_worker:
+    tool: wrangler
+    version: 4.38.0
+    invocation: npx --yes wrangler@${WRANGLER_VERSION} deploy --config infra/cloudflare/wrangler.toml
+    workflow: .github/workflows/deploy-worker.yml
+    config: infra/cloudflare/wrangler.toml
+  policy:
+    pinning_required: true
+    floating_latest_allowed: false
+    upgrade_cadence: Review before tagged releases or when Cloudflare requires a compatibility update.
+    validation_before_upgrade:
+      - npm ci
+      - npm run validate
+      - npm run lint
+      - npm test
+      - npx --yes wrangler@${WRANGLER_VERSION} --version
+    rollback:
+      method: Revert the Wrangler version change in deployment-toolchain.yaml and .github/workflows/deploy-worker.yml.
+  notes:
+    - Keep WRANGLER_VERSION in the workflow aligned with this file.
+    - Do not use wrangler@latest in release or deployment workflows.
+    - Record the deployed Wrangler version in workflow logs before deploy.

--- a/deployment-toolchain.yaml
+++ b/deployment-toolchain.yaml
@@ -4,7 +4,7 @@ deployment_toolchain:
   prepared_at: 2026-04-30
   cloudflare_worker:
     tool: wrangler
-    version: 4.38.0
+    version: 4.34.0
     invocation: npx --yes wrangler@${WRANGLER_VERSION} deploy --config infra/cloudflare/wrangler.toml
     workflow: .github/workflows/deploy-worker.yml
     config: infra/cloudflare/wrangler.toml

--- a/docs/deployment/wrangler-toolchain.md
+++ b/docs/deployment/wrangler-toolchain.md
@@ -1,0 +1,50 @@
+# Wrangler deployment toolchain
+
+ResearchOps deploys its Cloudflare Worker through GitHub Actions using Wrangler.
+
+The deployment workflow must use a pinned Wrangler version. It must not use `wrangler@latest`.
+
+## Current pinned version
+
+`4.38.0`
+
+The value is recorded in two places:
+
+- `.github/workflows/deploy-worker.yml`
+- `deployment-toolchain.yaml`
+
+Keep these values aligned.
+
+## Why this is pinned
+
+A floating deployment tool can change behaviour without a repository change.
+
+That makes release evidence weaker because a deployment that passed yesterday may use a different Wrangler release today.
+
+Pinning Wrangler gives the release gate and deployment workflow a stable toolchain boundary.
+
+## Upgrade process
+
+When upgrading Wrangler:
+
+1. Change `WRANGLER_VERSION` in `.github/workflows/deploy-worker.yml`.
+2. Change the matching version in `deployment-toolchain.yaml`.
+3. Run repository validation.
+4. Confirm `npx --yes wrangler@${WRANGLER_VERSION} --version` succeeds.
+5. Review Cloudflare release notes and any compatibility-date implications.
+6. Deploy through the workflow, not a local unrecorded command.
+
+## Release evidence
+
+Deployment evidence should include:
+
+- workflow run URL
+- commit SHA
+- Wrangler version
+- `wrangler.toml` path
+- deployment target
+- validation status before deployment
+
+## Rollback
+
+Revert the Wrangler version change in both files and rerun the deployment workflow.

--- a/docs/deployment/wrangler-toolchain.md
+++ b/docs/deployment/wrangler-toolchain.md
@@ -6,7 +6,7 @@ The deployment workflow must use a pinned Wrangler version. It must not use `wra
 
 ## Current pinned version
 
-`4.38.0`
+`4.34.0`
 
 The value is recorded in two places:
 

--- a/gap-register.yaml
+++ b/gap-register.yaml
@@ -41,14 +41,16 @@ gaps:
 
   - id: deployment-tool-pinning
     title: Pin Wrangler deployment tooling
-    status: open
+    status: implemented
     severity: medium
     owner: repository-maintainers
-    context: The deploy workflow uses wrangler through npx with latest resolution, which is convenient but less deterministic than a pinned toolchain.
-    mitigation: Pin Wrangler to a known version and document upgrade cadence.
+    context: The deploy workflow now uses a pinned Wrangler version through `WRANGLER_VERSION` instead of `wrangler@latest`.
+    mitigation: Keep `.github/workflows/deploy-worker.yml` aligned with `deployment-toolchain.yaml`, and review the pinned Wrangler version before tagged releases or Cloudflare compatibility changes.
     evidence:
       - .github/workflows/deploy-worker.yml
       - infra/cloudflare/wrangler.toml
+      - deployment-toolchain.yaml
+      - docs/deployment/wrangler-toolchain.md
 
   - id: release-provenance-artifacts
     title: Add signed or attested release artifacts

--- a/release-evidence.yaml
+++ b/release-evidence.yaml
@@ -2,11 +2,11 @@ release:
   repository: kevinrapley/ResearchOps
   release_profile: standard
   evidence_version: 1
-  prepared_at: 2026-04-29
+  prepared_at: 2026-04-30
   current_baseline:
     branch: main
-    latest_known_commit: 74d34c9b91a9f0da06e124dde1c5a52533bba112
-    source: GitHub repository state after PR #123 merge
+    latest_known_commit: c9aea09679b491f4b314faab1a5a330175a438db
+    source: GitHub repository state after PR #124 merge
     note: Confirm or regenerate this commit reference at release time before treating it as authoritative release evidence.
   controls:
     ci:
@@ -46,6 +46,9 @@ release:
       evidence:
         - .github/workflows/deploy-worker.yml
         - infra/cloudflare/wrangler.toml
+        - deployment-toolchain.yaml
+        - docs/deployment/wrangler-toolchain.md
+      note: Wrangler deployment tooling is pinned. Do not use wrangler@latest in release or deployment workflows.
     governance:
       status: implemented
       evidence:
@@ -66,5 +69,6 @@ release:
     - Confirm security-audit-policy.json still matches the intended risk appetite.
     - Confirm no unreviewed runtime or unknown-scope high or critical dependency issue is being promoted.
     - Confirm Cloudflare deployment secrets are present and scoped appropriately.
+    - Confirm Wrangler version evidence matches deployment-toolchain.yaml and the deployment workflow.
     - Confirm branch protection requires pull request review and required checks.
     - Confirm release evidence commit references match the release commit.


### PR DESCRIPTION
## Summary

Pins the Cloudflare Wrangler deployment toolchain used by the ResearchOps Worker deployment workflow.

Added:

- `deployment-toolchain.yaml`
- `docs/deployment/wrangler-toolchain.md`

Updated:

- `.github/workflows/deploy-worker.yml`
- `gap-register.yaml`
- `release-evidence.yaml`
- `RECENT_LEARNINGS.md`

## Why

The deploy workflow previously used `wrangler@latest`. A floating deployment tool can change behaviour without any repository change, which weakens release evidence and makes deployments less reproducible.

This PR pins Wrangler through `WRANGLER_VERSION` and records the chosen version in deployment evidence.

## What changed

- Replaces `npx wrangler@latest deploy` with `npx --yes wrangler@${WRANGLER_VERSION} deploy`.
- Adds a workflow step that records the pinned Wrangler version before deployment.
- Adds deployment toolchain evidence.
- Documents the Wrangler upgrade and rollback process.
- Marks the deployment-tool-pinning gap as implemented.

## Scope

Deployment determinism only.

This PR does not change runtime application code, CSS, route behaviour, Airtable integration, Mural integration, D1, KV, Workers AI, or Worker configuration semantics.

## Validation

Expected validation on this PR:

- CI should pass.
- Validate ResearchOps should pass.
- Release Gate should pass.
- Accessibility should remain clean because no page code or CSS changed.

The deployment workflow will validate the pinned Wrangler command when it runs on `main` or through manual dispatch.

## Risk / rollout

Medium-low.

The deployment workflow now depends on the pinned Wrangler package version being available. The version is recorded in `deployment-toolchain.yaml` and can be reverted in both files if deployment behaviour changes unexpectedly.