### PR TITLE
Gate BDD walkthrough Pages deployment

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -7,6 +7,11 @@ on:
         description: "Base URL to test"
         required: false
         type: string
+      publish_pages:
+        description: "Publish the BDD walkthrough to GitHub Pages"
+        required: false
+        default: false
+        type: boolean
   pull_request:
   push:
     branches: [main]
@@ -181,7 +186,13 @@ jobs:
           retention-days: 14
 
       - name: Upload Pages artifact
-        if: always() && steps.detect_site.outputs.present == 'true'
+        if: >-
+          ${{
+            always() &&
+            steps.detect_site.outputs.present == 'true' &&
+            github.event_name == 'workflow_dispatch' &&
+            inputs.publish_pages == true
+          }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: reports-site
@@ -192,7 +203,9 @@ jobs:
       ${{
         always() &&
         needs.walkthrough.result == 'success' &&
-        needs.walkthrough.outputs.has_site == 'true'
+        needs.walkthrough.outputs.has_site == 'true' &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.publish_pages == true
       }}
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
## Summary

Prevents the BDD walkthrough workflow from failing when GitHub Pages publishing is not enabled or not intended for a run.

## Changes

- Adds a manual `publish_pages` input to `workflow_dispatch`.
- Keeps the BDD walkthrough available as an Actions artifact by default.
- Uploads the Pages artifact only when the workflow is manually dispatched with `publish_pages: true`.
- Runs the deploy job only when `publish_pages: true` and a walkthrough site exists.

## Validation status

Not executed locally from this environment.

Recommended checks:

1. Run `qa-bdd` on `main` without `publish_pages`; confirm `walkthrough-site` uploads as an artifact and `deploy` is skipped.
2. If GitHub Pages is enabled for the repository, run `workflow_dispatch` with `publish_pages: true`; confirm the deploy job succeeds.

## Notes

The previous failure was from `actions/deploy-pages@v4` returning 404 while creating a Pages deployment. The BDD suite itself had already produced artifacts.