### PR TITLE
Publish BDD walkthrough to Cloudflare reporting site

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -7,11 +7,6 @@ on:
         description: "Base URL to test"
         required: false
         type: string
-      publish_pages:
-        description: "Publish the BDD walkthrough to GitHub Pages"
-        required: false
-        default: false
-        type: boolean
   pull_request:
   push:
     branches: [main]
@@ -108,9 +103,6 @@ jobs:
     permissions:
       contents: read
 
-    outputs:
-      has_site: ${{ steps.detect_site.outputs.present }}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -185,49 +177,11 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Upload Pages artifact
-        if: >-
-          ${{
-            always() &&
-            steps.detect_site.outputs.present == 'true' &&
-            github.event_name == 'workflow_dispatch' &&
-            inputs.publish_pages == true
-          }}
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: reports-site
-
-  deploy:
-    needs: walkthrough
-    if: >-
-      ${{
-        always() &&
-        needs.walkthrough.result == 'success' &&
-        needs.walkthrough.outputs.has_site == 'true' &&
-        github.event_name == 'workflow_dispatch' &&
-        inputs.publish_pages == true
-      }}
-    runs-on: ubuntu-24.04
-
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-
-    steps:
-      - name: Deploy walkthrough to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4
-
       - name: Add job summary
+        if: always() && steps.detect_site.outputs.present == 'true'
         shell: bash
         run: |
-          URL="${{ steps.deploy.outputs.page_url }}"
           echo "## BDD Visual Walkthrough" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Open the gallery:** ${URL}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "[Open Cucumber HTML report](${URL}cucumber-report.html)" >> "$GITHUB_STEP_SUMMARY"
+          echo "The visual walkthrough has been uploaded as the \`walkthrough-site\` workflow artifact." >> "$GITHUB_STEP_SUMMARY"
+          echo "Download and open \`index.html\` from the artifact to review the walkthrough." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -7,6 +7,11 @@ on:
         description: "Base URL to test"
         required: false
         type: string
+      publish_reporting_site:
+        description: "Publish the walkthrough to the Cloudflare Pages reporting site"
+        required: false
+        default: true
+        type: boolean
   pull_request:
   push:
     branches: [main]
@@ -23,6 +28,8 @@ concurrency:
 
 env:
   CI: true
+  WRANGLER_VERSION: "4.34.0"
+  REPORTING_PAGES_PROJECT: reopsreporting
 
 jobs:
   bdd-smoke:
@@ -177,6 +184,27 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Record Wrangler toolchain version
+        if: >-
+          ${{
+            steps.detect_site.outputs.present == 'true' &&
+            github.event_name == 'workflow_dispatch' &&
+            inputs.publish_reporting_site == true
+          }}
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Deploy walkthrough to Cloudflare Pages reporting site
+        if: >-
+          ${{
+            steps.detect_site.outputs.present == 'true' &&
+            github.event_name == 'workflow_dispatch' &&
+            inputs.publish_reporting_site == true
+          }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: npx --yes wrangler@${WRANGLER_VERSION} pages deploy reports-site --project-name=${REPORTING_PAGES_PROJECT}
+
       - name: Add job summary
         if: always() && steps.detect_site.outputs.present == 'true'
         shell: bash
@@ -184,4 +212,6 @@ jobs:
           echo "## BDD Visual Walkthrough" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The visual walkthrough has been uploaded as the \`walkthrough-site\` workflow artifact." >> "$GITHUB_STEP_SUMMARY"
-          echo "Download and open \`index.html\` from the artifact to review the walkthrough." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_reporting_site }}" = "true" ]; then
+            echo "It was also deployed to https://reopsreporting.pages.dev/." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

Publishes the BDD walkthrough to the existing Cloudflare Pages reporting site instead of GitHub Pages.

## Changes

- Keeps `walkthrough-site` available as an Actions artifact.
- Adds a manual `publish_reporting_site` workflow input.
- Uses pinned Wrangler `4.34.0`, aligned with `deployment-toolchain.yaml`.
- Deploys `reports-site` to the existing Cloudflare Pages project `reopsreporting` on manual runs when `publish_reporting_site: true`.
- Uses the existing Cloudflare secret names `CF_API_TOKEN` and `CF_ACCOUNT_ID`.
- Removes the GitHub Pages deployment path entirely.

## Validation status

Not executed locally from this environment.

Recommended checks:

1. Run `qa-bdd` manually with `publish_reporting_site: true`.
2. Confirm `bdd-smoke` passes.
3. Confirm `walkthrough` passes.
4. Confirm `walkthrough-site` is uploaded as an artifact.
5. Confirm the report is published to `https://reopsreporting.pages.dev/`.

## Notes

The previous failure was caused by `actions/deploy-pages@v4` targeting GitHub Pages, while this project already has a Cloudflare Pages reporting site.