### PR TITLE
Remove unavailable audit SARIF conversion

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: security-audit-${{ github.ref }}
@@ -50,18 +49,6 @@ jobs:
             artifacts/release-gate/security-audit-policy-stdout.json
           if-no-files-found: warn
           retention-days: 14
-
-      - name: Convert audit report to SARIF
-        if: always() && hashFiles('artifacts/release-gate/security-audit-raw.json') != ''
-        continue-on-error: true
-        run: npx audit2sarif@3 artifacts/release-gate/security-audit-raw.json > npm-audit.sarif
-
-      - name: Upload SARIF to GitHub Security tab
-        if: always() && hashFiles('npm-audit.sarif') != ''
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: npm-audit.sarif
 
       - name: Add summary
         if: always()


### PR DESCRIPTION
## Summary

Removes the optional SARIF conversion path from the `Security & dependencies` workflow.

## Changes

- Removes `npx audit2sarif@3`, which is not available in npm.
- Removes the SARIF upload step that failed on an empty invalid SARIF file.
- Reduces workflow permissions to `contents: read` only.
- Keeps the policy-classified npm audit as the authoritative security decision.
- Keeps the `npm-audit-policy-report` artifact upload and job summary.

## Validation status

Partially validated by the latest workflow log.

Observed result:

- `npm run audit:security` passed.
- 13 findings were classified as development-scope advisory.
- 0 findings were release-blocking.
- `npm-audit-policy-report` uploaded successfully.
- The only failure was the unavailable `audit2sarif@3` package and the resulting invalid SARIF upload.

Recommended checks:

1. Run the `Security & dependencies` workflow manually on this branch.
2. Confirm `npm-audit-policy-report` uploads.
3. Confirm the job passes when the policy result is `status: passed`.

## Notes

SARIF can be reintroduced later only with a pinned, available converter and a validation check that the generated file is non-empty valid SARIF before upload.