### PR TITLE
Verify BDD reporting site deployment

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -30,6 +30,7 @@ env:
   CI: true
   WRANGLER_VERSION: "4.34.0"
   REPORTING_PAGES_PROJECT: reopsreporting
+  REPORTING_PAGES_URL: https://reopsreporting.pages.dev/
 
 jobs:
   bdd-smoke:
@@ -203,7 +204,37 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        run: npx --yes wrangler@${WRANGLER_VERSION} pages deploy reports-site --project-name=${REPORTING_PAGES_PROJECT}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} pages deploy reports-site \
+            --project-name=${REPORTING_PAGES_PROJECT} \
+            --branch=main \
+            --commit-hash=${GITHUB_SHA} \
+            --commit-message="BDD walkthrough ${GITHUB_RUN_ID}"
+
+      - name: Verify reporting site was updated
+        if: >-
+          ${{
+            steps.detect_site.outputs.present == 'true' &&
+            github.event_name == 'workflow_dispatch' &&
+            inputs.publish_reporting_site == true
+          }}
+        shell: bash
+        run: |
+          expected_started_at="$(node -e "const fs = require('node:fs'); const html = fs.readFileSync('reports-site/index.html', 'utf8'); const match = html.match(/Run started: ([^<]+)/); if (!match) process.exit(1); console.log(match[1]);")"
+          echo "Expected reporting timestamp: ${expected_started_at}"
+
+          for attempt in {1..18}; do
+            body="$(curl --fail --silent --show-error --location --max-time 10 "${REPORTING_PAGES_URL}?run=${GITHUB_RUN_ID}-${attempt}" || true)"
+            if printf '%s' "$body" | grep -F "Run started: ${expected_started_at}" >/dev/null; then
+              echo "Reporting site updated: ${REPORTING_PAGES_URL}"
+              exit 0
+            fi
+            echo "Reporting site has not updated yet. Attempt ${attempt}/18."
+            sleep 10
+          done
+
+          echo "Reporting site did not show the generated run timestamp after deployment."
+          exit 1
 
       - name: Add job summary
         if: always() && steps.detect_site.outputs.present == 'true'
@@ -213,5 +244,5 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The visual walkthrough has been uploaded as the \`walkthrough-site\` workflow artifact." >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_reporting_site }}" = "true" ]; then
-            echo "It was also deployed to https://reopsreporting.pages.dev/." >> "$GITHUB_STEP_SUMMARY"
+            echo "It was also deployed and verified at ${REPORTING_PAGES_URL}." >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
## Summary

Updates the BDD walkthrough deployment so manual runs publish to the production Cloudflare Pages reporting URL and verify that the public site contains the newly generated run timestamp.

## Changes

- Adds `REPORTING_PAGES_URL` for the public reporting site.
- Forces Wrangler Pages deployment to the `main` branch of the `reopsreporting` project.
- Adds deployment commit metadata using the workflow commit SHA and run ID.
- Adds a post-deploy verification step that fetches `https://reopsreporting.pages.dev/` with a cache-busting query string.
- Fails the workflow if the public site does not show the generated `Run started` timestamp after deployment.
- Updates the job summary to say the reporting site was deployed and verified.

## Validation status

Not executed locally from this environment.

Recommended checks:

1. Run `qa-bdd` manually with `publish_reporting_site: true`.
2. Confirm the `walkthrough-site` artifact uploads.
3. Confirm the deploy step targets `reopsreporting` with `--branch=main`.
4. Confirm the verify step finds the same `Run started` timestamp on `https://reopsreporting.pages.dev/`.

## Notes

The public reporting site still showed `Run started: 2025-11-03T21:13:33.270Z`, which suggests the earlier deploy either went to a preview branch or did not update the production URL. This PR makes that failure visible by verifying the public site after deployment.