### PR TITLE
Persist BDD report on main branch runs

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -195,8 +195,7 @@ jobs:
         if: >-
           ${{
             steps.detect_site.outputs.present == 'true' &&
-            github.event_name == 'workflow_dispatch' &&
-            inputs.publish_reporting_site == true &&
+            github.event_name != 'pull_request' &&
             github.ref == 'refs/heads/main'
           }}
         shell: bash
@@ -273,7 +272,9 @@ jobs:
           echo "## BDD Visual Walkthrough" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The visual walkthrough has been uploaded as the \`walkthrough-site\` workflow artifact." >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_reporting_site }}" = "true" ]; then
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "The \`reports-site\` directory was persisted to the repository." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_reporting_site }}" = "true" ]; then
             echo "It was also deployed and verified at ${REPORTING_PAGES_URL}." >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
## Summary

Updates the BDD walkthrough workflow so successful `main` branch walkthrough runs persist the generated `reports-site` directory back into the repository.

## Changes

- Keeps `reports-site/**` ignored for push triggers to avoid a report-update loop.
- Changes the persistence condition from manual `workflow_dispatch` only to any non-PR run on `refs/heads/main`.
- Keeps pull request runs read-only for report generation.
- Keeps manual Cloudflare Pages deployment gated by `publish_reporting_site: true`.
- Updates the job summary so repository persistence and Cloudflare deployment are reported separately.

## Why

The previous workflow only committed `reports-site` on manual `workflow_dispatch` runs with `publish_reporting_site: true`. A successful build from a `push` or upstream `workflow_run` could generate the walkthrough artifact but skip repository persistence, leaving `main/reports-site` stale.

## Validation status

Not executed locally from this environment.

Recommended checks

1. Merge this PR.
2. Run `qa-bdd` from `main`, or let the next successful main-branch run complete.
3. Confirm the `Persist walkthrough site to repository` step runs.
4. Confirm a commit named `Update BDD walkthrough report` is created when `reports-site` changes.
5. Confirm `reports-site/index.html` in `main` shows the new `Run started` timestamp.

## Notes

The workflow still ignores report-only commits on `push`, so the generated report commit should not loop back into another BDD run.