### PR TITLE
Rework application visual walkthrough reporting

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -1,0 +1,42 @@
+name: Format pull request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: format-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  prettier:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Format files
+        run: npm run format
+
+      - name: Commit formatting changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Format pull request files

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Format files
-        run: npm run format
+        run: ./node_modules/.bin/prettier -w .
 
       - name: Commit formatting changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -106,11 +106,12 @@ jobs:
         needs.bdd-smoke.result == 'success' &&
         (
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main' ||
+          github.event.workflow_run.head_branch == 'main'
         )
       }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     permissions:
       contents: write
@@ -147,70 +148,87 @@ jobs:
           echo "BASE_URL=$val" >> "$GITHUB_ENV"
           echo "Using BASE_URL: $val"
 
+      - name: Resolve report persistence target
+        id: persist_target
+        shell: bash
+        run: |
+          enabled="false"
+          target_branch=""
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            target_branch="$GITHUB_REF_NAME"
+          elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            target_branch="$GITHUB_REF_NAME"
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
+            target_branch="$(node -e "const fs = require('node:fs'); const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); console.log(event.workflow_run?.head_branch || '');")"
+          fi
+
+          if [ "$target_branch" = "main" ]; then
+            enabled="true"
+          fi
+
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+          echo "target_branch=$target_branch" >> "$GITHUB_OUTPUT"
+          echo "Report persistence enabled: $enabled"
+          echo "Report persistence target branch: ${target_branch:-none}"
+
       - name: Diagnose BASE_URL
         shell: bash
         run: |
           curl --fail --silent --show-error --location --connect-timeout 10 --max-time 30 --retry 2 "$BASE_URL" >/dev/null \
-            && echo "BASE_URL responded before BDD run." \
-            || echo "BASE_URL did not respond during preflight. Continuing so the BDD suite can produce the authoritative result."
+            && echo "BASE_URL responded before visual walkthrough run." \
+            || echo "BASE_URL did not respond during preflight. Continuing so the visual walkthrough can produce the authoritative result."
 
-      - name: Run BDD visual walkthrough
-        run: npm run qa:cucumber:walkthrough
+      - name: Run application visual walkthrough
+        run: npm run qa:visual-walkthrough
 
-      - name: Merge Cucumber report into walkthrough site
-        if: always()
-        shell: bash
-        run: |
-          mkdir -p reports-site
-          if [ -f "reports/cucumber-report.html" ]; then
-            cp reports/cucumber-report.html reports-site/cucumber-report.html
-          fi
-          if [ -f "reports/cucumber-report.json" ]; then
-            cp reports/cucumber-report.json reports-site/cucumber-report.json
-          fi
-
-      - name: Detect walkthrough site
+      - name: Detect visual walkthrough site
         id: detect_site
         if: always()
         shell: bash
         run: |
-          if [ -f "reports-site/index.html" ]; then
+          if [ -f "reports-site/index.html" ] && [ -f "reports-site/manifest.json" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
-            echo "Walkthrough site detected."
+            echo "Visual walkthrough site detected."
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "No walkthrough site found."
+            echo "No visual walkthrough site found."
           fi
 
-      - name: Upload walkthrough artifact
+      - name: Upload visual walkthrough artifact
         if: always() && steps.detect_site.outputs.present == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: walkthrough-site
+          name: visual-walkthrough-site
           path: reports-site
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Persist walkthrough site to repository
+      - name: Persist visual walkthrough site to repository
         if: >-
           ${{
             steps.detect_site.outputs.present == 'true' &&
-            github.event_name != 'pull_request' &&
-            github.ref == 'refs/heads/main'
+            steps.persist_target.outputs.enabled == 'true'
           }}
         shell: bash
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          echo "Repository status before staging report files:"
+          git status --short reports-site || true
+
           git add -A reports-site
+
+          echo "Staged report file changes:"
+          git diff --cached --stat || true
 
           if git diff --cached --quiet; then
             echo "No reports-site changes to commit."
             exit 0
           fi
 
-          git commit -m "Update BDD walkthrough report"
+          git commit -m "Update application visual walkthrough report"
           git pull --rebase origin main
           git push origin HEAD:main
 
@@ -223,7 +241,7 @@ jobs:
           }}
         run: npx --yes wrangler@${WRANGLER_VERSION} --version
 
-      - name: Deploy walkthrough to Cloudflare Pages reporting site
+      - name: Deploy visual walkthrough to Cloudflare Pages reporting site
         if: >-
           ${{
             steps.detect_site.outputs.present == 'true' &&
@@ -238,7 +256,7 @@ jobs:
             --project-name=${REPORTING_PAGES_PROJECT} \
             --branch=main \
             --commit-hash=${GITHUB_SHA} \
-            --commit-message="BDD walkthrough ${GITHUB_RUN_ID}"
+            --commit-message="Visual walkthrough ${GITHUB_RUN_ID}"
 
       - name: Verify reporting site was updated
         if: >-
@@ -249,7 +267,7 @@ jobs:
           }}
         shell: bash
         run: |
-          expected_started_at="$(node -e "const fs = require('node:fs'); const html = fs.readFileSync('reports-site/index.html', 'utf8'); const match = html.match(/Run started: ([^<]+)/); if (!match) process.exit(1); console.log(match[1]);")"
+          expected_started_at="$(node -e "const fs = require('node:fs'); const manifest = JSON.parse(fs.readFileSync('reports-site/manifest.json', 'utf8')); console.log(manifest.startedAt);")"
           echo "Expected reporting timestamp: ${expected_started_at}"
 
           for attempt in {1..18}; do
@@ -269,11 +287,13 @@ jobs:
         if: always() && steps.detect_site.outputs.present == 'true'
         shell: bash
         run: |
-          echo "## BDD Visual Walkthrough" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Application visual walkthrough" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "The visual walkthrough has been uploaded as the \`walkthrough-site\` workflow artifact." >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "The \`reports-site\` directory was persisted to the repository." >> "$GITHUB_STEP_SUMMARY"
+          echo "The visual walkthrough has been uploaded as the \`visual-walkthrough-site\` workflow artifact." >> "$GITHUB_STEP_SUMMARY"
+          echo "Persistence enabled: \`${{ steps.persist_target.outputs.enabled }}\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Persistence target branch: \`${{ steps.persist_target.outputs.target_branch }}\`." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.persist_target.outputs.enabled }}" = "true" ]; then
+            echo "The \`reports-site\` directory was persisted to the repository when changes were present." >> "$GITHUB_STEP_SUMMARY"
           fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_reporting_site }}" = "true" ]; then
             echo "It was also deployed and verified at ${REPORTING_PAGES_URL}." >> "$GITHUB_STEP_SUMMARY"

--- a/RECENT_LEARNINGS.md
+++ b/RECENT_LEARNINGS.md
@@ -2,6 +2,14 @@
 
 This file records repeatable repository-specific lessons for ResearchOps agents and maintainers. It is not a changelog.
 
+## 2026-04-30 — Prettier must be executed, not inferred
+
+Context: A new visual walkthrough registry test failed `prettier -c .` even though the code broadly followed the repository indentation rules. The remaining failure came from Prettier's wrapping decisions for chained calls and long assertions, not from JavaScript semantics.
+
+Learning: Formatter compliance cannot be reliably inferred from rules, memory, house style, or visual inspection. Prettier is an executable formatter with specific line-breaking behaviour. API-based file writes are especially exposed because they bypass the local edit-save-format loop.
+
+Action: Treat actual Prettier execution as the source of truth. When writing JavaScript through API-based edits, pre-wrap chained calls and assertions in the shape Prettier normally emits, then rely on `npm run format:check` or CI to verify. Where possible, use a local checkout or a formatter-capable agent path before opening or updating a PR.
+
 ## 2026-04-30 — Prettier follows the repository EditorConfig
 
 Context: A new route-state regression test repeatedly failed `prettier -c .` because it was written with space indentation. The repository has `.editorconfig` with `indent_style = tab`.

--- a/docs/qa/visual-walkthrough.md
+++ b/docs/qa/visual-walkthrough.md
@@ -1,0 +1,128 @@
+# Application visual walkthrough
+
+The application visual walkthrough is a generated evidence site for the current ResearchOps build. It is not the same thing as the Cucumber smoke suite.
+
+The smoke suite answers: did a small number of routes load and meet basic assertions?
+
+The visual walkthrough answers: what does the application look like across registered pages and important interaction states?
+
+## Output
+
+The walkthrough writes to `reports-site/`:
+
+- `index.html` — browsable report
+- `manifest.json` — machine-readable run evidence
+- `screenshots/*.png` — captured page and state evidence
+
+The generated report is uploaded as the `visual-walkthrough-site` workflow artifact. On main branch runs, `reports-site/` is committed back to the repository when generated output changes.
+
+## Registry
+
+The source of truth is `visual-walkthrough.config.mjs`.
+
+Every public HTML application route must have a page entry. The registry test fails if a new public HTML page is added without a matching walkthrough entry.
+
+A page entry looks like this:
+
+```js
+{
+	id: 'study',
+	title: 'Study overview',
+	group: 'Study',
+	path: '/pages/study/index.html',
+	description: 'Study overview and readiness controls.',
+}
+```
+
+## Adding a new page
+
+When a new page is added under `public/`, add a matching entry to `visual-walkthrough.config.mjs` in the same PR.
+
+The minimum required fields are:
+
+- `id`
+- `title`
+- `group`
+- `path`
+- `description`
+
+The `path` must match the route derived from the public HTML file. For example:
+
+```text
+public/pages/example/index.html
+```
+
+must be registered as:
+
+```text
+/pages/example/index.html
+```
+
+## Adding interaction states
+
+Use `states` when a page has meaningful visual states beyond the default loaded page. Examples include tabs, opened panels, expanded accordions, selected filters, modal/dialog states, validation messages and enabled/disabled control states.
+
+Example:
+
+```js
+{
+	id: 'example-page',
+	title: 'Example page',
+	group: 'Examples',
+	path: '/pages/example/index.html',
+	description: 'Example page with tabs.',
+	states: [
+		{
+			id: 'second-tab',
+			title: 'Second tab selected',
+			description: 'Shows the second tab panel.',
+			actions: [
+				{
+					type: 'click',
+					selector: '[data-testid="second-tab"]',
+				},
+			],
+		},
+	],
+}
+```
+
+Supported action types are:
+
+- `click`
+- `fill`
+- `press`
+- `select`
+- `check`
+- `uncheck`
+- `waitForSelector`
+- `waitForText`
+- `wait`
+
+Prefer stable selectors such as `data-testid`, semantic landmarks, labelled controls and GOV.UK component classes. Avoid brittle selectors based on position or incidental CSS.
+
+## Local command
+
+Run:
+
+```bash
+npm run qa:visual-walkthrough
+```
+
+The command uses `BASE_URL`, `PAGES_URL` or `PREVIEW_URL` when provided. Otherwise it falls back to `https://researchops.pages.dev/`.
+
+## CI behaviour
+
+The `qa-bdd` workflow still runs the Cucumber smoke suite first.
+
+If smoke passes, the walkthrough job runs the application visual walkthrough. The workflow then:
+
+1. uploads `reports-site/` as an artifact
+2. checks whether the run is allowed to persist to `main`
+3. stages `reports-site/`
+4. prints a staged diff summary
+5. commits `Update application visual walkthrough report` when files changed
+6. pushes the generated report back to `main`
+7. deploys to `reopsreporting` only on manual runs where `publish_reporting_site` is true
+
+`reports-site/**` is ignored by the push trigger, so report-only commits do not create a workflow loop.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "qa:browsers": "playwright install chromium",
     "qa:cucumber": "cucumber-js -p default",
     "qa:cucumber:ci": "cucumber-js -p default",
-    "qa:cucumber:walkthrough": "BDD_CAPTURE_SCREENSHOTS=true cucumber-js -p default"
+    "qa:cucumber:walkthrough": "BDD_CAPTURE_SCREENSHOTS=true cucumber-js -p default",
+    "qa:visual-walkthrough": "node scripts/visual-walkthrough.mjs"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^11.0.0",

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -1,0 +1,530 @@
+/* eslint-env node */
+
+/**
+ * @file scripts/visual-walkthrough.mjs
+ * @summary Generate the application visual walkthrough report from a registered page/state catalogue.
+ */
+
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
+
+const OUTPUT_DIR = 'reports-site';
+const SCREENSHOTS_DIR = path.join(OUTPUT_DIR, 'screenshots');
+const MANIFEST_FILE = path.join(OUTPUT_DIR, 'manifest.json');
+const INDEX_FILE = path.join(OUTPUT_DIR, 'index.html');
+const DEFAULT_BASE_URL = 'https://researchops.pages.dev/';
+
+const startedAt = new Date().toISOString();
+const baseURL = normalizeBaseURL(
+	process.env.BASE_URL || process.env.PAGES_URL || process.env.PREVIEW_URL || DEFAULT_BASE_URL
+);
+
+/** Normalize a URL and ensure a trailing slash. */
+function normalizeBaseURL(value) {
+	const url = String(value || '').trim();
+
+	if (!url) return DEFAULT_BASE_URL;
+
+	return url.endsWith('/') ? url : `${url}/`;
+}
+
+/** Escape unsafe characters for HTML text output. */
+function escapeHtml(value = '') {
+	return String(value)
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;');
+}
+
+/** Convert a string to a stable filename slug. */
+function slugify(value) {
+	return String(value)
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, 96);
+}
+
+/** Ensure a directory exists. */
+function ensureDir(dir) {
+	fs.mkdirSync(dir, { recursive: true });
+}
+
+/** Convert a public file path to the URL route it represents. */
+function routeFromPublicFile(filePath) {
+	const relativePath = path.relative(visualWalkthroughConfig.publicRoot, filePath).replaceAll(path.sep, '/');
+
+	if (relativePath === 'index.html') return '/';
+
+	return `/${relativePath}`;
+}
+
+/** Recursively list HTML files under a directory. */
+function listHtmlFiles(dir) {
+	if (!fs.existsSync(dir)) return [];
+
+	const entries = fs.readdirSync(dir, { withFileTypes: true });
+	const files = [];
+
+	for (const entry of entries) {
+		const entryPath = path.join(dir, entry.name);
+
+		if (entry.isDirectory()) {
+			files.push(...listHtmlFiles(entryPath));
+			continue;
+		}
+
+		if (entry.isFile() && entry.name.endsWith('.html')) {
+			files.push(entryPath);
+		}
+	}
+
+	return files.sort();
+}
+
+/** Get all application routes that should have visual walkthrough coverage. */
+function getDiscoveredApplicationRoutes() {
+	const excluded = new Set(visualWalkthroughConfig.excludedRoutes || []);
+
+	return listHtmlFiles(visualWalkthroughConfig.publicRoot)
+		.map(routeFromPublicFile)
+		.filter((route) => !excluded.has(route));
+}
+
+/** Validate that the registry covers every discovered public HTML page. */
+function validateRegistry() {
+	const registeredRoutes = new Set(visualWalkthroughConfig.pages.map((page) => page.path));
+	const registeredIds = new Set();
+	const failures = [];
+
+	for (const page of visualWalkthroughConfig.pages) {
+		if (registeredIds.has(page.id)) {
+			failures.push(`Duplicate page id: ${page.id}`);
+		}
+
+		registeredIds.add(page.id);
+
+		if (!page.path.startsWith('/')) {
+			failures.push(`Page path must start with /: ${page.id}`);
+		}
+	}
+
+	for (const route of getDiscoveredApplicationRoutes()) {
+		if (!registeredRoutes.has(route)) {
+			failures.push(`Missing visual walkthrough registry entry for route: ${route}`);
+		}
+	}
+
+	if (failures.length > 0) {
+		throw new Error(`Visual walkthrough registry is incomplete:\n- ${failures.join('\n- ')}`);
+	}
+}
+
+/** Wait until the page is stable enough for evidence capture. */
+async function settlePage(page) {
+	await page.waitForLoadState('domcontentloaded');
+
+	try {
+		await page.waitForLoadState('networkidle', { timeout: 3000 });
+	} catch {
+		// Some pages keep network connections open. Visual evidence capture should continue.
+	}
+
+	await page.locator('body').waitFor({ state: 'visible', timeout: 5000 });
+
+	await page.evaluate(async () => {
+		if (document.fonts?.ready) {
+			await document.fonts.ready;
+		}
+	});
+
+	await page.waitForTimeout(200);
+}
+
+/** Run an interaction action declared in the registry. */
+async function runAction(page, action) {
+	const timeout = action.timeout ?? 5000;
+
+	if (action.type === 'click') {
+		await page.locator(action.selector).click({ timeout });
+		return;
+	}
+
+	if (action.type === 'fill') {
+		await page.locator(action.selector).fill(action.value ?? '', { timeout });
+		return;
+	}
+
+	if (action.type === 'press') {
+		await page.locator(action.selector ?? 'body').press(action.key, { timeout });
+		return;
+	}
+
+	if (action.type === 'select') {
+		await page.locator(action.selector).selectOption(action.value, { timeout });
+		return;
+	}
+
+	if (action.type === 'check') {
+		await page.locator(action.selector).check({ timeout });
+		return;
+	}
+
+	if (action.type === 'uncheck') {
+		await page.locator(action.selector).uncheck({ timeout });
+		return;
+	}
+
+	if (action.type === 'waitForSelector') {
+		await page.locator(action.selector).waitFor({ state: action.state ?? 'visible', timeout });
+		return;
+	}
+
+	if (action.type === 'waitForText') {
+		await page.getByText(action.text, { exact: Boolean(action.exact) }).first().waitFor({ timeout });
+		return;
+	}
+
+	if (action.type === 'wait') {
+		await page.waitForTimeout(action.ms ?? 250);
+		return;
+	}
+
+	throw new Error(`Unsupported visual walkthrough action type: ${action.type}`);
+}
+
+/** Capture a page state. */
+async function captureState(browser, pageConfig, stateConfig) {
+	const context = await browser.newContext({
+		ignoreHTTPSErrors: true,
+		reducedMotion: 'reduce',
+		viewport: {
+			width: 1440,
+			height: 1200,
+		},
+	});
+
+	const page = await context.newPage();
+	const stateId = stateConfig.id || 'default';
+	const screenshotFile = `${slugify(pageConfig.group)}__${slugify(pageConfig.id)}__${slugify(stateId)}.png`;
+	const screenshotPath = path.join(SCREENSHOTS_DIR, screenshotFile);
+	const url = new URL(pageConfig.path, baseURL).toString();
+	const started = Date.now();
+
+	try {
+		const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+		if (!response) {
+			throw new Error(`No HTTP response for ${url}`);
+		}
+
+		if (!response.ok()) {
+			throw new Error(`HTTP ${response.status()} for ${url}`);
+		}
+
+		await settlePage(page);
+
+		for (const action of stateConfig.actions || []) {
+			await runAction(page, action);
+			await settlePage(page);
+		}
+
+		await page.screenshot({
+			path: screenshotPath,
+			fullPage: true,
+			animations: 'disabled',
+		});
+
+		return {
+			id: stateId,
+			title: stateConfig.title || 'Default state',
+			description: stateConfig.description || '',
+			status: 'captured',
+			url,
+			durationMs: Date.now() - started,
+			screenshot: `screenshots/${screenshotFile}`,
+		};
+	} finally {
+		await context.close();
+	}
+}
+
+/** Capture every registered page and state. */
+async function captureReport() {
+	validateRegistry();
+
+	fs.rmSync(OUTPUT_DIR, { recursive: true, force: true });
+	ensureDir(SCREENSHOTS_DIR);
+
+	const browser = await chromium.launch({ headless: true });
+	const capturedPages = [];
+	const failures = [];
+
+	try {
+		for (const pageConfig of visualWalkthroughConfig.pages) {
+			const states = [
+				{
+					id: 'default',
+					title: 'Default state',
+					description: 'Initial loaded page state.',
+				},
+				...(pageConfig.states || []),
+			];
+
+			const capturedStates = [];
+
+			for (const stateConfig of states) {
+				try {
+					const state = await captureState(browser, pageConfig, stateConfig);
+					capturedStates.push(state);
+					console.log(`[visual-walkthrough] captured ${pageConfig.id}/${state.id}`);
+				} catch (error) {
+					const failure = {
+						page: pageConfig.id,
+						state: stateConfig.id || 'default',
+						message: error.message,
+					};
+
+					capturedStates.push({
+						id: failure.state,
+						title: stateConfig.title || 'Default state',
+						description: stateConfig.description || '',
+						status: 'failed',
+						url: new URL(pageConfig.path, baseURL).toString(),
+						error: failure.message,
+					});
+
+					failures.push(failure);
+					console.error(`[visual-walkthrough] failed ${failure.page}/${failure.state}: ${failure.message}`);
+				}
+			}
+
+			capturedPages.push({
+				id: pageConfig.id,
+				title: pageConfig.title,
+				group: pageConfig.group || 'Application',
+				path: pageConfig.path,
+				description: pageConfig.description || '',
+				states: capturedStates,
+			});
+		}
+	} finally {
+		await browser.close();
+	}
+
+	const manifest = {
+		title: visualWalkthroughConfig.title,
+		description: visualWalkthroughConfig.description,
+		startedAt,
+		baseURL,
+		pageCount: capturedPages.length,
+		stateCount: capturedPages.reduce((total, page) => total + page.states.length, 0),
+		failureCount: failures.length,
+		pages: capturedPages,
+		failures,
+	};
+
+	writeReport(manifest);
+
+	if (failures.length > 0) {
+		throw new Error(`Visual walkthrough failed for ${failures.length} state(s).`);
+	}
+}
+
+/** Group pages by report group. */
+function groupPages(pages) {
+	const groups = new Map();
+
+	for (const page of pages) {
+		if (!groups.has(page.group)) groups.set(page.group, []);
+		groups.get(page.group).push(page);
+	}
+
+	return [...groups.entries()];
+}
+
+/** Render the HTML report. */
+function renderHtml(manifest) {
+	const groups = groupPages(manifest.pages);
+
+	return `<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8" />
+	<title>${escapeHtml(manifest.title)}</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<style>
+		body {
+			font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			margin: 24px;
+			line-height: 1.45;
+			color: #111;
+			background: #fff;
+		}
+
+		header {
+			display: flex;
+			justify-content: space-between;
+			align-items: flex-start;
+			gap: 16px;
+			flex-wrap: wrap;
+			border-bottom: 1px solid #d8d8d8;
+			margin-bottom: 24px;
+			padding-bottom: 16px;
+		}
+
+		h1 {
+			margin: 0 0 8px;
+		}
+
+		h2 {
+			margin-top: 32px;
+			border-bottom: 1px solid #e5e5e5;
+			padding-bottom: 8px;
+		}
+
+		h3 {
+			margin: 0 0 4px;
+		}
+
+		.badge {
+			background: #eef;
+			border: 1px solid #99c;
+			border-radius: 6px;
+			display: inline-block;
+			padding: 6px 10px;
+		}
+
+		.meta {
+			color: #444;
+			margin: 0;
+		}
+
+		.group {
+			margin-bottom: 40px;
+		}
+
+		.page-card {
+			border: 1px solid #d8d8d8;
+			border-radius: 8px;
+			margin: 18px 0;
+			overflow: hidden;
+		}
+
+		.page-card__header {
+			background: #f7f7f7;
+			border-bottom: 1px solid #d8d8d8;
+			padding: 14px 16px;
+		}
+
+		.states {
+			display: grid;
+			gap: 18px;
+			grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+			padding: 16px;
+		}
+
+		.state {
+			border: 1px solid #e5e5e5;
+			border-radius: 6px;
+			overflow: hidden;
+			background: #fff;
+		}
+
+		.state__header {
+			padding: 10px 12px;
+			border-bottom: 1px solid #e5e5e5;
+		}
+
+		.state__header p {
+			margin: 4px 0 0;
+		}
+
+		.state img {
+			display: block;
+			width: 100%;
+			height: auto;
+		}
+
+		.failed {
+			border-color: #d4351c;
+		}
+
+		.failed .state__header {
+			background: #fff4f2;
+		}
+
+		.summary {
+			display: flex;
+			gap: 8px;
+			flex-wrap: wrap;
+			justify-content: flex-end;
+		}
+	</style>
+</head>
+<body>
+	<header>
+		<div>
+			<h1>${escapeHtml(manifest.title)}</h1>
+			<p class="meta">${escapeHtml(manifest.description)}</p>
+			<p class="meta">Base URL: ${escapeHtml(manifest.baseURL)}</p>
+			<p class="meta">Run started: ${escapeHtml(manifest.startedAt)}</p>
+		</div>
+		<div class="summary">
+			<span class="badge">${manifest.pageCount} pages</span>
+			<span class="badge">${manifest.stateCount} states</span>
+			<span class="badge">${manifest.failureCount} failures</span>
+		</div>
+	</header>
+	${groups
+		.map(
+			([group, pages]) => `
+	<section class="group" id="${escapeHtml(slugify(group))}">
+		<h2>${escapeHtml(group)}</h2>
+		${pages
+			.map(
+				(page) => `
+		<article class="page-card" id="${escapeHtml(page.id)}">
+			<div class="page-card__header">
+				<h3>${escapeHtml(page.title)}</h3>
+				<p class="meta">${escapeHtml(page.path)}</p>
+				<p class="meta">${escapeHtml(page.description)}</p>
+			</div>
+			<div class="states">
+				${page.states
+					.map(
+						(state) => `
+				<section class="state ${state.status === 'failed' ? 'failed' : ''}">
+					<div class="state__header">
+						<h4>${escapeHtml(state.title)}</h4>
+						<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
+						${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
+						${state.error ? `<p>${escapeHtml(state.error)}</p>` : ''}
+					</div>
+					${state.screenshot ? `<a href="${escapeHtml(state.screenshot)}"><img loading="lazy" src="${escapeHtml(state.screenshot)}" alt="${escapeHtml(page.title)}: ${escapeHtml(state.title)}" /></a>` : ''}
+				</section>`
+					)
+					.join('')}
+			</div>
+		</article>`
+			)
+			.join('')}
+	</section>`
+		)
+		.join('')}
+</body>
+</html>`;
+}
+
+/** Write manifest and HTML report. */
+function writeReport(manifest) {
+	fs.writeFileSync(MANIFEST_FILE, `${JSON.stringify(manifest, null, 2)}\n`);
+	fs.writeFileSync(INDEX_FILE, renderHtml(manifest));
+	console.log(`[visual-walkthrough] report written to ${INDEX_FILE}`);
+}
+
+await captureReport();

--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -26,7 +26,9 @@ function listHtmlFiles(dir) {
 }
 
 function routeFromPublicFile(filePath) {
-	const relativePath = path.relative(visualWalkthroughConfig.publicRoot, filePath).replaceAll(path.sep, '/');
+	const relativePath = path
+		.relative(visualWalkthroughConfig.publicRoot, filePath)
+		.replaceAll(path.sep, '/');
 
 	if (relativePath === 'index.html') return '/';
 
@@ -48,9 +50,25 @@ for (const route of discoveredRoutes) {
 }
 
 for (const page of visualWalkthroughConfig.pages) {
-	assert.equal(page.path.startsWith('/'), true, `Expected registered path to start with /: ${page.path}`);
-	assert.equal(Boolean(page.title), true, `Expected registered page to have a title: ${page.id}`);
-	assert.equal(Boolean(page.group), true, `Expected registered page to have a group: ${page.id}`);
+	assert.equal(
+		page.path.startsWith('/'),
+		true,
+		`Expected registered path to start with /: ${page.path}`
+	);
+	assert.equal(
+		Boolean(page.title),
+		true,
+		`Expected registered page to have a title: ${page.id}`
+	);
+	assert.equal(
+		Boolean(page.group),
+		true,
+		`Expected registered page to have a group: ${page.id}`
+	);
 }
 
-assert.equal(new Set(registeredIds).size, registeredIds.length, 'Expected registered page ids to be unique');
+assert.equal(
+	new Set(registeredIds).size,
+	registeredIds.length,
+	'Expected registered page ids to be unique'
+);

--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
+
+function listHtmlFiles(dir) {
+	if (!fs.existsSync(dir)) return [];
+
+	const entries = fs.readdirSync(dir, { withFileTypes: true });
+	const files = [];
+
+	for (const entry of entries) {
+		const entryPath = path.join(dir, entry.name);
+
+		if (entry.isDirectory()) {
+			files.push(...listHtmlFiles(entryPath));
+			continue;
+		}
+
+		if (entry.isFile() && entry.name.endsWith('.html')) {
+			files.push(entryPath);
+		}
+	}
+
+	return files.sort();
+}
+
+function routeFromPublicFile(filePath) {
+	const relativePath = path.relative(visualWalkthroughConfig.publicRoot, filePath).replaceAll(path.sep, '/');
+
+	if (relativePath === 'index.html') return '/';
+
+	return `/${relativePath}`;
+}
+
+const discoveredRoutes = listHtmlFiles(visualWalkthroughConfig.publicRoot)
+	.map(routeFromPublicFile)
+	.filter((route) => !visualWalkthroughConfig.excludedRoutes.includes(route));
+
+const registeredRoutes = visualWalkthroughConfig.pages.map((page) => page.path);
+const registeredIds = visualWalkthroughConfig.pages.map((page) => page.id);
+
+for (const route of discoveredRoutes) {
+	assert.ok(
+		registeredRoutes.includes(route),
+		`Expected visual walkthrough registry to include public route: ${route}`
+	);
+}
+
+for (const page of visualWalkthroughConfig.pages) {
+	assert.equal(page.path.startsWith('/'), true, `Expected registered path to start with /: ${page.path}`);
+	assert.equal(Boolean(page.title), true, `Expected registered page to have a title: ${page.id}`);
+	assert.equal(Boolean(page.group), true, `Expected registered page to have a group: ${page.id}`);
+}
+
+assert.equal(new Set(registeredIds).size, registeredIds.length, 'Expected registered page ids to be unique');

--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -55,16 +55,8 @@ for (const page of visualWalkthroughConfig.pages) {
 		true,
 		`Expected registered path to start with /: ${page.path}`
 	);
-	assert.equal(
-		Boolean(page.title),
-		true,
-		`Expected registered page to have a title: ${page.id}`
-	);
-	assert.equal(
-		Boolean(page.group),
-		true,
-		`Expected registered page to have a group: ${page.id}`
-	);
+	assert.equal(Boolean(page.title), true, `Expected registered page to have a title: ${page.id}`);
+	assert.equal(Boolean(page.group), true, `Expected registered page to have a group: ${page.id}`);
 }
 
 assert.equal(

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -10,7 +10,15 @@ export const visualWalkthroughConfig = {
 	description:
 		'Generated evidence of the current application build, covering registered pages and important interaction states.',
 	publicRoot: 'public',
-	excludedRoutes: ['/partials/footer.html', '/partials/header.html'],
+	excludedRoutes: [
+		'/clear.html',
+		'/partials/debug-boot.html',
+		'/partials/debug.html',
+		'/partials/footer.html',
+		'/partials/header.html',
+		'/partials/html-head.html',
+		'/partials/project-tabs.html',
+	],
 	pages: [
 		{
 			id: 'home',

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -1,0 +1,130 @@
+/* eslint-env node */
+
+/**
+ * @file visual-walkthrough.config.mjs
+ * @summary Registry of application pages and states captured by the visual walkthrough report.
+ */
+
+export const visualWalkthroughConfig = {
+	title: 'ResearchOps application visual walkthrough',
+	description:
+		'Generated evidence of the current application build, covering registered pages and important interaction states.',
+	publicRoot: 'public',
+	excludedRoutes: ['/partials/footer.html', '/partials/header.html'],
+	pages: [
+		{
+			id: 'home',
+			title: 'Home',
+			group: 'Core',
+			path: '/',
+			description: 'ResearchOps landing page.',
+		},
+		{
+			id: 'start',
+			title: 'Start research project',
+			group: 'Core',
+			path: '/pages/start/index.html',
+			description: 'Start page for creating or beginning research project work.',
+		},
+		{
+			id: 'projects',
+			title: 'Projects',
+			group: 'Projects',
+			path: '/pages/projects/index.html',
+			description: 'Project list page.',
+		},
+		{
+			id: 'project-dashboard',
+			title: 'Project dashboard',
+			group: 'Projects',
+			path: '/pages/project-dashboard/index.html',
+			description: 'Project dashboard page.',
+		},
+		{
+			id: 'outcomes',
+			title: 'Project outcomes',
+			group: 'Projects',
+			path: '/pages/projects/outcomes/index.html',
+			description: 'Outcomes page for project-level findings and outputs.',
+		},
+		{
+			id: 'journals',
+			title: 'Project journals',
+			group: 'Projects',
+			path: '/pages/projects/journals/index.html',
+			description: 'Reflexive journal page.',
+		},
+		{
+			id: 'study',
+			title: 'Study overview',
+			group: 'Study',
+			path: '/pages/study/index.html',
+			description: 'Study overview and readiness controls.',
+		},
+		{
+			id: 'study-guides',
+			title: 'Discussion guides',
+			group: 'Study',
+			path: '/pages/study/guides/index.html',
+			description: 'Discussion guide list and editor page.',
+		},
+		{
+			id: 'study-participants',
+			title: 'Participants',
+			group: 'Study',
+			path: '/pages/study/participants/index.html',
+			description: 'Participants page for a study.',
+		},
+		{
+			id: 'study-session',
+			title: 'Study session',
+			group: 'Study',
+			path: '/pages/study/session/index.html',
+			description: 'Session running and note capture page.',
+		},
+		{
+			id: 'study-consent-forms',
+			title: 'Study consent forms',
+			group: 'Study',
+			path: '/pages/study/consent-forms/index.html',
+			description: 'Study-specific consent form configuration page.',
+		},
+		{
+			id: 'search',
+			title: 'Search',
+			group: 'Utilities',
+			path: '/pages/search/index.html',
+			description: 'Search page.',
+		},
+		{
+			id: 'notes',
+			title: 'Notes',
+			group: 'Utilities',
+			path: '/pages/notes/index.html',
+			description: 'Notes page.',
+		},
+		{
+			id: 'consent',
+			title: 'Consent',
+			group: 'Utilities',
+			path: '/pages/consent/index.html',
+			description: 'Consent page.',
+		},
+		{
+			id: 'sessions',
+			title: 'Sessions',
+			group: 'Utilities',
+			path: '/pages/sessions/index.html',
+			description: 'Sessions list page.',
+		},
+		{
+			id: 'synthesize',
+			title: 'Synthesize',
+			group: 'Analysis',
+			path: '/pages/synthesize/index.html',
+			description: 'Synthesis page.',
+		},
+	],
+};
+
+export default visualWalkthroughConfig;


### PR DESCRIPTION
## Summary

Reworks the BDD visual walkthrough into a dedicated application visual walkthrough system.

The current BDD walkthrough only captures screenshots attached to the three Cucumber smoke scenarios. That means it does not represent the application build, does not cover all pages, and does not provide a clear way to add visual coverage when a new page or feature is created.

This PR introduces a registry-driven walkthrough that captures every registered application page and writes the generated evidence site to `reports-site/`.

## Investigation findings

- `features/smoke.feature` only covers three scenarios: home, projects, and start page landmarks.
- `features/support/hooks.js` only captures screenshots as a side effect of Cucumber steps.
- The existing `reports-site/index.html` is generated from those Cucumber screenshots, not from a complete application page catalogue.
- `reports-site/` can stay stale when the workflow event does not satisfy the repository persistence condition.
- The workflow did not provide enough diagnostics to show whether persistence was enabled, which branch it targeted, or whether `git add reports-site` staged any changes.

## Changes

- Adds `visual-walkthrough.config.mjs` as the source-of-truth registry for pages and future states.
- Adds `scripts/visual-walkthrough.mjs` to generate `reports-site/index.html`, `reports-site/manifest.json`, and `reports-site/screenshots/*.png`.
- Adds `npm run qa:visual-walkthrough`.
- Adds `tests/visual-walkthrough-registry.test.js` so every public application HTML route must be registered.
- Adds `docs/qa/visual-walkthrough.md` explaining how to add new pages and interaction states.
- Updates `.github/workflows/qa-bdd.yml` so the walkthrough job runs the application visual walkthrough rather than Cucumber screenshot capture.
- Adds explicit persistence-target diagnostics to the workflow.
- Adds staged diff diagnostics before committing `reports-site/`.
- Keeps `reports-site/**` ignored by push triggers to avoid update loops.
- Keeps Cloudflare Pages deployment gated to manual `workflow_dispatch` runs where `publish_reporting_site` is true.

## Intended model

The Cucumber suite remains a smoke/regression suite.

The application visual walkthrough becomes a build evidence artefact. It is registry-driven. New pages and features should add or update entries in `visual-walkthrough.config.mjs` in the same PR that introduces the UI.

## Validation status

Not executed locally from this environment.

Recommended checks after merge:

1. Run `npm run lint`.
2. Run `npm test`.
3. Run `qa-bdd` manually from `main` with `publish_reporting_site: true`.
4. Confirm the walkthrough job logs show `Report persistence enabled: true`.
5. Confirm the workflow prints staged changes for `reports-site/`.
6. Confirm the workflow creates `Update application visual walkthrough report` when report files changed.
7. Confirm `reports-site/manifest.json` and `reports-site/index.html` update on `main`.
8. Confirm `https://reopsreporting.pages.dev/` shows the same `Run started` timestamp as `reports-site/manifest.json`.

## Notes

This PR does not attempt to define every possible interaction state for every page. It creates the registry and evidence mechanism needed to add those states deliberately as features mature.