### PR TITLE
Extend visual walkthrough for start wizard states

### DIFF
--- a/docs/qa/visual-walkthrough.md
+++ b/docs/qa/visual-walkthrough.md
@@ -101,6 +101,89 @@ Supported action types are:
 
 Prefer stable selectors such as `data-testid`, semantic landmarks, labelled controls and GOV.UK component classes. Avoid brittle selectors based on position or incidental CSS.
 
+## Capturing wizard flows
+
+Wizard flows should be captured as a sequence of named states on the same page entry.
+
+A state should recreate all preceding steps needed to reach that point. This makes each screenshot independent and prevents state leakage between screenshots.
+
+Example:
+
+```js
+const stepOneActions = [
+	{
+		type: 'fill',
+		selector: '#p_name',
+		value: 'Assisted Digital Support Discovery',
+	},
+	{
+		type: 'fill',
+		selector: '#p_desc',
+		value: 'Research how users find and use assisted digital support.',
+	},
+];
+
+const stepTwoActions = [
+	...stepOneActions,
+	{
+		type: 'click',
+		selector: '#next2',
+	},
+	{
+		type: 'waitForSelector',
+		selector: '#step2',
+		state: 'visible',
+	},
+];
+```
+
+## Mocking AI and network-dependent states
+
+Use `mockRoutes` for deterministic visual states that depend on an API response. This avoids making the visual walkthrough dependent on live AI responses, model latency, quota or content variation.
+
+Example:
+
+```js
+{
+	id: 'objectives-ai-rewrite-shown',
+	title: 'Objectives AI rewrite shown',
+	description: 'Shows the AI rewrite panel after the objectives threshold is met.',
+	mockRoutes: [
+		{
+			url: '**/api/ai-rewrite**',
+			method: 'POST',
+			body: {
+				summary: 'The objectives are clear and researchable.',
+				suggestions: [
+					{
+						category: 'Focus',
+						severity: 'medium',
+						tip: 'Make each objective test one decision or assumption.',
+						why: 'This helps the team trace findings back to specific service decisions.',
+					},
+				],
+				rewrite: '1. Understand where users need support.\n2. Identify operational signals.',
+				flags: {
+					possible_personal_data: false,
+				},
+			},
+		},
+	],
+	actions: [
+		{
+			type: 'click',
+			selector: '#btn-obj-ai-rewrite',
+		},
+		{
+			type: 'waitForText',
+			text: 'Concise rewrite (optional):',
+		},
+	],
+}
+```
+
+Prefer mocked AI responses for walkthrough evidence. Live AI calls should be reserved for integration tests where the purpose is to test the service boundary.
+
 ## Local command
 
 Run:

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -145,6 +145,31 @@ async function settlePage(page) {
 	await page.waitForTimeout(200);
 }
 
+/** Register deterministic network fixtures declared in the registry state. */
+async function registerMockRoutes(page, stateConfig) {
+	for (const mockRoute of stateConfig.mockRoutes || []) {
+		await page.route(mockRoute.url, async (route) => {
+			const request = route.request();
+			const requestMethod = request.method().toUpperCase();
+			const expectedMethod = String(mockRoute.method || requestMethod).toUpperCase();
+
+			if (requestMethod !== expectedMethod) {
+				await route.fallback();
+				return;
+			}
+
+			const body = typeof mockRoute.body === 'string' ? mockRoute.body : JSON.stringify(mockRoute.body ?? {});
+
+			await route.fulfill({
+				status: mockRoute.status ?? 200,
+				contentType: mockRoute.contentType || 'application/json',
+				headers: mockRoute.headers || {},
+				body,
+			});
+		});
+	}
+}
+
 /** Run an interaction action declared in the registry. */
 async function runAction(page, action) {
 	const timeout = action.timeout ?? 5000;
@@ -216,6 +241,8 @@ async function captureState(browser, pageConfig, stateConfig) {
 	const started = Date.now();
 
 	try {
+		await registerMockRoutes(page, stateConfig);
+
 		const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
 		if (!response) {

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -5,6 +5,94 @@
  * @summary Registry of application pages and states captured by the visual walkthrough report.
  */
 
+const startWizardProjectName = 'Assisted Digital Support Discovery';
+const startWizardProjectDescription =
+	'This discovery will examine how caseworkers and support staff help people who cannot complete a digital application without assistance. The research will focus on where users lose confidence, what information they need before starting, and how staff currently identify safeguarding, accessibility and language support needs.';
+const startWizardStakeholders = [
+	'Priya Shah | Service owner | priya.shah@example.gov.uk',
+	'Mark Evans | Operations lead | mark.evans@example.gov.uk',
+	'Amelia Brown | Policy adviser | amelia.brown@example.gov.uk',
+].join('\n');
+const startWizardObjectives = [
+	'Understand where users need assisted digital support during the application journey, including before they start, while completing evidence tasks, and after submission.',
+	'Identify the operational signals that help staff recognise accessibility, safeguarding, language and confidence-related needs without collecting unnecessary personal data.',
+	'Assess whether existing content and contact routes give users enough confidence to complete the service or seek support at the right time.',
+].join('\n');
+const startWizardUserGroups =
+	'Applicants with low digital confidence, support workers, caseworkers, users with accessibility needs, users who need language support';
+const startWizardLeadName = 'Alex Morgan';
+const startWizardLeadEmail = 'alex.morgan@example.gov.uk';
+const startWizardNotes =
+	'Initial recruitment should include users with different levels of digital confidence and staff who handle assisted digital requests. The team should review safeguarding and consent wording before moderated sessions begin.';
+
+const startWizardStepOneActions = [
+	{
+		type: 'fill',
+		selector: '#p_name',
+		value: startWizardProjectName,
+	},
+	{
+		type: 'fill',
+		selector: '#p_desc',
+		value: startWizardProjectDescription,
+	},
+	{
+		type: 'select',
+		selector: '#p_phase',
+		value: 'discovery',
+	},
+	{
+		type: 'select',
+		selector: '#p_status',
+		value: 'planning',
+	},
+];
+
+const startWizardStepTwoActions = [
+	...startWizardStepOneActions,
+	{
+		type: 'click',
+		selector: '#next2',
+	},
+	{
+		type: 'waitForSelector',
+		selector: '#step2',
+		state: 'visible',
+	},
+];
+
+const startWizardStepTwoFilledActions = [
+	...startWizardStepTwoActions,
+	{
+		type: 'fill',
+		selector: '#p_stakeholders',
+		value: startWizardStakeholders,
+	},
+	{
+		type: 'fill',
+		selector: '#p_objectives',
+		value: startWizardObjectives,
+	},
+	{
+		type: 'fill',
+		selector: '#p_usergroups',
+		value: startWizardUserGroups,
+	},
+];
+
+const startWizardStepThreeActions = [
+	...startWizardStepTwoFilledActions,
+	{
+		type: 'click',
+		selector: '#next3',
+	},
+	{
+		type: 'waitForSelector',
+		selector: '#step3',
+		state: 'visible',
+	},
+];
+
 export const visualWalkthroughConfig = {
 	title: 'ResearchOps application visual walkthrough',
 	description:
@@ -33,6 +121,110 @@ export const visualWalkthroughConfig = {
 			group: 'Core',
 			path: '/pages/start/index.html',
 			description: 'Start page for creating or beginning research project work.',
+			states: [
+				{
+					id: 'step-1-filled',
+					title: 'Step 1 completed with project definition',
+					description:
+						'Project name, description, phase and status entered using believable discovery-stage dummy data.',
+					actions: startWizardStepOneActions,
+				},
+				{
+					id: 'step-2-default',
+					title: 'Step 2 default state',
+					description:
+						'Second wizard step after a valid project definition has been entered on step 1.',
+					actions: startWizardStepTwoActions,
+				},
+				{
+					id: 'step-2-filled-no-ai',
+					title: 'Step 2 completed without AI rewrite invoked',
+					description:
+						'Stakeholders, objectives and user groups entered with realistic planning data before the AI rewrite is requested.',
+					actions: startWizardStepTwoFilledActions,
+				},
+				{
+					id: 'step-2-ai-rewrite-shown',
+					title: 'Step 2 AI rewrite shown',
+					description:
+						'Objectives meet the AI assistance threshold and the objectives AI rewrite panel is shown using a deterministic mocked response.',
+					mockRoutes: [
+						{
+							url: '**/api/ai-rewrite?mode=objectives',
+							method: 'POST',
+							body: {
+								summary:
+									'The objectives are clear and researchable. They could be tightened by separating user confidence, operational triage and content assurance into distinct learning goals.',
+								suggestions: [
+									{
+										category: 'Focus',
+										severity: 'medium',
+										tip: 'Make each objective test one decision or assumption.',
+										why: 'This helps the team trace findings back to specific service decisions.',
+									},
+									{
+										category: 'Inclusion',
+										severity: 'high',
+										tip: 'Include users with low digital confidence and users who need accessibility or language support.',
+										why: 'Assisted digital services can otherwise optimise for confident users and miss support needs.',
+									},
+								],
+								rewrite:
+									'1. Understand where applicants lose confidence or need assisted digital support during the application journey.\n2. Identify operational signals that help staff recognise accessibility, safeguarding and language support needs without collecting unnecessary personal data.\n3. Assess whether content and contact routes help users decide what to do next and seek support at the right time.',
+								flags: {
+									possible_personal_data: false,
+								},
+							},
+						},
+					],
+					actions: [
+						...startWizardStepTwoFilledActions,
+						{
+							type: 'waitForSelector',
+							selector: '#ai-objectives-tools:not(.hidden)',
+						},
+						{
+							type: 'click',
+							selector: '#btn-obj-ai-rewrite',
+						},
+						{
+							type: 'waitForText',
+							text: 'Concise rewrite (optional):',
+						},
+					],
+				},
+				{
+					id: 'step-3-default',
+					title: 'Step 3 default state',
+					description:
+						'Final wizard step after the project definition, stakeholders, objectives and user groups have been entered.',
+					actions: startWizardStepThreeActions,
+				},
+				{
+					id: 'step-3-filled',
+					title: 'Step 3 completed before create project',
+					description:
+						'Lead researcher, email and project notes entered on the final wizard step before project creation is submitted.',
+					actions: [
+						...startWizardStepThreeActions,
+						{
+							type: 'fill',
+							selector: '#lead_name',
+							value: startWizardLeadName,
+						},
+						{
+							type: 'fill',
+							selector: '#lead_email',
+							value: startWizardLeadEmail,
+						},
+						{
+							type: 'fill',
+							selector: '#p_notes',
+							value: startWizardNotes,
+						},
+					],
+				},
+			],
 		},
 		{
 			id: 'projects',

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -150,7 +150,7 @@ export const visualWalkthroughConfig = {
 						'Objectives meet the AI assistance threshold and the objectives AI rewrite panel is shown using a deterministic mocked response.',
 					mockRoutes: [
 						{
-							url: '**/api/ai-rewrite?mode=objectives',
+							url: '**/api/ai-rewrite**',
 							method: 'POST',
 							body: {
 								summary:


### PR DESCRIPTION
## Summary

Extends the application visual walkthrough so the `Start a new research project` wizard is captured as a staged flow rather than only as a default page screenshot.

## What changed

- Adds believable dummy project data for the start wizard walkthrough.
- Captures the default state automatically through the existing visual walkthrough generator.
- Adds explicit wizard states for:
  - step 1 completed with project name, description, service phase and status
  - step 2 default state after continuing from step 1
  - step 2 completed with stakeholders, objectives and user groups, before AI rewrite
  - step 2 with the objectives AI rewrite panel shown
  - step 3 default state after continuing from step 2
  - step 3 completed with lead researcher, email and notes
- Adds `mockRoutes` support to the visual walkthrough generator so AI-dependent states can be captured deterministically.
- Documents wizard-state capture and mocked AI/network states in `docs/qa/visual-walkthrough.md`.

## Why

The start page is the first step in a 3-step wizard. Capturing only the initial page state does not show the actual flow or the progressive form states a user experiences.

The AI rewrite state also needs deterministic capture. The walkthrough should not rely on a live AI response, model latency, quota or prompt variation. This PR adds registry-level network fixtures so the visual evidence remains stable.

## Validation status

Not executed locally from this environment.

Expected CI behaviour:

- `Format pull request` should auto-format if required.
- `npm run lint` should pass after formatting.
- `npm test` should continue to pass.
- A manual `qa-bdd` run from `main` after merge should regenerate the reporting site with the new start wizard states.

## Notes

This PR implements the first requested extension only: the start wizard walkthrough. It does not broaden state capture for other pages yet.