### PR TITLE
Make project dashboard navigation more explicit

### DIFF
--- a/public/css/projects.css
+++ b/public/css/projects.css
@@ -23,19 +23,21 @@
 	}
 
 .project-title .govuk-link {
-	color: #0b0c0c;
-	text-decoration: none;
+	color: #1d70b8;
 	font-weight: 700;
+	text-decoration: underline;
+	text-decoration-thickness: max(1px, .0625rem);
+	text-underline-offset: 0.1em;
 	}
 
 .project-title .govuk-link:hover,
 .project-title .govuk-link:focus {
-	color: #0b0c0c;
-	text-decoration: underline;
+	color: #003078;
+	text-decoration-thickness: max(3px, .1875rem);
 	}
 
 .project-title .govuk-link:visited {
-	color: #0b0c0c;
+	color: #4c2c92;
 	}
 
 .project-meta {
@@ -48,6 +50,17 @@
 
 .project-summary {
 	margin-bottom: 8px;
+	}
+
+.project-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	margin: 12px 0 8px;
+	}
+
+.project-dashboard-action {
+	margin-bottom: 0;
 	}
 
 .user-groups {

--- a/public/js/projects-page.js
+++ b/public/js/projects-page.js
@@ -177,8 +177,18 @@ async function listProjects() {
 	}
 }
 
+function projectDashboardHref(projectId) {
+	return `/pages/project-dashboard/?id=${encodeURIComponent(projectId || "")}`;
+}
+
+function projectDashboardLabel(project) {
+	return `View dashboard for ${project.name || "this project"}`;
+}
+
 function projectCard(project) {
 	const projectId = encodeURIComponent(project.id || "");
+	const dashboardHref = projectDashboardHref(project.id || "");
+	const dashboardLabel = escapeHtml(projectDashboardLabel(project));
 	const groups = (project.user_groups || [])
 		.map(group => `<li><span class="tag">${escapeHtml(group)}</span></li>`)
 		.join("");
@@ -196,10 +206,13 @@ function projectCard(project) {
 <article class="card" aria-labelledby="project-title-${projectId}">
 	<p class="project-org">${escapeHtml(project.org || project.Org || "Home Office Biometrics")}</p>
 	<h2 id="project-title-${projectId}" class="project-title govuk-heading-m">
-		<a class="govuk-link" href="/pages/project-dashboard/?id=${projectId}" rel="bookmark">${escapeHtml(project.name)}</a>
+		<a class="govuk-link" href="${dashboardHref}" rel="bookmark">${escapeHtml(project.name)}</a>
 	</h2>
 	<p class="project-meta"><strong>Phase:</strong> ${escapeHtml(project["rops:servicePhase"] || "")} · <strong>Status:</strong> ${escapeHtml(project["rops:projectStatus"] || "")}</p>
 	${project.description ? `<section class="project-summary"><p>${escapeHtml(project.description)}</p></section>` : ""}
+	<p class="project-actions">
+		<a class="govuk-button govuk-button--secondary project-dashboard-action" href="${dashboardHref}" aria-label="${dashboardLabel}">View dashboard</a>
+	</p>
 	${project.user_groups?.length ? `<section class="user-groups" aria-labelledby="user-groups-${projectId}"><h3 id="user-groups-${projectId}" class="project-groups-title">User Groups</h3><ul class="tags" role="list">${groups}</ul></section>` : ""}
 	<section class="project-extra">
 		<details class="project-details">

--- a/public/pages/projects/index.html
+++ b/public/pages/projects/index.html
@@ -13,6 +13,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/projects.css" media="screen" />
 
 	<script type="module" src="/components/layout.js" defer></script>

--- a/tests/projects-page-route-state.test.js
+++ b/tests/projects-page-route-state.test.js
@@ -14,6 +14,7 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "href=\"/css/screen.css\"", "Projects page");
+includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "Projects page");
 includes(pageSource, "href=\"/css/projects.css\"", "Projects page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/projects-page.js\"", "Projects page");
 includes(pageSource, "src=\"/js/projects-page.js\"", "Projects page");
@@ -25,6 +26,10 @@ includes(stylesheetSource, ".project-org", "Projects stylesheet");
 includes(stylesheetSource, ".project-title", "Projects stylesheet");
 includes(stylesheetSource, ".project-meta", "Projects stylesheet");
 includes(stylesheetSource, ".project-summary", "Projects stylesheet");
+includes(stylesheetSource, ".project-actions", "Projects stylesheet");
+includes(stylesheetSource, ".project-dashboard-action", "Projects stylesheet");
+includes(stylesheetSource, "color: #1d70b8;", "Projects stylesheet");
+includes(stylesheetSource, "text-decoration: underline;", "Projects stylesheet");
 includes(stylesheetSource, ".user-groups", "Projects stylesheet");
 includes(stylesheetSource, ".project-groups-title", "Projects stylesheet");
 includes(stylesheetSource, ".tags", "Projects stylesheet");
@@ -41,6 +46,13 @@ includes(controllerSource, "project-org", "Projects controller");
 includes(controllerSource, "project-title", "Projects controller");
 includes(controllerSource, "project-meta", "Projects controller");
 includes(controllerSource, "project-summary", "Projects controller");
+includes(controllerSource, "project-actions", "Projects controller");
+includes(controllerSource, "project-dashboard-action", "Projects controller");
+includes(controllerSource, "View dashboard", "Projects controller");
+includes(controllerSource, "View dashboard for", "Projects controller");
+includes(controllerSource, "projectDashboardHref", "Projects controller");
+includes(controllerSource, "projectDashboardLabel", "Projects controller");
+includes(controllerSource, "govuk-button govuk-button--secondary", "Projects controller");
 includes(controllerSource, "user-groups", "Projects controller");
 includes(controllerSource, "project-groups-title", "Projects controller");
 includes(controllerSource, "tags", "Projects controller");


### PR DESCRIPTION
## Summary

Makes the route from the Projects page to each Project Dashboard more visible and actionable.

## Role-led decision

- User Research: the current project-name-only link is easy to overlook in a dense list, especially where users scan the project title as a heading rather than an action.
- Interaction Design: a dedicated row/card action makes the next step clearer without removing the existing project-name link.
- Accessibility: the new action has visible text and an accessible name that includes the project name, for example `View dashboard for Assisted Digital Support Discovery`.
- GOV.UK: keeps navigation as an anchor with `href`, styled using the GOV.UK secondary button class for a strong navigation affordance.
- Content Design: uses `View dashboard`, which is concise, destination-led and more descriptive than `Open` or `More`.
- Information Architecture: treats Project Dashboard as the primary destination from a project entity in the Projects list.
- Software Development: keeps the existing dashboard URL construction and adds small helper functions to prevent duplicate inline URL/label logic.

## Changes

- Adds `/css/govuk/govuk-buttons.css` to the Projects page.
- Keeps the project title link, but restores standard GOV.UK link affordance: blue, underlined, visited colour.
- Adds an explicit `View dashboard` secondary GOV.UK button-style link to each project card.
- Adds an accessible `aria-label` that names the project.
- Adds route-state assertions for the new button, helper functions and stylesheet contract.

## Validation

Not executed locally from this environment. The repository PR formatter should format the changed files if Prettier finds any difference.

Expected checks:

- `npm run lint`
- `npm test`
- visual walkthrough update for `/pages/projects/` after merge

## Notes

This keeps the project-name link for users who already expect it, but no longer makes that hidden-looking title link the only route into the dashboard.