### PR TITLE
Bust Projects page asset cache for dashboard action

### DIFF
--- a/public/pages/projects/index.html
+++ b/public/pages/projects/index.html
@@ -9,12 +9,12 @@
 
 	<link rel="dns-prefetch" href="//rops-api.digikev-kevin-rapley.workers.dev" />
 	<link rel="preconnect" href="https://rops-api.digikev-kevin-rapley.workers.dev" crossorigin />
-	<link rel="modulepreload" href="/js/projects-page.js" />
+	<link rel="modulepreload" href="/js/projects-page.js?v=projects-dashboard-action-20260501" />
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/projects.css" media="screen" />
+	<link rel="stylesheet" href="/css/projects.css?v=projects-dashboard-action-20260501" media="screen" />
 
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -35,7 +35,7 @@
 	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'>
 	</x-include>
 
-	<script type="module" src="/js/projects-page.js"></script>
+	<script type="module" src="/js/projects-page.js?v=projects-dashboard-action-20260501"></script>
 </body>
 
 </html>

--- a/tests/projects-page-route-state.test.js
+++ b/tests/projects-page-route-state.test.js
@@ -15,9 +15,21 @@ function excludes(source, text, label) {
 
 includes(pageSource, "href=\"/css/screen.css\"", "Projects page");
 includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "Projects page");
-includes(pageSource, "href=\"/css/projects.css\"", "Projects page");
-includes(pageSource, "rel=\"modulepreload\" href=\"/js/projects-page.js\"", "Projects page");
-includes(pageSource, "src=\"/js/projects-page.js\"", "Projects page");
+includes(
+  pageSource,
+  "href=\"/css/projects.css?v=projects-dashboard-action-20260501\"",
+  "Projects page"
+);
+includes(
+  pageSource,
+  "rel=\"modulepreload\" href=\"/js/projects-page.js?v=projects-dashboard-action-20260501\"",
+  "Projects page"
+);
+includes(
+  pageSource,
+  "src=\"/js/projects-page.js?v=projects-dashboard-action-20260501\"",
+  "Projects page"
+);
 includes(pageSource, "src=\"/components/layout.js\" defer", "Projects page");
 includes(pageSource, "id=\"list\"", "Projects page");
 excludes(pageSource, "<script type=\"module\">", "Projects page");


### PR DESCRIPTION
## Summary

Fixes the live Projects page showing the updated link styling but not the new `View dashboard` button on iPad Chrome.

## Diagnosis

The evidence points to a mixed asset state: the deployed stylesheet is fresh enough to show the restored GOV.UK link styling, but the browser is still executing a stale `/js/projects-page.js` module. The button is rendered by `projects-page.js`, not by the HTML or CSS. That means the page can look partly updated while still missing the action button.

## Changes

- Adds a version query to the Projects page `modulepreload` reference for `/js/projects-page.js`.
- Adds the same version query to the executable Projects page module script.
- Adds a version query to `/css/projects.css` so this route's page-specific stylesheet updates as a pair with the page controller.
- Updates route-state assertions so future work protects the cache-busting contract.

## Validation

Expected checks:

- `npm run lint`
- `npm test`
- `npm run validate`

After deployment, verify:

- `https://researchops.pages.dev/pages/projects/?v=projects-dashboard-action-20260501`
- `https://researchops.pages.dev/js/projects-page.js?v=projects-dashboard-action-20260501` contains `View dashboard`

## Notes

This is a targeted route-level cache fix. It does not change the project card rendering logic already merged in PR 138.