### PR TITLE
Add synthesis visual walkthrough states

### DIFF
--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -204,10 +204,12 @@ async function captureReport() {
 
 	try {
 		for (const pageConfig of visualWalkthroughConfig.pages) {
-			const states = [
-				{ id: 'default', title: 'Default state', description: 'Initial loaded page state.' },
-				...(pageConfig.states || []),
-			];
+			const defaultState = pageConfig.defaultState || {
+				id: 'default',
+				title: 'Default state',
+				description: 'Initial loaded page state.',
+			};
+			const states = [defaultState, ...(pageConfig.states || [])];
 			const capturedStates = [];
 
 			for (const stateConfig of states) {

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -9,6 +9,10 @@ import { chromium } from 'playwright';
 import fs from 'node:fs';
 import path from 'node:path';
 import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
+import {
+	synthesisDefaultState,
+	synthesisVisualStates,
+} from '../visual-walkthrough.synthesis-states.mjs';
 
 const OUTPUT_DIR = 'reports-site';
 const SCREENSHOTS_DIR = path.join(OUTPUT_DIR, 'screenshots');
@@ -93,6 +97,18 @@ function validateRegistry() {
 	if (failures.length > 0) {
 		throw new Error(`Visual walkthrough registry is incomplete:\n- ${failures.join('\n- ')}`);
 	}
+}
+
+function pageCaptureConfig(pageConfig) {
+	if (pageConfig.id !== 'synthesize') return pageConfig;
+
+	return {
+		...pageConfig,
+		title: 'Study synthesis',
+		description: 'Study-scoped evidence grouping and theme creation page.',
+		defaultState: synthesisDefaultState,
+		states: [...(pageConfig.states || []), ...synthesisVisualStates],
+	};
 }
 
 async function settlePage(page) {
@@ -203,7 +219,8 @@ async function captureReport() {
 	const failures = [];
 
 	try {
-		for (const pageConfig of visualWalkthroughConfig.pages) {
+		for (const rawPageConfig of visualWalkthroughConfig.pages) {
+			const pageConfig = pageCaptureConfig(rawPageConfig);
 			const defaultState = pageConfig.defaultState || {
 				id: 'default',
 				title: 'Default state',

--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -2,6 +2,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
+import { synthesisPath } from '../visual-walkthrough.synthesis-fixtures.mjs';
+import {
+	synthesisDefaultState,
+	synthesisVisualStates,
+} from '../visual-walkthrough.synthesis-states.mjs';
 
 function listHtmlFiles(dir) {
 	if (!fs.existsSync(dir)) return [];
@@ -41,6 +46,7 @@ const discoveredRoutes = listHtmlFiles(visualWalkthroughConfig.publicRoot)
 
 const registeredRoutes = visualWalkthroughConfig.pages.map((page) => page.path);
 const registeredIds = visualWalkthroughConfig.pages.map((page) => page.id);
+const synthesisStateIds = synthesisVisualStates.map((state) => state.id);
 
 for (const route of discoveredRoutes) {
 	assert.ok(
@@ -64,3 +70,38 @@ assert.equal(
 	registeredIds.length,
 	'Expected registered page ids to be unique'
 );
+
+assert.equal(
+	synthesisDefaultState.id,
+	'missing-sid-error',
+	'Expected synthesis walkthrough to capture the missing study ID error as its default state'
+);
+
+assert.deepEqual(
+	synthesisStateIds,
+	[
+		'empty-evidence',
+		'evidence-loaded',
+		'working-cluster-created',
+		'evidence-added-to-cluster',
+		'theme-blocked-without-evidence',
+		'theme-created',
+	],
+	'Expected synthesis walkthrough states to cover the production first-slice workflow'
+);
+
+for (const state of synthesisVisualStates) {
+	assert.equal(
+		state.path,
+		synthesisPath,
+		`Expected synthesis state to use the study-scoped route: ${state.id}`
+	);
+	assert.ok(
+		Array.isArray(state.mockRoutes) && state.mockRoutes.length >= 2,
+		`Expected synthesis state to provide mocked API routes: ${state.id}`
+	);
+	assert.ok(
+		Array.isArray(state.actions) && state.actions.length >= 1,
+		`Expected synthesis state to provide capture actions: ${state.id}`
+	);
+}

--- a/visual-walkthrough.synthesis-fixtures.mjs
+++ b/visual-walkthrough.synthesis-fixtures.mjs
@@ -12,7 +12,8 @@ export const synthesisPath = `/pages/synthesize/?pid=${synthesisProjectId}&sid=$
 const synthesisEvidenceRoute = /\/api\/synthesis\/evidence(?:\?.*)?$/;
 const synthesisSummaryRoute = /\/api\/synthesis(?:\?.*)?$/;
 const synthesisClusterCreateRoute = /\/api\/synthesis\/clusters(?:\?.*)?$/;
-const synthesisClusterUpdateRoute = /\/api\/synthesis\/clusters\/cluster-confidence-start(?:\?.*)?$/;
+const synthesisClusterUpdateRoute =
+	/\/api\/synthesis\/clusters\/cluster-confidence-start(?:\?.*)?$/;
 const synthesisThemeCreateRoute = /\/api\/synthesis\/themes(?:\?.*)?$/;
 
 export const synthesisStudy = {
@@ -73,7 +74,12 @@ export const synthesisTheme = {
 	evidenceIds: ['ev-confidence-before-start', 'ev-language-support'],
 };
 
-export function synthesisMockRoutes({ evidence = synthesisEvidence, clusters = [], themes = [], extraRoutes = [] } = {}) {
+export function synthesisMockRoutes({
+	evidence = synthesisEvidence,
+	clusters = [],
+	themes = [],
+	extraRoutes = [],
+} = {}) {
 	return [
 		{
 			url: synthesisEvidenceRoute,

--- a/visual-walkthrough.synthesis-fixtures.mjs
+++ b/visual-walkthrough.synthesis-fixtures.mjs
@@ -1,0 +1,132 @@
+/* eslint-env node */
+
+/**
+ * @file visual-walkthrough.synthesis-fixtures.mjs
+ * @summary Deterministic mocked states for the study synthesis visual walkthrough.
+ */
+
+export const synthesisProjectId = 'recVisualProject001';
+export const synthesisStudyId = 'recVisualStudy001';
+export const synthesisPath = `/pages/synthesize/?pid=${synthesisProjectId}&sid=${synthesisStudyId}`;
+
+const synthesisEvidenceRoute = /\/api\/synthesis\/evidence(?:\?.*)?$/;
+const synthesisSummaryRoute = /\/api\/synthesis(?:\?.*)?$/;
+const synthesisClusterCreateRoute = /\/api\/synthesis\/clusters(?:\?.*)?$/;
+const synthesisClusterUpdateRoute = /\/api\/synthesis\/clusters\/cluster-confidence-start(?:\?.*)?$/;
+const synthesisThemeCreateRoute = /\/api\/synthesis\/themes(?:\?.*)?$/;
+
+export const synthesisStudy = {
+	id: synthesisStudyId,
+	studyId: 'STUDY-ADS-001',
+	projectId: synthesisProjectId,
+	projectName: 'Assisted Digital Support Discovery',
+	title: 'Assisted digital support interview round 1',
+	method: 'Moderated interview',
+	status: 'Analysis',
+};
+
+export const synthesisEvidence = [
+	{
+		id: 'ev-confidence-before-start',
+		sessionId: 'session-assisted-digital-01',
+		sourceLabel: 'Session 1 · Applicant with low digital confidence',
+		excerpt:
+			'I was not sure whether I had the right documents before I started, so I nearly called the helpline instead of continuing online.',
+		tags: ['confidence', 'before-start', 'assisted-digital'],
+	},
+	{
+		id: 'ev-language-support',
+		sessionId: 'session-assisted-digital-02',
+		sourceLabel: 'Session 2 · Support worker',
+		excerpt:
+			'People often need to understand what evidence is being asked for before they feel ready to enter anything into the form.',
+		tags: ['language-support', 'evidence', 'trust'],
+	},
+	{
+		id: 'ev-operational-handoff',
+		sessionId: 'session-assisted-digital-03',
+		sourceLabel: 'Session 3 · Caseworker',
+		excerpt:
+			'Staff need a clear way to recognise when a user cannot complete the journey without a supported handoff.',
+		tags: ['handoff', 'operations', 'support'],
+	},
+];
+
+export const synthesisEmptyCluster = {
+	id: 'cluster-confidence-start',
+	label: 'Confidence before the form starts',
+	description: 'Evidence about how users judge whether they are ready to begin the service.',
+	evidenceIds: [],
+};
+
+export const synthesisClusterWithEvidence = {
+	...synthesisEmptyCluster,
+	evidenceIds: ['ev-confidence-before-start', 'ev-language-support'],
+};
+
+export const synthesisTheme = {
+	id: 'theme-confidence-before-start',
+	clusterId: 'cluster-confidence-start',
+	label: 'Digital confidence is shaped before the form starts',
+	description:
+		'Users decide whether to continue based on evidence expectations, support routes and confidence before they begin entering details.',
+	evidenceIds: ['ev-confidence-before-start', 'ev-language-support'],
+};
+
+export function synthesisMockRoutes({ evidence = synthesisEvidence, clusters = [], themes = [], extraRoutes = [] } = {}) {
+	return [
+		{
+			url: synthesisEvidenceRoute,
+			method: 'GET',
+			body: {
+				ok: true,
+				study: synthesisStudy,
+				evidence,
+			},
+		},
+		{
+			url: synthesisSummaryRoute,
+			method: 'GET',
+			body: {
+				ok: true,
+				study: synthesisStudy,
+				clusters,
+				themes,
+			},
+		},
+		...extraRoutes,
+	];
+}
+
+export function clusterCreateMockRoute() {
+	return {
+		url: synthesisClusterCreateRoute,
+		method: 'POST',
+		body: {
+			ok: true,
+			cluster: synthesisEmptyCluster,
+		},
+	};
+}
+
+export function clusterUpdateMockRoute() {
+	return {
+		url: synthesisClusterUpdateRoute,
+		method: 'PATCH',
+		body: {
+			ok: true,
+			cluster: synthesisClusterWithEvidence,
+		},
+	};
+}
+
+export function themeCreateMockRoute() {
+	return {
+		url: synthesisThemeCreateRoute,
+		method: 'POST',
+		body: {
+			ok: true,
+			theme: synthesisTheme,
+		},
+	};
+}

--- a/visual-walkthrough.synthesis-states.mjs
+++ b/visual-walkthrough.synthesis-states.mjs
@@ -1,0 +1,181 @@
+/* eslint-env node */
+
+/**
+ * @file visual-walkthrough.synthesis-states.mjs
+ * @summary State catalogue for the study synthesis visual walkthrough.
+ */
+
+import {
+	clusterCreateMockRoute,
+	clusterUpdateMockRoute,
+	synthesisClusterWithEvidence,
+	synthesisEmptyCluster,
+	synthesisEvidence,
+	synthesisMockRoutes,
+	synthesisPath,
+	synthesisTheme,
+	themeCreateMockRoute,
+} from './visual-walkthrough.synthesis-fixtures.mjs';
+
+export const synthesisDefaultState = {
+	id: 'missing-sid-error',
+	title: 'Missing study ID error state',
+	description: 'Synthesis loaded without a study ID; the page shows the blocking route-context error.',
+};
+
+export const synthesisVisualStates = [
+	{
+		id: 'empty-evidence',
+		title: 'Empty evidence state',
+		description: 'Study synthesis loaded with valid study context but no captured evidence notes.',
+		path: synthesisPath,
+		mockRoutes: synthesisMockRoutes({ evidence: [] }),
+		actions: [
+			{
+				type: 'waitForText',
+				text: 'No evidence has been captured for this study yet',
+			},
+		],
+	},
+	{
+		id: 'evidence-loaded',
+		title: 'Evidence loaded state',
+		description: 'Study synthesis with realistic evidence notes loaded from mocked session evidence.',
+		path: synthesisPath,
+		mockRoutes: synthesisMockRoutes(),
+		actions: [
+			{
+				type: 'waitForText',
+				text: synthesisEvidence[0].excerpt,
+			},
+		],
+	},
+	{
+		id: 'working-cluster-created',
+		title: 'Working cluster grouping created',
+		description: 'A researcher creates a provisional working cluster grouping before adding evidence.',
+		path: synthesisPath,
+		mockRoutes: synthesisMockRoutes({ extraRoutes: [clusterCreateMockRoute()] }),
+		actions: [
+			{
+				type: 'fill',
+				selector: '#cluster-label',
+				value: synthesisEmptyCluster.label,
+			},
+			{
+				type: 'fill',
+				selector: '#cluster-description',
+				value: synthesisEmptyCluster.description,
+			},
+			{
+				type: 'click',
+				selector: '#create-cluster',
+			},
+			{
+				type: 'waitForText',
+				text: `Created cluster ${synthesisEmptyCluster.label}.`,
+			},
+		],
+	},
+	{
+		id: 'evidence-added-to-cluster',
+		title: 'Evidence added to working cluster grouping',
+		description:
+			'A researcher selects two evidence notes and adds them to an existing working cluster grouping.',
+		path: synthesisPath,
+		mockRoutes: synthesisMockRoutes({
+			clusters: [synthesisEmptyCluster],
+			extraRoutes: [clusterUpdateMockRoute()],
+		}),
+		actions: [
+			{
+				type: 'check',
+				selector: '#evidence-ev-confidence-before-start',
+			},
+			{
+				type: 'check',
+				selector: '#evidence-ev-language-support',
+			},
+			{
+				type: 'select',
+				selector: '#target-cluster',
+				value: synthesisEmptyCluster.id,
+			},
+			{
+				type: 'click',
+				selector: '#add-selected-evidence',
+			},
+			{
+				type: 'waitForText',
+				text: `Added 2 evidence items to ${synthesisEmptyCluster.label}.`,
+			},
+		],
+	},
+	{
+		id: 'theme-blocked-without-evidence',
+		title: 'Theme creation blocked without evidence',
+		description: 'Theme creation is blocked until the selected cluster contains source evidence.',
+		path: synthesisPath,
+		mockRoutes: synthesisMockRoutes({ clusters: [synthesisEmptyCluster] }),
+		actions: [
+			{
+				type: 'select',
+				selector: '#theme-cluster',
+				value: synthesisEmptyCluster.id,
+			},
+			{
+				type: 'fill',
+				selector: '#theme-label',
+				value: synthesisTheme.label,
+			},
+			{
+				type: 'click',
+				selector: '#create-theme',
+			},
+			{
+				type: 'waitForText',
+				text: 'Add at least one evidence item to the cluster before creating a theme.',
+			},
+		],
+	},
+	{
+		id: 'theme-created',
+		title: 'Theme created with evidence traceability',
+		description:
+			'A theme is created from a populated cluster and the source evidence IDs remain inspectable.',
+		path: synthesisPath,
+		mockRoutes: synthesisMockRoutes({
+			clusters: [synthesisClusterWithEvidence],
+			extraRoutes: [themeCreateMockRoute()],
+		}),
+		actions: [
+			{
+				type: 'select',
+				selector: '#theme-cluster',
+				value: synthesisEmptyCluster.id,
+			},
+			{
+				type: 'fill',
+				selector: '#theme-label',
+				value: synthesisTheme.label,
+			},
+			{
+				type: 'fill',
+				selector: '#theme-description',
+				value: synthesisTheme.description,
+			},
+			{
+				type: 'click',
+				selector: '#create-theme',
+			},
+			{
+				type: 'waitForText',
+				text: `Created theme ${synthesisTheme.label}.`,
+			},
+			{
+				type: 'click',
+				selector: '.theme-card .govuk-details__summary',
+			},
+		],
+	},
+];

--- a/visual-walkthrough.synthesis-states.mjs
+++ b/visual-walkthrough.synthesis-states.mjs
@@ -20,7 +20,8 @@ import {
 export const synthesisDefaultState = {
 	id: 'missing-sid-error',
 	title: 'Missing study ID error state',
-	description: 'Synthesis loaded without a study ID; the page shows the blocking route-context error.',
+	description:
+		'Synthesis loaded without a study ID; the page shows the blocking route-context error.',
 };
 
 export const synthesisVisualStates = [
@@ -40,7 +41,8 @@ export const synthesisVisualStates = [
 	{
 		id: 'evidence-loaded',
 		title: 'Evidence loaded state',
-		description: 'Study synthesis with realistic evidence notes loaded from mocked session evidence.',
+		description:
+			'Study synthesis with realistic evidence notes loaded from mocked session evidence.',
 		path: synthesisPath,
 		mockRoutes: synthesisMockRoutes(),
 		actions: [
@@ -53,7 +55,8 @@ export const synthesisVisualStates = [
 	{
 		id: 'working-cluster-created',
 		title: 'Working cluster grouping created',
-		description: 'A researcher creates a provisional working cluster grouping before adding evidence.',
+		description:
+			'A researcher creates a provisional working cluster grouping before adding evidence.',
 		path: synthesisPath,
 		mockRoutes: synthesisMockRoutes({ extraRoutes: [clusterCreateMockRoute()] }),
 		actions: [


### PR DESCRIPTION
## Summary

Adds deterministic visual walkthrough states for the study-scoped synthesis page.

## Changes

- Adds a small runner hook for page-level custom default states.
- Adds dedicated synthesis walkthrough fixtures.
- Adds a dedicated synthesis walkthrough state catalogue.
- Adds contract coverage for the synthesis state catalogue.

## States covered

- missing study ID
- empty evidence
- evidence loaded
- working cluster grouping created
- evidence added to grouping
- theme creation blocked until evidence exists
- theme created with source evidence IDs

## Validation

Not run locally from this environment. Expected checks are `npm run lint`, `npm test`, `npm run validate`, and `npm run qa:visual-walkthrough`.