### PR TITLE
Fix synthesis walkthrough action states

### DIFF
--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
-import { synthesisPath } from '../visual-walkthrough.synthesis-fixtures.mjs';
+import { synthesisEmptyCluster, synthesisPath } from '../visual-walkthrough.synthesis-fixtures.mjs';
 import {
 	synthesisDefaultState,
 	synthesisVisualStates,
@@ -38,6 +38,16 @@ function routeFromPublicFile(filePath) {
 	if (relativePath === 'index.html') return '/';
 
 	return `/${relativePath}`;
+}
+
+function stateById(stateId) {
+	return synthesisVisualStates.find((state) => state.id === stateId);
+}
+
+function actionTextValues(stateId) {
+	return (stateById(stateId)?.actions || [])
+		.filter((action) => action.type === 'waitForText')
+		.map((action) => action.text);
 }
 
 const discoveredRoutes = listHtmlFiles(visualWalkthroughConfig.publicRoot)
@@ -88,6 +98,20 @@ assert.deepEqual(
 		'theme-created',
 	],
 	'Expected synthesis walkthrough states to cover the production first-slice workflow'
+);
+
+assert.ok(
+	actionTextValues('working-cluster-created').includes(
+		`Created working cluster grouping ${synthesisEmptyCluster.label}.`
+	),
+	'Expected cluster creation capture to wait for the production status text'
+);
+
+assert.ok(
+	actionTextValues('theme-blocked-without-evidence').includes(
+		'Add evidence to a working cluster grouping before creating a theme.'
+	),
+	'Expected blocked theme capture to wait for the disabled-control hint rather than selecting a disabled control'
 );
 
 for (const state of synthesisVisualStates) {

--- a/visual-walkthrough.synthesis-states.mjs
+++ b/visual-walkthrough.synthesis-states.mjs
@@ -76,7 +76,7 @@ export const synthesisVisualStates = [
 			},
 			{
 				type: 'waitForText',
-				text: `Created cluster ${synthesisEmptyCluster.label}.`,
+				text: `Created working cluster grouping ${synthesisEmptyCluster.label}.`,
 			},
 		],
 	},
@@ -122,22 +122,12 @@ export const synthesisVisualStates = [
 		mockRoutes: synthesisMockRoutes({ clusters: [synthesisEmptyCluster] }),
 		actions: [
 			{
-				type: 'select',
-				selector: '#theme-cluster',
-				value: synthesisEmptyCluster.id,
-			},
-			{
-				type: 'fill',
-				selector: '#theme-label',
-				value: synthesisTheme.label,
-			},
-			{
-				type: 'click',
-				selector: '#create-theme',
+				type: 'waitForText',
+				text: synthesisEmptyCluster.label,
 			},
 			{
 				type: 'waitForText',
-				text: 'Add at least one evidence item to the cluster before creating a theme.',
+				text: 'Add evidence to a working cluster grouping before creating a theme.',
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

Fixes the two failing synthesis visual walkthrough states from the latest run.

## Failure analysis

The visual walkthrough runner reached the new synthesis states correctly, but two state actions were out of sync with the production page controller:

```text
failed synthesize/working-cluster-created
waiting for getByText('Created cluster Confidence before the form starts.').first()
```

The production controller emits:

```text
Created working cluster grouping Confidence before the form starts.
```

The walkthrough was waiting for stale status text.

```text
failed synthesize/theme-blocked-without-evidence
locator.selectOption: Timeout 5000ms exceeded
locator('#theme-cluster') resolved to disabled select
```

That state was trying to select a disabled theme-cluster control. The page is behaving correctly. A cluster with no evidence is intentionally not eligible for theme creation, so the theme selector is disabled. The visual state should capture the disabled-control/hint state rather than trying to force an impossible interaction.

## Changes

- Updates `working-cluster-created` to wait for the real production status text.
- Reworks `theme-blocked-without-evidence` to capture the disabled state by waiting for:
  - the empty cluster label
  - the production hint: `Add evidence to a working cluster grouping before creating a theme.`
- Adds registry test assertions so these two behaviours stay aligned with the page controller.

## Expected result

The next walkthrough run should capture all synthesis states without failures and allow report persistence to continue to `reports-site`.

Expected synthesis captures:

```text
synthesize/missing-sid-error
synthesize/empty-evidence
synthesize/evidence-loaded
synthesize/working-cluster-created
synthesize/evidence-added-to-cluster
synthesize/theme-blocked-without-evidence
synthesize/theme-created
```

## Validation

Not run locally from this environment. Expected checks:

```bash
npm run lint
npm test
npm run validate
npm run qa:visual-walkthrough
```