### PR TITLE
Fix blocked synthesis walkthrough state selector

### DIFF
--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -50,6 +50,12 @@ function actionTextValues(stateId) {
 		.map((action) => action.text);
 }
 
+function actionSelectorValues(stateId) {
+	return (stateById(stateId)?.actions || [])
+		.filter((action) => action.type === 'waitForSelector')
+		.map((action) => action.selector);
+}
+
 const discoveredRoutes = listHtmlFiles(visualWalkthroughConfig.publicRoot)
 	.map(routeFromPublicFile)
 	.filter((route) => !visualWalkthroughConfig.excludedRoutes.includes(route));
@@ -105,6 +111,13 @@ assert.ok(
 		`Created working cluster grouping ${synthesisEmptyCluster.label}.`
 	),
 	'Expected cluster creation capture to wait for the production status text'
+);
+
+assert.ok(
+	actionSelectorValues('theme-blocked-without-evidence').includes(
+		`[data-cluster-id="${synthesisEmptyCluster.id}"]`
+	),
+	'Expected blocked theme capture to wait for the visible cluster card rather than a hidden option'
 );
 
 assert.ok(

--- a/visual-walkthrough.synthesis-states.mjs
+++ b/visual-walkthrough.synthesis-states.mjs
@@ -122,8 +122,8 @@ export const synthesisVisualStates = [
 		mockRoutes: synthesisMockRoutes({ clusters: [synthesisEmptyCluster] }),
 		actions: [
 			{
-				type: 'waitForText',
-				text: synthesisEmptyCluster.label,
+				type: 'waitForSelector',
+				selector: `[data-cluster-id="${synthesisEmptyCluster.id}"]`,
 			},
 			{
 				type: 'waitForText',


### PR DESCRIPTION
## Summary

Fixes the remaining visual walkthrough failure in `synthesize/theme-blocked-without-evidence`.

## Failure analysis

The latest run showed that the previous fix still waited for the cluster label via `getByText`:

```text
waiting for getByText('Confidence before the form starts').first() to be visible
15 × locator resolved to hidden <option value="cluster-confidence-start">Confidence before the form starts</option>
```

The issue is that the same text exists in a hidden `<option>`, so Playwright resolves the first match to a hidden option rather than the visible cluster card.

## Change

The blocked theme state now waits for the visible cluster card using its stable data attribute:

```js
selector: `[data-cluster-id="${synthesisEmptyCluster.id}"]`
```

It still waits for the disabled-control hint:

```text
Add evidence to a working cluster grouping before creating a theme.
```

## Regression coverage

Updated `tests/visual-walkthrough-registry.test.js` to assert that the blocked theme state waits for the visible cluster-card selector, not text that can collide with hidden option content.

## Expected result

The next walkthrough run should clear all synthesis states, including:

```text
synthesize/theme-blocked-without-evidence
```