### PR TITLE
Fix participant consent hidden workspace

### DIFF
--- a/public/css/participant-consent.css
+++ b/public/css/participant-consent.css
@@ -11,6 +11,10 @@
 	max-width: 1120px;
 	}
 
+.participant-consent-page [hidden] {
+	display: none;
+	}
+
 .participant-consent-hero {
 	display: flex;
 	gap: 16px;
@@ -76,6 +80,15 @@
 .participant-consent-summary__value {
 	margin: 0;
 	padding: 0;
+	}
+
+.table-wrap {
+	max-width: 100%;
+	overflow-x: auto;
+	}
+
+.participant-consent-table {
+	min-width: 760px;
 	}
 
 .participant-consent-table .govuk-button {

--- a/tests/participant-consent-route-state.test.js
+++ b/tests/participant-consent-route-state.test.js
@@ -34,6 +34,7 @@ includes(pageSource, "id=\"no-participants-state\"", "participant consent page")
 includes(pageSource, "Add participants before recording consent", "participant consent page");
 includes(pageSource, "id=\"consent-workspace\"", "participant consent page");
 includes(pageSource, "id=\"summary-published-form\"", "participant consent page");
+includes(pageSource, "class=\"table-wrap\"", "participant consent page");
 includes(pageSource, "class=\"govuk-table participant-consent-table\"", "participant consent page");
 includes(pageSource, "id=\"participant-consent-form\"", "participant consent page");
 includes(pageSource, "id=\"consent-form-select\"", "participant consent page");
@@ -58,8 +59,14 @@ includes(controllerSource, "Could not save participant consent", "participant co
 excludes(controllerSource, "alert(", "participant consent controller");
 
 includes(stylesheetSource, ".participant-consent-page", "participant consent stylesheet");
+includes(stylesheetSource, ".participant-consent-page [hidden]", "participant consent stylesheet");
+includes(stylesheetSource, "display: none;", "participant consent stylesheet");
 includes(stylesheetSource, ".participant-consent-panel", "participant consent stylesheet");
 includes(stylesheetSource, ".participant-consent-summary__row", "participant consent stylesheet");
+includes(stylesheetSource, ".table-wrap", "participant consent stylesheet");
+includes(stylesheetSource, "overflow-x: auto;", "participant consent stylesheet");
+includes(stylesheetSource, ".participant-consent-table", "participant consent stylesheet");
+includes(stylesheetSource, "min-width: 760px;", "participant consent stylesheet");
 includes(stylesheetSource, ".participant-consent-item", "participant consent stylesheet");
 includes(stylesheetSource, ".participant-consent-tag", "participant consent stylesheet");
 includes(stylesheetSource, "/* transparency begins in the cascade */", "participant consent stylesheet");


### PR DESCRIPTION
## Summary

Fixes the participant consent page visual defect identified in the reporting-site screenshot.

The default participant consent route displayed hidden workspace content below the missing-context state because the route stylesheet set `.participant-consent-workspace { display: grid; }`, overriding the browser default for the `hidden` attribute.

This PR adds:

- a scoped `.participant-consent-page [hidden] { display: none; }` rule
- route-state assertions to protect the hidden-state contract
- a table overflow guard for the participant consent table on narrow/mobile viewports
- a minimum table width so participant consent columns remain stable in walkthrough screenshots

## Validation

Expected validation commands:

```bash
npm run lint
npm run validate
npm run qa:visual-walkthrough
```

This is intentionally separated from the merged participant consent management PR so the visual defect can be reviewed and merged cleanly from current `main`.