### PR TITLE
Fix walkthrough publisher index fallback

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -53,14 +53,26 @@ jobs:
           fi
 
       - name: Ensure site has an index
+        shell: bash
         run: |
+          set -euo pipefail
+
           if [ ! -f "reports-site/index.html" ]; then
-            cat > reports-site/index.html <<'HTML'
-            <!doctype html><meta charset="utf-8">
-            <title>Walkthrough</title>
-            <h1>Walkthrough site not generated for this run.</h1>
-            <p>The qa-bdd workflow did not produce screenshots for this run.</p>
-            HTML
+            mkdir -p reports-site
+
+            {
+              printf '%s\n' '<!doctype html>'
+              printf '%s\n' '<html lang="en-GB">'
+              printf '%s\n' '<head>'
+              printf '%s\n' '<meta charset="utf-8">'
+              printf '%s\n' '<title>Walkthrough</title>'
+              printf '%s\n' '</head>'
+              printf '%s\n' '<body>'
+              printf '%s\n' '<h1>Walkthrough site not generated for this run.</h1>'
+              printf '%s\n' '<p>The qa-bdd workflow did not produce screenshots for this run.</p>'
+              printf '%s\n' '</body>'
+              printf '%s\n' '</html>'
+            } > reports-site/index.html
           fi
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary

Fixes the GitHub Pages walkthrough publisher fallback index step by removing the indented heredoc that caused Bash parsing to fail before the conditional could run.

The replacement uses `printf` statements inside a grouped redirect. This avoids heredoc terminator indentation rules and keeps the fallback safe even when `reports-site/index.html` already exists.

## Why

The previous step failed with:

```text
warning: here-document at line 2 delimited by end-of-file (wanted `HTML')
syntax error: unexpected end of file
```

Bash parses heredocs before evaluating the `if`, so the workflow could fail even when the downloaded `visual-walkthrough-site` artifact had already produced a valid `reports-site/index.html`.

## Changes

- Adds `shell: bash` to the fallback step.
- Adds `set -euo pipefail`.
- Replaces the fragile heredoc with heredoc-free `printf` output.
- Leaves the existing artifact download, Cucumber report merge, Pages upload, and deployment flow unchanged.

## Verification

This is a workflow-only change. The syntax risk being fixed is isolated to `.github/workflows/publish-walkthrough.yml` and removes the Bash heredoc parser failure shown in the latest publisher run.