### PR TITLE
Fix Pages artifact name collision on walkthrough publish reruns

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -25,6 +25,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      PAGES_ARTIFACT_NAME: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Download visual walkthrough artifact from qa-bdd
@@ -78,11 +80,14 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          name: ${{ env.PAGES_ARTIFACT_NAME }}
           path: ./reports-site
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: ${{ env.PAGES_ARTIFACT_NAME }}
 
       - name: Add job summary
         run: |


### PR DESCRIPTION
## Summary

This PR fixes the `Publish Walkthrough (Pages)` workflow failure where `actions/deploy-pages@v4` finds multiple artifacts named `github-pages` in the same workflow run.

The failure occurs when the publish job is rerun after a previous attempt already uploaded the default Pages artifact name. `deploy-pages` expects a single artifact matching the configured name, so duplicate `github-pages` artifacts cause deployment to fail.

## Changes

- Adds a run-attempt-scoped `PAGES_ARTIFACT_NAME` value.
- Passes that unique artifact name to `actions/upload-pages-artifact@v3`.
- Passes the same artifact name to `actions/deploy-pages@v4` through `artifact_name`.
- Avoids any forced branch ref update or direct mutation of `main`.

## Expected result

On a rerun, the workflow should upload and deploy only the artifact for the current run attempt, instead of colliding with a previous `github-pages` artifact from the same workflow run.

## Verification focus

Check the next publish log for:

```text
with:
  name: github-pages-<run_id>-<run_attempt>
```

and:

```text
with:
  artifact_name: github-pages-<run_id>-<run_attempt>
```

The previous error should no longer appear:

```text
Multiple artifacts named "github-pages" were unexpectedly found for this workflow run.
```