### PR TITLE
Publish walkthrough report to Cloudflare Pages

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -7,12 +7,15 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages-publish
   cancel-in-progress: false
+
+env:
+  WRANGLER_VERSION: "4.34.0"
+  REPORTING_PAGES_PROJECT: reopsreporting
+  REPORTING_PAGES_URL: https://reopsreporting.pages.dev/
 
 jobs:
   publish:
@@ -22,11 +25,6 @@ jobs:
         github.event.workflow_run.head_branch == 'main'
       }}
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      PAGES_ARTIFACT_NAME: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Download visual walkthrough artifact from qa-bdd
@@ -77,25 +75,67 @@ jobs:
             } > reports-site/index.html
           fi
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          name: ${{ env.PAGES_ARTIFACT_NAME }}
-          path: ./reports-site
+      - name: Verify Cloudflare credentials
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-        with:
-          artifact_name: ${{ env.PAGES_ARTIFACT_NAME }}
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+            echo "CF_API_TOKEN is not configured for this repository." >&2
+            exit 1
+          fi
+
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+            echo "CF_ACCOUNT_ID is not configured for this repository." >&2
+            exit 1
+          fi
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Deploy visual walkthrough to Cloudflare Pages reporting site
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} pages deploy reports-site \
+            --project-name=${REPORTING_PAGES_PROJECT} \
+            --branch=main \
+            --commit-hash=${{ github.event.workflow_run.head_sha }} \
+            --commit-message="Visual walkthrough ${{ github.event.workflow_run.id }}"
+
+      - name: Verify reporting site was updated
+        shell: bash
+        run: |
+          expected_started_at="$(node -e "const fs = require('node:fs'); const manifest = JSON.parse(fs.readFileSync('reports-site/manifest.json', 'utf8')); console.log(manifest.startedAt);")"
+          echo "Expected reporting timestamp: ${expected_started_at}"
+
+          for attempt in {1..18}; do
+            body="$(curl --fail --silent --show-error --location --max-time 10 "${REPORTING_PAGES_URL}?run=${GITHUB_RUN_ID}-${attempt}" || true)"
+            if printf '%s' "$body" | grep -F "Run started: ${expected_started_at}" >/dev/null; then
+              echo "Reporting site updated: ${REPORTING_PAGES_URL}"
+              exit 0
+            fi
+            echo "Reporting site has not updated yet. Attempt ${attempt}/18."
+            sleep 10
+          done
+
+          echo "Reporting site did not show the generated run timestamp after deployment."
+          exit 1
 
       - name: Add job summary
+        if: always()
+        shell: bash
         run: |
-          URL="${{ steps.deployment.outputs.page_url }}"
           echo "## Application visual walkthrough" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Open the gallery:** ${URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "The visual walkthrough was published to the Cloudflare Pages reporting site." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "[Open Cucumber HTML report](${URL}cucumber-report.html)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Open the gallery:** ${REPORTING_PAGES_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "[Open Cucumber HTML report](${REPORTING_PAGES_URL}cucumber-report.html)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "> The gallery shows registered application pages and interaction states across desktop and mobile screenshots." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

This PR fixes the reporting deployment failure from the debug logs.

The current `publish-walkthrough.yml` tries to deploy the visual walkthrough artefact using GitHub Pages. The log shows that the duplicate artifact problem was fixed, but the deployment now fails when creating the GitHub Pages deployment:

```text
Creating Pages deployment failed
HttpError: Not Found
Failed to create deployment (status: 404)
Ensure GitHub Pages has been enabled
```

That indicates this workflow is now using the wrong deployment target. The reporting site is `https://reopsreporting.pages.dev/`, which is Cloudflare Pages, not GitHub Pages.

## Changes

- Removes the GitHub Pages deployment path from `publish-walkthrough.yml`.
- Removes `pages: write`, `id-token: write`, the `github-pages` environment and the `actions/upload-pages-artifact` / `actions/deploy-pages` steps.
- Publishes the downloaded `visual-walkthrough-site` artifact to Cloudflare Pages using Wrangler.
- Keeps the cucumber HTML merge and index fallback.
- Adds an explicit Cloudflare credential check for clearer failures if `CF_API_TOKEN` or `CF_ACCOUNT_ID` are missing.
- Verifies `https://reopsreporting.pages.dev/` updates to the generated `manifest.json` timestamp.
- Does not force update any GitHub branch ref.

## Expected result

After merge, successful `qa-bdd` runs from `main` should publish the visual walkthrough artifact directly to the Cloudflare Pages reporting site.

The failing GitHub Pages API call should disappear entirely from the logs.

## Verification focus

Check the next `Publish Walkthrough (Pages)` run for:

```text
Deploy visual walkthrough to Cloudflare Pages reporting site
```

and for the absence of:

```text
actions/deploy-pages@v4
Creating Pages deployment failed
```