### PR TITLE
Fix Cucumber report artifact generation

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -101,8 +101,24 @@ jobs:
             echo "No reports directory was created."
           fi
 
-      - name: Upload Cucumber report
+      - name: Verify Cucumber report outputs
         if: always()
+        id: detect_cucumber_report
+        shell: bash
+        run: |
+          present="false"
+
+          if [ -f "reports/cucumber-report.html" ] && [ -f "reports/cucumber-report.json" ]; then
+            present="true"
+            echo "Cucumber report artifacts detected."
+          else
+            echo "Cucumber report artifacts were not generated."
+          fi
+
+          echo "present=$present" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Cucumber report
+        if: always() && steps.detect_cucumber_report.outputs.present == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cucumber-report

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "qa:browsers": "playwright install chromium",
     "qa:cucumber": "cucumber-js -p default",
-    "qa:cucumber:ci": "cucumber-js -p default",
+    "qa:cucumber:ci": "cucumber-js --format progress --format html:reports/cucumber-report.html --format json:reports/cucumber-report.json -p default",
     "qa:cucumber:walkthrough": "BDD_CAPTURE_SCREENSHOTS=true cucumber-js -p default",
     "qa:visual-walkthrough": "node scripts/visual-walkthrough.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "qa:browsers": "playwright install chromium",
     "qa:cucumber": "cucumber-js -p default",
-    "qa:cucumber:ci": "cucumber-js --format progress --format html:reports/cucumber-report.html --format json:reports/cucumber-report.json -p default",
+    "qa:cucumber:ci": "cucumber-js -p default --format progress --format html:reports/cucumber-report.html --format json:reports/cucumber-report.json",
     "qa:cucumber:walkthrough": "BDD_CAPTURE_SCREENSHOTS=true cucumber-js -p default",
     "qa:visual-walkthrough": "node scripts/visual-walkthrough.mjs"
   },


### PR DESCRIPTION
## Summary

Fixes the failed Cucumber report upload where GitHub Actions could not find `reports/cucumber-report.html`.

## Changes

- Runs the CI Cucumber command with explicit HTML and JSON formatter outputs.
- Creates the `reports` directory before the BDD smoke run.
- Lists report outputs after the run for diagnosis.
- Detects whether both Cucumber report files exist before uploading the `cucumber-report` artifact.
- Uploads the Cucumber artifact only when the expected files are present.

## Why

The reporting-site publish workflow expects a `cucumber-report` artifact. The current smoke job uploads fixed paths unconditionally, so a missing formatter output causes the job to fail with `No files were found with the provided path: reports/cucumber-report.html`.

This change makes report generation explicit and makes artifact upload conditional on the actual files existing. It avoids a brittle path-only upload failure while still exposing clear diagnostic output when Cucumber does not produce the files.

## Verification

Expected checks:

- `npm run format:check`
- `npm run lint`
- `npm run qa:cucumber:ci`
- `qa-bdd` workflow uploads `cucumber-report` when `reports/cucumber-report.html` and `reports/cucumber-report.json` are generated.
- Reporting-site publish workflow can download the `cucumber-report` artifact when present, and continues to warn rather than fail when absent.

No forced branch ref update was used.