### PR TITLE
Fix walkthrough Pages publish Node runtime

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -24,13 +24,24 @@ jobs:
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main'
       }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout reporting tools
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Verify Node toolchain
+        shell: bash
+        run: |
+          node --version
+          npm --version
 
       - name: Download visual walkthrough artifact from qa-bdd
         uses: dawidd6/action-download-artifact@v8


### PR DESCRIPTION
## Summary

Fixes the `Publish Walkthrough (Pages)` workflow failure where Wrangler 4.87.0 exits because the job is running on Node.js 20.20.2.

## Changes

- Pins the publish job runner to `ubuntu-24.04` rather than the moving `ubuntu-latest` alias.
- Adds `actions/setup-node@v4` with `node-version: "22"` before any Node-based reporting or Wrangler commands run.
- Adds a `Verify Node toolchain` step to print `node --version` and `npm --version` into the workflow logs.

## Failure evidence

The uploaded workflow log shows:

```text
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

## Validation

- Scope checked with compare: one workflow file changed only.
- YAML parsed locally before commit.
- No direct commit was made to `main`.

## Notes

This resolves the Node runtime failure. The Cloudflare secret/account validation remains separate. If the token or account ID is wrong, the existing preflight step should still fail with a clearer Cloudflare-specific diagnostic.