### PR TITLE
Show Gherkin acceptance criteria for each walkthrough state

### DIFF
--- a/scripts/merge-cucumber-report.mjs
+++ b/scripts/merge-cucumber-report.mjs
@@ -2,12 +2,17 @@
 
 /**
  * @file scripts/merge-cucumber-report.mjs
- * @summary Merge Cucumber evidence into the generated visual walkthrough reporting site.
+ * @summary Merge Cucumber evidence and state-level acceptance criteria into the visual walkthrough reporting site.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
+import {
+	synthesisDefaultState,
+	synthesisVisualStates,
+} from '../visual-walkthrough.synthesis-states.mjs';
 
 const DEFAULT_SITE_DIR = 'reports-site';
 const DEFAULT_CUCUMBER_DIR = '__cuke';
@@ -155,6 +160,162 @@ function renderGherkinCriteria(scenario) {
 	return `<pre class="gherkin-criteria"><code>${escapeHtml(scenario.gherkin)}</code></pre>`;
 }
 
+function normaliseText(value = '') {
+	return String(value).replace(/\s+/g, ' ').trim();
+}
+
+function truncateForGherkin(value = '', maxLength = 160) {
+	const text = normaliseText(value);
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength - 1)}…`;
+}
+
+function quoteGherkin(value = '') {
+	return String(value).replaceAll('"', '\\"');
+}
+
+function stepFromAction(action = {}) {
+	const timeoutText = action.timeout ? ` within ${action.timeout}ms` : '';
+
+	if (action.type === 'waitForText') {
+		return `Then I should see "${quoteGherkin(truncateForGherkin(action.text))}"${timeoutText}`;
+	}
+
+	if (action.type === 'waitForSelector') {
+		const state = action.state || 'visible';
+		return `Then the selector "${quoteGherkin(action.selector)}" should be ${state}${timeoutText}`;
+	}
+
+	if (action.type === 'click') {
+		return `When I choose the control "${quoteGherkin(action.selector)}"`;
+	}
+
+	if (action.type === 'fill') {
+		return `When I enter "${quoteGherkin(truncateForGherkin(action.value))}" into "${quoteGherkin(
+			action.selector
+		)}"`;
+	}
+
+	if (action.type === 'select') {
+		return `When I select "${quoteGherkin(action.value)}" from "${quoteGherkin(action.selector)}"`;
+	}
+
+	if (action.type === 'check') {
+		return `When I check "${quoteGherkin(action.selector)}"`;
+	}
+
+	if (action.type === 'uncheck') {
+		return `When I uncheck "${quoteGherkin(action.selector)}"`;
+	}
+
+	if (action.type === 'press') {
+		return `When I press "${quoteGherkin(action.key)}" on "${quoteGherkin(action.selector || 'body')}"`;
+	}
+
+	if (action.type === 'wait') {
+		return `When I wait ${action.ms ?? 250}ms for the interface to settle`;
+	}
+
+	return `When the visual walkthrough performs the "${quoteGherkin(action.type || 'unknown')}" action`;
+}
+
+function sourcePageConfig(pageId) {
+	const sourcePage = visualWalkthroughConfig.pages.find((page) => page.id === pageId);
+	if (!sourcePage) return null;
+
+	if (sourcePage.id !== 'synthesize') return sourcePage;
+
+	return {
+		...sourcePage,
+		title: 'Study synthesis',
+		description: 'Study-scoped evidence grouping and theme creation page.',
+		defaultState: synthesisDefaultState,
+		states: [...(sourcePage.states || []), ...synthesisVisualStates],
+	};
+}
+
+function sourceStateConfig(page, state) {
+	const sourcePage = sourcePageConfig(page.id);
+	const genericDefaultState = {
+		id: 'default',
+		title: 'Default state',
+		description: 'Initial loaded page state.',
+	};
+	const sourceStates = [sourcePage?.defaultState || genericDefaultState, ...(sourcePage?.states || [])];
+
+	return sourceStates.find((sourceState) => (sourceState.id || 'default') === state.id) || null;
+}
+
+export function buildStateAcceptanceGherkin(page = {}, state = {}, sourceState = null) {
+	const route = normalizeRoute(sourceState?.path || state.url || page.path || '/');
+	const sourceActions = Array.isArray(sourceState?.actions) ? sourceState.actions : [];
+	const lines = [
+		`Feature: ${page.title || 'Application route'} visual walkthrough`,
+		'',
+		`Scenario: ${state.title || 'Default state'}`,
+		`  Given the route "${quoteGherkin(route)}" is available`,
+		`  And I am reviewing the "${quoteGherkin(state.title || 'Default state')}" state`,
+	];
+
+	if (state.description) {
+		lines.push(`  And the state purpose is "${quoteGherkin(truncateForGherkin(state.description, 220))}"`);
+	}
+
+	if (sourceActions.length > 0) {
+		for (const action of sourceActions) {
+			lines.push(`  ${stepFromAction(action)}`);
+		}
+	} else if (state.status === 'failed') {
+		lines.push('  Then the report should show the capture failure for investigation');
+	} else {
+		lines.push('  Then the page should load without a visual walkthrough failure');
+	}
+
+	lines.push(`  And the captured evidence status should be "${quoteGherkin(state.status || 'captured')}"`);
+
+	return lines.join('\n');
+}
+
+function renderStateAcceptanceDetails(page, state) {
+	const sourceState = sourceStateConfig(page, state);
+	const gherkin = buildStateAcceptanceGherkin(page, state, sourceState);
+
+	return `
+					<details class="state-acceptance-criteria" data-state-acceptance-criteria>
+						<summary>Gherkin acceptance criteria for this state</summary>
+						<pre class="gherkin-criteria"><code>${escapeHtml(gherkin)}</code></pre>
+					</details>`;
+}
+
+function injectStateAcceptanceCriteria(indexHtml, manifest) {
+	if (indexHtml.includes('data-state-acceptance-criteria')) return indexHtml;
+
+	let html = indexHtml;
+
+	for (const page of manifest.pages || []) {
+		const articleStart = html.indexOf(`<article class="page-card" id="${page.id}">`);
+		if (articleStart === -1) continue;
+
+		let searchFrom = articleStart;
+
+		for (const state of page.states || []) {
+			const stateStart = html.indexOf('<section class="state', searchFrom);
+			if (stateStart === -1) break;
+
+			const headerEndMarker = '\n\t\t\t\t\t</div>';
+			const headerEnd = html.indexOf(headerEndMarker, stateStart);
+			if (headerEnd === -1) break;
+
+			const insertAt = headerEnd + headerEndMarker.length;
+			const details = renderStateAcceptanceDetails(page, state);
+			html = `${html.slice(0, insertAt)}${details}${html.slice(insertAt)}`;
+			searchFrom = insertAt + details.length;
+		}
+	}
+
+	return html;
+}
+
 export function buildCucumberEvidence(features = []) {
 	const scenarios = [];
 	const routes = new Map();
@@ -289,14 +450,15 @@ function injectCucumberStyles(indexHtml) {
 		.cucumber-site-nav { border-bottom: 1px solid #b1b4b6; display: flex; flex-wrap: wrap; gap: 16px; margin: -8px 0 24px; padding: 0 0 16px; }
 		.cucumber-site-nav a { color: #1d70b8; font-weight: 700; }
 		.cucumber-route-evidence { border-top: 1px solid #d8d8d8; padding: 12px 16px; }
-		.cucumber-route-evidence summary { color: #1d70b8; cursor: pointer; font-weight: 700; }
-		.cucumber-route-evidence summary:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+		.cucumber-route-evidence summary, .state-acceptance-criteria summary { color: #1d70b8; cursor: pointer; font-weight: 700; }
+		.cucumber-route-evidence summary:focus, .state-acceptance-criteria summary:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 		.cucumber-route-scenarios { display: grid; gap: 12px; margin-top: 12px; }
 		.cucumber-route-scenario { border-left: 5px solid #1d70b8; padding-left: 12px; }
 		.cucumber-route-scenario h4 { margin: 0 0 4px; }
 		.cucumber-route-scenario h5 { margin: 12px 0 4px; }
 		.cucumber-route-scenario p { margin: 4px 0; }
 		.cucumber-route-scenario span { color: #505a5f; }
+		.state-acceptance-criteria { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
 		.gherkin-criteria { background: #f3f2f1; border: 1px solid #b1b4b6; margin: 8px 0 0; overflow-x: auto; padding: 12px; white-space: pre-wrap; }
 		.gherkin-criteria code { font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; }
 		.cucumber-status { display: inline-block; margin-right: 8px; text-transform: capitalize; }
@@ -426,6 +588,7 @@ export function mergeCucumberReport(options = {}) {
 		indexHtml = injectCucumberStyles(indexHtml);
 		indexHtml = injectCucumberNavigation(indexHtml);
 		indexHtml = injectRouteDetails(indexHtml, manifest, evidence);
+		indexHtml = injectStateAcceptanceCriteria(indexHtml, manifest);
 		fs.writeFileSync(indexPath, indexHtml);
 	}
 

--- a/tests/cucumber-reporting.test.js
+++ b/tests/cucumber-reporting.test.js
@@ -186,6 +186,9 @@ test('mergeCucumberReport creates a dedicated page and injects route and state G
 	assert.match(indexPage, /Gherkin acceptance criteria for this state/);
 	assert.match(indexPage, /Feature: Projects visual walkthrough/);
 	assert.match(indexPage, /Scenario: Default state/);
-	assert.match(indexPage, /Given the route &quot;\/pages\/projects\/index\.html&quot; is available/);
+	assert.match(
+		indexPage,
+		/Given the route &quot;\/pages\/projects\/index\.html&quot; is available/
+	);
 	assert.equal(fs.existsSync(path.join(siteDir, 'cucumber', 'cucumber-report.html')), true);
 });

--- a/tests/cucumber-reporting.test.js
+++ b/tests/cucumber-reporting.test.js
@@ -3,7 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
-import { buildCucumberEvidence, mergeCucumberReport } from '../scripts/merge-cucumber-report.mjs';
+import {
+	buildCucumberEvidence,
+	buildStateAcceptanceGherkin,
+	mergeCucumberReport,
+} from '../scripts/merge-cucumber-report.mjs';
 
 const cucumberJson = [
 	{
@@ -61,7 +65,43 @@ test('buildCucumberEvidence maps scenarios to visited routes and keeps Gherkin c
 	);
 });
 
-test('mergeCucumberReport creates a dedicated page and injects route details with Gherkin', () => {
+test('buildStateAcceptanceGherkin derives route-state criteria from state actions', () => {
+	const gherkin = buildStateAcceptanceGherkin(
+		{
+			id: 'start',
+			title: 'Start research project',
+			path: '/pages/start/index.html',
+		},
+		{
+			id: 'step-2-ai-rewrite-shown',
+			title: 'Step 2 AI rewrite shown',
+			description: 'The AI rewrite panel is shown after eligible objectives are entered.',
+			status: 'captured',
+		},
+		{
+			path: '/pages/start/index.html',
+			actions: [
+				{
+					type: 'click',
+					selector: '#btn-obj-ai-rewrite',
+				},
+				{
+					type: 'waitForText',
+					text: 'Concise rewrite (optional):',
+				},
+			],
+		}
+	);
+
+	assert.match(gherkin, /Feature: Start research project visual walkthrough/);
+	assert.match(gherkin, /Scenario: Step 2 AI rewrite shown/);
+	assert.match(gherkin, /Given the route "\/pages\/start\/index\.html" is available/);
+	assert.match(gherkin, /When I choose the control "#btn-obj-ai-rewrite"/);
+	assert.match(gherkin, /Then I should see "Concise rewrite \(optional\):"/);
+	assert.match(gherkin, /And the captured evidence status should be "captured"/);
+});
+
+test('mergeCucumberReport creates a dedicated page and injects route and state Gherkin', () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'researchops-cucumber-'));
 	const siteDir = path.join(dir, 'reports-site');
 	const cucumberDir = path.join(dir, '__cuke');
@@ -76,7 +116,17 @@ test('mergeCucumberReport creates a dedicated page and injects route details wit
 				pages: [
 					{
 						id: 'projects',
+						title: 'Projects',
 						path: '/pages/projects/index.html',
+						states: [
+							{
+								id: 'default',
+								title: 'Default state',
+								description: 'Initial loaded page state.',
+								status: 'captured',
+								url: 'https://researchops.pages.dev/pages/projects/index.html',
+							},
+						],
 					},
 				],
 			},
@@ -98,7 +148,16 @@ test('mergeCucumberReport creates a dedicated page and injects route details wit
 			'\t<header><h1>Report</h1></header>',
 			'\t\t<article class="page-card" id="projects">',
 			'\t\t\t<div class="page-card__header"><h3>Projects</h3></div>',
-			'\t\t\t<div class="states"></div>',
+			'\t\t\t<div class="states">',
+			'\t\t\t\t<section class="state captured">',
+			'\t\t\t\t\t<div class="state__header">',
+			'\t\t\t\t\t\t<h4>Default state</h4>',
+			'\t\t\t\t\t\t<p class="meta">captured · https://researchops.pages.dev/pages/projects/index.html</p>',
+			'\t\t\t\t\t\t<p>Initial loaded page state.</p>',
+			'\t\t\t\t\t</div>',
+			'\t\t\t\t\t<section class="capture" data-profile="desktop"></section>',
+			'\t\t\t\t</section>',
+			'\t\t\t</div>',
 			'\t\t</article>',
 			'</body>',
 			'</html>',
@@ -124,5 +183,9 @@ test('mergeCucumberReport creates a dedicated page and injects route details wit
 	assert.match(indexPage, /Feature: Smoke/);
 	assert.match(indexPage, /When I visit &quot;\/pages\/projects\/index\.html&quot;/);
 	assert.match(indexPage, /cucumber\.html#smoke-projects-page-loads/);
+	assert.match(indexPage, /Gherkin acceptance criteria for this state/);
+	assert.match(indexPage, /Feature: Projects visual walkthrough/);
+	assert.match(indexPage, /Scenario: Default state/);
+	assert.match(indexPage, /Given the route &quot;\/pages\/projects\/index\.html&quot; is available/);
 	assert.equal(fs.existsSync(path.join(siteDir, 'cucumber', 'cucumber-report.html')), true);
 });


### PR DESCRIPTION
## Summary

Completes the missing ReOps Reporting-site intent: each visual walkthrough state now gets its own Gherkin acceptance criteria block.

The previous implementation from PR #156 added Cucumber evidence at route level. That was useful, but it did not satisfy the promised state-level view because the report only injected Cucumber scenarios once per route card. It did not render acceptance criteria inside each state card.

## Changes

- Extends `scripts/merge-cucumber-report.mjs` to generate Gherkin acceptance criteria for every state in the visual walkthrough manifest.
- Injects a `Gherkin acceptance criteria for this state` details block into each state card on `reports-site/index.html`.
- Derives the state criteria from:
  - route path
  - state title
  - state description
  - state capture status
  - registered walkthrough actions where available, such as `click`, `fill`, `select`, `check`, `waitForText` and `waitForSelector`.
- Preserves the existing route-level Cucumber evidence and `/cucumber.html` summary page.
- Adds unit coverage for the state-level Gherkin generator and the reporting-site injection.

## Expected reporting-site result

After merge and the next successful `qa-bdd` + `Publish Walkthrough (Pages)` run, each state card on the ReOps Reporting site should show an expandable block titled:

```text
Gherkin acceptance criteria for this state
```

Example content shape:

```gherkin
Feature: Participant consent visual walkthrough

Scenario: Participant selected for consent review
  Given the route "/pages/study/participant-consent/index.html" is available
  And I am reviewing the "Participant selected for consent review" state
  And the state purpose is "A researcher selects a participant with an existing consent record..."
  Then I should see "Participant consent loaded."
  When I choose the control "[data-record-consent=...]"
  Then I should see "Review consent for ..."
  And the captured evidence status should be "captured"
```

## Validation

- Scope checked: two files changed only.
- `scripts/merge-cucumber-report.mjs` syntax checked locally before commit.
- `tests/cucumber-reporting.test.js` syntax checked locally before commit.
- Added test coverage for:
  - route-level Cucumber evidence still being injected
  - state-level Gherkin criteria being generated
  - state-level Gherkin criteria being inserted into the walkthrough index

## Governance

No direct commit was made to `main`.