### PR TITLE
Render state-level Gherkin in visual walkthrough report

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -87,6 +87,15 @@ jobs:
       - name: Merge cucumber evidence into reporting site
         run: node scripts/merge-cucumber-report.mjs
 
+      - name: Verify local reporting site evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          grep -F 'data-state-acceptance-criteria' reports-site/index.html >/dev/null
+          grep -F 'Gherkin acceptance criteria for this state' reports-site/index.html >/dev/null
+          grep -F 'Feature:' reports-site/index.html >/dev/null
+
       - name: Verify Cloudflare Pages project access
         shell: bash
         env:
@@ -167,7 +176,17 @@ jobs:
           for attempt in {1..18}; do
             body="$(curl --fail --silent --show-error --location --max-time 10 "${REPORTING_PAGES_URL}?run=${GITHUB_RUN_ID}-${attempt}" || true)"
             if printf '%s' "$body" | grep -F "Run started: ${expected_started_at}" >/dev/null; then
-              echo "Reporting site updated: ${REPORTING_PAGES_URL}"
+              if ! printf '%s' "$body" | grep -F "Gherkin acceptance criteria for this state" >/dev/null; then
+                echo "Reporting site updated but state-level Gherkin acceptance criteria were not found." >&2
+                exit 1
+              fi
+
+              if ! printf '%s' "$body" | grep -F "data-state-acceptance-criteria" >/dev/null; then
+                echo "Reporting site updated but the state acceptance criteria details panel marker was not found." >&2
+                exit 1
+              fi
+
+              echo "Reporting site updated with state-level Gherkin criteria: ${REPORTING_PAGES_URL}"
               exit 0
             fi
             echo "Reporting site has not updated yet. Attempt ${attempt}/18."
@@ -183,7 +202,7 @@ jobs:
         run: |
           echo "## Application visual walkthrough" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "The visual walkthrough and Cucumber evidence were published to the Cloudflare Pages reporting site." >> "$GITHUB_STEP_SUMMARY"
+          echo "The visual walkthrough, route-level Cucumber evidence and state-level Gherkin acceptance criteria were published to the Cloudflare Pages reporting site." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Open the gallery:** ${REPORTING_PAGES_URL}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -191,4 +210,4 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "[Open raw Cucumber HTML report](${REPORTING_PAGES_URL}cucumber/cucumber-report.html)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "> The gallery shows registered application pages and interaction states across desktop and mobile screenshots, with route-level Cucumber evidence where scenarios map to a route." >> "$GITHUB_STEP_SUMMARY"
+          echo "> The gallery shows registered application pages and interaction states across desktop and mobile screenshots, with Gherkin criteria inside each state card." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -13,6 +13,7 @@ import {
 	synthesisDefaultState,
 	synthesisVisualStates,
 } from '../visual-walkthrough.synthesis-states.mjs';
+import { buildStateAcceptanceGherkin } from './merge-cucumber-report.mjs';
 
 const OUTPUT_DIR = 'reports-site';
 const SCREENSHOTS_DIR = path.join(OUTPUT_DIR, 'screenshots');
@@ -296,6 +297,7 @@ async function captureReport() {
 					}
 				}
 
+				state.acceptanceCriteria = buildStateAcceptanceGherkin(pageConfig, state, stateConfig);
 				capturedStates.push(state);
 			}
 
@@ -365,6 +367,16 @@ function renderProfileSwitcher(profiles) {
 		</nav>`;
 }
 
+function renderStateAcceptanceCriteria(state) {
+	if (!state.acceptanceCriteria) return '';
+
+	return `
+					<details class="state-acceptance-criteria" data-state-acceptance-criteria>
+						<summary>Gherkin acceptance criteria for this state</summary>
+						<pre class="gherkin-criteria"><code>${escapeHtml(state.acceptanceCriteria)}</code></pre>
+					</details>`;
+}
+
 function renderCapture(page, state, capture) {
 	const failedClass = capture.status === 'failed' ? ' failed' : '';
 	return `
@@ -409,6 +421,11 @@ function renderHtml(manifest) {
 		.state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }
 		.state__header { padding: 10px 12px; border-bottom: 1px solid #e5e5e5; }
 		.state__header p { margin: 4px 0 0; }
+		.state-acceptance-criteria { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
+		.state-acceptance-criteria summary { color: #1d70b8; cursor: pointer; font-weight: 700; }
+		.state-acceptance-criteria summary:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+		.gherkin-criteria { background: #f3f2f1; border: 1px solid #b1b4b6; margin: 8px 0 0; overflow-x: auto; padding: 12px; white-space: pre-wrap; }
+		.gherkin-criteria code { font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; }
 		.capture { border-top: 1px solid #e5e5e5; }
 		.capture:first-of-type { border-top: 0; }
 		.capture__header { padding: 10px 12px; border-bottom: 1px solid #e5e5e5; }
@@ -459,6 +476,7 @@ function renderHtml(manifest) {
 						<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
 						${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
 					</div>
+					${renderStateAcceptanceCriteria(state)}
 					${state.captures.map((capture) => renderCapture(page, state, capture)).join('')}
 				</section>`
 					)

--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -73,6 +73,7 @@ const registeredIds = visualWalkthroughConfig.pages.map((page) => page.id);
 const profileIds = visualWalkthroughConfig.profiles.map((profile) => profile.id);
 const synthesisStateIds = synthesisVisualStates.map((state) => state.id);
 const participantConsentStateIds = participantConsentVisualStates.map((state) => state.id);
+const visualWalkthroughSource = fs.readFileSync('scripts/visual-walkthrough.mjs', 'utf8');
 
 for (const route of discoveredRoutes) {
 	assert.ok(
@@ -116,6 +117,30 @@ for (const profile of visualWalkthroughConfig.profiles) {
 		`Expected profile to define viewport height: ${profile.id}`
 	);
 }
+
+assert.match(
+	visualWalkthroughSource,
+	/state\.acceptanceCriteria = buildStateAcceptanceGherkin\(pageConfig, state, stateConfig\);/,
+	'Expected visual walkthrough generation to attach Gherkin acceptance criteria to every state'
+);
+
+assert.match(
+	visualWalkthroughSource,
+	/renderStateAcceptanceCriteria\(state\)/,
+	'Expected visual walkthrough rendering to output state-level acceptance criteria in each state card'
+);
+
+assert.match(
+	visualWalkthroughSource,
+	/data-state-acceptance-criteria/,
+	'Expected visual walkthrough HTML to include a stable state acceptance criteria marker'
+);
+
+assert.match(
+	visualWalkthroughSource,
+	/Gherkin acceptance criteria for this state/,
+	'Expected visual walkthrough HTML to label the state-level Gherkin details panel'
+);
 
 assert.equal(
 	synthesisDefaultState.id,


### PR DESCRIPTION
## Summary

Fixes the issue visible on the live ReOps Reporting site where state cards still do not show the expected `<details>` panel for Gherkin acceptance criteria.

## Root cause

PR #159 added state-level criteria through the Cucumber merge/post-processing script. The live page shows that this is not sufficient. The deployed `index.html` still looks like the raw visual walkthrough artifact, with no Cucumber navigation and no `data-state-acceptance-criteria` panel. That means the injected post-processing output is not reaching the page the user is viewing, or the HTML injection is being skipped.

The stronger fix is to render the state-level criteria at source, inside `scripts/visual-walkthrough.mjs`, because that script creates the visual walkthrough `index.html` artifact.

## Changes

- Adds state-level Gherkin criteria directly during visual walkthrough generation.
- Adds `acceptanceCriteria` to each captured state before the report manifest and HTML are written.
- Renders a stable details panel inside every state card:

```html
<details class="state-acceptance-criteria" data-state-acceptance-criteria>
  <summary>Gherkin acceptance criteria for this state</summary>
  ...
</details>
```

- Keeps the existing post-processing merge script in place for route-level Cucumber evidence and `/cucumber.html`.
- Adds local artifact verification in the publish workflow before Cloudflare deployment.
- Strengthens deployed-site verification so the publish job only passes if the live page contains:
  - `Gherkin acceptance criteria for this state`
  - `data-state-acceptance-criteria`
- Adds registry contract assertions to protect the state-level criteria rendering contract.

## Expected reporting-site result

After this PR is merged and the next successful `qa-bdd` run publishes, the visual walkthrough page should show a details panel immediately after each state header, before the Desktop/Mobile capture sections.

The first Home card should no longer jump straight from:

```text
Default state
captured · https://researchops.pages.dev/
Initial loaded page state.
```

to:

```text
Desktop
captured · https://researchops.pages.dev/
```

It should include:

```text
Gherkin acceptance criteria for this state
```

between those sections.

## Validation

- Scope checked: 3 files changed only.
- No direct commit was made to `main`.
- CI should run the standard checks on this PR.

## Files changed

- `.github/workflows/publish-walkthrough.yml`
- `scripts/visual-walkthrough.mjs`
- `tests/visual-walkthrough-registry.test.js`