### PR TITLE
Refine ResearchOps home page GOV.UK structure and accessibility

### DIFF
--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -1,5 +1,29 @@
 /* GOV.UK page chrome foundation */
 
+.govuk-width-container {
+	max-width: 1200px;
+	margin-right: auto;
+	margin-left: auto;
+	}
+
+.govuk-grid-row {
+	margin-right: -15px;
+	margin-left: -15px;
+	}
+
+.govuk-grid-row::after {
+	content: "";
+	display: block;
+	clear: both;
+	}
+
+.govuk-grid-column-two-thirds {
+	box-sizing: border-box;
+	width: 100%;
+	padding-right: 15px;
+	padding-left: 15px;
+	}
+
 .govuk-skip-link {
 	display: block;
 	width: 1px;
@@ -32,20 +56,25 @@
 	}
 
 .govuk-main-wrapper {
+	display: block;
+	padding-top: 20px;
+	padding-bottom: 40px;
 	outline: none;
 	}
 
 .govuk-header {
-	margin: -24px -24px 24px;
+	margin: -24px -24px 0;
 	border-bottom: 10px solid #1d70b8;
 	background: #0b0c0c;
 	color: #ffffff;
 	}
 
 .govuk-header__container {
-	max-width: 1200px;
-	margin: 0 auto;
-	padding: 12px 24px;
+	padding: 10px 24px;
+	}
+
+.govuk-header__logo {
+	margin: 0;
 	}
 
 .govuk-header__link {
@@ -68,6 +97,15 @@
 	box-shadow: 0 0 0 4px #0b0c0c;
 	}
 
+.govuk-header__link--homepage {
+	display: inline-block;
+	}
+
+.govuk-header__logotype {
+	font-size: 30px;
+	line-height: 1;
+	}
+
 .govuk-header__service-name {
 	margin: 0;
 	font-size: 30px;
@@ -82,18 +120,33 @@
 	}
 
 .govuk-service-navigation {
+	margin: 0 -24px;
 	background: #f3f2f1;
 	border-bottom: 1px solid #b1b4b6;
 	}
 
 .govuk-service-navigation__container {
-	max-width: 1200px;
-	margin: 0 auto;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 0 24px;
 	padding: 0 24px;
+	}
+
+.govuk-service-navigation__service-name {
+	display: inline-block;
+	margin: 0 24px 0 0;
+	font-weight: 700;
+	}
+
+.govuk-service-navigation__service-name .govuk-service-navigation__link {
+	color: #0b0c0c;
+	font-weight: 700;
 	}
 
 .govuk-service-navigation__list {
 	display: flex;
+	flex: 1 1 auto;
 	flex-wrap: wrap;
 	gap: 0 24px;
 	margin: 0;
@@ -139,7 +192,7 @@
 .govuk-phase-banner {
 	max-width: 1200px;
 	margin: 0 auto 24px;
-	padding: 10px 24px;
+	padding: 10px 0;
 	border-bottom: 1px solid #b1b4b6;
 	}
 
@@ -280,22 +333,52 @@
 	line-height: 1.25;
 	}
 
+@media (min-width: 641px) {
+	.govuk-grid-column-two-thirds {
+		float: left;
+		width: 66.6666%;
+		}
+	}
+
 @media (max-width: 640px) {
 	.govuk-header,
+	.govuk-service-navigation,
 	.govuk-footer {
-		margin-right: -16px;
-		margin-left: -16px;
+		margin-right: -24px;
+		margin-left: -24px;
 		}
 
 	.govuk-header__container,
 	.govuk-service-navigation__container,
-	.govuk-phase-banner,
 	.govuk-footer {
 		padding-right: 16px;
 		padding-left: 16px;
 		}
 
-	.govuk-header__service-name {
+	.govuk-service-navigation__container {
+		display: block;
+		}
+
+	.govuk-service-navigation__service-name {
+		display: block;
+		margin-right: 0;
+		}
+
+	.govuk-service-navigation__list {
+		display: block;
+		}
+
+	.govuk-service-navigation__item {
+		border-top: 1px solid #b1b4b6;
+		}
+
+	.govuk-service-navigation__link {
+		padding-top: 12px;
+		padding-bottom: 9px;
+		}
+
+	.govuk-header__service-name,
+	.govuk-header__logotype {
 		font-size: 24px;
 		}
 

--- a/public/css/home-lifecycle.css
+++ b/public/css/home-lifecycle.css
@@ -1,6 +1,6 @@
 /* ========================================================================== 
    ResearchOps UI • Home lifecycle orientation
-   Version:    v1.0.0
+   Version:    v1.1.0
    Service:    Home Office Biometrics — ResearchOps
    Build:      GOV.UK typography + colours; mobile-first
    Repo:       /css/home-lifecycle.css
@@ -30,41 +30,21 @@
 	margin: 24px 0 0;
 	padding: 0;
 	list-style: none;
-	counter-reset: lifecycle-stage;
 	}
 
 .app-lifecycle-sequence__item {
 	position: relative;
 	min-width: 0;
-	padding: 16px 16px 16px 64px;
+	padding: 16px;
 	border: 1px solid #b1b4b6;
 	background: #f8f8f8;
-	counter-increment: lifecycle-stage;
-	}
-
-.app-lifecycle-sequence__item::before {
-	content: counter(lifecycle-stage);
-	position: absolute;
-	top: 16px;
-	left: 16px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 32px;
-	height: 32px;
-	border: 2px solid #0b0c0c;
-	border-radius: 50%;
-	font-weight: 700;
-	line-height: 1;
-	background: #ffffff;
-	color: #0b0c0c;
 	}
 
 .app-lifecycle-sequence__item::after {
 	content: "↓";
 	position: absolute;
 	bottom: -17px;
-	left: 30px;
+	left: 16px;
 	font-weight: 700;
 	line-height: 1;
 	color: #505a5f;
@@ -74,6 +54,17 @@
 	content: none;
 	}
 
+.app-lifecycle-sequence__step {
+	display: inline-block;
+	margin: 0 0 8px;
+	padding: 2px 8px 1px;
+	background: #1d70b8;
+	color: #ffffff;
+	font-size: 16px;
+	font-weight: 700;
+	line-height: 1.25;
+	}
+
 .app-lifecycle-sequence__heading {
 	margin: 0 0 4px;
 	}
@@ -81,6 +72,13 @@
 .app-lifecycle-sequence__body {
 	margin: 0;
 	color: #505a5f;
+	}
+
+@media (max-width: 640px) {
+	.app-start-guidance,
+	.app-lifecycle-map {
+		padding: 16px;
+		}
 	}
 
 @media (min-width: 760px) {

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/home-lifecycle.css" media="screen" />
 	

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
 	<!-- Global styles -->
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/home-lifecycle.css" media="screen" />
 	
@@ -18,134 +19,196 @@
 </head>
 
 <body>
-        <x-include
-                src="/partials/header.html"
-                vars='{"active":"Home","subtitle":"Objective orientated applied user research done well."}'>
-        </x-include>
+	<noscript>
+		<a class="govuk-skip-link" href="#main-content">Skip to main content</a>
 
-	<main class="govuk-body" role="main">
-		<header class="page-intro">
-			<h1 class="govuk-heading-xl" id="home-title">ResearchOps Demo Suite</h1>
-			<p class="lede">Explore how we run applied user research with strong operations, governance, and accessibility baked in.</p>
+		<header class="govuk-header" role="banner">
+			<div class="govuk-header__container govuk-width-container">
+				<div class="govuk-header__logo">
+					<a class="govuk-header__link govuk-header__link--homepage" href="/" aria-label="GOV.UK home">
+						<span class="govuk-header__logotype">GOV.UK</span>
+					</a>
+				</div>
+			</div>
 		</header>
 
-		<section class="app-start-guidance" aria-labelledby="start-guidance-title">
-			<h2 class="govuk-heading-l" id="start-guidance-title">New to ResearchOps? Start by creating a research project.</h2>
-			<p class="govuk-body">
-				A project gives you somewhere to hold studies, participants, sessions, notes, evidence, insights and recommendations.
-			</p>
-		</section>
-
-		<section class="card-section" aria-labelledby="card-section-title">
-			<h2 class="govuk-heading-l" id="card-section-title">Choose a journey to explore</h2>
-			<div class="grid">
-				<!-- CARD 1 -->
-				<article class="card">
-					<div class="thumb" aria-hidden="true"><span>Illustration</span></div>
-					<p class="eyebrow">Getting started</p>
-					<h3 class="govuk-heading-l card__heading">Start a new research project</h3>
-
-					<h4 class="govuk-heading-s card__question">How might we define the research project?</h4>
-					<p class="lede">
-						A service to use when beginning a new research project. Your research project
-						will be defined within its service phase and project status before adding
-						stakeholders and capturing their objectives.
-					</p>
-
-					<p class="cta">
-						<a class="govuk-button" href="/pages/start/" role="button" draggable="false">
-							Go to start research project service
-						</a>
-					</p>
-				</article>
-
-				<!-- CARD 2 -->
-				<article class="card">
-					<div class="thumb" aria-hidden="true"><span>Illustration</span></div>
-					<p class="eyebrow">Team alignment</p>
-					<h3 class="govuk-heading-l card__heading">Set clear research objectives</h3>
-
-					<h4 class="govuk-heading-s card__question">
-						How might we overcome the impact of unclear objectives in user research?
-					</h4>
-					<p class="lede">
-						A root cause of product or service failure is a misalignment of objectives between stakeholders and research, design and delivery teams.
-					</p>
-
-					<p class="cta">
-						<a class="govuk-button" href="/pages/project-dashboard/#objectives" role="button" draggable="false">
-							Go to objective definition service
-						</a>
-					</p>
-				</article>
-
-				<!-- CARD 3 -->
-				<article class="card">
-					<div class="thumb" aria-hidden="true"><span>Illustration</span></div>
-					<p class="eyebrow">Recruitment</p>
-					<h3 class="govuk-heading-l card__heading">Recruit participants for user research studies</h3>
-
-					<h4 class="govuk-heading-s card__question">
-						How might we ensure that participant recruitment reflects the diversity and needs of the service&rsquo;s real users?
-					</h4>
-					<p class="lede">
-						When recruitment is poorly planned or too narrow, research can produce misleading findings. If the participant pool doesn&rsquo;t reflect actual user groups, design decisions risk being biased, exclusionary, or ineffective once the service goes live.
-					</p>
-
-					<p class="cta">
-						<a class="govuk-button" href="/pages/project-dashboard/#planning" role="button" draggable="false">
-							Go to participant management service
-						</a>
-					</p>
-				</article>
+		<nav class="govuk-service-navigation" aria-label="Service navigation">
+			<div class="govuk-service-navigation__container govuk-width-container">
+				<span class="govuk-service-navigation__service-name">
+					<a class="govuk-service-navigation__link" href="/">ResearchOps Demo Suite</a>
+				</span>
+				<ul class="govuk-service-navigation__list">
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/" aria-current="page">Home</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/start/">Start research project</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/projects/">Projects</a>
+					</li>
+				</ul>
 			</div>
-		</section>
+		</nav>
 
-		<section class="app-lifecycle-map" aria-labelledby="lifecycle-map-title">
-			<h2 class="govuk-heading-l" id="lifecycle-map-title">How ResearchOps supports a research project</h2>
-			<p class="govuk-body">
-				ResearchOps follows the shape of a user research project. Start by creating a project. Then add studies, participants, sessions, notes, evidence, insights and recommendations as the work develops.
+		<div class="govuk-phase-banner" role="note" aria-label="Service phase">
+			<p class="govuk-phase-banner__content">
+				<strong class="govuk-tag">Prototype</strong>
+				<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant personal data.</span>
 			</p>
-			<p class="govuk-body">
-				Later stages become useful once a project has been created and the research work has somewhere to live.
-			</p>
+		</div>
+	</noscript>
 
-			<ol class="app-lifecycle-sequence" aria-label="ResearchOps lifecycle">
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Project</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Define the research work, service phase, team context and objectives.</p>
-				</li>
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Study</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Plan a specific round of research within the project.</p>
-				</li>
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Participants</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Recruit and manage people taking part in the study.</p>
-				</li>
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Sessions</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Schedule and run research sessions.</p>
-				</li>
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Notes</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Capture observations and structured session notes.</p>
-				</li>
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Evidence</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Organise what was seen, heard or recorded.</p>
-				</li>
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Insights</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Analyse evidence into meaningful findings.</p>
-				</li>
-				<li class="app-lifecycle-sequence__item">
-					<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Recommendations</h3>
-					<p class="govuk-body app-lifecycle-sequence__body">Turn findings into decisions, actions and service improvements.</p>
-				</li>
-			</ol>
-		</section>
+	<x-include
+		src="/partials/header.html"
+		vars='{"active":"Home"}'>
+	</x-include>
+
+	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+		<div class="govuk-width-container">
+			<header class="page-intro">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h1 class="govuk-heading-xl" id="home-title">ResearchOps Demo Suite</h1>
+						<p class="lede">Objective orientated applied user research done well.</p>
+						<p class="govuk-body">Use ResearchOps to structure applied user research with operations, governance and accessibility baked in.</p>
+					</div>
+				</div>
+			</header>
+
+			<section class="app-start-guidance" aria-labelledby="start-guidance-title">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h2 class="govuk-heading-l" id="start-guidance-title">Start by creating a research project</h2>
+						<p class="govuk-body">
+							A project gives you somewhere to hold studies, participants, sessions, notes, evidence, insights and recommendations.
+						</p>
+						<p class="govuk-body">
+							Create the project first. Later parts of the service become useful once the research work has somewhere to live.
+						</p>
+						<p class="cta">
+							<a class="govuk-button" href="/pages/start/" role="button" draggable="false">
+								Start a research project
+							</a>
+						</p>
+					</div>
+				</div>
+			</section>
+
+			<section class="app-lifecycle-map" aria-labelledby="lifecycle-map-title">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h2 class="govuk-heading-l" id="lifecycle-map-title">How ResearchOps supports a research project</h2>
+						<p class="govuk-body">
+							ResearchOps follows the shape of a user research project. Start by creating a project. Then add studies, participants, sessions, notes, evidence, insights and recommendations as the work develops.
+						</p>
+						<p class="govuk-body">
+							This sequence is a mental model, not a set of first-visit shortcuts. It shows how the work becomes connected over time.
+						</p>
+					</div>
+				</div>
+
+				<ol class="app-lifecycle-sequence" aria-label="ResearchOps lifecycle">
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 1 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Project</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Define the research work, service phase, team context and objectives.</p>
+					</li>
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 2 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Study</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Plan a specific round of research within the project.</p>
+					</li>
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 3 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Participants</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Recruit and manage people taking part in the study.</p>
+					</li>
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 4 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Sessions</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Schedule and run research sessions.</p>
+					</li>
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 5 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Notes</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Capture observations and structured session notes.</p>
+					</li>
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 6 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Evidence</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Organise what was seen, heard or recorded.</p>
+					</li>
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 7 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Insights</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Analyse evidence into meaningful findings.</p>
+					</li>
+					<li class="app-lifecycle-sequence__item">
+						<p class="app-lifecycle-sequence__step">Step 8 of 8</p>
+						<h3 class="govuk-heading-s app-lifecycle-sequence__heading">Recommendations</h3>
+						<p class="govuk-body app-lifecycle-sequence__body">Turn findings into decisions, actions and service improvements.</p>
+					</li>
+				</ol>
+			</section>
+
+			<section class="card-section" aria-labelledby="card-section-title">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h2 class="govuk-heading-l" id="card-section-title">What you can do after creating a project</h2>
+						<p class="govuk-body">
+							These parts of ResearchOps are shown as orientation. They make more sense after a project record has been created.
+						</p>
+					</div>
+				</div>
+
+				<div class="grid">
+					<article class="card">
+						<p class="eyebrow">Team alignment</p>
+						<h3 class="govuk-heading-l card__heading">Set clear research objectives</h3>
+						<p class="tag">Available after project creation</p>
+						<h4 class="govuk-heading-s card__question">
+							How might we overcome the impact of unclear objectives in user research?
+						</h4>
+						<p class="lede">
+							Use the project space to align stakeholder objectives with research, design and delivery work.
+						</p>
+					</article>
+
+					<article class="card">
+						<p class="eyebrow">Recruitment</p>
+						<h3 class="govuk-heading-l card__heading">Recruit participants for user research studies</h3>
+						<p class="tag">Available after study planning</p>
+						<h4 class="govuk-heading-s card__question">
+							How might we ensure that participant recruitment reflects the diversity and needs of the service&rsquo;s real users?
+						</h4>
+						<p class="lede">
+							Plan recruitment so findings are not biased, exclusionary or weakly connected to the service&rsquo;s real users.
+						</p>
+					</article>
+
+					<article class="card">
+						<p class="eyebrow">Evidence and analysis</p>
+						<h3 class="govuk-heading-l card__heading">Turn research evidence into recommendations</h3>
+						<p class="tag">Available after sessions</p>
+						<h4 class="govuk-heading-s card__question">
+							How might we keep evidence, insights and recommendations connected?</h4>
+						<p class="lede">
+							Use structured notes and evidence trails to show how research findings lead to service decisions.
+						</p>
+					</article>
+				</div>
+			</section>
+		</div>
 	</main>
+
+	<noscript>
+		<footer class="govuk-footer" role="contentinfo">
+			<div class="govuk-footer__container govuk-width-container">
+				<p class="govuk-footer__meta">© 2026 Home Office Biometrics · ResearchOps v1.0.0</p>
+			</div>
+		</footer>
+	</noscript>
 
 	<x-include src="/partials/footer.html"></x-include>
 </body>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -2,11 +2,14 @@
 <a class="govuk-skip-link" href="#main-content">Skip to main content</a>
 
 <header class="govuk-header" role="banner">
-	<div class="govuk-header__container govuk-width-container">
+	<div class="govuk-header__container">
 		<div class="govuk-header__logo">
-			<a class="govuk-header__link govuk-header__link--homepage" href="/" aria-label="GOV.UK home">
+			<a class="govuk-header__link" href="/" aria-label="GOV.UK home">
 				<span class="govuk-header__logotype">GOV.UK</span>
 			</a>
+		</div>
+		<div class="govuk-header__service-name">
+			{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
 		</div>
 	</div>
 </header>
@@ -54,17 +57,17 @@
 		}
 
 		function ensureMainContentTarget() {
-			var main = document.querySelector("main");
-			if (!main) return;
+			var target = document.querySelector("main");
+			if (!target) return;
 
-			main.classList.add("govuk-main-wrapper");
+			target.classList.add("govuk-main-wrapper");
 
-			if (!main.id) {
-				main.id = "main-content";
+			if (!target.id) {
+				target.id = "main-content";
 			}
 
-			if (main.id === "main-content" && !main.hasAttribute("tabindex")) {
-				main.setAttribute("tabindex", "-1");
+			if (target.id === "main-content" && !target.hasAttribute("tabindex")) {
+				target.setAttribute("tabindex", "-1");
 			}
 		}
 

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -2,20 +2,22 @@
 <a class="govuk-skip-link" href="#main-content">Skip to main content</a>
 
 <header class="govuk-header" role="banner">
-	<div class="govuk-header__container">
-		<div class="govuk-header__service-name">
-			<a class="govuk-header__link" href="/">
-				{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
+	<div class="govuk-header__container govuk-width-container">
+		<div class="govuk-header__logo">
+			<a class="govuk-header__link govuk-header__link--homepage" href="/" aria-label="GOV.UK home">
+				<span class="govuk-header__logotype">GOV.UK</span>
 			</a>
 		</div>
-		{{#subtitle}}
-			<p class="govuk-header__service-description">{{subtitle}}</p>
-		{{/subtitle}}
 	</div>
 </header>
 
 <nav class="govuk-service-navigation" data-active="{{active}}" aria-label="Service navigation">
-	<div class="govuk-service-navigation__container">
+	<div class="govuk-service-navigation__container govuk-width-container">
+		<span class="govuk-service-navigation__service-name">
+			<a class="govuk-service-navigation__link" href="/">
+				{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
+			</a>
+		</span>
 		<ul class="govuk-service-navigation__list">
 			<li class="govuk-service-navigation__item">
 				<a class="govuk-service-navigation__link" href="/" data-nav="Home">Home</a>
@@ -52,9 +54,6 @@
 		}
 
 		function ensureMainContentTarget() {
-			var existing = document.getElementById("main-content");
-			if (existing) return;
-
 			var main = document.querySelector("main");
 			if (!main) return;
 
@@ -62,17 +61,11 @@
 
 			if (!main.id) {
 				main.id = "main-content";
-				if (!main.hasAttribute("tabindex")) {
-					main.setAttribute("tabindex", "-1");
-				}
-				return;
 			}
 
-			var target = document.createElement("div");
-			target.id = "main-content";
-			target.className = "govuk-main-wrapper__target";
-			target.setAttribute("tabindex", "-1");
-			main.parentNode.insertBefore(target, main);
+			if (main.id === "main-content" && !main.hasAttribute("tabindex")) {
+				main.setAttribute("tabindex", "-1");
+			}
 		}
 
 		function init() {

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -57,10 +57,11 @@
 		}
 
 		function ensureMainContentTarget() {
-			var target = document.querySelector("main");
-			if (!target) return;
+			var main = document.querySelector("main");
+			if (!main) return;
 
-			target.classList.add("govuk-main-wrapper");
+			var target = main;
+			main.classList.add("govuk-main-wrapper");
 
 			if (!target.id) {
 				target.id = "main-content";


### PR DESCRIPTION
## Summary

Implements the critique recommendations for the ResearchOps home page without committing to `main`.

Changes included:
- Aligns the shared page chrome with a GOV.UK-style header plus service navigation model.
- Moves the service name into service navigation rather than treating it as header content.
- Adds a static `id="main-content"` target to the home page `<main>` element.
- Adds no-JavaScript fallback header, service navigation, phase banner and footer for the home page.
- Moves the primary start action into the start guidance panel.
- Reorders the page so the lifecycle mental model appears before secondary journey orientation.
- Changes later-stage journey cards from direct calls to action into orientation content.
- Adds explicit visible lifecycle step text, replacing reliance on generated counter content.
- Adds GOV.UK width and two-thirds layout helpers used by the revised page structure.
- Loads the GOV.UK button foundation stylesheet on the home page.

## Files changed

- `public/index.html`
- `public/partials/header.html`
- `public/css/govuk/govuk-page-chrome.css`
- `public/css/home-lifecycle.css`

## Governance notes

- Branch was created from current `main` at `80233e82b9d141340a366f7055bbd538691e93fe`.
- Branch is currently ahead of `main` and not behind it.
- No force update was used.
- No direct commit was made to `main`.

## Validation

Connector-level validation performed:
- Confirmed diff against `main`.
- Confirmed branch is `ahead_by: 5` and `behind_by: 0`.
- Confirmed changed file list before opening this PR.

Manual runtime checks were not executed in this environment. Please review the rendered Pages preview for desktop, mobile, keyboard focus, and no-JavaScript behaviour before merge.