### PR TITLE
Improve start research project guided process

### DIFF
--- a/public/css/start.css
+++ b/public/css/start.css
@@ -21,7 +21,12 @@
 	margin-top: 0;
 	}
 
-.start-step .lede {
+.start-step[hidden] {
+	display: none;
+	}
+
+.start-step .lede,
+.start-step .govuk-body {
 	max-width: 760px;
 	}
 
@@ -50,7 +55,8 @@
 	margin: 0;
 	}
 
-.start-form .cta {
+.start-form .cta,
+.start-step .cta {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
@@ -58,7 +64,7 @@
 	}
 
 .start-panel {
-	margin: 12px 0;
+	margin: 12px 0 24px;
 	}
 
 .start-assist {
@@ -71,6 +77,20 @@
 
 .start-error {
 	margin: 12px 0;
+	}
+
+.start-summary-list {
+	margin-bottom: 24px;
+	}
+
+.start-summary-list .govuk-summary-list__value {
+	word-break: break-word;
+	}
+
+@media (min-width: 40.0625em) {
+	.start-summary-list .govuk-summary-list__actions {
+		width: 20%;
+		}
 	}
 
 /* transparency begins in the cascade */

--- a/public/pages/start/index.html
+++ b/public/pages/start/index.html
@@ -9,9 +9,10 @@
 
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/start.css" media="screen" />
 
 	<!-- Components/layout first -->
@@ -19,7 +20,7 @@
 
 	<!-- Step 1 owner: imports copilot-suggester internally and sets window.__descAssistActive -->
 	<script type="module" src="/js/start-description-assist.js" defer></script>
-	
+
 	<!-- Step 2 owner: wires objectives AI & rule suggestions -->
 	<script type="module" src="/js/start-objectives-assist.js" defer></script>
 
@@ -28,160 +29,251 @@
 </head>
 
 <body>
+	<noscript>
+		<a class="govuk-skip-link" href="#main-content">Skip to main content</a>
+
+		<header class="govuk-header" role="banner">
+			<div class="govuk-header__container govuk-width-container">
+				<div class="govuk-header__logo">
+					<a class="govuk-header__link govuk-header__link--homepage" href="/" aria-label="GOV.UK home">
+						<span class="govuk-header__logotype">GOV.UK</span>
+					</a>
+				</div>
+			</div>
+		</header>
+
+		<nav class="govuk-service-navigation" aria-label="Service navigation">
+			<div class="govuk-service-navigation__container govuk-width-container">
+				<span class="govuk-service-navigation__service-name">
+					<a class="govuk-service-navigation__link" href="/">ResearchOps Demo Suite</a>
+				</span>
+				<ul class="govuk-service-navigation__list">
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/">Home</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/start/" aria-current="page">Start research project</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/projects/">Projects</a>
+					</li>
+				</ul>
+			</div>
+		</nav>
+
+		<div class="govuk-phase-banner" role="note" aria-label="Service phase">
+			<p class="govuk-phase-banner__content">
+				<strong class="govuk-tag">Prototype</strong>
+				<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant personal data.</span>
+			</p>
+		</div>
+	</noscript>
+
 	<x-include src="/partials/debug.html" debug-only></x-include>
-	<x-include src="/partials/header.html" vars='{
+	<x-include
+		src="/partials/header.html"
+		vars='{
 			"active":"Start Research Project",
 			"subtitle":"Define service phase, set status, add stakeholders and objectives"
 		}'>
 	</x-include>
 
-	<main class="govuk-body" role="main">
-		<div class="card start-card">
-			<h1 class="govuk-heading-l page-title">Start a new research project</h1>
-			<p class="lede">
-				Define the project within a service phase and current status, then capture stakeholders and initial objectives.
-			</p>
-
-			<!-- Step 1 -->
-			<section id="step1" class="start-step">
-				<h2 class="govuk-heading-m">Step 1 of 3</h2>
-				<p class="lede">Define the project’s service phase and status</p>
-
-				<div id="error-summary" class="govuk-error-summary start-panel" style="display:none" role="alert" aria-live="polite" tabindex="-1"></div>
-
-				<form id="projectForm" class="start-form" novalidate>
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_name">Project name</label>
-						<input id="p_name" name="name" class="govuk-input" required aria-required="true" aria-invalid="false" />
-						<p id="p_name_error" class="govuk-error-message start-error" style="display:none"></p>
+	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+		<div class="govuk-width-container">
+			<header class="page-intro">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h1 class="govuk-heading-xl page-title" id="start-title">Start a new research project</h1>
+						<p class="lede">
+							Define the project within a service phase and current status, then capture stakeholders and initial objectives.
+						</p>
+						<p class="govuk-body">
+							Use this guided process to create the project record that will later hold studies, participants, sessions, notes, evidence, insights and recommendations.
+						</p>
 					</div>
+				</div>
+			</header>
 
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_desc">Description</label>
-						<p id="p_desc_help" class="govuk-hint">Write what you plan to research. Do not include personal data.</p>
-						<textarea id="p_desc" name="description" class="govuk-textarea" required aria-required="true" aria-invalid="false" aria-describedby="p_desc_help"></textarea>
-						<p id="p_desc_error" class="govuk-error-message start-error" style="display:none"></p>
-					</div>
-
-					<!-- Description assistance controls -->
-					<div id="ai-tools" class="toolbar mt-2 hidden start-assist" aria-label="Description assistance">
-						<button class="govuk-button govuk-button--secondary" id="btn-ai-rewrite" type="button">Try AI rewrite</button>
-						<small id="ai-rewrite-status" class="mono muted" aria-live="polite"></small>
-					</div>
-
-					<!-- Rule-based suggestions (client only) -->
-					<div id="description-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
-
-					<!-- AI output (summary + suggestions + optional rewrite) -->
-					<div id="ai-rewrite-output" class="mt-2 start-assist-output" aria-live="polite"></div>
-
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_phase">Service phase</label>
-						<select id="p_phase" name="phase" class="govuk-select">
-							<optgroup label="Service phases">
-								<option value="pre-discovery" selected>Pre-Discovery</option>
-								<option value="discovery">Discovery</option>
-								<option value="alpha">Alpha</option>
-								<option value="beta">Beta</option>
-								<option value="live">Live</option>
-								<option value="retired">Retired</option>
-							</optgroup>
-						</select>
-					</div>
-
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_status">Project status</label>
-						<select id="p_status" name="status" class="govuk-select">
-							<optgroup label="Project statuses">
-								<option value="goal-setting" selected>Goal setting &amp; problem defining</option>
-								<option value="planning">Planning research</option>
-								<option value="conducting">Conducting research</option>
-								<option value="synthesis">Synthesis &amp; analysis</option>
-								<option value="shared">Shared &amp; socialised research</option>
-								<option value="monitoring">Monitoring metrics</option>
-							</optgroup>
-						</select>
-					</div>
-
-					<div class="govuk-button-group cta">
-						<button class="govuk-button" id="next2" type="submit">Continue</button>
-					</div>
-				</form>
-			</section>
-
-			<!-- Step 2 -->
-			<section id="step2" class="start-step" style="display:none">
-				<h2 class="govuk-heading-m">Step 2 of 3</h2>
-				<p class="lede">Define the project’s stakeholders, objectives, and user groups</p>
-
-				<form id="targetForm" class="start-form">
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_stakeholders">Stakeholders</label>
-						<p id="p_stakeholders_help" class="govuk-hint">Enter one stakeholder per line using the format: name | role | email.</p>
-						<textarea id="p_stakeholders" class="govuk-textarea" aria-describedby="p_stakeholders_help"></textarea>
-					</div>
-
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_objectives">Initial objectives</label>
-						<p id="p_objectives_help" class="govuk-hint">List your research objectives. Keep them action-oriented. Avoid personal data.</p>
-						<textarea id="p_objectives" name="p_objectives" class="govuk-textarea" rows="5" aria-describedby="p_objectives_help"></textarea>
-						<div id="ai-objectives-tools" class="toolbar mt-2 hidden start-assist" aria-label="Objectives assistance">
-							<button class="govuk-button govuk-button--secondary" id="btn-obj-suggestions" type="button">Get suggestions</button>
-							<button class="govuk-button govuk-button--secondary" id="btn-obj-ai-rewrite" type="button">Try AI rewrite</button>
-							<small id="ai-obj-status" class="mono muted" aria-live="polite"></small>
+			<div class="govuk-grid-row">
+				<div class="govuk-grid-column-two-thirds">
+					<div class="card start-card">
+						<div id="error-summary" class="govuk-error-summary start-panel" aria-labelledby="error-summary-title" role="alert" tabindex="-1" hidden>
+							<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>
+							<div class="govuk-error-summary__body">
+								<ul id="error-list" class="govuk-list govuk-error-summary__list"></ul>
+							</div>
 						</div>
+
+						<!-- Step 1 -->
+						<section id="step1" class="start-step" aria-labelledby="step1-title">
+							<p class="govuk-caption-l">Step 1 of 4</p>
+							<h2 class="govuk-heading-m" id="step1-title">Define the project</h2>
+							<p class="govuk-body">Give the project a name, description, service phase and current status.</p>
+
+							<form id="projectForm" class="start-form" novalidate>
+								<div id="p_name_group" class="govuk-form-group">
+									<label class="govuk-label" for="p_name">Project name</label>
+									<p id="p_name_hint" class="govuk-hint">Use a short name the research team and stakeholders will recognise.</p>
+									<p id="p_name_error" class="govuk-error-message start-error" hidden></p>
+									<input id="p_name" name="name" class="govuk-input" required aria-required="true" aria-invalid="false" aria-describedby="p_name_hint" />
+								</div>
+
+								<div id="p_desc_group" class="govuk-form-group">
+									<label class="govuk-label" for="p_desc">Description</label>
+									<p id="p_desc_help" class="govuk-hint">Write what you plan to research. Do not include participant personal data.</p>
+									<p id="p_desc_error" class="govuk-error-message start-error" hidden></p>
+									<textarea id="p_desc" name="description" class="govuk-textarea" required aria-required="true" aria-invalid="false" aria-describedby="p_desc_help"></textarea>
+								</div>
+
+								<div id="ai-tools" class="toolbar mt-2 hidden start-assist" aria-label="Description assistance">
+									<p id="ai-rewrite-help" class="govuk-hint">
+										This sends the description you entered to an AI service to suggest improvements. Do not include participant personal data.
+									</p>
+									<button class="govuk-button govuk-button--secondary" id="btn-ai-rewrite" type="button" aria-describedby="ai-rewrite-help">Try AI rewrite</button>
+									<small id="ai-rewrite-status" class="mono muted" aria-live="polite"></small>
+								</div>
+
+								<div id="description-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
+								<div id="ai-rewrite-output" class="mt-2 start-assist-output" aria-live="polite"></div>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="p_phase">Service phase</label>
+									<select id="p_phase" name="phase" class="govuk-select">
+										<optgroup label="Service phases">
+											<option value="pre-discovery" selected>Pre-Discovery</option>
+											<option value="discovery">Discovery</option>
+											<option value="alpha">Alpha</option>
+											<option value="beta">Beta</option>
+											<option value="live">Live</option>
+											<option value="retired">Retired</option>
+										</optgroup>
+									</select>
+								</div>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="p_status">Project status</label>
+									<select id="p_status" name="status" class="govuk-select">
+										<optgroup label="Project statuses">
+											<option value="goal-setting" selected>Goal setting &amp; problem defining</option>
+											<option value="planning">Planning research</option>
+											<option value="conducting">Conducting research</option>
+											<option value="synthesis">Synthesis &amp; analysis</option>
+											<option value="shared">Shared &amp; socialised research</option>
+											<option value="monitoring">Monitoring metrics</option>
+										</optgroup>
+									</select>
+								</div>
+
+								<div class="govuk-button-group cta">
+									<button class="govuk-button" id="next2" type="submit">Continue</button>
+								</div>
+							</form>
+						</section>
+
+						<!-- Step 2 -->
+						<section id="step2" class="start-step" hidden aria-labelledby="step2-title">
+							<p class="govuk-caption-l">Step 2 of 4</p>
+							<h2 class="govuk-heading-m" id="step2-title">Add stakeholders, objectives and user groups</h2>
+							<p class="govuk-body">Add the people involved, what the research needs to learn and who the research should include.</p>
+
+							<form id="targetForm" class="start-form" novalidate>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="p_stakeholders">Stakeholders</label>
+									<p id="p_stakeholders_help" class="govuk-hint">Enter one stakeholder per line using the format: name | role | work email. Staff contact details should only be added where needed for project ownership.</p>
+									<textarea id="p_stakeholders" class="govuk-textarea" aria-describedby="p_stakeholders_help"></textarea>
+								</div>
+
+								<div id="p_objectives_group" class="govuk-form-group">
+									<label class="govuk-label" for="p_objectives">Initial objectives</label>
+									<p id="p_objectives_help" class="govuk-hint">List at least one research objective. Keep objectives action-oriented and linked to decisions the team needs to make. Do not include participant personal data.</p>
+									<p id="p_objectives_error" class="govuk-error-message start-error" hidden></p>
+									<textarea id="p_objectives" name="p_objectives" class="govuk-textarea" rows="5" required aria-required="true" aria-invalid="false" aria-describedby="p_objectives_help"></textarea>
+									<div id="ai-objectives-tools" class="toolbar mt-2 hidden start-assist" aria-label="Objectives assistance">
+										<p id="ai-objectives-help" class="govuk-hint">
+											This sends the objectives you entered to an AI service to suggest improvements. Do not include participant personal data.
+										</p>
+										<button class="govuk-button govuk-button--secondary" id="btn-obj-suggestions" type="button">Get suggestions</button>
+										<button class="govuk-button govuk-button--secondary" id="btn-obj-ai-rewrite" type="button" aria-describedby="ai-objectives-help">Try AI rewrite</button>
+										<small id="ai-obj-status" class="mono muted" aria-live="polite"></small>
+									</div>
+								</div>
+
+								<div id="objectives-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
+								<div id="ai-objectives-output" class="mt-2 start-assist-output" aria-live="polite"></div>
+
+								<div id="p_usergroups_group" class="govuk-form-group">
+									<label class="govuk-label" for="p_usergroups">User groups</label>
+									<p id="p_usergroups_help" class="govuk-hint">Enter at least one user group as a comma-separated list.</p>
+									<p id="p_usergroups_error" class="govuk-error-message start-error" hidden></p>
+									<input id="p_usergroups" class="govuk-input" required aria-required="true" aria-invalid="false" aria-describedby="p_usergroups_help" />
+								</div>
+
+								<div class="govuk-button-group cta">
+									<button class="govuk-button govuk-button--secondary" id="prev1" type="button">Back</button>
+									<button class="govuk-button" id="next3" type="button">Continue</button>
+								</div>
+							</form>
+						</section>
+
+						<!-- Step 3 -->
+						<section id="step3" class="start-step" hidden aria-labelledby="step3-title">
+							<p class="govuk-caption-l">Step 3 of 4</p>
+							<h2 class="govuk-heading-m" id="step3-title">Add project ownership and notes</h2>
+							<p class="govuk-body">Add supplementary information about who owns the research and anything the team should know before the project is created.</p>
+
+							<form id="researchForm" class="start-form" novalidate>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="lead_name">Lead researcher</label>
+									<input id="lead_name" class="govuk-input" value="" />
+								</div>
+
+								<div id="lead_email_group" class="govuk-form-group">
+									<label class="govuk-label" for="lead_email">Researcher&rsquo;s email</label>
+									<p id="lead_email_hint" class="govuk-hint">Use a work email address.</p>
+									<p id="lead_email_error" class="govuk-error-message start-error" hidden></p>
+									<input id="lead_email" type="email" class="govuk-input" value="" aria-invalid="false" aria-describedby="lead_email_hint" />
+								</div>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="p_notes">Notes</label>
+									<p id="p_notes_help" class="govuk-hint">Add project notes that will help the team start the work. Do not include participant personal data.</p>
+									<textarea id="p_notes" class="govuk-textarea" aria-describedby="p_notes_help"></textarea>
+								</div>
+
+								<div class="govuk-button-group cta">
+									<button class="govuk-button govuk-button--secondary" id="prev2" type="button">Back</button>
+									<button class="govuk-button" id="next4" type="button">Continue</button>
+								</div>
+							</form>
+						</section>
+
+						<!-- Step 4 -->
+						<section id="step4" class="start-step" hidden aria-labelledby="step4-title">
+							<p class="govuk-caption-l">Step 4 of 4</p>
+							<h2 class="govuk-heading-m" id="step4-title">Check your answers before creating the project</h2>
+							<p class="govuk-body">Review the project setup before it is saved. You can go back to change anything that is missing or unclear.</p>
+
+							<dl id="check-answers-list" class="govuk-summary-list start-summary-list" aria-live="polite"></dl>
+
+							<div class="govuk-button-group cta">
+								<button class="govuk-button govuk-button--secondary" id="prev3" type="button">Back</button>
+								<button class="govuk-button" id="finish" type="button">Create project</button>
+							</div>
+						</section>
 					</div>
-
-					<!-- Rule-based/AI suggestions (Objectives) -->
-					<div id="objectives-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
-
-					<!-- AI rewrite preview (Objectives) -->
-					<div id="ai-objectives-output" class="mt-2 start-assist-output" aria-live="polite"></div>
-
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_usergroups">User groups</label>
-						<p id="p_usergroups_help" class="govuk-hint">Enter user groups as a comma-separated list.</p>
-						<input id="p_usergroups" class="govuk-input" aria-describedby="p_usergroups_help" />
-					</div>
-
-					<div class="govuk-button-group cta">
-						<button class="govuk-button" id="prev1" type="button">Back</button>
-						<button class="govuk-button" id="next3" type="button">Continue</button>
-					</div>
-				</form>
-			</section>
-
-			<!-- Step 3 -->
-			<section id="step3" class="start-step" style="display:none">
-				<h2 class="govuk-heading-m">Step 3 of 3</h2>
-				<p class="lede">Supplementary information about the project</p>
-
-				<form id="researchForm" class="start-form">
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="lead_name">Lead researcher</label>
-						<input id="lead_name" class="govuk-input" value="" />
-					</div>
-
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="lead_email">Researcher&rsquo;s email</label>
-						<input id="lead_email" type="email" class="govuk-input" value="" />
-					</div>
-
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="p_notes">Notes</label>
-						<textarea id="p_notes" class="govuk-textarea"></textarea>
-					</div>
-
-					<div class="govuk-button-group cta">
-						<button class="govuk-button" id="prev2" type="button">Back</button>
-						<button class="govuk-button" id="finish" type="button">Create project</button>
-					</div>
-				</form>
-			</section>
+				</div>
+			</div>
 		</div>
 	</main>
 
-	<!-- Global footer -->
+	<noscript>
+		<footer class="govuk-footer" role="contentinfo">
+			<div class="govuk-footer__container govuk-width-container">
+				<p class="govuk-footer__meta">© 2026 Home Office Biometrics · ResearchOps v1.0.0</p>
+			</div>
+		</footer>
+	</noscript>
+
 	<x-include src="/partials/footer.html"></x-include>
 </body>
 

--- a/public/pages/start/start-new-project.js
+++ b/public/pages/start/start-new-project.js
@@ -1,135 +1,95 @@
 /**
  * @file start-new-project.js
  * @module StartNewProject
- * @summary Start → 3-step flow controller (navigation + validation + submit).
- *
- * @description
- * - Step navigation: #step1 ↔ #step2 ↔ #step3
- * - Validates Step 1 when continuing to Step 2.
- * - Builds payload and POSTs to /api/projects on Finish.
- * - Uses robust Airtable select coercion to avoid 422 errors.
- *
- * NOTE: AI assist (description/objectives) is handled by their own modules.
+ * @summary Start → 4-step flow controller (navigation + validation + review + submit).
  */
 
-/* =========================
- * Utilities
- * ========================= */
-
-/** Escape for safe HTML. */
-function esc(s) {
-	return String(s ?? "").replace(/[&<>"']/g, c => ({
+function esc(value) {
+	return String(value ?? "").replace(/[&<>"']/g, c => ({
 		"&": "&amp;",
 		"<": "&lt;",
 		">": "&gt;",
 		'"': "&quot;",
 		"'": "&#39;"
-	} [c]));
+	}[c]));
 }
 
-/** Show error in a summary panel. */
-function showError(el, msg) {
-	if (!el) return;
-	el.innerHTML = esc(msg);
-	el.style.display = "block";
+function valueOf(field) {
+	return (field?.value || "").trim();
 }
 
-/** Hide error summary. */
-function hideError(el) {
-	if (!el) return;
-	el.style.display = "none";
-	el.textContent = "";
+function selectedText(field) {
+	return field?.selectedOptions?.[0]?.textContent?.trim() || valueOf(field);
 }
 
-/**
- * Mark a field as required (inline + aria-invalid).
- * @param {HTMLInputElement|HTMLTextAreaElement} field
- * @param {HTMLElement} inlineError
- * @param {string} label
- */
-function requireField(field, inlineError, label) {
-	const val = (field?.value || "").trim();
-	const ok = val.length > 0;
-	if (field) field.setAttribute("aria-invalid", ok ? "false" : "true");
-	if (inlineError) {
-		inlineError.style.display = ok ? "none" : "block";
-		inlineError.textContent = ok ? "" : `${label} is required.`;
+const steps = [
+	document.querySelector("#step1"),
+	document.querySelector("#step2"),
+	document.querySelector("#step3"),
+	document.querySelector("#step4")
+];
+
+const errorSummary = document.querySelector("#error-summary");
+const errorList = document.querySelector("#error-list");
+
+const projectForm = document.querySelector("#projectForm");
+
+const p_name = document.querySelector("#p_name");
+const p_desc = document.querySelector("#p_desc");
+const p_phase = document.querySelector("#p_phase");
+const p_status = document.querySelector("#p_status");
+const taStakeholders = document.querySelector("#p_stakeholders");
+const taObjectives = document.querySelector("#p_objectives");
+const inputUserGroups = document.querySelector("#p_usergroups");
+const leadName = document.querySelector("#lead_name");
+const leadEmail = document.querySelector("#lead_email");
+const notes = document.querySelector("#p_notes");
+const checkAnswersList = document.querySelector("#check-answers-list");
+
+const btnPrev1 = document.querySelector("#prev1");
+const btnNext3 = document.querySelector("#next3");
+const btnPrev2 = document.querySelector("#prev2");
+const btnNext4 = document.querySelector("#next4");
+const btnPrev3 = document.querySelector("#prev3");
+const btnFinish = document.querySelector("#finish");
+
+const FIELD_META = {
+	p_name: {
+		field: p_name,
+		group: document.querySelector("#p_name_group"),
+		error: document.querySelector("#p_name_error"),
+		describedBy: ["p_name_hint"],
+		message: "Enter a project name."
+	},
+	p_desc: {
+		field: p_desc,
+		group: document.querySelector("#p_desc_group"),
+		error: document.querySelector("#p_desc_error"),
+		describedBy: ["p_desc_help"],
+		message: "Enter a project description."
+	},
+	p_objectives: {
+		field: taObjectives,
+		group: document.querySelector("#p_objectives_group"),
+		error: document.querySelector("#p_objectives_error"),
+		describedBy: ["p_objectives_help"],
+		message: "Enter at least one research objective."
+	},
+	p_usergroups: {
+		field: inputUserGroups,
+		group: document.querySelector("#p_usergroups_group"),
+		error: document.querySelector("#p_usergroups_error"),
+		describedBy: ["p_usergroups_help"],
+		message: "Enter at least one user group."
+	},
+	lead_email: {
+		field: leadEmail,
+		group: document.querySelector("#lead_email_group"),
+		error: document.querySelector("#lead_email_error"),
+		describedBy: ["lead_email_hint"],
+		message: "Enter a work email address in the correct format, like name@example.gov.uk."
 	}
-	return ok;
-}
-
-/* =========================
- * DOM refs
- * ========================= */
-
-// Sections
-const step1 = document.querySelector("#step1");
-const step2 = document.querySelector("#step2");
-const step3 = document.querySelector("#step3");
-
-// Forms
-const projectForm = /** @type {HTMLFormElement|null} */ (document.querySelector("#projectForm"));
-
-// Error summary (Step 1)
-const errorSummary = /** @type {HTMLElement|null} */ (document.querySelector("#error-summary"));
-
-// Step 1 fields
-const p_name = /** @type {HTMLInputElement|null} */ (document.querySelector("#p_name"));
-const p_name_error = /** @type {HTMLElement|null} */ (document.querySelector("#p_name_error"));
-const p_desc = /** @type {HTMLTextAreaElement|null} */ (document.querySelector("#p_desc"));
-const p_desc_error = /** @type {HTMLElement|null} */ (document.querySelector("#p_desc_error"));
-const p_phase = /** @type {HTMLSelectElement|null} */ (document.querySelector("#p_phase"));
-const p_status = /** @type {HTMLSelectElement|null} */ (document.querySelector("#p_status"));
-
-// Step 2 fields
-const taObjectives = /** @type {HTMLTextAreaElement|null} */ (document.querySelector("#p_objectives"));
-const inputUserGroups = /** @type {HTMLInputElement|null} */ (document.querySelector("#p_usergroups"));
-const taStakeholders = /** @type {HTMLTextAreaElement|null} */ (document.querySelector("#p_stakeholders"));
-
-// Step 3 fields
-const leadName = /** @type {HTMLInputElement|null} */ (document.querySelector("#lead_name"));
-const leadEmail = /** @type {HTMLInputElement|null} */ (document.querySelector("#lead_email"));
-const notes = /** @type {HTMLTextAreaElement|null} */ (document.querySelector("#p_notes"));
-
-// Nav buttons
-const btnPrev1 = /** @type {HTMLButtonElement|null} */ (document.querySelector("#prev1"));
-const btnNext3 = /** @type {HTMLButtonElement|null} */ (document.querySelector("#next3"));
-const btnPrev2 = /** @type {HTMLButtonElement|null} */ (document.querySelector("#prev2"));
-const btnFinish = /** @type {HTMLButtonElement|null} */ (document.querySelector("#finish"));
-
-/* =========================
- * Step visibility helpers
- * ========================= */
-
-/**
- * Show one step, hide the rest, keep ARIA state tidy.
- * @param {1|2|3} n
- */
-function goToStep(n) {
-	const map = new Map([
-		[1, step1],
-		[2, step2],
-		[3, step3]
-	]);
-
-	for (const [idx, el] of map.entries()) {
-		if (!el) continue;
-		const on = idx === n;
-		el.style.display = on ? "" : "none";
-		el.setAttribute("aria-hidden", on ? "false" : "true");
-	}
-
-	// Move focus to first focusable in the step (progressive)
-	const target = map.get(n);
-	if (target) {
-		const focusable = target.querySelector("input, textarea, select, button, [tabindex]");
-		if (focusable && typeof focusable.focus === "function") focusable.focus();
-	}
-}
-
-/* =========================
- * Airtable select coercion
- * ========================= */
+};
 
 const PHASE_OPTIONS = ["Pre-Discovery", "Discovery", "Alpha", "Beta", "Live", "Retired"];
 const STATUS_OPTIONS = [
@@ -141,90 +101,138 @@ const STATUS_OPTIONS = [
 	"Monitoring metrics"
 ];
 
-/**
- * Coerce a free/loose value to one of the exact Airtable labels.
- * @param {string} raw
- * @param {string[]} allowed
- */
-function coerceSelect(raw, allowed) {
-	const norm = (s) => String(s || "").toLowerCase().replace(/[\s_-]+/g, "-").trim();
-	const wanted = norm(raw);
-	for (const opt of allowed)
-		if (norm(opt) === wanted) return opt;
-	const starts = allowed.find(o => norm(o).startsWith(wanted) || wanted.startsWith(norm(o)));
-	if (starts) return starts;
-	const contains = allowed.find(o => norm(o).includes(wanted) || wanted.includes(norm(o)));
-	if (contains) return contains;
-	return "";
+function goToStep(n) {
+	steps.forEach((step, index) => {
+		if (!step) return;
+		const isCurrent = index === n - 1;
+		step.hidden = !isCurrent;
+		step.setAttribute("aria-hidden", isCurrent ? "false" : "true");
+	});
+
+	const current = steps[n - 1];
+	const focusable = current?.querySelector("input, textarea, select, button, [tabindex]");
+	if (focusable && typeof focusable.focus === "function") focusable.focus();
 }
 
-/* =========================
- * Payload builder
- * ========================= */
+function clearError(meta) {
+	meta.group?.classList.remove("govuk-form-group--error");
+	meta.error && (meta.error.hidden = true);
+	meta.error && (meta.error.textContent = "");
+	meta.field?.setAttribute("aria-invalid", "false");
+	meta.field?.setAttribute("aria-describedby", meta.describedBy.filter(Boolean).join(" "));
+}
 
-/**
- * Build payload for /api/projects (omits invalid selects).
- */
+function setError(meta) {
+	meta.group?.classList.add("govuk-form-group--error");
+	meta.error && (meta.error.hidden = false);
+	meta.error && (meta.error.textContent = meta.message);
+	meta.field?.setAttribute("aria-invalid", "true");
+	meta.field?.setAttribute("aria-describedby", [...meta.describedBy, meta.error?.id].filter(Boolean).join(" "));
+}
+
+function clearAllErrors() {
+	if (errorSummary) errorSummary.hidden = true;
+	if (errorList) errorList.innerHTML = "";
+	Object.values(FIELD_META).forEach(clearError);
+}
+
+function showErrorSummary(errors) {
+	if (!errorSummary || !errorList || errors.length === 0) return;
+	errorList.innerHTML = errors.map(meta => `<li><a href="#${esc(meta.field?.id || "main-content")}">${esc(meta.message)}</a></li>`).join("");
+	errorSummary.hidden = false;
+	errorSummary.focus();
+}
+
+function validateRequired(names) {
+	clearAllErrors();
+	const errors = names.map(name => FIELD_META[name]).filter(meta => !valueOf(meta.field));
+	errors.forEach(setError);
+	showErrorSummary(errors);
+	return errors.length === 0;
+}
+
+function validateStep1() {
+	return validateRequired(["p_name", "p_desc"]);
+}
+
+function validateStep2() {
+	return validateRequired(["p_objectives", "p_usergroups"]);
+}
+
+function validateStep3() {
+	clearAllErrors();
+	const email = valueOf(leadEmail);
+	const meta = FIELD_META.lead_email;
+	const errors = email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? [meta] : [];
+	errors.forEach(setError);
+	showErrorSummary(errors);
+	return errors.length === 0;
+}
+
+function coerceSelect(raw, allowed) {
+	const norm = s => String(s || "").toLowerCase().replace(/[\s_-]+/g, "-").trim();
+	const wanted = norm(raw);
+	for (const opt of allowed) if (norm(opt) === wanted) return opt;
+	return allowed.find(opt => norm(opt).startsWith(wanted) || wanted.startsWith(norm(opt))) || "";
+}
+
 function buildPayload() {
-	const coercedPhase = coerceSelect(p_phase?.value, PHASE_OPTIONS);
-	const coercedStatus = coerceSelect(p_status?.value, STATUS_OPTIONS);
-
-	const objectives = (taObjectives?.value || "")
-		.split("\n")
-		.map(s => s.trim())
-		.filter(Boolean);
-
-	const user_groups = (inputUserGroups?.value || "")
-		.split(",")
-		.map(s => s.trim())
-		.filter(Boolean);
-
-	const stakeholders = (taStakeholders?.value || "")
-		.split("\n")
-		.map(line => line.trim())
-		.filter(Boolean)
-		.map(line => {
-			const parts = line.split("|").map(s => s.trim());
-			return { name: parts[0] || "", role: parts[1] || "", email: parts[2] || "" };
-		});
-
-	/** @type {{org?:string,name:string,description:string,phase?:string,status?:string,objectives:string[],user_groups:string[],stakeholders:any[],lead_researcher?:string,lead_researcher_email?:string,notes?:string,id?:string}} */
+	const objectives = valueOf(taObjectives).split("\n").map(s => s.trim()).filter(Boolean);
+	const user_groups = valueOf(inputUserGroups).split(",").map(s => s.trim()).filter(Boolean);
+	const stakeholders = valueOf(taStakeholders).split("\n").map(s => s.trim()).filter(Boolean).map(line => {
+		const parts = line.split("|").map(s => s.trim());
+		return { name: parts[0] || "", role: parts[1] || "", email: parts[2] || "" };
+	});
 	const out = {
 		org: "Home Office Biometrics",
-		name: (p_name?.value || "").trim(),
-		description: (p_desc?.value || "").trim(),
+		name: valueOf(p_name),
+		description: valueOf(p_desc),
 		objectives,
 		user_groups,
 		stakeholders,
-		lead_researcher: (leadName?.value || "").trim(),
-		lead_researcher_email: (leadEmail?.value || "").trim(),
-		notes: (notes?.value || "").trim(),
+		lead_researcher: valueOf(leadName),
+		lead_researcher_email: valueOf(leadEmail),
+		notes: valueOf(notes),
 		id: ""
 	};
-
-	if (coercedPhase) out.phase = coercedPhase;
-	if (coercedStatus) out.status = coercedStatus;
-
+	const phase = coerceSelect(p_phase?.value, PHASE_OPTIONS);
+	const status = coerceSelect(p_status?.value, STATUS_OPTIONS);
+	if (phase) out.phase = phase;
+	if (status) out.status = status;
 	return out;
 }
 
-/* =========================
- * Fetch wrapper
- * ========================= */
+function summaryValue(value) {
+	const text = String(value || "").trim();
+	return text ? esc(text).replaceAll("\n", "<br />") : '<span class="muted">Not provided</span>';
+}
 
-/**
- * POST with timeout; structured return (json OR text).
- * @param {string} url
- * @param {any} body
- * @param {{timeoutMs?:number, headers?:Record<string,string>}} [opts]
- */
+function renderCheckAnswers() {
+	if (!checkAnswersList) return;
+	const rows = [
+		["Project name", valueOf(p_name), "#p_name"],
+		["Description", valueOf(p_desc), "#p_desc"],
+		["Service phase", selectedText(p_phase), "#p_phase"],
+		["Project status", selectedText(p_status), "#p_status"],
+		["Stakeholders", valueOf(taStakeholders), "#p_stakeholders"],
+		["Initial objectives", valueOf(taObjectives), "#p_objectives"],
+		["User groups", valueOf(inputUserGroups), "#p_usergroups"],
+		["Lead researcher", valueOf(leadName), "#lead_name"],
+		["Researcher’s email", valueOf(leadEmail), "#lead_email"],
+		["Notes", valueOf(notes), "#p_notes"]
+	];
+	checkAnswersList.innerHTML = rows.map(([key, value, href]) => `
+		<div class="govuk-summary-list__row">
+			<dt class="govuk-summary-list__key">${esc(key)}</dt>
+			<dd class="govuk-summary-list__value">${summaryValue(value)}</dd>
+			<dd class="govuk-summary-list__actions"><a class="govuk-link" href="${esc(href)}" data-change-target="${esc(href)}">Change<span class="govuk-visually-hidden"> ${esc(key)}</span></a></dd>
+		</div>`).join("");
+}
+
 async function apiPost(url, body, opts = {}) {
-	const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : 15000;
 	const controller = new AbortController();
+	const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : 15000;
 	const id = setTimeout(() => controller.abort(new Error("timeout")), timeoutMs);
-
-	window.__ropsDebug?.log?.(`→ POST ${url}`);
-
 	try {
 		const res = await fetch(url, {
 			method: "POST",
@@ -232,186 +240,93 @@ async function apiPost(url, body, opts = {}) {
 			body: JSON.stringify(body),
 			signal: controller.signal
 		});
-
-		const ct = res.headers.get("content-type") || "";
-		let payload;
-		if (ct.includes("application/json")) {
-			payload = await res.json().catch(() => null);
-		} else {
-			payload = await res.text().catch(() => "");
-		}
-
-		window.__ropsDebug?.log?.(`← ${res.status} ${res.ok ? "OK" : "ERROR"}`);
-
-		return { ok: res.ok, status: res.status, json: (payload && typeof payload === "object") ? payload : null, text: (typeof payload === "string") ? payload : "" };
+		const contentType = res.headers.get("content-type") || "";
+		const payload = contentType.includes("application/json") ? await res.json().catch(() => null) : await res.text().catch(() => "");
+		return { ok: res.ok, status: res.status, json: (payload && typeof payload === "object") ? payload : null, text: typeof payload === "string" ? payload : "" };
 	} finally {
 		clearTimeout(id);
 	}
 }
 
-/* =========================
- * Submit (keep createProject())
- * ========================= */
-
-/**
- * Create the project via API and route on success.
- */
-async function createProject() {
-	if (!btnFinish) return;
-	// Step 1 fields are critical even if user navigated back
-	hideError(errorSummary);
-
-	const okName = p_name ? requireField(p_name, p_name_error, "Project name") : true;
-	const okDesc = p_desc ? requireField(p_desc, p_desc_error, "Description") : true;
-	if (!okName || !okDesc) {
-		showError(errorSummary, "Please fix the highlighted fields.");
-		window.__ropsDebug?.show?.();
-		window.__ropsDebug?.log?.("Validation failed for required Step 1 fields.");
+function validateBeforeCreate() {
+	if (!validateStep1()) {
 		goToStep(1);
-		return;
+		showErrorSummary([FIELD_META.p_name, FIELD_META.p_desc].filter(meta => !valueOf(meta.field)));
+		return false;
 	}
+	if (!validateStep2()) {
+		goToStep(2);
+		showErrorSummary([FIELD_META.p_objectives, FIELD_META.p_usergroups].filter(meta => !valueOf(meta.field)));
+		return false;
+	}
+	if (!validateStep3()) {
+		goToStep(3);
+		showErrorSummary([FIELD_META.lead_email]);
+		return false;
+	}
+	return true;
+}
 
+async function createProject() {
+	if (!btnFinish || !validateBeforeCreate()) return;
 	btnFinish.textContent = "Creating…";
 	btnFinish.disabled = true;
 
 	try {
-		const payload = buildPayload();
-		window.__ropsDebug?.log?.(`Submitting /api/projects payload: ${JSON.stringify(payload)}`);
-
-		const res = await apiPost("/api/projects", payload, { timeoutMs: 15000 });
-
-		if (!res.ok) {
-			if (res.json && res.json.error) {
-				const detail = String(res.json.detail || "");
-				if (/INVALID_MULTIPLE_CHOICE_OPTIONS/i.test(detail)) {
-					const lines = ["One or more select values are not allowed by Airtable."];
-					lines.push(`Service phase must be: ${PHASE_OPTIONS.join(", ")}.`);
-					lines.push(`Project status must be: ${STATUS_OPTIONS.join(", ")}.`);
-					lines.push("Update the selections and try again.");
-					showError(errorSummary, lines.join(" "));
-					window.__ropsDebug?.show?.();
-					window.__ropsDebug?.log?.(`Airtable 422 detail: ${detail}`);
-					goToStep(1);
-				} else {
-					showError(
-						errorSummary,
-						`Error ${res.status}: ${esc(res.json.error)}${res.json.detail ? ` — ${esc(res.json.detail)}` : ""}`
-					);
-					window.__ropsDebug?.show?.();
-					window.__ropsDebug?.log?.(`Server error ${res.status}: ${JSON.stringify(res.json)}`);
-					goToStep(1);
-				}
-			} else if (res.text) {
-				showError(errorSummary, `Error ${res.status}: ${esc(res.text)}`);
-				window.__ropsDebug?.show?.();
-				window.__ropsDebug?.log?.(`Server text error ${res.status}: ${res.text}`);
-				goToStep(1);
-			} else {
-				showError(errorSummary, `Error ${res.status}: Request failed.`);
-				window.__ropsDebug?.show?.();
-				window.__ropsDebug?.log?.(`Generic failure ${res.status}`);
-				goToStep(1);
-			}
-
-			btnFinish.textContent = "Create project";
-			btnFinish.disabled = false;
-			return;
-		}
-
-		if (res.json && res.json.ok) {
-			window.__ropsDebug?.log?.(`Project created: ${res.json.project_id}`);
+		const res = await apiPost("/api/projects", buildPayload(), { timeoutMs: 15000 });
+		if (res.ok && res.json?.ok) {
 			window.location.href = "/pages/projects/";
 			return;
 		}
-
-		showError(errorSummary, "Unexpected response from the server.");
-		window.__ropsDebug?.show?.();
-		window.__ropsDebug?.log?.(`Unexpected response: ${JSON.stringify(res.json || res.text || {})}`);
-		btnFinish.textContent = "Create project";
-		btnFinish.disabled = false;
-
+		const message = res.json?.detail || res.json?.error || res.text || "Request failed.";
+		showErrorSummary([{ field: btnFinish, message: `Error ${res.status}: ${message}` }]);
 	} catch (err) {
-		const msg = (err && err.message) ? err.message : String(err);
-		showError(errorSummary, `Network error: ${esc(msg)}`);
-		window.__ropsDebug?.show?.();
-		window.__ropsDebug?.log?.(`Network error: ${msg}`);
+		showErrorSummary([{ field: btnFinish, message: `Network error: ${(err && err.message) ? err.message : String(err)}` }]);
+	} finally {
 		btnFinish.textContent = "Create project";
 		btnFinish.disabled = false;
 	}
 }
 
-/* =========================
- * Navigation handlers
- * ========================= */
-
-function onNextFromStep1() {
-	hideError(errorSummary);
-	const okName = p_name ? requireField(p_name, p_name_error, "Project name") : true;
-	const okDesc = p_desc ? requireField(p_desc, p_desc_error, "Description") : true;
-	if (!okName || !okDesc) {
-		showError(errorSummary, "Please fix the highlighted fields.");
-		return;
-	}
-	goToStep(2);
-}
-
-function onProjectFormSubmit(event) {
+function onChangeAnswer(event) {
+	const link = event.target.closest?.("[data-change-target]");
+	if (!link) return;
 	event.preventDefault();
-	onNextFromStep1();
+	const target = link.getAttribute("data-change-target") || "";
+	if (["#p_name", "#p_desc", "#p_phase", "#p_status"].includes(target)) goToStep(1);
+	else if (["#p_stakeholders", "#p_objectives", "#p_usergroups"].includes(target)) goToStep(2);
+	else goToStep(3);
+	document.querySelector(target)?.focus?.();
 }
-
-function onBackToStep1() {
-	hideError(errorSummary);
-	goToStep(1);
-}
-
-function onNextFromStep2() {
-	// No hard validation here (objectives optional), just proceed
-	goToStep(3);
-}
-
-function onBackToStep2() {
-	goToStep(2);
-}
-
-/* =========================
- * Wire up
- * ========================= */
 
 function wire() {
-	// Initial state
 	goToStep(1);
-
-	// Forms and buttons
-	projectForm?.addEventListener("submit", onProjectFormSubmit);
-	btnPrev1?.addEventListener("click", onBackToStep1);
-	btnNext3?.addEventListener("click", onNextFromStep2);
-	btnPrev2?.addEventListener("click", onBackToStep2);
-	btnFinish?.addEventListener("click", createProject);
-
-	// Basic Enter-key prevention on Step 1 inputs to avoid accidental submit
-	[p_name, p_desc].forEach(el => {
-		el?.addEventListener("keydown", (e) => {
-			if (e.key === "Enter" && !e.shiftKey) {
-				// allow Enter in textarea to make a new line
-				if (el.tagName !== "TEXTAREA") e.preventDefault();
-			}
-		});
+	projectForm?.addEventListener("submit", event => {
+		event.preventDefault();
+		if (validateStep1()) goToStep(2);
 	});
+	btnPrev1?.addEventListener("click", () => goToStep(1));
+	btnNext3?.addEventListener("click", () => validateStep2() && goToStep(3));
+	btnPrev2?.addEventListener("click", () => goToStep(2));
+	btnNext4?.addEventListener("click", () => {
+		if (!validateStep3()) return;
+		renderCheckAnswers();
+		goToStep(4);
+	});
+	btnPrev3?.addEventListener("click", () => goToStep(3));
+	btnFinish?.addEventListener("click", createProject);
+	checkAnswersList?.addEventListener("click", onChangeAnswer);
 }
 
-if (document.readyState === "loading") {
-	document.addEventListener("DOMContentLoaded", wire);
-} else {
-	wire();
-}
+if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", wire);
+else wire();
 
-// Exports for testing if needed
 export {
 	createProject,
 	buildPayload,
 	coerceSelect,
 	PHASE_OPTIONS,
 	STATUS_OPTIONS,
-	goToStep
+	goToStep,
+	renderCheckAnswers
 };

--- a/scripts/researchops-start-acceptance.mjs
+++ b/scripts/researchops-start-acceptance.mjs
@@ -1,0 +1,242 @@
+/* eslint-env node */
+
+/**
+ * @file scripts/researchops-start-acceptance.mjs
+ * @summary Generate start-page acceptance criteria from the current ResearchOps start-page source.
+ */
+
+import fs from 'node:fs';
+
+const SOURCE = 'public/pages/start/index.html';
+const ENTITIES = { amp: '&', copy: '©', lt: '<', gt: '>', middot: '·', nbsp: ' ', quot: '"', rsquo: '’' };
+
+function html() {
+	try {
+		return fs.readFileSync(SOURCE, 'utf8');
+	} catch {
+		return '';
+	}
+}
+
+function decode(value = '') {
+	return String(value).replace(/&(#\d+|#x[a-f0-9]+|[a-z]+);/gi, (entity, token) => {
+		const key = token.toLowerCase();
+		if (key.startsWith('#x')) return String.fromCodePoint(Number.parseInt(key.slice(2), 16));
+		if (key.startsWith('#')) return String.fromCodePoint(Number.parseInt(key.slice(1), 10));
+		return ENTITIES[key] || entity;
+	});
+}
+
+function text(value = '') {
+	return decode(String(value).replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+function quote(value = '') {
+	return String(value).replaceAll('"', '\\"');
+}
+
+function first(source = '', pattern, fallback = '') {
+	const match = source.match(pattern);
+	return match ? text(match[1]) : fallback;
+}
+
+function all(source = '', pattern) {
+	return [...source.matchAll(pattern)].map(match => text(match[1])).filter(Boolean);
+}
+
+function byId(source = '', id = '') {
+	const pattern = new RegExp(`<([a-z0-9-]+)\\b(?=[^>]*id=["']${id}["'])[^>]*>([\\s\\S]*?)<\\/\\1>`, 'i');
+	return source.match(pattern)?.[0] || '';
+}
+
+function label(source = '', id = '', fallback = '') {
+	return first(source, new RegExp(`<label\\b(?=[^>]*for=["']${id}["'])[^>]*>([\\s\\S]*?)<\\/label>`, 'i'), fallback);
+}
+
+function hint(source = '', id = '', fallback = '') {
+	return first(source, new RegExp(`<p\\b(?=[^>]*id=["']${id}["'])[^>]*>([\\s\\S]*?)<\\/p>`, 'i'), fallback);
+}
+
+function step(source = '', id = '', fallback = []) {
+	const section = byId(source, id);
+	return [
+		first(section, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-caption-l\b)[^>]*>([\s\S]*?)<\/p>/i, fallback[0]),
+		first(section, /<h2\b[^>]*>([\s\S]*?)<\/h2>/i, fallback[1]),
+		first(section, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-body\b)[^>]*>([\s\S]*?)<\/p>/i, fallback[2]),
+	];
+}
+
+function options(source = '', id = '', fallback = []) {
+	const select = byId(source, id);
+	const found = all(select, /<option\b[^>]*>([\s\S]*?)<\/option>/gi);
+	return found.length ? found : fallback;
+}
+
+function rows(values = []) {
+	return values.map(row => `      | ${row.map(item => quote(item)).join(' | ')} |`);
+}
+
+function model() {
+	const source = html();
+	const intro = source.match(/<header\b(?=[^>]*class=["'][^"']*\bpage-intro\b)[^>]*>([\s\S]*?)<\/header>/i)?.[0] || '';
+	const nav = all(source, /<a\b(?=[^>]*class=["'][^"']*\bgovuk-service-navigation__link\b)[^>]*>([\s\S]*?)<\/a>/gi).filter(item => item !== 'ResearchOps Demo Suite');
+	return {
+		heading: first(source, /<h1\b(?=[^>]*id=["']start-title["'])[^>]*>([\s\S]*?)<\/h1>/i, 'Start a new research project'),
+		lede: first(intro, /<p\b(?=[^>]*class=["'][^"']*\blede\b)[^>]*>([\s\S]*?)<\/p>/i, 'Define the project within a service phase and current status, then capture stakeholders and initial objectives.'),
+		intro: first(intro, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-body\b)[^>]*>([\s\S]*?)<\/p>/i, 'Use this guided process to create the project record that will later hold studies, participants, sessions, notes, evidence, insights and recommendations.'),
+		prototype: first(source, /<span\b(?=[^>]*class=["'][^"']*\bgovuk-phase-banner__text\b)[^>]*>([\s\S]*?)<\/span>/i, 'This is a ResearchOps prototype. Do not enter real participant personal data.'),
+		nav: nav.length ? nav : ['Home', 'Start research project', 'Projects'],
+		steps: [
+			step(source, 'step1', ['Step 1 of 4', 'Define the project', 'Give the project a name, description, service phase and current status.']),
+			step(source, 'step2', ['Step 2 of 4', 'Add stakeholders, objectives and user groups', 'Add the people involved, what the research needs to learn and who the research should include.']),
+			step(source, 'step3', ['Step 3 of 4', 'Add project ownership and notes', 'Add supplementary information about who owns the research and anything the team should know before the project is created.']),
+			step(source, 'step4', ['Step 4 of 4', 'Check your answers before creating the project', 'Review the project setup before it is saved. You can go back to change anything that is missing or unclear.']),
+		],
+		projectFields: [
+			[label(source, 'p_name', 'Project name'), hint(source, 'p_name_hint', 'Use a short name the research team and stakeholders will recognise.')],
+			[label(source, 'p_desc', 'Description'), hint(source, 'p_desc_help', 'Write what you plan to research. Do not include participant personal data.')],
+			[label(source, 'p_phase', 'Service phase'), 'No additional hint text.'],
+			[label(source, 'p_status', 'Project status'), 'No additional hint text.'],
+		],
+		targetFields: [
+			[label(source, 'p_stakeholders', 'Stakeholders'), hint(source, 'p_stakeholders_help', 'Enter one stakeholder per line using the format: name | role | work email.')],
+			[label(source, 'p_objectives', 'Initial objectives'), hint(source, 'p_objectives_help', 'List at least one research objective.')],
+			[label(source, 'p_usergroups', 'User groups'), hint(source, 'p_usergroups_help', 'Enter at least one user group as a comma-separated list.')],
+		],
+		ownershipFields: [
+			[label(source, 'lead_name', 'Lead researcher'), 'No additional hint text.'],
+			[label(source, 'lead_email', 'Researcher’s email'), hint(source, 'lead_email_hint', 'Use a work email address.')],
+			[label(source, 'p_notes', 'Notes'), hint(source, 'p_notes_help', 'Add project notes that will help the team start the work.')],
+		],
+		phases: options(source, 'p_phase', ['Pre-Discovery', 'Discovery', 'Alpha', 'Beta', 'Live', 'Retired']),
+		statuses: options(source, 'p_status', ['Goal setting & problem defining', 'Planning research', 'Conducting research', 'Synthesis & analysis', 'Shared & socialised research', 'Monitoring metrics']),
+		descriptionAi: hint(source, 'ai-rewrite-help', 'This sends the description you entered to an AI service to suggest improvements. Do not include participant personal data.'),
+		objectivesAi: hint(source, 'ai-objectives-help', 'This sends the objectives you entered to an AI service to suggest improvements. Do not include participant personal data.'),
+		footer: first(source, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-footer__meta\b)[^>]*>([\s\S]*?)<\/p>/i, '© 2026 Home Office Biometrics · ResearchOps v1.0.0'),
+	};
+}
+
+function fieldRows(fields = []) {
+	return rows(fields.map(([field, guidance]) => [field, guidance || 'No additional hint text.']));
+}
+
+export function buildStartAcceptanceCriteriaFromSource() {
+	const page = model();
+	const reviewFields = [...page.projectFields, ...page.targetFields, ...page.ownershipFields].map(([field]) => [field]);
+	return [
+		'Feature: Start a new research project',
+		'',
+		'  As a user researcher',
+		'  I want to define a research project with clear context, objectives and ownership',
+		'  So that my team can start research work with shared intent and traceable setup information',
+		'',
+		'  Background:',
+		'    Given I am a user researcher',
+		'    When I visit the start research project service',
+		'',
+		'  Scenario: View the guided process identity',
+		'    Then I should see the service name "ResearchOps Demo Suite"',
+		`    And I should see the page heading "${quote(page.heading)}"`,
+		`    And I should see introductory text that says "${quote(page.lede)}"`,
+		`    And I should see supporting text that says "${quote(page.intro)}"`,
+		'',
+		'  Scenario: Understand that the service is a prototype',
+		'    Then I should see a prototype banner',
+		`    And the banner should say "${quote(page.prototype)}"`,
+		'',
+		'  Scenario: Navigate using the primary navigation',
+		'    Then I should see primary navigation links for:',
+		...rows(page.nav.map(item => [item])),
+		'    And the "Start research project" navigation item should be shown as the current page',
+		'',
+		'  Scenario: Understand the steps in the guided process',
+		'    Then I should be guided through these steps in order:',
+		'      | Step | Heading | Purpose |',
+		...rows(page.steps),
+		'',
+		'  Scenario: Define the project',
+		`    Given I am on "${quote(page.steps[0][1])}"`,
+		'    Then I should be asked for:',
+		'      | Field | Guidance |',
+		...fieldRows(page.projectFields),
+		'    And I should be able to choose a service phase from:',
+		...rows(page.phases.map(item => [item])),
+		'    And I should be able to choose a project status from:',
+		...rows(page.statuses.map(item => [item])),
+		'',
+		'  Scenario: Recover when required project definition fields are missing',
+		`    Given I am on "${quote(page.steps[0][1])}"`,
+		'    When I try to continue without a project name or description',
+		'    Then I should see a GOV.UK error summary headed "There is a problem"',
+		'    And the error summary should link to the fields that need attention',
+		'    And each invalid field should expose its error message to assistive technology',
+		'',
+		'  Scenario: Use AI assistance for the project description deliberately',
+		`    Given I have entered enough text in "${quote(page.projectFields[1][0])}"`,
+		`    Then I should see AI disclosure text that says "${quote(page.descriptionAi)}"`,
+		'    And AI rewrite should only run when I explicitly select "Try AI rewrite"',
+		'',
+		'  Scenario: Add stakeholders, objectives and user groups',
+		`    Given I have completed "${quote(page.steps[0][1])}"`,
+		`    When I continue to "${quote(page.steps[1][1])}"`,
+		'    Then I should be asked for:',
+		'      | Field | Guidance |',
+		...fieldRows(page.targetFields),
+		'',
+		'  Scenario: Recover when required research framing fields are missing',
+		`    Given I am on "${quote(page.steps[1][1])}"`,
+		'    When I try to continue without objectives or user groups',
+		'    Then I should see a GOV.UK error summary headed "There is a problem"',
+		`    And the error summary should link to "${quote(page.targetFields[1][0])}"`,
+		`    And the error summary should link to "${quote(page.targetFields[2][0])}"`,
+		'',
+		'  Scenario: Use AI assistance for objectives deliberately',
+		`    Given I have entered enough text in "${quote(page.targetFields[1][0])}"`,
+		`    Then I should see AI disclosure text that says "${quote(page.objectivesAi)}"`,
+		'    And AI rewrite should only run when I explicitly select "Try AI rewrite"',
+		'',
+		'  Scenario: Add project ownership and notes',
+		`    Given I have completed "${quote(page.steps[1][1])}"`,
+		`    When I continue to "${quote(page.steps[2][1])}"`,
+		'    Then I should be asked for:',
+		'      | Field | Guidance |',
+		...fieldRows(page.ownershipFields),
+		'',
+		'  Scenario: Check answers before creating the project',
+		`    Given I have completed "${quote(page.steps[2][1])}"`,
+		`    When I continue to "${quote(page.steps[3][1])}"`,
+		'    Then I should see a GOV.UK summary list containing:',
+		...rows(reviewFields),
+		'    And I should be able to go back and change any answer before creating the project',
+		'',
+		'  Scenario: Create the project',
+		`    Given I have reviewed "${quote(page.steps[3][1])}"`,
+		'    When I select "Create project"',
+		'    Then the project should be submitted to ResearchOps',
+		'    And I should be taken to the projects page when creation succeeds',
+		'',
+		'  Scenario: Recover from a project creation error',
+		'    When project creation fails',
+		'    Then I should see a GOV.UK error summary',
+		'    And I should remain in the guided process so I can recover without losing my answers',
+		'',
+		'  Scenario: Complete the guided process using a keyboard',
+		'    Given I am navigating with a keyboard',
+		'    Then I should be able to move focus through each field and button in order',
+		'    And I should be able to move forward and back through the steps without a mouse',
+		'    And validation errors should move focus to the error summary',
+		'',
+		'  Scenario: Understand the guided process with assistive technology',
+		'    Then the page should have one clear main heading',
+		'    And each step should have a meaningful heading',
+		'    And field labels, hints and error messages should be exposed in a logical reading order',
+		'    And the check answers step should expose each answer as a summary list row',
+		'',
+		'  Scenario: Use the guided process on a mobile device',
+		'    Then the fields, buttons, AI disclosure text and check answers list should remain readable',
+		'    And no content should require horizontal scrolling',
+		'',
+		'  Scenario: View footer information',
+		`    Then I should see the footer text "${quote(page.footer)}"`,
+	].join('\n');
+}

--- a/scripts/researchops-start-acceptance.mjs
+++ b/scripts/researchops-start-acceptance.mjs
@@ -9,6 +9,12 @@ import fs from 'node:fs';
 
 const SOURCE = 'public/pages/start/index.html';
 const ENTITIES = { amp: '&', copy: '©', lt: '<', gt: '>', middot: '·', nbsp: ' ', quot: '"', rsquo: '’' };
+const VALIDATION_MESSAGES = {
+	projectName: 'Enter a project name.',
+	projectDescription: 'Enter a project description.',
+	objectives: 'Enter at least one research objective.',
+	userGroups: 'Enter at least one user group.',
+};
 
 function html() {
 	try {
@@ -169,6 +175,8 @@ export function buildStartAcceptanceCriteriaFromSource() {
 		'    When I try to continue without a project name or description',
 		'    Then I should see a GOV.UK error summary headed "There is a problem"',
 		'    And the error summary should link to the fields that need attention',
+		`    And I should see the error message "${quote(VALIDATION_MESSAGES.projectName)}"`,
+		`    And I should see the error message "${quote(VALIDATION_MESSAGES.projectDescription)}"`,
 		'    And each invalid field should expose its error message to assistive technology',
 		'',
 		'  Scenario: Use AI assistance for the project description deliberately',
@@ -189,6 +197,8 @@ export function buildStartAcceptanceCriteriaFromSource() {
 		'    Then I should see a GOV.UK error summary headed "There is a problem"',
 		`    And the error summary should link to "${quote(page.targetFields[1][0])}"`,
 		`    And the error summary should link to "${quote(page.targetFields[2][0])}"`,
+		`    And I should see the error message "${quote(VALIDATION_MESSAGES.objectives)}"`,
+		`    And I should see the error message "${quote(VALIDATION_MESSAGES.userGroups)}"`,
 		'',
 		'  Scenario: Use AI assistance for objectives deliberately',
 		`    Given I have entered enough text in "${quote(page.targetFields[1][0])}"`,

--- a/scripts/researchops-state-acceptance.mjs
+++ b/scripts/researchops-state-acceptance.mjs
@@ -6,6 +6,7 @@
  */
 
 import { buildHomeAcceptanceCriteriaFromSource } from './researchops-home-acceptance.mjs';
+import { buildStartAcceptanceCriteriaFromSource } from './researchops-start-acceptance.mjs';
 
 const PAGE_STORIES = {
 	home: {
@@ -15,10 +16,10 @@ const PAGE_STORIES = {
 		so: 'I can choose the right ResearchOps journey for my work',
 	},
 	start: {
-		feature: 'Define a research project',
+		feature: 'Start a new research project',
 		context: 'start research project service',
-		want: 'define a research project with objectives, stakeholders and ownership',
-		so: 'my team can start research work with shared context and traceable intent',
+		want: 'define a research project with clear context, objectives and ownership',
+		so: 'my team can start research work with shared intent and traceable setup information',
 	},
 	projects: {
 		feature: 'Review research projects',
@@ -123,12 +124,15 @@ const SELECTOR_LABELS = {
 	'#lead_name': 'Lead researcher name',
 	'#lead_email': 'Lead researcher email',
 	'#p_notes': 'Project notes',
-	'#next2': 'Continue to stakeholders and objectives',
-	'#next3': 'Continue to lead researcher and notes',
+	'#next2': 'Continue to stakeholders, objectives and user groups',
+	'#next3': 'Continue to project ownership and notes',
+	'#next4': 'Continue to check your answers',
+	'#finish': 'Create project',
 	'#btn-obj-ai-rewrite': 'Improve objectives with AI',
 	'#ai-objectives-tools:not(.hidden)': 'AI objectives support panel',
 	'#step2': 'Stakeholders, objectives and user groups step',
-	'#step3': 'Lead researcher and notes step',
+	'#step3': 'Project ownership and notes step',
+	'#step4': 'Check your answers step',
 	'#cluster-label': 'Working cluster label',
 	'#cluster-description': 'Working cluster description',
 	'#create-cluster': 'Create working cluster grouping',
@@ -248,6 +252,7 @@ function buildActionScenario(sourceActions = []) {
 
 export function buildStateAcceptanceGherkin(page = {}, state = {}, sourceState = null) {
 	if (page.id === 'home') return buildHomeAcceptanceCriteriaFromSource();
+	if (page.id === 'start') return buildStartAcceptanceCriteriaFromSource();
 
 	const story = storyForPage(page);
 	const statePurpose = state.description

--- a/tests/cucumber-reporting.test.js
+++ b/tests/cucumber-reporting.test.js
@@ -97,7 +97,7 @@ test('buildStateAcceptanceGherkin writes ResearchOps home criteria from a user r
 	assert.doesNotMatch(gherkin, /captured evidence status/);
 });
 
-test('buildStateAcceptanceGherkin derives user-centred criteria from state actions', () => {
+test('buildStateAcceptanceGherkin writes source-derived start-project criteria', () => {
 	const gherkin = buildStateAcceptanceGherkin(
 		{
 			id: 'start',
@@ -106,9 +106,9 @@ test('buildStateAcceptanceGherkin derives user-centred criteria from state actio
 			description: 'Start page for creating or beginning research project work.',
 		},
 		{
-			id: 'step-2-ai-rewrite-shown',
-			title: 'Step 2 AI rewrite shown',
-			description: 'The AI rewrite panel is shown after eligible objectives are entered.',
+			id: 'step-4-check-answers',
+			title: 'Step 4 check your answers before create project',
+			description: 'The review step is shown before project creation is submitted.',
 			status: 'captured',
 		},
 		{
@@ -116,30 +116,69 @@ test('buildStateAcceptanceGherkin derives user-centred criteria from state actio
 			actions: [
 				{
 					type: 'click',
-					selector: '#btn-obj-ai-rewrite',
-				},
-				{
-					type: 'waitForText',
-					text: 'Concise rewrite (optional):',
+					selector: '#next4',
 				},
 			],
 		}
 	);
 
-	assert.match(gherkin, /Feature: Define a research project/);
+	assert.match(gherkin, /Feature: Start a new research project/);
 	assert.match(gherkin, /As a user researcher/);
 	assert.match(
 		gherkin,
-		/I want to define a research project with objectives, stakeholders and ownership/
+		/I want to define a research project with clear context, objectives and ownership/
 	);
 	assert.match(gherkin, /When I visit the start research project service/);
-	assert.match(gherkin, /Scenario: Work with the "Step 2 AI rewrite shown" state/);
-	assert.match(gherkin, /When I select "Improve objectives with AI"/);
-	assert.match(gherkin, /Then I should see "Concise rewrite \(optional\):"/);
-	assert.match(gherkin, /Scenario: Use the state accessibly/);
+	assert.match(gherkin, /Scenario: Understand the steps in the guided process/);
+	assert.match(gherkin, /Step 1 of 4 \| Define the project/);
+	assert.match(gherkin, /Step 4 of 4 \| Check your answers before creating the project/);
+	assert.match(gherkin, /Scenario: Recover when required research framing fields are missing/);
+	assert.match(gherkin, /Enter at least one research objective/);
+	assert.match(gherkin, /Enter at least one user group/);
+	assert.match(gherkin, /This sends the objectives you entered to an AI service/);
+	assert.match(gherkin, /Scenario: Check answers before creating the project/);
+	assert.match(gherkin, /GOV\.UK summary list/);
+	assert.match(gherkin, /Scenario: Complete the guided process using a keyboard/);
 	assert.doesNotMatch(gherkin, /Given the route/);
 	assert.doesNotMatch(gherkin, /I am reviewing/);
 	assert.doesNotMatch(gherkin, /captured evidence status/);
+});
+
+test('buildStateAcceptanceGherkin derives user-centred criteria from state actions for generic pages', () => {
+	const gherkin = buildStateAcceptanceGherkin(
+		{
+			id: 'synthesize',
+			title: 'Synthesize',
+			path: '/pages/synthesize/index.html',
+			description: 'Synthesis page.',
+		},
+		{
+			id: 'theme-created',
+			title: 'Theme created',
+			description: 'A theme has been created from grouped evidence.',
+			status: 'captured',
+		},
+		{
+			path: '/pages/synthesize/index.html',
+			actions: [
+				{
+					type: 'fill',
+					selector: '#theme-label',
+					value: 'Confidence and support needs',
+				},
+				{
+					type: 'click',
+					selector: '#create-theme',
+				},
+			],
+		}
+	);
+
+	assert.match(gherkin, /Feature: Synthesize research evidence/);
+	assert.match(gherkin, /When I enter "Confidence and support needs" into the "Theme label" field/);
+	assert.match(gherkin, /And I select "Create theme"/);
+	assert.match(gherkin, /Scenario: Use the state accessibly/);
+	assert.doesNotMatch(gherkin, /Given the route/);
 });
 
 test('mergeCucumberReport creates a dedicated page and keeps existing state Gherkin panels', () => {

--- a/tests/start-page-route-state.test.js
+++ b/tests/start-page-route-state.test.js
@@ -13,6 +13,7 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+includes(pageSource, "href=\"/css/govuk/govuk-page-chrome.css\"", "start page");
 includes(pageSource, "href=\"/css/screen.css\"", "start page");
 includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "start page");
 includes(pageSource, "href=\"/css/start.css\"", "start page");
@@ -20,7 +21,12 @@ includes(pageSource, "src=\"/components/layout.js\" defer", "start page");
 includes(pageSource, "src=\"/js/start-description-assist.js\" defer", "start page");
 includes(pageSource, "src=\"/js/start-objectives-assist.js\" defer", "start page");
 includes(pageSource, "src=\"start-new-project.js\" defer", "start page");
+includes(pageSource, "<main class=\"govuk-main-wrapper\" id=\"main-content\" role=\"main\" tabindex=\"-1\">", "start page");
+includes(pageSource, "<div class=\"govuk-width-container\">", "start page");
+includes(pageSource, "<div class=\"govuk-grid-column-two-thirds\">", "start page");
 includes(pageSource, "class=\"card start-card\"", "start page");
+includes(pageSource, "id=\"error-summary\" class=\"govuk-error-summary start-panel\"", "start page");
+includes(pageSource, "id=\"error-list\" class=\"govuk-list govuk-error-summary__list\"", "start page");
 includes(pageSource, "class=\"start-step\"", "start page");
 includes(pageSource, "class=\"start-form\"", "start page");
 includes(pageSource, "class=\"toolbar mt-2 hidden start-assist\"", "start page");
@@ -30,9 +36,20 @@ includes(pageSource, "class=\"govuk-button govuk-button--secondary\"", "start pa
 includes(pageSource, "id=\"projectForm\"", "start page");
 includes(pageSource, "id=\"targetForm\"", "start page");
 includes(pageSource, "id=\"researchForm\"", "start page");
-includes(pageSource, "id=\"step1\"", "start page");
-includes(pageSource, "id=\"step2\" class=\"start-step\" style=\"display:none\"", "start page");
-includes(pageSource, "id=\"step3\" class=\"start-step\" style=\"display:none\"", "start page");
+includes(pageSource, "id=\"step1\" class=\"start-step\"", "start page");
+includes(pageSource, "id=\"step2\" class=\"start-step\" hidden", "start page");
+includes(pageSource, "id=\"step3\" class=\"start-step\" hidden", "start page");
+includes(pageSource, "id=\"step4\" class=\"start-step\" hidden", "start page");
+includes(pageSource, "Step 1 of 4", "start page");
+includes(pageSource, "Step 4 of 4", "start page");
+includes(pageSource, "Check your answers before creating the project", "start page");
+includes(pageSource, "id=\"check-answers-list\" class=\"govuk-summary-list start-summary-list\"", "start page");
+includes(pageSource, "id=\"p_objectives_error\"", "start page");
+includes(pageSource, "id=\"p_usergroups_error\"", "start page");
+includes(pageSource, "This sends the description you entered to an AI service", "start page");
+includes(pageSource, "This sends the objectives you entered to an AI service", "start page");
+includes(pageSource, "Do not include participant personal data", "start page");
+excludes(pageSource, "style=\"display:none\"", "start page");
 excludes(pageSource, "class=\"btn", "start page");
 excludes(pageSource, "<script type=\"module\">", "start page");
 
@@ -42,9 +59,11 @@ includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 
 includes(stylesheetSource, ".start-card", "start stylesheet");
 includes(stylesheetSource, ".start-step", "start stylesheet");
+includes(stylesheetSource, ".start-step[hidden]", "start stylesheet");
 includes(stylesheetSource, ".start-form", "start stylesheet");
 includes(stylesheetSource, ".start-panel", "start stylesheet");
 includes(stylesheetSource, ".start-assist", "start stylesheet");
 includes(stylesheetSource, ".start-assist-output", "start stylesheet");
 includes(stylesheetSource, ".start-error", "start stylesheet");
+includes(stylesheetSource, ".start-summary-list", "start stylesheet");
 includes(stylesheetSource, "/* transparency begins in the cascade */", "start stylesheet");

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -88,6 +88,39 @@ const stepThreeActions = [
 	},
 ];
 
+const stepThreeFilledActions = [
+	...stepThreeActions,
+	{
+		type: 'fill',
+		selector: '#lead_name',
+		value: 'Alex Morgan',
+	},
+	{
+		type: 'fill',
+		selector: '#lead_email',
+		value: 'alex.morgan@example.gov.uk',
+	},
+	{
+		type: 'fill',
+		selector: '#p_notes',
+		value:
+			'Initial recruitment should include users with different levels of digital confidence and staff who handle assisted digital requests.',
+	},
+];
+
+const checkAnswersActions = [
+	...stepThreeFilledActions,
+	{
+		type: 'click',
+		selector: '#next4',
+	},
+	{
+		type: 'waitForSelector',
+		selector: '#step4',
+		state: 'visible',
+	},
+];
+
 export const visualWalkthroughConfig = {
 	title: 'ResearchOps application visual walkthrough',
 	description:
@@ -215,33 +248,22 @@ export const visualWalkthroughConfig = {
 					id: 'step-3-default',
 					title: 'Step 3 default state',
 					description:
-						'Final wizard step after the project definition, stakeholders, objectives and user groups have been entered.',
+						'Final data-entry step after the project definition, stakeholders, objectives and user groups have been entered.',
 					actions: stepThreeActions,
 				},
 				{
 					id: 'step-3-filled',
-					title: 'Step 3 completed before create project',
+					title: 'Step 3 completed before check answers',
 					description:
-						'Lead researcher, email and project notes entered on the final wizard step before project creation is submitted.',
-					actions: [
-						...stepThreeActions,
-						{
-							type: 'fill',
-							selector: '#lead_name',
-							value: 'Alex Morgan',
-						},
-						{
-							type: 'fill',
-							selector: '#lead_email',
-							value: 'alex.morgan@example.gov.uk',
-						},
-						{
-							type: 'fill',
-							selector: '#p_notes',
-							value:
-								'Initial recruitment should include users with different levels of digital confidence and staff who handle assisted digital requests.',
-						},
-					],
+						'Lead researcher, email and project notes entered on the final data-entry step before the check-your-answers review.',
+					actions: stepThreeFilledActions,
+				},
+				{
+					id: 'step-4-check-answers',
+					title: 'Step 4 check your answers before create project',
+					description:
+						'Check-your-answers step summarising the project definition, research framing, ownership and notes before project creation is submitted.',
+					actions: checkAnswersActions,
 				},
 			],
 		},


### PR DESCRIPTION
## Summary

- Reworked the Start research project page with GOV.UK structural wrapping, including `govuk-main-wrapper`, `govuk-width-container`, grid columns and no-JS page chrome fallback.
- Added a four-step guided flow with GOV.UK error summary behaviour, required project/objectives/user-group validation, AI disclosure text and a check-your-answers review step.
- Added source-derived start-page acceptance criteria and routed the visual walkthrough reporting to use them for the start route.
- Added the check-your-answers state to the visual walkthrough registry and updated route-state and Cucumber reporting assertions.

## Validation

- Locally checked syntax while preparing the changed JS/MJS files.
- Ran `node --test tests/start-page-route-state.test.js` locally against the updated start route-state assertions.
- Full repository CI should run on this PR.

## Branch note

This branch was created from the then-current `main` merge commit and has not been force-updated. `main` has since moved ahead, so GitHub may show the branch as behind until it is updated through the normal PR workflow.