### PR TITLE
Harden Projects page GOV.UK structure and recovery states

### DIFF
--- a/docs/design-system/projects-page-critical-evaluation.md
+++ b/docs/design-system/projects-page-critical-evaluation.md
@@ -1,0 +1,78 @@
+# Projects page critical evaluation
+
+Route: `/pages/projects/`
+
+Status: completed for the focused GOV.UK structure and recovery-state hardening pass.
+
+## Evaluation summary
+
+The Projects page was operationally useful but under-structured. It listed records, but it did not yet explain the page purpose, expose a static page structure, provide a no-JavaScript fallback, or give resilient empty and error states.
+
+The page also contained a faulty empty-state link. From the Projects route, `./pages/start/` can resolve to the wrong nested path. The corrected route is `/pages/start/`.
+
+## Team review
+
+### Service owner
+
+The page needed to behave as a project workbench, not only a rendered list. The implemented change adds clearer page purpose and a primary action to start a research project.
+
+Residual risk: the page still needs later filtering or sorting if the number of projects grows.
+
+### Senior user researcher
+
+The page needed to support common researcher questions: which project is available, what state is it in, and where do I continue work?
+
+The implemented change keeps project cards and dashboard links, but adds a clearer framing section and explicit project-list section.
+
+Residual risk: user research is still needed around project-finding tasks across phase, ownership and recency.
+
+### Interaction designer
+
+The page needed a clearer hierarchy. The implemented change introduces a page intro, a project-list section heading, loading state, empty state, and error state.
+
+Residual risk: the repeated project-title link and dashboard button should be reviewed once real project volumes are known.
+
+### Content designer
+
+The page needed explicit service language. The implemented change explains that projects hold studies, participants, sessions, notes, evidence, insights and recommendations.
+
+The empty and error states now give a safe next action instead of leaving the user with only a technical failure.
+
+### Accessibility specialist
+
+The page needed stronger structural and state accessibility. The implemented change adds a static skip link fallback, `main-content`, `govuk-main-wrapper`, a labelled project-list region, `aria-busy`, a no-JavaScript fallback, and explicit status or alert semantics for empty and error states.
+
+Residual risk: this should still be checked with keyboard navigation and screen reader smoke testing once deployed.
+
+### GOV.UK specialist
+
+The page needed to match the GOV.UK-style page chrome used on the Home and Start pages. The implemented change adds the GOV.UK structural wrapping and fallback navigation pattern used elsewhere in the prototype.
+
+The page now follows the service navigation and phase banner conventions already established in the ResearchOps prototype.
+
+### Front-end engineer
+
+The page already had sensible defensive data handling. The implemented change hardens rendering around load state, empty state and total failure state, and protects the corrected start-project route with a route-state test.
+
+Residual risk: the API origin configuration remains environment-coupled and should be centralised in a future infrastructure pass.
+
+### Delivery manager
+
+This was kept as a contained hardening pass. The branch changes page structure, client rendering states, styles and route-state tests. It does not change the reporting site.
+
+## Implemented changes
+
+- Added GOV.UK page-chrome stylesheet to the Projects page.
+- Added static no-JavaScript skip link, service navigation, phase banner and footer fallback.
+- Replaced the thin `<main class="govuk-body">` wrapper with `govuk-main-wrapper`, `govuk-width-container`, `main-content` and focused tabindex support.
+- Added page-intro content and a primary “Start a research project” action.
+- Added a labelled project-list section.
+- Added a visible loading state and `aria-busy` handling.
+- Added empty-state and error-state rendering.
+- Fixed the start-project link from `./pages/start/` to `/pages/start/`.
+- Changed project card subheadings to maintain a cleaner heading hierarchy under the page section.
+- Expanded route-state tests to protect the structural wrapping, corrected link, no-JavaScript fallback, empty state and error state.
+
+## Recommended next iteration
+
+Add visual walkthrough states for loaded, empty, fallback and failure conditions. Then add source-derived acceptance criteria for the Projects page if the reporting evidence model needs the same treatment as Home and Start.

--- a/public/css/projects.css
+++ b/public/css/projects.css
@@ -7,6 +7,37 @@
    License:    All rights reserved
    ========================================================================== */
 
+/* Projects page structure */
+
+.projects-page-actions {
+	margin: 24px 0 0;
+	}
+
+.projects-list-section {
+	margin-top: 16px;
+	}
+
+.projects-list {
+	margin-top: 16px;
+	}
+
+.projects-empty-state,
+.projects-error-state {
+	margin: 24px 0;
+	border-left: 5px solid #1d70b8;
+	padding: 16px 20px;
+	background: #f3f2f1;
+	}
+
+.projects-error-state {
+	border-left-color: #d4351c;
+	}
+
+.projects-empty-state .govuk-heading-m,
+.projects-error-state .govuk-heading-m {
+	margin-top: 0;
+	}
+
 /* Projects page card content */
 
 .project-org {

--- a/public/js/projects-page.js
+++ b/public/js/projects-page.js
@@ -13,12 +13,17 @@ const CONFIG = Object.freeze({
 
 const container = document.getElementById("list");
 
+function setListBusy(isBusy) {
+	if (!container) return;
+	container.setAttribute("aria-busy", isBusy ? "true" : "false");
+}
+
 function escapeHtml(value) {
 	return String(value ?? "")
 		.replace(/&/g, "&amp;")
 		.replace(/</g, "&lt;")
 		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;")
+		.replace(/\"/g, "&quot;")
 		.replace(/'/g, "&#39;");
 }
 
@@ -205,18 +210,18 @@ function projectCard(project) {
 	return `
 <article class="card" aria-labelledby="project-title-${projectId}">
 	<p class="project-org">${escapeHtml(project.org || project.Org || "Home Office Biometrics")}</p>
-	<h2 id="project-title-${projectId}" class="project-title govuk-heading-m">
+	<h3 id="project-title-${projectId}" class="project-title govuk-heading-m">
 		<a class="govuk-link" href="${dashboardHref}" rel="bookmark">${escapeHtml(project.name)}</a>
-	</h2>
+	</h3>
 	<p class="project-meta"><strong>Phase:</strong> ${escapeHtml(project["rops:servicePhase"] || "")} · <strong>Status:</strong> ${escapeHtml(project["rops:projectStatus"] || "")}</p>
 	${project.description ? `<section class="project-summary"><p>${escapeHtml(project.description)}</p></section>` : ""}
 	<p class="project-actions">
 		<a class="govuk-button govuk-button--secondary project-dashboard-action" href="${dashboardHref}" aria-label="${dashboardLabel}">View dashboard</a>
 	</p>
-	${project.user_groups?.length ? `<section class="user-groups" aria-labelledby="user-groups-${projectId}"><h3 id="user-groups-${projectId}" class="project-groups-title">User Groups</h3><ul class="tags" role="list">${groups}</ul></section>` : ""}
+	${project.user_groups?.length ? `<section class="user-groups" aria-labelledby="user-groups-${projectId}"><h4 id="user-groups-${projectId}" class="project-groups-title">User groups</h4><ul class="tags" role="list">${groups}</ul></section>` : ""}
 	<section class="project-extra">
 		<details class="project-details">
-			<summary class="govuk-link">Stakeholders &amp; Objectives</summary>
+			<summary class="govuk-link">Stakeholders and objectives</summary>
 			<div class="details-columns">
 				<div><h4 class="govuk-heading-s">Stakeholders</h4><ul role="list">${stakeholders || "<li class='lede'>None</li>"}</ul></div>
 				<div><h4 class="govuk-heading-s">Objectives</h4><ul role="list">${objectives || "<li class='lede'>None</li>"}</ul></div>
@@ -226,10 +231,29 @@ function projectCard(project) {
 </article>`;
 }
 
+function renderEmptyState() {
+	container.innerHTML = `
+<div class="projects-empty-state" role="status">
+	<h3 class="govuk-heading-m">No projects yet</h3>
+	<p class="govuk-body">Create a research project to hold studies, participants, sessions, notes, evidence, insights and recommendations.</p>
+	<p><a class="govuk-link" href="/pages/start/">Start a research project</a></p>
+</div>`;
+}
+
+function renderErrorState(error) {
+	container.innerHTML = `
+<div class="projects-error-state" role="alert">
+	<h3 class="govuk-heading-m">Could not load projects</h3>
+	<p class="govuk-body">Project records could not be loaded. Try again, or start a new project if you need to continue setting up research work.</p>
+	<p class="govuk-body">Technical detail: ${escapeHtml(error?.message || error)}</p>
+	<p><a class="govuk-link" href="/pages/start/">Start a research project</a></p>
+</div>`;
+}
+
 function render(projects, source) {
 	projects.sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
 	if (!projects.length) {
-		container.innerHTML = '<p class="lede">No projects yet. <a class="govuk-link" href="./pages/start/">Create one</a>.</p>';
+		renderEmptyState();
 		return;
 	}
 	container.innerHTML = projects.map(projectCard).join("");
@@ -243,11 +267,14 @@ function render(projects, source) {
 
 (async () => {
 	if (!container) return;
+	setListBusy(true);
 	try {
 		const { source, projects } = await listProjects();
 		render(projects, source);
 	} catch (error) {
-		container.innerHTML = `<p class="lede">Could not load projects (${escapeHtml(error?.message || error)}).</p>`;
+		renderErrorState(error);
+	} finally {
+		setListBusy(false);
 	}
 })();
 

--- a/public/pages/projects/index.html
+++ b/public/pages/projects/index.html
@@ -12,25 +12,109 @@
 	<link rel="modulepreload" href="/js/projects-page.js?v=projects-dashboard-action-20260501" />
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/projects.css?v=projects-dashboard-action-20260501" media="screen" />
 
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
 
 <body>
+	<noscript>
+		<a class="govuk-skip-link" href="#main-content">Skip to main content</a>
+
+		<header class="govuk-header" role="banner">
+			<div class="govuk-header__container govuk-width-container">
+				<div class="govuk-header__logo">
+					<a class="govuk-header__link govuk-header__link--homepage" href="/" aria-label="GOV.UK home">
+						<span class="govuk-header__logotype">GOV.UK</span>
+					</a>
+				</div>
+			</div>
+		</header>
+
+		<nav class="govuk-service-navigation" aria-label="Service navigation">
+			<div class="govuk-service-navigation__container govuk-width-container">
+				<span class="govuk-service-navigation__service-name">
+					<a class="govuk-service-navigation__link" href="/">ResearchOps Demo Suite</a>
+				</span>
+				<ul class="govuk-service-navigation__list">
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/">Home</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/start/">Start research project</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/projects/" aria-current="page">Projects</a>
+					</li>
+				</ul>
+			</div>
+		</nav>
+
+		<div class="govuk-phase-banner" role="note" aria-label="Service phase">
+			<p class="govuk-phase-banner__content">
+				<strong class="govuk-tag">Prototype</strong>
+				<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant personal data.</span>
+			</p>
+		</div>
+	</noscript>
+
 	<x-include src="/partials/debug.html" debug-only></x-include>
-	<x-include src="/partials/header.html" vars='{
+	<x-include
+		src="/partials/header.html"
+		vars='{
 			"active":"Projects",
 			"subtitle":"Browse projects created in this demo suite"
 		}'>
 	</x-include>
 
-	<main class="govuk-body" role="main">
-		<h1 class="govuk-heading-l page-title">Projects</h1>
-		<div id="list" aria-live="polite"></div>
+	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+		<div class="govuk-width-container">
+			<header class="page-intro">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h1 class="govuk-heading-xl page-title" id="projects-title">Projects</h1>
+						<p class="lede">Review research projects created in ResearchOps.</p>
+						<p class="govuk-body">Open a project dashboard to manage studies, participants, sessions, notes, evidence, insights and recommendations.</p>
+						<p class="projects-page-actions">
+							<a class="govuk-button" href="/pages/start/" role="button" draggable="false">Start a research project</a>
+						</p>
+					</div>
+				</div>
+			</header>
+
+			<section class="projects-list-section" aria-labelledby="projects-list-title">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h2 class="govuk-heading-l" id="projects-list-title">Research projects</h2>
+						<p class="govuk-body">Projects are shown with the newest created project first.</p>
+					</div>
+				</div>
+
+				<div id="list" class="projects-list" aria-live="polite" aria-busy="true" aria-labelledby="projects-list-title">
+					<p class="lede">Loading projects.</p>
+				</div>
+
+				<noscript>
+					<div class="projects-empty-state" role="status">
+						<h3 class="govuk-heading-m">Project records need JavaScript to load</h3>
+						<p class="govuk-body">You can still start a new research project from this page.</p>
+						<p><a class="govuk-link" href="/pages/start/">Start a research project</a></p>
+					</div>
+				</noscript>
+			</section>
+		</div>
 	</main>
+
+	<noscript>
+		<footer class="govuk-footer" role="contentinfo">
+			<div class="govuk-footer__container govuk-width-container">
+				<p class="govuk-footer__meta">© 2026 Home Office Biometrics · ResearchOps v1.0.0</p>
+			</div>
+		</footer>
+	</noscript>
 
 	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'>
 	</x-include>

--- a/scripts/researchops-projects-acceptance.mjs
+++ b/scripts/researchops-projects-acceptance.mjs
@@ -1,0 +1,221 @@
+/* eslint-env node */
+
+/**
+ * @file scripts/researchops-projects-acceptance.mjs
+ * @summary Generate Projects-page acceptance criteria from the current ResearchOps Projects-page source.
+ */
+
+import fs from 'node:fs';
+
+const PAGE_SOURCE = 'public/pages/projects/index.html';
+const CONTROLLER_SOURCE = 'public/js/projects-page.js';
+const ENTITIES = { amp: '&', copy: '©', gt: '>', lt: '<', middot: '·', nbsp: ' ', quot: '"', rsquo: '’' };
+const FALLBACK = {
+	serviceName: 'ResearchOps Demo Suite',
+	heading: 'Projects',
+	lede: 'Review research projects created in ResearchOps.',
+	intro: 'Open a project dashboard to manage studies, participants, sessions, notes, evidence, insights and recommendations.',
+	prototype: 'This is a ResearchOps prototype. Do not enter real participant personal data.',
+	nav: ['Home', 'Start research project', 'Projects'],
+	primaryAction: 'Start a research project',
+	listTitle: 'Research projects',
+	listDescription: 'Projects are shown with the newest created project first.',
+	loadingText: 'Loading projects.',
+	noScriptTitle: 'Project records need JavaScript to load',
+	noScriptText: 'You can still start a new research project from this page.',
+	emptyTitle: 'No projects yet',
+	emptyText: 'Create a research project to hold studies, participants, sessions, notes, evidence, insights and recommendations.',
+	errorTitle: 'Could not load projects',
+	errorText: 'Project records could not be loaded. Try again, or start a new project if you need to continue setting up research work.',
+	cardFields: [
+		'Project organisation',
+		'Project title',
+		'Phase',
+		'Status',
+		'Description',
+		'View dashboard',
+		'User groups',
+		'Stakeholders and objectives',
+	],
+	footer: '© 2026 Home Office Biometrics · ResearchOps v1.0.0',
+};
+
+function readFile(filePath = '') {
+	try {
+		return fs.readFileSync(filePath, 'utf8');
+	} catch {
+		return '';
+	}
+}
+
+function decode(value = '') {
+	return String(value).replace(/&(#\d+|#x[a-f0-9]+|[a-z]+);/gi, (entity, token) => {
+		const key = token.toLowerCase();
+		if (key.startsWith('#x')) return String.fromCodePoint(Number.parseInt(key.slice(2), 16));
+		if (key.startsWith('#')) return String.fromCodePoint(Number.parseInt(key.slice(1), 10));
+		return ENTITIES[key] || entity;
+	});
+}
+
+function text(value = '') {
+	return decode(String(value).replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+function quote(value = '') {
+	return String(value).replaceAll('"', '\\"');
+}
+
+function first(source = '', pattern, fallback = '') {
+	const match = source.match(pattern);
+	return match ? text(match[1]) : fallback;
+}
+
+function all(source = '', pattern) {
+	return [...source.matchAll(pattern)].map((match) => text(match[1])).filter(Boolean);
+}
+
+function section(source = '', className = '') {
+	const pattern = new RegExp(`<section\\b(?=[^>]*class=["'][^"']*\\b${className}\\b)[^>]*>([\\s\\S]*?)<\\/section>`, 'i');
+	const match = source.match(pattern);
+	return match ? match[0] : '';
+}
+
+function byId(source = '', id = '') {
+	const pattern = new RegExp(`<([a-z0-9-]+)\\b(?=[^>]*id=["']${id}["'])[^>]*>([\\s\\S]*?)<\\/\\1>`, 'i');
+	return source.match(pattern)?.[0] || '';
+}
+
+function byClass(source = '', className = '') {
+	const pattern = new RegExp(`<([a-z0-9-]+)\\b(?=[^>]*class=["'][^"']*\\b${className}\\b)[^>]*>([\\s\\S]*?)<\\/\\1>`, 'i');
+	return source.match(pattern)?.[0] || '';
+}
+
+function rows(values = []) {
+	return values.map((row) => `      | ${row.map((item) => quote(item)).join(' | ')} |`);
+}
+
+function model() {
+	const source = readFile(PAGE_SOURCE);
+	const controller = readFile(CONTROLLER_SOURCE);
+	const intro = source.match(/<header\b(?=[^>]*class=["'][^"']*\bpage-intro\b)[^>]*>([\s\S]*?)<\/header>/i)?.[0] || '';
+	const listSection = section(source, 'projects-list-section');
+	const list = byId(source, 'list');
+	const noScriptState = byClass(source, 'projects-empty-state');
+	const nav = all(source, /<a\b(?=[^>]*class=["'][^"']*\bgovuk-service-navigation__link\b)[^>]*>([\s\S]*?)<\/a>/gi).filter(
+		(item) => item !== FALLBACK.serviceName
+	);
+
+	return {
+		serviceName: first(source, /<a\b(?=[^>]*class=["'][^"']*\bgovuk-service-navigation__link\b)[^>]*href=["']\/["'][^>]*>([\s\S]*?)<\/a>/i, FALLBACK.serviceName),
+		heading: first(source, /<h1\b(?=[^>]*id=["']projects-title["'])[^>]*>([\s\S]*?)<\/h1>/i, FALLBACK.heading),
+		lede: first(intro, /<p\b(?=[^>]*class=["'][^"']*\blede\b)[^>]*>([\s\S]*?)<\/p>/i, FALLBACK.lede),
+		intro: first(intro, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-body\b)[^>]*>([\s\S]*?)<\/p>/i, FALLBACK.intro),
+		prototype: first(source, /<span\b(?=[^>]*class=["'][^"']*\bgovuk-phase-banner__text\b)[^>]*>([\s\S]*?)<\/span>/i, FALLBACK.prototype),
+		nav: nav.length ? nav : FALLBACK.nav,
+		primaryAction: first(intro, /<a\b(?=[^>]*class=["'][^"']*\bgovuk-button\b)[^>]*>([\s\S]*?)<\/a>/i, FALLBACK.primaryAction),
+		listTitle: first(listSection, /<h2\b(?=[^>]*id=["']projects-list-title["'])[^>]*>([\s\S]*?)<\/h2>/i, FALLBACK.listTitle),
+		listDescription: first(listSection, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-body\b)[^>]*>([\s\S]*?)<\/p>/i, FALLBACK.listDescription),
+		loadingText: first(list, /<p\b(?=[^>]*class=["'][^"']*\blede\b)[^>]*>([\s\S]*?)<\/p>/i, FALLBACK.loadingText),
+		noScriptTitle: first(noScriptState, /<h3\b[^>]*>([\s\S]*?)<\/h3>/i, FALLBACK.noScriptTitle),
+		noScriptText: first(noScriptState, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-body\b)[^>]*>([\s\S]*?)<\/p>/i, FALLBACK.noScriptText),
+		emptyTitle: first(controller, /<h3\b(?=[^>]*class=\"govuk-heading-m\")[^>]*>(No projects yet)<\/h3>/i, FALLBACK.emptyTitle),
+		emptyText: first(controller, /<p\b(?=[^>]*class=\"govuk-body\")[^>]*>(Create a research project[\s\S]*?)<\/p>/i, FALLBACK.emptyText),
+		errorTitle: first(controller, /<h3\b(?=[^>]*class=\"govuk-heading-m\")[^>]*>(Could not load projects)<\/h3>/i, FALLBACK.errorTitle),
+		errorText: first(controller, /<p\b(?=[^>]*class=\"govuk-body\")[^>]*>(Project records could not be loaded[\s\S]*?)<\/p>/i, FALLBACK.errorText),
+		cardFields: FALLBACK.cardFields,
+		footer: first(source, /<p\b(?=[^>]*class=["'][^"']*\bgovuk-footer__meta\b)[^>]*>([\s\S]*?)<\/p>/i, FALLBACK.footer),
+	};
+}
+
+export function buildProjectsAcceptanceCriteriaFromSource() {
+	const page = model();
+
+	return [
+		'Feature: Review research projects',
+		'',
+		'  As a user researcher',
+		'  I want to review existing research projects',
+		'  So that I can find the right project and continue the right ResearchOps task',
+		'',
+		'  Background:',
+		'    Given I am a user researcher',
+		'    When I visit the projects page',
+		'',
+		'  Scenario: View the Projects page identity',
+		`    Then I should see the service name "${quote(page.serviceName)}"`,
+		`    And I should see the page heading "${quote(page.heading)}"`,
+		`    And I should see introductory text that says "${quote(page.lede)}"`,
+		`    And I should see supporting text that says "${quote(page.intro)}"`,
+		'',
+		'  Scenario: Understand that the service is a prototype',
+		'    Then I should see a prototype banner',
+		`    And the banner should say "${quote(page.prototype)}"`,
+		'',
+		'  Scenario: Navigate using the primary navigation',
+		'    Then I should see primary navigation links for:',
+		...rows(page.nav.map((item) => [item])),
+		'    And the "Projects" navigation item should be shown as the current page',
+		'',
+		'  Scenario: Start a new project from the Projects page',
+		`    Then I should see the primary action "${quote(page.primaryAction)}"`,
+		`    When I select "${quote(page.primaryAction)}"`,
+		'    Then I should be taken to the start research project service',
+		'',
+		'  Scenario: Understand the project list',
+		`    Then I should see a section called "${quote(page.listTitle)}"`,
+		`    And I should see text explaining that "${quote(page.listDescription)}"`,
+		`    And I should see loading text that says "${quote(page.loadingText)}" until project records are ready`,
+		'    And project records should be presented newest first when they load',
+		'',
+		'  Scenario: Review loaded project records',
+		'    When project records load successfully',
+		'    Then each project card should expose:',
+		...rows(page.cardFields.map((item) => [item])),
+		'    And each project card should provide a dashboard link for continuing work on that project',
+		'',
+		'  Scenario: Open a project dashboard',
+		'    Given project records have loaded',
+		'    When I select "View dashboard" for a project',
+		'    Then I should be taken to that project dashboard',
+		'    And the selected project should be identified by its project ID',
+		'',
+		'  Scenario: Recover when there are no projects yet',
+		'    When no project records are available',
+		`    Then I should see a status message headed "${quote(page.emptyTitle)}"`,
+		`    And I should see text explaining that "${quote(page.emptyText)}"`,
+		`    And I should be able to select "${quote(page.primaryAction)}"`,
+		'',
+		'  Scenario: Recover when project records cannot load',
+		'    When project records cannot be loaded',
+		`    Then I should see an alert headed "${quote(page.errorTitle)}"`,
+		`    And I should see text explaining that "${quote(page.errorText)}"`,
+		`    And I should be able to select "${quote(page.primaryAction)}" so I can continue setting up research work`,
+		'',
+		'  Scenario: Use the page without JavaScript',
+		'    Given JavaScript is not available',
+		`    Then I should see fallback guidance headed "${quote(page.noScriptTitle)}"`,
+		`    And I should see text explaining that "${quote(page.noScriptText)}"`,
+		`    And I should still be able to select "${quote(page.primaryAction)}"`,
+		'',
+		'  Scenario: Access the Projects page using a keyboard',
+		'    Given I am navigating with a keyboard',
+		'    Then I should be able to move focus to the main content',
+		'    And I should be able to move focus through the primary navigation links',
+		`    And I should be able to move focus to "${quote(page.primaryAction)}"`,
+		'    And I should be able to activate project dashboard links without a mouse',
+		'',
+		'  Scenario: Understand the page structure with assistive technology',
+		'    Then the page should have one clear main heading',
+		`    And the project list should be labelled by "${quote(page.listTitle)}"`,
+		'    And the project list should announce loading, empty and error-state changes politely or as an alert as appropriate',
+		'    And the project list should expose when it is busy loading project records',
+		'    And each project card should expose its heading, metadata, user groups, stakeholders and objectives in a logical reading order',
+		'',
+		'  Scenario: Use the Projects page on a mobile device',
+		'    Then the page introduction, project list, project cards, empty state and error state should remain readable',
+		'    And no content should require horizontal scrolling',
+		'',
+		'  Scenario: View footer information',
+		`    Then I should see the footer text "${quote(page.footer)}"`,
+	].join('\n');
+}

--- a/scripts/researchops-state-acceptance.mjs
+++ b/scripts/researchops-state-acceptance.mjs
@@ -6,6 +6,7 @@
  */
 
 import { buildHomeAcceptanceCriteriaFromSource } from './researchops-home-acceptance.mjs';
+import { buildProjectsAcceptanceCriteriaFromSource } from './researchops-projects-acceptance.mjs';
 import { buildStartAcceptanceCriteriaFromSource } from './researchops-start-acceptance.mjs';
 
 const PAGE_STORIES = {
@@ -253,6 +254,7 @@ function buildActionScenario(sourceActions = []) {
 export function buildStateAcceptanceGherkin(page = {}, state = {}, sourceState = null) {
 	if (page.id === 'home') return buildHomeAcceptanceCriteriaFromSource();
 	if (page.id === 'start') return buildStartAcceptanceCriteriaFromSource();
+	if (page.id === 'projects') return buildProjectsAcceptanceCriteriaFromSource();
 
 	const story = storyForPage(page);
 	const statePurpose = state.description

--- a/scripts/sync-report-acceptance-criteria.mjs
+++ b/scripts/sync-report-acceptance-criteria.mjs
@@ -9,8 +9,22 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildHomeAcceptanceCriteriaFromSource } from './researchops-home-acceptance.mjs';
+import { buildProjectsAcceptanceCriteriaFromSource } from './researchops-projects-acceptance.mjs';
 
 const DEFAULT_SITE_DIR = 'reports-site';
+
+const CRITERIA_BUILDERS = {
+	home: {
+		path: 'public/index.html',
+		generator: 'scripts/researchops-home-acceptance.mjs',
+		build: buildHomeAcceptanceCriteriaFromSource,
+	},
+	projects: {
+		path: 'public/pages/projects/index.html',
+		generator: 'scripts/researchops-projects-acceptance.mjs',
+		build: buildProjectsAcceptanceCriteriaFromSource,
+	},
+};
 
 function escapeHtml(value = '') {
 	return String(value)
@@ -29,17 +43,17 @@ function writeJson(filePath, value) {
 	fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
-function findHomeState(manifest) {
-	const homePage = (manifest.pages || []).find((page) => page.id === 'home');
-	if (!homePage) throw new Error('No home page entry found in reports-site manifest.');
+function findPage(manifest, pageId) {
+	return (manifest.pages || []).find((page) => page.id === pageId);
+}
 
-	const defaultState = (homePage.states || []).find((state) => state.id === 'default');
-	if (!defaultState) throw new Error('No default home state found in reports-site manifest.');
-
+function findDefaultState(page, pageId) {
+	const defaultState = (page.states || []).find((state) => state.id === 'default');
+	if (!defaultState) throw new Error(`No default ${pageId} state found in reports-site manifest.`);
 	return defaultState;
 }
 
-function replaceHtmlCriteria(html, oldCriteria, nextCriteria) {
+function replaceHtmlCriteria(html, pageId, oldCriteria, nextCriteria) {
 	const oldEscaped = escapeHtml(oldCriteria || '');
 	const nextEscaped = escapeHtml(nextCriteria || '');
 
@@ -47,12 +61,47 @@ function replaceHtmlCriteria(html, oldCriteria, nextCriteria) {
 		return html.replace(oldEscaped, nextEscaped);
 	}
 
-	const homeArticlePattern = /(<article\b[^>]*id="home"[^>]*>[\s\S]*?<pre\b[^>]*class="gherkin-criteria"[^>]*>\s*<code>)([\s\S]*?)(<\/code>\s*<\/pre>[\s\S]*?<\/article>)/i;
-	if (!homeArticlePattern.test(html)) {
-		throw new Error('Could not find the home-page acceptance criteria block in reports-site/index.html.');
+	const articlePattern = new RegExp(
+		`(<article\\b[^>]*id=["']${pageId}["'][^>]*>[\\s\\S]*?<pre\\b[^>]*class=["']gherkin-criteria["'][^>]*>\\s*<code>)([\\s\\S]*?)(<\\/code>\\s*<\\/pre>[\\s\\S]*?<\\/article>)`,
+		'i'
+	);
+
+	if (!articlePattern.test(html)) {
+		throw new Error(`Could not find the ${pageId} acceptance criteria block in reports-site/index.html.`);
 	}
 
-	return html.replace(homeArticlePattern, `$1${nextEscaped}$3`);
+	return html.replace(articlePattern, `$1${nextEscaped}$3`);
+}
+
+function syncPageAcceptanceCriteria(manifest, html, pageId, config) {
+	const page = findPage(manifest, pageId);
+	if (!page) {
+		return {
+			pageId,
+			changed: false,
+			skipped: true,
+			reason: `No ${pageId} page entry found in reports-site manifest.`,
+		};
+	}
+
+	const state = findDefaultState(page, pageId);
+	const previousCriteria = state.acceptanceCriteria || '';
+	const nextCriteria = config.build();
+
+	state.acceptanceCriteria = nextCriteria;
+	state.criteriaSource = {
+		type: 'source-derived',
+		path: config.path,
+		generator: config.generator,
+	};
+
+	return {
+		pageId,
+		changed: previousCriteria !== nextCriteria,
+		previousLength: previousCriteria.length,
+		nextLength: nextCriteria.length,
+		html: replaceHtmlCriteria(html, pageId, previousCriteria, nextCriteria),
+	};
 }
 
 export function syncReportAcceptanceCriteria(options = {}) {
@@ -64,27 +113,29 @@ export function syncReportAcceptanceCriteria(options = {}) {
 	if (!fs.existsSync(indexPath)) throw new Error(`Missing ${indexPath}.`);
 
 	const manifest = readJson(manifestPath);
-	const homeState = findHomeState(manifest);
-	const previousCriteria = homeState.acceptanceCriteria || '';
-	const nextCriteria = buildHomeAcceptanceCriteriaFromSource();
+	let html = fs.readFileSync(indexPath, 'utf8');
+	const pages = options.pages || Object.keys(CRITERIA_BUILDERS);
+	const results = [];
 
-	homeState.acceptanceCriteria = nextCriteria;
-	homeState.criteriaSource = {
-		type: 'source-derived',
-		path: 'public/index.html',
-		generator: 'scripts/researchops-home-acceptance.mjs',
-	};
+	for (const pageId of pages) {
+		const config = CRITERIA_BUILDERS[pageId];
+		if (!config) throw new Error(`No acceptance criteria builder registered for ${pageId}.`);
+
+		const result = syncPageAcceptanceCriteria(manifest, html, pageId, config);
+		if (result.html) html = result.html;
+		results.push(Object.fromEntries(Object.entries(result).filter(([key]) => key !== 'html')));
+	}
 
 	writeJson(manifestPath, manifest);
+	fs.writeFileSync(indexPath, html, 'utf8');
 
-	const html = fs.readFileSync(indexPath, 'utf8');
-	const updatedHtml = replaceHtmlCriteria(html, previousCriteria, nextCriteria);
-	fs.writeFileSync(indexPath, updatedHtml, 'utf8');
+	const changed = results.some((result) => result.changed);
 
 	return {
-		changed: previousCriteria !== nextCriteria,
-		previousLength: previousCriteria.length,
-		nextLength: nextCriteria.length,
+		changed,
+		results,
+		previousLength: results[0]?.previousLength || 0,
+		nextLength: results[0]?.nextLength || 0,
 	};
 }
 

--- a/tests/projects-page-route-state.test.js
+++ b/tests/projects-page-route-state.test.js
@@ -14,6 +14,7 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "href=\"/css/screen.css\"", "Projects page");
+includes(pageSource, "href=\"/css/govuk/govuk-page-chrome.css\"", "Projects page");
 includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "Projects page");
 includes(
   pageSource,
@@ -31,9 +32,31 @@ includes(
   "Projects page"
 );
 includes(pageSource, "src=\"/components/layout.js\" defer", "Projects page");
-includes(pageSource, "id=\"list\"", "Projects page");
+includes(pageSource, "class=\"govuk-skip-link\" href=\"#main-content\"", "Projects page");
+includes(pageSource, "class=\"govuk-service-navigation\"", "Projects page");
+includes(pageSource, "href=\"/pages/projects/\" aria-current=\"page\"", "Projects page");
+includes(pageSource, "class=\"govuk-phase-banner\"", "Projects page");
+includes(pageSource, "Do not enter real participant personal data", "Projects page");
+includes(pageSource, "<main class=\"govuk-main-wrapper\" id=\"main-content\" role=\"main\" tabindex=\"-1\">", "Projects page");
+includes(pageSource, "class=\"govuk-width-container\"", "Projects page");
+includes(pageSource, "id=\"projects-title\"", "Projects page");
+includes(pageSource, "Review research projects created in ResearchOps.", "Projects page");
+includes(pageSource, "id=\"projects-list-title\"", "Projects page");
+includes(pageSource, "id=\"list\" class=\"projects-list\"", "Projects page");
+includes(pageSource, "aria-busy=\"true\"", "Projects page");
+includes(pageSource, "aria-labelledby=\"projects-list-title\"", "Projects page");
+includes(pageSource, "Project records need JavaScript to load", "Projects page");
+includes(pageSource, "href=\"/pages/start/\"", "Projects page");
+excludes(pageSource, "href=\"./pages/start/\"", "Projects page");
 excludes(pageSource, "<script type=\"module\">", "Projects page");
 
+includes(stylesheetSource, ".projects-page-actions", "Projects stylesheet");
+includes(stylesheetSource, ".projects-list-section", "Projects stylesheet");
+includes(stylesheetSource, ".projects-list", "Projects stylesheet");
+includes(stylesheetSource, ".projects-empty-state", "Projects stylesheet");
+includes(stylesheetSource, ".projects-error-state", "Projects stylesheet");
+includes(stylesheetSource, "border-left: 5px solid #1d70b8;", "Projects stylesheet");
+includes(stylesheetSource, "border-left-color: #d4351c;", "Projects stylesheet");
 includes(stylesheetSource, ".project-org", "Projects stylesheet");
 includes(stylesheetSource, ".project-title", "Projects stylesheet");
 includes(stylesheetSource, ".project-meta", "Projects stylesheet");
@@ -54,6 +77,8 @@ excludes(stylesheetSource, ".projects-grid", "Projects stylesheet");
 excludes(stylesheetSource, ".project-card", "Projects stylesheet");
 excludes(stylesheetSource, ".skel", "Projects stylesheet");
 
+includes(controllerSource, "setListBusy", "Projects controller");
+includes(controllerSource, "aria-busy", "Projects controller");
 includes(controllerSource, "project-org", "Projects controller");
 includes(controllerSource, "project-title", "Projects controller");
 includes(controllerSource, "project-meta", "Projects controller");
@@ -66,9 +91,17 @@ includes(controllerSource, "projectDashboardHref", "Projects controller");
 includes(controllerSource, "projectDashboardLabel", "Projects controller");
 includes(controllerSource, "govuk-button govuk-button--secondary", "Projects controller");
 includes(controllerSource, "user-groups", "Projects controller");
+includes(controllerSource, "User groups", "Projects controller");
+includes(controllerSource, "Stakeholders and objectives", "Projects controller");
 includes(controllerSource, "project-groups-title", "Projects controller");
 includes(controllerSource, "tags", "Projects controller");
 includes(controllerSource, "tag", "Projects controller");
 includes(controllerSource, "project-extra", "Projects controller");
 includes(controllerSource, "project-details", "Projects controller");
 includes(controllerSource, "details-columns", "Projects controller");
+includes(controllerSource, "renderEmptyState", "Projects controller");
+includes(controllerSource, "No projects yet", "Projects controller");
+includes(controllerSource, "href=\"/pages/start/\"", "Projects controller");
+includes(controllerSource, "renderErrorState", "Projects controller");
+includes(controllerSource, "Could not load projects", "Projects controller");
+excludes(controllerSource, "href=\"./pages/start/\"", "Projects controller");

--- a/tests/researchops-home-acceptance-sync.test.js
+++ b/tests/researchops-home-acceptance-sync.test.js
@@ -23,7 +23,10 @@ test('projects criteria are generated from the current Projects page source', ()
 
 	assert.match(gherkin, /Feature: Review research projects/);
 	assert.match(gherkin, /Review research projects created in ResearchOps/);
-	assert.match(gherkin, /Open a project dashboard to manage studies, participants, sessions, notes, evidence, insights and recommendations/);
+	assert.match(
+		gherkin,
+		/Open a project dashboard to manage studies, participants, sessions, notes, evidence, insights and recommendations/
+	);
 	assert.match(gherkin, /Scenario: Start a new project from the Projects page/);
 	assert.match(gherkin, /Scenario: Understand the project list/);
 	assert.match(gherkin, /Projects are shown with the newest created project first/);
@@ -155,7 +158,10 @@ test('syncReportAcceptanceCriteria refreshes stale Projects criteria in the repo
 	assert.match(projectsState.acceptanceCriteria, /No projects yet/);
 	assert.match(projectsState.acceptanceCriteria, /Project records need JavaScript to load/);
 	assert.equal(projectsState.criteriaSource.path, 'public/pages/projects/index.html');
-	assert.equal(projectsState.criteriaSource.generator, 'scripts/researchops-projects-acceptance.mjs');
+	assert.equal(
+		projectsState.criteriaSource.generator,
+		'scripts/researchops-projects-acceptance.mjs'
+	);
 	assert.match(indexHtml, /Project records need JavaScript to load/);
 	assert.doesNotMatch(indexHtml, /Stale projects criteria/);
 });

--- a/tests/researchops-home-acceptance-sync.test.js
+++ b/tests/researchops-home-acceptance-sync.test.js
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { buildHomeAcceptanceCriteriaFromSource } from '../scripts/researchops-home-acceptance.mjs';
+import { buildProjectsAcceptanceCriteriaFromSource } from '../scripts/researchops-projects-acceptance.mjs';
 import { syncReportAcceptanceCriteria } from '../scripts/sync-report-acceptance-criteria.mjs';
 
 test('home criteria are generated from the current home page source', () => {
@@ -15,6 +16,28 @@ test('home criteria are generated from the current home page source', () => {
 	assert.match(gherkin, /Available after sessions/);
 	assert.doesNotMatch(gherkin, /Choose a journey to explore/);
 	assert.doesNotMatch(gherkin, /Go to objective definition service/);
+});
+
+test('projects criteria are generated from the current Projects page source', () => {
+	const gherkin = buildProjectsAcceptanceCriteriaFromSource();
+
+	assert.match(gherkin, /Feature: Review research projects/);
+	assert.match(gherkin, /Review research projects created in ResearchOps/);
+	assert.match(gherkin, /Open a project dashboard to manage studies, participants, sessions, notes, evidence, insights and recommendations/);
+	assert.match(gherkin, /Scenario: Start a new project from the Projects page/);
+	assert.match(gherkin, /Scenario: Understand the project list/);
+	assert.match(gherkin, /Projects are shown with the newest created project first/);
+	assert.match(gherkin, /Scenario: Review loaded project records/);
+	assert.match(gherkin, /Project title/);
+	assert.match(gherkin, /Stakeholders and objectives/);
+	assert.match(gherkin, /Scenario: Recover when there are no projects yet/);
+	assert.match(gherkin, /No projects yet/);
+	assert.match(gherkin, /Scenario: Recover when project records cannot load/);
+	assert.match(gherkin, /Could not load projects/);
+	assert.match(gherkin, /Scenario: Use the page without JavaScript/);
+	assert.match(gherkin, /Project records need JavaScript to load/);
+	assert.doesNotMatch(gherkin, /Given the route/);
+	assert.doesNotMatch(gherkin, /captured evidence status/);
 });
 
 test('syncReportAcceptanceCriteria refreshes stale home criteria in the reporting site', () => {
@@ -62,7 +85,7 @@ test('syncReportAcceptanceCriteria refreshes stale home criteria in the reportin
 		'utf8'
 	);
 
-	const result = syncReportAcceptanceCriteria({ siteDir });
+	const result = syncReportAcceptanceCriteria({ siteDir, pages: ['home'] });
 	const manifest = JSON.parse(fs.readFileSync(path.join(siteDir, 'manifest.json'), 'utf8'));
 	const indexHtml = fs.readFileSync(path.join(siteDir, 'index.html'), 'utf8');
 	const homeState = manifest.pages[0].states[0];
@@ -74,4 +97,65 @@ test('syncReportAcceptanceCriteria refreshes stale home criteria in the reportin
 	assert.equal(homeState.criteriaSource.generator, 'scripts/researchops-home-acceptance.mjs');
 	assert.match(indexHtml, /What you can do after creating a project/);
 	assert.doesNotMatch(indexHtml, /Choose a journey to explore/);
+});
+
+test('syncReportAcceptanceCriteria refreshes stale Projects criteria in the reporting site', () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'researchops-report-sync-'));
+	const siteDir = path.join(dir, 'reports-site');
+	const staleCriteria = [
+		'Feature: Stale projects criteria',
+		'',
+		'  Scenario: Old generic projects language',
+		'    Then I should see "Review research projects"',
+	].join('\n');
+
+	fs.mkdirSync(siteDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(siteDir, 'manifest.json'),
+		`${JSON.stringify(
+			{
+				pages: [
+					{
+						id: 'projects',
+						states: [
+							{
+								id: 'default',
+								acceptanceCriteria: staleCriteria,
+							},
+						],
+					},
+				],
+			},
+			null,
+			2
+		)}\n`,
+		'utf8'
+	);
+	fs.writeFileSync(
+		path.join(siteDir, 'index.html'),
+		[
+			'<!doctype html>',
+			'<article class="page-card" id="projects">',
+			'<details data-state-acceptance-criteria>',
+			'<pre class="gherkin-criteria"><code>Feature: Stale projects criteria\n\n  Scenario: Old generic projects language\n    Then I should see &quot;Review research projects&quot;</code></pre>',
+			'</details>',
+			'</article>',
+		].join('\n'),
+		'utf8'
+	);
+
+	const result = syncReportAcceptanceCriteria({ siteDir, pages: ['projects'] });
+	const manifest = JSON.parse(fs.readFileSync(path.join(siteDir, 'manifest.json'), 'utf8'));
+	const indexHtml = fs.readFileSync(path.join(siteDir, 'index.html'), 'utf8');
+	const projectsState = manifest.pages[0].states[0];
+
+	assert.equal(result.changed, true);
+	assert.match(projectsState.acceptanceCriteria, /Feature: Review research projects/);
+	assert.match(projectsState.acceptanceCriteria, /Scenario: Understand the project list/);
+	assert.match(projectsState.acceptanceCriteria, /No projects yet/);
+	assert.match(projectsState.acceptanceCriteria, /Project records need JavaScript to load/);
+	assert.equal(projectsState.criteriaSource.path, 'public/pages/projects/index.html');
+	assert.equal(projectsState.criteriaSource.generator, 'scripts/researchops-projects-acceptance.mjs');
+	assert.match(indexHtml, /Project records need JavaScript to load/);
+	assert.doesNotMatch(indexHtml, /Stale projects criteria/);
 });


### PR DESCRIPTION
## Summary

This PR completes the focused Projects page critical evaluation work and now includes the reporting-site acceptance-criteria sync work needed to keep the reporting evidence model aligned with the Projects page implementation.

It implements the evaluation findings for the `/pages/projects/` route by:

- adding GOV.UK structural wrapping consistent with Home and Start
- adding static no-JavaScript skip link, service navigation, phase banner and footer fallbacks
- adding a clear page intro and primary start-project action
- adding a labelled project-list section with loading copy and `aria-busy`
- adding explicit empty and error states with safe recovery actions
- fixing the empty-state start-project link from `./pages/start/` to `/pages/start/`
- improving card heading hierarchy and sentence case
- expanding the Projects route-state contract to protect these behaviours
- documenting the critical evaluation with the same team roles, including the GOV.UK specialist

It also completes the reporting-site acceptance-criteria work by:

- adding `scripts/researchops-projects-acceptance.mjs`
- routing Projects visual states through source-derived Projects Gherkin
- extending the report acceptance sync to refresh Projects criteria as well as Home criteria
- adding test coverage proving stale Projects criteria is rewritten in the reporting site

## Files changed

- `public/pages/projects/index.html`
- `public/js/projects-page.js`
- `public/css/projects.css`
- `tests/projects-page-route-state.test.js`
- `docs/design-system/projects-page-critical-evaluation.md`
- `scripts/researchops-projects-acceptance.mjs`
- `scripts/researchops-state-acceptance.mjs`
- `scripts/sync-report-acceptance-criteria.mjs`
- `tests/researchops-home-acceptance-sync.test.js`

## Validation

The branch includes route-state coverage for the new Projects page structure and recovery states, plus source-derived Projects acceptance-criteria generation and reporting sync coverage. CI should run the repository release gate on the PR.