### PR TITLE
Fix Project Dashboard GOV.UK chrome and project-scoped actions

### DIFF
--- a/public/js/project-dashboard-context.js
+++ b/public/js/project-dashboard-context.js
@@ -22,36 +22,40 @@ function projectScopedHref(path, queryKey, projectId, hash = "") {
 	return `${path}?${query}${hash ? `#${hash}` : ""}`;
 }
 
-function setProjectContext() {
-	const projectId = currentProjectId();
+function resolvedProjectId() {
+	return currentProjectId() || document.querySelector("main")?.dataset?.projectId || "";
+}
+
+function syncProjectContext() {
+	const projectId = resolvedProjectId();
+	if (!projectId) return;
+
 	const main = document.querySelector("main");
-	if (main && projectId) {
+	if (main) {
 		main.dataset.projectId = projectId;
 		main.dataset.projectAirtableId = projectId;
 	}
-	return projectId;
-}
-
-function syncProjectScopedLinks() {
-	const projectId = currentProjectId() || document.querySelector("main")?.dataset?.projectId || "";
-	if (!projectId) return;
 
 	for (const [id, path, queryKey, hash] of PROJECT_SCOPED_LINKS) {
 		const link = document.getElementById(id);
 		if (!link) continue;
-		link.setAttribute("href", projectScopedHref(path, queryKey, projectId, hash));
+
+		const href = projectScopedHref(path, queryKey, projectId, hash);
+		if (link.getAttribute("href") !== href) {
+			link.setAttribute("href", href);
+		}
 	}
 }
 
 function initProjectDashboardContext() {
-	setProjectContext();
-	syncProjectScopedLinks();
+	syncProjectContext();
 
-	const observer = new MutationObserver(() => syncProjectScopedLinks());
-	for (const [id] of PROJECT_SCOPED_LINKS) {
-		const link = document.getElementById(id);
-		if (link) observer.observe(link, { attributes: true, attributeFilter: ["href"] });
-	}
+	let attempts = 0;
+	const timer = window.setInterval(() => {
+		syncProjectContext();
+		attempts += 1;
+		if (attempts >= 50) window.clearInterval(timer);
+	}, 100);
 }
 
 if (document.readyState === "loading") {

--- a/public/js/project-dashboard-context.js
+++ b/public/js/project-dashboard-context.js
@@ -1,0 +1,61 @@
+const PROJECT_ID_PARAMS = ["id", "pid"];
+const PROJECT_SCOPED_LINKS = Object.freeze([
+	["journal-link", "/pages/projects/journals/", "id"],
+	["outcomes-link", "/pages/projects/outcomes/", "id"],
+	["add-participant-link", "/pages/project-dashboard/participants/", "pid"],
+	["import-participants-link", "/pages/project-dashboard/participants/import/", "pid"],
+	["add-study-link", "/pages/study/new/", "pid"],
+	["add-insight-link", "/pages/projects/outcomes/", "id", "impact-form"]
+]);
+
+function currentProjectId() {
+	const params = new URLSearchParams(location.search);
+	for (const key of PROJECT_ID_PARAMS) {
+		const value = params.get(key);
+		if (value) return value;
+	}
+	return "";
+}
+
+function projectScopedHref(path, queryKey, projectId, hash = "") {
+	const query = `${queryKey}=${encodeURIComponent(projectId || "")}`;
+	return `${path}?${query}${hash ? `#${hash}` : ""}`;
+}
+
+function setProjectContext() {
+	const projectId = currentProjectId();
+	const main = document.querySelector("main");
+	if (main && projectId) {
+		main.dataset.projectId = projectId;
+		main.dataset.projectAirtableId = projectId;
+	}
+	return projectId;
+}
+
+function syncProjectScopedLinks() {
+	const projectId = currentProjectId() || document.querySelector("main")?.dataset?.projectId || "";
+	if (!projectId) return;
+
+	for (const [id, path, queryKey, hash] of PROJECT_SCOPED_LINKS) {
+		const link = document.getElementById(id);
+		if (!link) continue;
+		link.setAttribute("href", projectScopedHref(path, queryKey, projectId, hash));
+	}
+}
+
+function initProjectDashboardContext() {
+	setProjectContext();
+	syncProjectScopedLinks();
+
+	const observer = new MutationObserver(() => syncProjectScopedLinks());
+	for (const [id] of PROJECT_SCOPED_LINKS) {
+		const link = document.getElementById(id);
+		if (link) observer.observe(link, { attributes: true, attributeFilter: ["href"] });
+	}
+}
+
+if (document.readyState === "loading") {
+	document.addEventListener("DOMContentLoaded", initProjectDashboardContext, { once: true });
+} else {
+	initProjectDashboardContext();
+}

--- a/public/js/project-participant-context.js
+++ b/public/js/project-participant-context.js
@@ -1,0 +1,43 @@
+const projectId = new URLSearchParams(location.search).get("pid") || new URLSearchParams(location.search).get("id") || "";
+
+function applyProjectId() {
+	const main = document.querySelector("main");
+	if (main && projectId) main.dataset.projectId = projectId;
+
+	const input = document.getElementById("project-id");
+	if (input && projectId) input.value = projectId;
+}
+
+function patchParticipantRequests() {
+	if (!projectId || window.__projectParticipantContextPatched) return;
+	window.__projectParticipantContextPatched = true;
+
+	const nativeFetch = window.fetch.bind(window);
+	window.fetch = (input, init = {}) => {
+		const url = typeof input === "string" ? input : input?.url || "";
+		const method = String(init?.method || "GET").toUpperCase();
+		const body = typeof init?.body === "string" ? init.body : "";
+
+		if (method === "POST" && url.includes("/api/participants") && body) {
+			try {
+				const payload = JSON.parse(body);
+				if (!payload.project_airtable_id) {
+					return nativeFetch(input, {
+						...init,
+						body: JSON.stringify({
+							...payload,
+							project_airtable_id: projectId
+						})
+					});
+				}
+			} catch {
+				return nativeFetch(input, init);
+			}
+		}
+
+		return nativeFetch(input, init);
+	};
+}
+
+applyProjectId();
+patchParticipantRequests();

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -8,258 +8,273 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Project Dashboard — ResearchOps</title>
 
-	<!-- Project name hint for integrations (kept in sync by renderProject) -->
 	<meta name="project:name" content="">
 
-	<!-- Foundations -->
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/project-dashboard.css" media="screen" />
+	<link rel="modulepreload" href="/js/project-dashboard-context.js" />
 	<link rel="modulepreload" href="/js/project-dashboard.js" />
 	<script type="module" src="/components/layout.js" defer></script>
+	<script type="module" src="/js/project-dashboard-context.js" defer></script>
 </head>
 
 <body typeof="schema:WebPage" resource="#page" about="#page" vocab="https://schema.org/">
-
-	<!-- Page metadata -->
 	<meta property="schema:name" content="Project Dashboard — ResearchOps" />
 	<meta property="schema:creator" content="Home Office ResearchOps Platform" />
 	<meta property="schema:dateModified" content="2026-05-05" />
 	<meta property="dcterms:language" content="en-GB" />
 
-	<!-- Global header -->
+	<noscript>
+		<a class="govuk-skip-link" href="#main-content">Skip to main content</a>
+
+		<header class="govuk-header" role="banner">
+			<div class="govuk-header__container govuk-width-container">
+				<div class="govuk-header__logo">
+					<a class="govuk-header__link govuk-header__link--homepage" href="/" aria-label="GOV.UK home">
+						<span class="govuk-header__logotype">GOV.UK</span>
+					</a>
+				</div>
+			</div>
+		</header>
+
+		<nav class="govuk-service-navigation" aria-label="Service navigation">
+			<div class="govuk-service-navigation__container govuk-width-container">
+				<span class="govuk-service-navigation__service-name">
+					<a class="govuk-service-navigation__link" href="/">ResearchOps Demo Suite</a>
+				</span>
+				<ul class="govuk-service-navigation__list">
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/">Home</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/start/">Start research project</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/projects/" aria-current="page">Projects</a>
+					</li>
+				</ul>
+			</div>
+		</nav>
+
+		<div class="govuk-phase-banner" role="note" aria-label="Service phase">
+			<p class="govuk-phase-banner__content">
+				<strong class="govuk-tag">Prototype</strong>
+				<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant personal data.</span>
+			</p>
+		</div>
+	</noscript>
+
+	<x-include src="/partials/debug.html" debug-only></x-include>
 	<x-include src="/partials/header.html" vars='{
 			"active":"Projects",
 			"subtitle":"Manage your research project"
 		}'>
 	</x-include>
 
-	<main class="govuk-body" role="main" data-project-name="" data-project-id="" typeof="schema:ResearchProject" resource="#project">
+	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1" data-project-name="" data-project-id="" typeof="schema:ResearchProject" resource="#project">
+		<div class="govuk-width-container">
+			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
+				<ol class="govuk-breadcrumbs__list">
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Projects</span>
+						</a>
+						<meta property="schema:position" content="1" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Project</span>
+						</a>
+						<meta property="schema:position" content="2" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem" aria-current="page">
+						<span property="schema:name">Dashboard</span>
+						<meta property="schema:position" content="3" />
+					</li>
+				</ol>
+			</nav>
 
-		<!-- BREADCRUMBS -->
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Projects</span>
-					</a>
-					<meta property="schema:position" content="1" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Project</span>
-					</a>
-					<meta property="schema:position" content="2" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem" aria-current="page">
-					<span property="schema:name">Dashboard</span>
-					<meta property="schema:position" content="3" />
-				</li>
-			</ol>
-		</nav>
+			<div class="dashboard-hero">
+				<p id="eyebrow-org" class="project-org" property="schema:sourceOrganization" typeof="schema:Organization"></p>
+				<h1 id="project-title" class="govuk-heading-l" property="schema:name"></h1>
+				<p id="project-subtitle" class="lede" property="schema:description"></p>
+			</div>
 
-		<!-- HERO -->
-		<div class="dashboard-hero">
-			<p id="eyebrow-org" class="project-org" property="schema:sourceOrganization" typeof="schema:Organization"></p>
+			<section class="kv" typeof="schema:ResearchProject" aria-label="Project key information">
+				<dl class="govuk-summary-list">
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">Service Stage</dt>
+						<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">Project Stage</dt>
+						<dd class="govuk-summary-list__value" id="kv-project-stage" property="schema:projectStatus">–</dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">Client Name</dt>
+						<dd class="govuk-summary-list__value" id="kv-client-name" property="schema:client">–</dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">Lead Researcher</dt>
+						<dd class="govuk-summary-list__value" id="kv-lead-researcher" property="schema:author" typeof="schema:Person"></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">Lead Researcher Email</dt>
+						<dd class="govuk-summary-list__value"><a id="kv-lead-email" property="schema:email" href="mailto:">–</a></dd>
+					</div>
+				</dl>
+			</section>
 
-			<h1 id="project-title" class="govuk-heading-l" property="schema:name"></h1>
+			<nav class="board" typeof="schema:SiteNavigationElement">
+				<a href="/pages/projects/journals/?id=" id="journal-link" class="board__item" property="schema:relatedLink">Reflexive Journal</a>
+				<a href="#stakeholders" class="board__item" property="schema:relatedLink">Stakeholder Management</a>
+				<a href="#planning" class="board__item" property="schema:relatedLink">Research Planning</a>
+				<a href="/pages/projects/outcomes/?id=" id="outcomes-link" class="board__item" property="schema:relatedLink">Research Outcomes</a>
+			</nav>
 
-			<p id="project-subtitle" class="lede" property="schema:description"></p>
+			<section id="mural-integration" class="card">
+				<h2 class="govuk-heading-m">Mural</h2>
+				<p id="mural-status" class="status" aria-live="polite" aria-atomic="true">
+					<span class="pill pill--neutral">Checking&hellip;</span>
+				</p>
+				<div class="actions">
+					<button id="mural-connect" class="govuk-button" type="button">Connect Mural</button>
+					<button id="mural-setup" class="govuk-button govuk-button--secondary" type="button" disabled>Create “Reflexive Journal”</button>
+				</div>
+				<p class="hint">We’ll verify your Mural account is in the Home Office workspace, create a folder named after this project in your private room, and add a board called <em>Reflexive Journal</em>.</p>
+			</section>
+
+			<section id="stakeholders" class="section">
+				<div class="section__header">
+					<h2 class="section__title govuk-heading-m">Stakeholder Management</h2>
+					<button id="add-stakeholder-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-stakeholder-panel">Add stakeholder</button>
+				</div>
+				<div class="section__body section__grid">
+					<div>
+						<h3 class="govuk-heading-s">Stakeholders</h3>
+						<ul class="list-unstyled list-divided" id="stakeholders-list"><li>No stakeholders yet.</li></ul>
+						<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
+							<form id="add-stakeholder-form" novalidate>
+								<h4 class="govuk-heading-s">Add stakeholder</h4>
+								<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="stakeholder-name">Name</label>
+									<input class="govuk-input" id="stakeholder-name" name="name" autocomplete="name" required />
+								</div>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="stakeholder-role">Role</label>
+									<input class="govuk-input" id="stakeholder-role" name="role" autocomplete="organization-title" required />
+								</div>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="stakeholder-email">Work email</label>
+									<div id="stakeholder-email-hint" class="govuk-hint">Only add staff contact details where needed for project ownership or coordination.</div>
+									<input class="govuk-input" id="stakeholder-email" name="email" type="email" autocomplete="email" aria-describedby="stakeholder-email-hint" />
+								</div>
+								<div class="govuk-button-group">
+									<button class="govuk-button" type="submit">Save stakeholder</button>
+									<button class="govuk-button govuk-button--secondary" type="button" data-close-panel="add-stakeholder-panel" data-toggle="add-stakeholder-toggle">Cancel</button>
+								</div>
+							</form>
+						</div>
+					</div>
+					<div>
+						<h3 class="govuk-heading-s">Objectives</h3>
+						<ul class="list-unstyled list-divided" id="objectives-list"><li>No objectives yet.</li></ul>
+						<button id="add-objective-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-objective-panel">Add objective</button>
+						<div id="add-objective-panel" class="dashboard-action-panel" hidden>
+							<form id="add-objective-form" novalidate>
+								<h4 class="govuk-heading-s">Add objective</h4>
+								<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="objective-text">Research objective</label>
+									<div id="objective-text-hint" class="govuk-hint">Keep objectives action-oriented and linked to decisions the team needs to make. Do not include participant personal data.</div>
+									<textarea class="govuk-textarea" id="objective-text" name="objective" rows="4" required aria-describedby="objective-text-hint"></textarea>
+								</div>
+								<div class="govuk-button-group">
+									<button class="govuk-button" type="submit">Save objective</button>
+									<button class="govuk-button govuk-button--secondary" type="button" data-close-panel="add-objective-panel" data-toggle="add-objective-toggle">Cancel</button>
+								</div>
+							</form>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section id="planning" class="section">
+				<div class="section__header">
+					<h2 class="section__title govuk-heading-m">Research Planning</h2>
+				</div>
+				<div class="section__body section__grid">
+					<div>
+						<h3 class="govuk-heading-s">User Groups</h3>
+						<ul class="list-unstyled list-divided" id="user-groups-list"><li>No user groups yet.</li></ul>
+						<button id="add-user-group-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-user-group-panel">Add user group</button>
+						<div id="add-user-group-panel" class="dashboard-action-panel" hidden>
+							<form id="add-user-group-form" novalidate>
+								<h4 class="govuk-heading-s">Add user group</h4>
+								<div id="add-user-group-status" class="dashboard-action-status" aria-live="polite"></div>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="user-group-name">User group</label>
+									<div id="user-group-name-hint" class="govuk-hint">Use a short group name the research team will recognise.</div>
+									<input class="govuk-input" id="user-group-name" name="user-group" required aria-describedby="user-group-name-hint" />
+								</div>
+								<div class="govuk-button-group">
+									<button class="govuk-button" type="submit">Save user group</button>
+									<button class="govuk-button govuk-button--secondary" type="button" data-close-panel="add-user-group-panel" data-toggle="add-user-group-toggle">Cancel</button>
+								</div>
+							</form>
+						</div>
+					</div>
+					<div>
+						<h3 class="govuk-heading-s">Participants</h3>
+						<ul class="list-unstyled list-divided" id="participants-list"><li>No participants yet.</li></ul>
+						<p class="hint">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
+						<div class="govuk-button-group">
+							<a id="add-participant-link" href="/pages/project-dashboard/participants/?pid=" class="govuk-button govuk-button--secondary">Add participant</a>
+							<a id="import-participants-link" href="/pages/project-dashboard/participants/import/?pid=" class="govuk-button govuk-button--secondary">Bulk upload participants via CSV</a>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section id="outcomes" class="section">
+				<div class="section__header">
+					<h2 class="section__title govuk-heading-m">Research Outcomes</h2>
+				</div>
+				<div class="section__body section__grid">
+					<div>
+						<h3 class="govuk-heading-s">Studies</h3>
+						<ul class="list-unstyled list-divided" id="studies-list"><li>No studies yet.</li></ul>
+						<a id="add-study-link" class="govuk-button govuk-button--secondary" href="/pages/study/new/?pid=">Add study</a>
+					</div>
+					<div>
+						<h3 class="govuk-heading-s">Insights</h3>
+						<ul class="list-unstyled list-divided" id="insights-list"><li>No insights yet.</li></ul>
+						<p class="hint">Insights and impact records are managed from the outcomes workflow so they remain linked to evidence and decisions.</p>
+						<a id="add-insight-link" href="/pages/projects/outcomes/?id=#impact-form" class="govuk-button govuk-button--secondary">Add insight</a>
+					</div>
+				</div>
+			</section>
 		</div>
-
-		<!-- KEY INFORMATION -->
-		<section class="kv" typeof="schema:ResearchProject" aria-label="Project key information">
-			<dl class="govuk-summary-list">
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Service Stage</dt>
-					<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Project Stage</dt>
-					<dd class="govuk-summary-list__value" id="kv-project-stage" property="schema:projectStatus">–</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Client Name</dt>
-					<dd class="govuk-summary-list__value" id="kv-client-name" property="schema:client">–</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Lead Researcher</dt>
-					<dd class="govuk-summary-list__value" id="kv-lead-researcher" property="schema:author" typeof="schema:Person"></dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Lead Researcher Email</dt>
-					<dd class="govuk-summary-list__value"><a id="kv-lead-email" property="schema:email" href="mailto:">–</a></dd>
-				</div>
-			</dl>
-		</section>
-
-		<!-- NAV BOARD -->
-		<nav class="board" typeof="schema:SiteNavigationElement">
-			<a href="/pages/projects/journals/?id=" id="journal-link" class="board__item" property="schema:relatedLink">Reflexive Journal</a>
-			<a href="#stakeholders" class="board__item" property="schema:relatedLink">Stakeholder Management</a>
-			<a href="#planning" class="board__item" property="schema:relatedLink">Research Planning</a>
-			<a href="/pages/projects/outcomes/?id=" id="outcomes-link" class="board__item" property="schema:relatedLink">Research Outcomes</a>
-		</nav>
-
-		<!-- MURAL INTEGRATIONS -->
-		<section id="mural-integration" class="card">
-			<h2 class="govuk-heading-m">Mural</h2>
-
-			<p id="mural-status" class="status" aria-live="polite" aria-atomic="true">
-				<span class="pill pill--neutral">Checking&hellip;</span>
-			</p>
-
-			<div class="actions">
-				<button id="mural-connect" class="govuk-button" type="button">Connect Mural</button>
-				<button id="mural-setup" class="govuk-button govuk-button--secondary" type="button" disabled>Create “Reflexive Journal”</button>
-			</div>
-
-			<p class="hint">
-				We’ll verify your Mural account is in the Home Office workspace, create a folder named after this project in your private room, and add a board called <em>Reflexive Journal</em>.
-			</p>
-		</section>
-
-		<!-- STAKEHOLDERS -->
-		<section id="stakeholders" class="section">
-			<header class="section__header">
-				<h2 class="section__title govuk-heading-m">Stakeholder Management</h2>
-				<button id="add-stakeholder-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-stakeholder-panel">Add stakeholder</button>
-			</header>
-			<div class="section__body section__grid">
-				<div>
-					<h3 class="govuk-heading-s">Stakeholders</h3>
-					<ul class="list-unstyled list-divided" id="stakeholders-list">
-						<li>No stakeholders yet.</li>
-					</ul>
-
-					<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
-						<form id="add-stakeholder-form" novalidate>
-							<h4 class="govuk-heading-s">Add stakeholder</h4>
-							<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="stakeholder-name">Name</label>
-								<input class="govuk-input" id="stakeholder-name" name="name" autocomplete="name" required />
-							</div>
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="stakeholder-role">Role</label>
-								<input class="govuk-input" id="stakeholder-role" name="role" autocomplete="organization-title" required />
-							</div>
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="stakeholder-email">Work email</label>
-								<div id="stakeholder-email-hint" class="govuk-hint">Only add staff contact details where needed for project ownership or coordination.</div>
-								<input class="govuk-input" id="stakeholder-email" name="email" type="email" autocomplete="email" aria-describedby="stakeholder-email-hint" />
-							</div>
-							<div class="govuk-button-group">
-								<button class="govuk-button" type="submit">Save stakeholder</button>
-								<button class="govuk-button govuk-button--secondary" type="button" data-close-panel="add-stakeholder-panel" data-toggle="add-stakeholder-toggle">Cancel</button>
-							</div>
-						</form>
-					</div>
-				</div>
-				<div>
-					<h3 class="govuk-heading-s">Objectives</h3>
-					<ul class="list-unstyled list-divided" id="objectives-list">
-						<li>No objectives yet.</li>
-					</ul>
-					<button id="add-objective-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-objective-panel">Add objective</button>
-
-					<div id="add-objective-panel" class="dashboard-action-panel" hidden>
-						<form id="add-objective-form" novalidate>
-							<h4 class="govuk-heading-s">Add objective</h4>
-							<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="objective-text">Research objective</label>
-								<div id="objective-text-hint" class="govuk-hint">Keep objectives action-oriented and linked to decisions the team needs to make. Do not include participant personal data.</div>
-								<textarea class="govuk-textarea" id="objective-text" name="objective" rows="4" required aria-describedby="objective-text-hint"></textarea>
-							</div>
-							<div class="govuk-button-group">
-								<button class="govuk-button" type="submit">Save objective</button>
-								<button class="govuk-button govuk-button--secondary" type="button" data-close-panel="add-objective-panel" data-toggle="add-objective-toggle">Cancel</button>
-							</div>
-						</form>
-					</div>
-				</div>
-			</div>
-		</section>
-
-		<!-- RESEARCH PLANNING -->
-		<section id="planning" class="section">
-			<header class="section__header">
-				<h2 class="section__title govuk-heading-m">Research Planning</h2>
-			</header>
-			<div class="section__body section__grid">
-				<div>
-					<h3 class="govuk-heading-s">User Groups</h3>
-					<ul class="list-unstyled list-divided" id="user-groups-list">
-						<li>No user groups yet.</li>
-					</ul>
-					<button id="add-user-group-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-user-group-panel">Add user group</button>
-
-					<div id="add-user-group-panel" class="dashboard-action-panel" hidden>
-						<form id="add-user-group-form" novalidate>
-							<h4 class="govuk-heading-s">Add user group</h4>
-							<div id="add-user-group-status" class="dashboard-action-status" aria-live="polite"></div>
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="user-group-name">User group</label>
-								<div id="user-group-name-hint" class="govuk-hint">Use a short group name the research team will recognise.</div>
-								<input class="govuk-input" id="user-group-name" name="user-group" required aria-describedby="user-group-name-hint" />
-							</div>
-							<div class="govuk-button-group">
-								<button class="govuk-button" type="submit">Save user group</button>
-								<button class="govuk-button govuk-button--secondary" type="button" data-close-panel="add-user-group-panel" data-toggle="add-user-group-toggle">Cancel</button>
-							</div>
-						</form>
-					</div>
-				</div>
-				<div>
-					<h3 class="govuk-heading-s">Participants</h3>
-					<ul class="list-unstyled list-divided" id="participants-list">
-						<li>No participants yet.</li>
-					</ul>
-					<p class="hint">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
-					<div class="govuk-button-group">
-						<a id="add-participant-link" href="/pages/project-dashboard/participants/?id=" class="govuk-button govuk-button--secondary">Add participant</a>
-						<a id="import-participants-link" href="/pages/project-dashboard/participants/import/?id=" class="govuk-button govuk-button--secondary">Bulk upload participants via CSV</a>
-					</div>
-				</div>
-			</div>
-		</section>
-
-		<!-- RESEARCH OUTCOMES -->
-		<section id="outcomes" class="section">
-			<header class="section__header">
-				<h2 class="section__title govuk-heading-m">Research Outcomes</h2>
-			</header>
-			<div class="section__body section__grid">
-				<div>
-					<h3 class="govuk-heading-s">Studies</h3>
-					<ul class="list-unstyled list-divided" id="studies-list">
-						<li>No studies yet.</li>
-					</ul>
-					<a id="add-study-link" class="govuk-button govuk-button--secondary" href="/pages/study/new/?pid=">Add study</a>
-				</div>
-				<div>
-					<h3 class="govuk-heading-s">Insights</h3>
-					<ul class="list-unstyled list-divided" id="insights-list">
-						<li>No insights yet.</li>
-					</ul>
-					<p class="hint">Insights and impact records are managed from the outcomes workflow so they remain linked to evidence and decisions.</p>
-					<a id="add-insight-link" href="/pages/projects/outcomes/?id=#impact-form" class="govuk-button govuk-button--secondary">Add insight</a>
-				</div>
-			</div>
-		</section>
 	</main>
+
+	<noscript>
+		<footer class="govuk-footer" role="contentinfo">
+			<div class="govuk-footer__container govuk-width-container">
+				<p class="govuk-footer__meta">© 2026 Home Office Biometrics · ResearchOps v1.0.0</p>
+			</div>
+		</footer>
+	</noscript>
 
 	<x-include src="/partials/footer.html"></x-include>
 
-	<!-- JS -->
 	<script type="module" src="/js/project-dashboard.js"></script>
-
-	<!-- Mural integration (OAuth + setup). Relies on project name/id set by renderProject(). -->
 	<script type="module" src="/components/mural-integration.js"></script>
 </body>
 

--- a/public/pages/project-dashboard/participants/import/index.html
+++ b/public/pages/project-dashboard/participants/import/index.html
@@ -9,10 +9,11 @@
 	<title>Import participants — ResearchOps</title>
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="modulepreload" href="/pages/project-dashboard/participants/import/import-participants.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -29,91 +30,95 @@
 		}'>
 	</x-include>
 
-	<main id="main" class="govuk-body" role="main" data-project-id="">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Projects</span>
-					</a>
-					<meta property="schema:position" content="1" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Project</span>
-					</a>
-					<meta property="schema:position" content="2" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
-					<span property="schema:name">Import participants</span>
-					<meta property="schema:position" content="3" />
-				</li>
-			</ol>
-		</nav>
+	<main id="main-content" class="govuk-main-wrapper" role="main" tabindex="-1" data-project-id="">
+		<div class="govuk-width-container">
+			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
+				<ol class="govuk-breadcrumbs__list">
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Projects</span>
+						</a>
+						<meta property="schema:position" content="1" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Project</span>
+						</a>
+						<meta property="schema:position" content="2" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
+						<span property="schema:name">Import participants</span>
+						<meta property="schema:position" content="3" />
+					</li>
+				</ol>
+			</nav>
 
-		<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
+			<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
 
-		<div class="dashboard-hero">
-			<p id="project-eyebrow" class="project-org">Project</p>
-			<h1 class="govuk-heading-l">Import participants</h1>
-			<p class="lede">Upload a CSV, preview the rows and create participants against a study only after checking the data.</p>
+			<div class="dashboard-hero">
+				<p id="project-eyebrow" class="project-org">Project</p>
+				<h1 class="govuk-heading-l">Import participants</h1>
+				<p class="lede">Upload a CSV, preview the rows and create participants against a study only after checking the data.</p>
+			</div>
+
+			<div id="import-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="import-error-summary-title" hidden>
+				<h2 id="import-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
+				<div class="govuk-error-summary__body">
+					<ul class="govuk-list govuk-error-summary__list" id="import-error-list"></ul>
+				</div>
+			</div>
+
+			<div id="no-studies-panel" class="card" hidden>
+				<h2 class="govuk-heading-m">Create a study first</h2>
+				<p>Participants must be linked to a study before they can be imported.</p>
+				<a id="create-study-link" href="/pages/study/new/?pid=" class="govuk-button">Add study</a>
+			</div>
+
+			<form id="import-participants-form" novalidate>
+				<input id="project-id" name="project_airtable_id" type="hidden" value="" />
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="study-select">Study</label>
+					<div id="study-select-hint" class="govuk-hint">Choose the study these participants belong to.</div>
+					<select id="study-select" name="study" class="govuk-select" aria-describedby="study-select-hint" required>
+						<option value="">Choose a study</option>
+					</select>
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="participants-csv">CSV file</label>
+					<div id="participants-csv-hint" class="govuk-hint">Use headings: display_name, email, phone, channel_pref, access_needs. Do not upload unnecessary personal data.</div>
+					<input id="participants-csv" name="csv" class="govuk-file-upload" type="file" accept=".csv,text/csv" aria-describedby="participants-csv-hint" required />
+				</div>
+
+				<div class="govuk-button-group">
+					<button id="preview-csv" class="govuk-button govuk-button--secondary" type="button">Preview CSV</button>
+					<button id="import-submit" class="govuk-button" type="submit" disabled>Create participants</button>
+					<a id="cancel-import" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
+				</div>
+
+				<p id="import-status" class="hint" role="status" aria-live="polite"></p>
+			</form>
+
+			<section id="preview-section" class="govuk-!-margin-top-6" aria-labelledby="preview-heading" hidden>
+				<h2 id="preview-heading" class="govuk-heading-m">Preview participants</h2>
+				<div class="table-wrap">
+					<table class="govuk-table">
+						<caption class="govuk-table__caption govuk-table__caption--s">Rows to import</caption>
+						<thead class="govuk-table__head">
+							<tr class="govuk-table__row">
+								<th scope="col" class="govuk-table__header">Display name</th>
+								<th scope="col" class="govuk-table__header">Email</th>
+								<th scope="col" class="govuk-table__header">Phone</th>
+								<th scope="col" class="govuk-table__header">Channel</th>
+								<th scope="col" class="govuk-table__header">Access needs</th>
+							</tr>
+						</thead>
+						<tbody id="preview-body" class="govuk-table__body"></tbody>
+					</table>
+				</div>
+			</section>
 		</div>
-
-		<div id="import-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="import-error-summary-title" hidden>
-			<h2 id="import-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
-			<div class="govuk-error-summary__body">
-				<ul class="govuk-list govuk-error-summary__list" id="import-error-list"></ul>
-			</div>
-		</div>
-
-		<div id="no-studies-panel" class="card" hidden>
-			<h2 class="govuk-heading-m">Create a study first</h2>
-			<p>Participants must be linked to a study before they can be imported.</p>
-			<a id="create-study-link" href="/pages/study/new/?pid=" class="govuk-button">Add study</a>
-		</div>
-
-		<form id="import-participants-form" novalidate>
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="study-select">Study</label>
-				<div id="study-select-hint" class="govuk-hint">Choose the study these participants belong to.</div>
-				<select id="study-select" name="study" class="govuk-select" aria-describedby="study-select-hint" required>
-					<option value="">Choose a study</option>
-				</select>
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="participants-csv">CSV file</label>
-				<div id="participants-csv-hint" class="govuk-hint">Use headings: display_name, email, phone, channel_pref, access_needs. Do not upload unnecessary personal data.</div>
-				<input id="participants-csv" name="csv" class="govuk-file-upload" type="file" accept=".csv,text/csv" aria-describedby="participants-csv-hint" required />
-			</div>
-
-			<div class="govuk-button-group">
-				<button id="preview-csv" class="govuk-button govuk-button--secondary" type="button">Preview CSV</button>
-				<button id="import-submit" class="govuk-button" type="submit" disabled>Create participants</button>
-				<a id="cancel-import" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
-			</div>
-
-			<p id="import-status" class="hint" role="status" aria-live="polite"></p>
-		</form>
-
-		<section id="preview-section" class="govuk-!-margin-top-6" aria-labelledby="preview-heading" hidden>
-			<h2 id="preview-heading" class="govuk-heading-m">Preview participants</h2>
-			<div class="table-wrap">
-				<table class="govuk-table">
-					<caption class="govuk-table__caption govuk-table__caption--s">Rows to import</caption>
-					<thead class="govuk-table__head">
-						<tr class="govuk-table__row">
-							<th scope="col" class="govuk-table__header">Display name</th>
-							<th scope="col" class="govuk-table__header">Email</th>
-							<th scope="col" class="govuk-table__header">Phone</th>
-							<th scope="col" class="govuk-table__header">Channel</th>
-							<th scope="col" class="govuk-table__header">Access needs</th>
-						</tr>
-					</thead>
-					<tbody id="preview-body" class="govuk-table__body"></tbody>
-				</table>
-			</div>
-		</section>
 	</main>
 
 	<x-include src="/partials/footer.html"></x-include>

--- a/public/pages/project-dashboard/participants/import/index.html
+++ b/public/pages/project-dashboard/participants/import/index.html
@@ -14,6 +14,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="modulepreload" href="/js/project-participant-context.js" />
 	<link rel="modulepreload" href="/pages/project-dashboard/participants/import/import-participants.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -123,6 +124,7 @@
 
 	<x-include src="/partials/footer.html"></x-include>
 
+	<script type="module" src="/js/project-participant-context.js"></script>
 	<script type="module" src="/pages/project-dashboard/participants/import/import-participants.js"></script>
 </body>
 

--- a/public/pages/project-dashboard/participants/index.html
+++ b/public/pages/project-dashboard/participants/index.html
@@ -14,6 +14,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="modulepreload" href="/js/project-participant-context.js" />
 	<link rel="modulepreload" href="/pages/project-dashboard/participants/participants-project.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -127,6 +128,7 @@
 
 	<x-include src="/partials/footer.html"></x-include>
 
+	<script type="module" src="/js/project-participant-context.js"></script>
 	<script type="module" src="/pages/project-dashboard/participants/participants-project.js"></script>
 </body>
 

--- a/public/pages/project-dashboard/participants/index.html
+++ b/public/pages/project-dashboard/participants/index.html
@@ -9,10 +9,11 @@
 	<title>Add participant — ResearchOps</title>
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="modulepreload" href="/pages/project-dashboard/participants/participants-project.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -29,95 +30,99 @@
 		}'>
 	</x-include>
 
-	<main id="main" class="govuk-body" role="main" data-project-id="">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Projects</span>
-					</a>
-					<meta property="schema:position" content="1" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Project</span>
-					</a>
-					<meta property="schema:position" content="2" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
-					<span property="schema:name">Add participant</span>
-					<meta property="schema:position" content="3" />
-				</li>
-			</ol>
-		</nav>
+	<main id="main-content" class="govuk-main-wrapper" role="main" tabindex="-1" data-project-id="">
+		<div class="govuk-width-container">
+			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
+				<ol class="govuk-breadcrumbs__list">
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Projects</span>
+						</a>
+						<meta property="schema:position" content="1" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Project</span>
+						</a>
+						<meta property="schema:position" content="2" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
+						<span property="schema:name">Add participant</span>
+						<meta property="schema:position" content="3" />
+					</li>
+				</ol>
+			</nav>
 
-		<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
+			<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
 
-		<div class="dashboard-hero">
-			<p id="project-eyebrow" class="project-org">Project</p>
-			<h1 class="govuk-heading-l">Add participant</h1>
-			<p class="lede">Add participants through a study-specific workflow so recruitment, consent and sessions remain traceable.</p>
+			<div class="dashboard-hero">
+				<p id="project-eyebrow" class="project-org">Project</p>
+				<h1 class="govuk-heading-l">Add participant</h1>
+				<p class="lede">Add participants through a study-specific workflow so recruitment, consent and sessions remain traceable.</p>
+			</div>
+
+			<div id="participant-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="participant-error-summary-title" hidden>
+				<h2 id="participant-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
+				<div class="govuk-error-summary__body">
+					<ul class="govuk-list govuk-error-summary__list" id="participant-error-list"></ul>
+				</div>
+			</div>
+
+			<div id="no-studies-panel" class="card" hidden>
+				<h2 class="govuk-heading-m">Create a study first</h2>
+				<p>Participants must be linked to a study before they can be added.</p>
+				<a id="create-study-link" href="/pages/study/new/?pid=" class="govuk-button">Add study</a>
+			</div>
+
+			<form id="add-participant-form" novalidate>
+				<input id="project-id" name="project_airtable_id" type="hidden" value="" />
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="study-select">Study</label>
+					<div id="study-select-hint" class="govuk-hint">Choose the study this participant belongs to.</div>
+					<select id="study-select" name="study" class="govuk-select" aria-describedby="study-select-hint" required>
+						<option value="">Choose a study</option>
+					</select>
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="participant-display-name">Display name</label>
+					<div id="participant-display-name-hint" class="govuk-hint">Use a pseudonym or operational display name. Do not add unnecessary personal data.</div>
+					<input id="participant-display-name" name="display_name" class="govuk-input govuk-!-width-two-thirds" autocomplete="off" aria-describedby="participant-display-name-hint" required />
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="participant-email">Email</label>
+					<input id="participant-email" name="email" class="govuk-input govuk-!-width-two-thirds" type="email" autocomplete="off" />
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="participant-phone">Phone</label>
+					<input id="participant-phone" name="phone" class="govuk-input govuk-!-width-two-thirds" type="tel" autocomplete="off" />
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="participant-channel">Channel preference</label>
+					<select id="participant-channel" name="channel_pref" class="govuk-select">
+						<option value="email">Email</option>
+						<option value="sms">SMS</option>
+					</select>
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="participant-access-needs">Access needs</label>
+					<div id="participant-access-needs-hint" class="govuk-hint">Only record support needs needed to run the research safely and accessibly.</div>
+					<textarea id="participant-access-needs" name="access_needs" class="govuk-textarea govuk-!-width-two-thirds" rows="4" aria-describedby="participant-access-needs-hint"></textarea>
+				</div>
+
+				<div class="govuk-button-group">
+					<button id="participant-submit" class="govuk-button" type="submit">Create participant</button>
+					<a id="cancel-participant" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
+				</div>
+
+				<p id="participant-status" class="hint" role="status" aria-live="polite"></p>
+			</form>
 		</div>
-
-		<div id="participant-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="participant-error-summary-title" hidden>
-			<h2 id="participant-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
-			<div class="govuk-error-summary__body">
-				<ul class="govuk-list govuk-error-summary__list" id="participant-error-list"></ul>
-			</div>
-		</div>
-
-		<div id="no-studies-panel" class="card" hidden>
-			<h2 class="govuk-heading-m">Create a study first</h2>
-			<p>Participants must be linked to a study before they can be added.</p>
-			<a id="create-study-link" href="/pages/study/new/?pid=" class="govuk-button">Add study</a>
-		</div>
-
-		<form id="add-participant-form" novalidate>
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="study-select">Study</label>
-				<div id="study-select-hint" class="govuk-hint">Choose the study this participant belongs to.</div>
-				<select id="study-select" name="study" class="govuk-select" aria-describedby="study-select-hint" required>
-					<option value="">Choose a study</option>
-				</select>
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="participant-display-name">Display name</label>
-				<div id="participant-display-name-hint" class="govuk-hint">Use a pseudonym or operational display name. Do not add unnecessary personal data.</div>
-				<input id="participant-display-name" name="display_name" class="govuk-input govuk-!-width-two-thirds" autocomplete="off" aria-describedby="participant-display-name-hint" required />
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="participant-email">Email</label>
-				<input id="participant-email" name="email" class="govuk-input govuk-!-width-two-thirds" type="email" autocomplete="off" />
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="participant-phone">Phone</label>
-				<input id="participant-phone" name="phone" class="govuk-input govuk-!-width-two-thirds" type="tel" autocomplete="off" />
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="participant-channel">Channel preference</label>
-				<select id="participant-channel" name="channel_pref" class="govuk-select">
-					<option value="email">Email</option>
-					<option value="sms">SMS</option>
-				</select>
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="participant-access-needs">Access needs</label>
-				<div id="participant-access-needs-hint" class="govuk-hint">Only record support needs needed to run the research safely and accessibly.</div>
-				<textarea id="participant-access-needs" name="access_needs" class="govuk-textarea govuk-!-width-two-thirds" rows="4" aria-describedby="participant-access-needs-hint"></textarea>
-			</div>
-
-			<div class="govuk-button-group">
-				<button id="participant-submit" class="govuk-button" type="submit">Create participant</button>
-				<a id="cancel-participant" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
-			</div>
-
-			<p id="participant-status" class="hint" role="status" aria-live="polite"></p>
-		</form>
 	</main>
 
 	<x-include src="/partials/footer.html"></x-include>

--- a/public/pages/project-dashboard/participants/participants-project.js
+++ b/public/pages/project-dashboard/participants/participants-project.js
@@ -1,182 +1,189 @@
 const API_ORIGIN =
-  document.documentElement?.dataset?.apiOrigin ||
-  window.API_ORIGIN ||
-  (location.hostname.endsWith("pages.dev") ?
-    "https://rops-api.digikev-kevin-rapley.workers.dev" :
-    location.origin);
+	document.documentElement?.dataset?.apiOrigin ||
+	window.API_ORIGIN ||
+	(location.hostname.endsWith("pages.dev") ?
+		"https://rops-api.digikev-kevin-rapley.workers.dev" :
+		location.origin);
 
 const $ = (selector, root = document) => root.querySelector(selector);
 
 function projectIdFromUrl() {
-  return new URLSearchParams(location.search).get("id") || new URLSearchParams(location.search).get("pid") || "";
+	return new URLSearchParams(location.search).get("pid") || new URLSearchParams(location.search).get("id") || "";
 }
 
 function fieldValue(selector) {
-  return String($(selector)?.value || "").trim();
+	return String($(selector)?.value || "").trim();
 }
 
 function fallbackStudyTitle(study = {}) {
-  const method = String(study.method || "Study").trim();
-  const date = study.createdAt ? new Date(study.createdAt) : new Date();
-  const yyyy = date.getUTCFullYear();
-  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(date.getUTCDate()).padStart(2, "0");
-  return `${method} — ${yyyy}-${mm}-${dd}`;
+	const method = String(study.method || "Study").trim();
+	const date = study.createdAt ? new Date(study.createdAt) : new Date();
+	const yyyy = date.getUTCFullYear();
+	const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+	const dd = String(date.getUTCDate()).padStart(2, "0");
+	return `${method} — ${yyyy}-${mm}-${dd}`;
 }
 
 function pickStudyTitle(study = {}) {
-  return String(study.title || study.Title || "").trim() || fallbackStudyTitle(study);
+	return String(study.title || study.Title || "").trim() || fallbackStudyTitle(study);
 }
 
 function setProjectLinks(projectId, project = {}) {
-  const dashboardHref = `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
-  const projectName = project.name || project.Name || "Project";
+	const dashboardHref = `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
+	const projectName = project.name || project.Name || "Project";
 
-  const main = $("#main");
-  if (main) main.dataset.projectId = projectId;
+	const main = $("#main-content");
+	if (main) main.dataset.projectId = projectId;
 
-  const breadcrumbProject = $("#breadcrumb-project");
-  if (breadcrumbProject) {
-    breadcrumbProject.href = dashboardHref;
-    breadcrumbProject.textContent = projectName;
-  }
+	const projectInput = $("#project-id");
+	if (projectInput) projectInput.value = projectId;
 
-  const back = $("#back-to-project");
-  if (back) back.href = dashboardHref;
+	const breadcrumbProject = $("#breadcrumb-project");
+	if (breadcrumbProject) {
+		breadcrumbProject.href = dashboardHref;
+		breadcrumbProject.textContent = projectName;
+	}
 
-  const cancel = $("#cancel-participant");
-  if (cancel) cancel.href = dashboardHref;
+	const back = $("#back-to-project");
+	if (back) back.href = dashboardHref;
 
-  const eyebrow = $("#project-eyebrow");
-  if (eyebrow) eyebrow.textContent = projectName;
+	const cancel = $("#cancel-participant");
+	if (cancel) cancel.href = dashboardHref;
 
-  const createStudy = $("#create-study-link");
-  if (createStudy) createStudy.href = `/pages/study/new/?pid=${encodeURIComponent(projectId)}`;
+	const eyebrow = $("#project-eyebrow");
+	if (eyebrow) eyebrow.textContent = projectName;
+
+	const createStudy = $("#create-study-link");
+	if (createStudy) createStudy.href = `/pages/study/new/?pid=${encodeURIComponent(projectId)}`;
 }
 
 async function loadProject(projectId) {
-  const res = await fetch(`${API_ORIGIN}/api/projects/${encodeURIComponent(projectId)}?ts=${Date.now()}`, { cache: "no-store" });
-  if (!res.ok) return {};
-  return res.json().catch(() => ({}));
+	const res = await fetch(`${API_ORIGIN}/api/projects/${encodeURIComponent(projectId)}?ts=${Date.now()}`, { cache: "no-store" });
+	if (!res.ok) return {};
+	return res.json().catch(() => ({}));
 }
 
 async function loadStudies(projectId) {
-  const res = await fetch(`${API_ORIGIN}/api/studies?project=${encodeURIComponent(projectId)}&ts=${Date.now()}`, { cache: "no-store" });
-  const json = await res.json().catch(() => ({}));
-  if (!res.ok || !json?.ok || !Array.isArray(json.studies)) return [];
-  return json.studies;
+	const res = await fetch(`${API_ORIGIN}/api/studies?project=${encodeURIComponent(projectId)}&ts=${Date.now()}`, { cache: "no-store" });
+	const json = await res.json().catch(() => ({}));
+	if (!res.ok || !json?.ok || !Array.isArray(json.studies)) return [];
+	return json.studies;
 }
 
 function populateStudies(studies = []) {
-  const select = $("#study-select");
-  const noStudies = $("#no-studies-panel");
-  const form = $("#add-participant-form");
-  if (!select) return;
+	const select = $("#study-select");
+	const noStudies = $("#no-studies-panel");
+	const form = $("#add-participant-form");
+	if (!select) return;
 
-  select.innerHTML = '<option value="">Choose a study</option>';
-  studies.forEach((study) => {
-    const option = document.createElement("option");
-    option.value = study.id || "";
-    option.textContent = pickStudyTitle(study);
-    select.append(option);
-  });
+	select.innerHTML = '<option value="">Choose a study</option>';
+	studies.forEach((study) => {
+		const option = document.createElement("option");
+		option.value = study.id || "";
+		option.textContent = pickStudyTitle(study);
+		select.append(option);
+	});
 
-  if (noStudies) noStudies.hidden = studies.length > 0;
-  if (form) form.hidden = studies.length === 0;
+	if (noStudies) noStudies.hidden = studies.length > 0;
+	if (form) form.hidden = studies.length === 0;
 }
 
 function showErrors(errors) {
-  const summary = $("#participant-error-summary");
-  const list = $("#participant-error-list");
-  if (!summary || !list) return;
+	const summary = $("#participant-error-summary");
+	const list = $("#participant-error-list");
+	if (!summary || !list) return;
 
-  if (!errors.length) {
-    summary.hidden = true;
-    list.innerHTML = "";
-    return;
-  }
+	if (!errors.length) {
+		summary.hidden = true;
+		list.innerHTML = "";
+		return;
+	}
 
-  list.innerHTML = errors.map((error) => `<li><a href="#${error.id}">${error.message}</a></li>`).join("");
-  summary.hidden = false;
-  summary.focus();
+	list.innerHTML = errors.map((error) => `<li><a href="#${error.id}">${error.message}</a></li>`).join("");
+	summary.hidden = false;
+	summary.focus();
 }
 
 function validate() {
-  const errors = [];
-  if (!fieldValue("#study-select")) {
-    errors.push({ id: "study-select", message: "Choose a study" });
-  }
-  if (!fieldValue("#participant-display-name")) {
-    errors.push({ id: "participant-display-name", message: "Enter a display name" });
-  }
-  return errors;
+	const errors = [];
+	if (!fieldValue("#project-id")) {
+		errors.push({ id: "project-id", message: "Missing project id" });
+	}
+	if (!fieldValue("#study-select")) {
+		errors.push({ id: "study-select", message: "Choose a study" });
+	}
+	if (!fieldValue("#participant-display-name")) {
+		errors.push({ id: "participant-display-name", message: "Enter a display name" });
+	}
+	return errors;
 }
 
-async function createParticipant() {
-  const payload = {
-    study_airtable_id: fieldValue("#study-select"),
-    display_name: fieldValue("#participant-display-name"),
-    email: fieldValue("#participant-email"),
-    phone: fieldValue("#participant-phone"),
-    channel_pref: fieldValue("#participant-channel") || "email",
-    access_needs: fieldValue("#participant-access-needs"),
-    status: "invited",
-    consent_status: "not_sent",
-  };
+async function createParticipant(projectId) {
+	const payload = {
+		project_airtable_id: projectId,
+		study_airtable_id: fieldValue("#study-select"),
+		display_name: fieldValue("#participant-display-name"),
+		email: fieldValue("#participant-email"),
+		phone: fieldValue("#participant-phone"),
+		channel_pref: fieldValue("#participant-channel") || "email",
+		access_needs: fieldValue("#participant-access-needs"),
+		status: "invited",
+		consent_status: "not_sent",
+	};
 
-  const res = await fetch(`${API_ORIGIN}/api/participants`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+	const res = await fetch(`${API_ORIGIN}/api/participants`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
 
-  const json = await res.json().catch(() => ({}));
-  if (!res.ok || json?.ok === false) {
-    throw new Error(json?.error || json?.detail || `HTTP ${res.status}`);
-  }
+	const json = await res.json().catch(() => ({}));
+	if (!res.ok || json?.ok === false) {
+		throw new Error(json?.error || json?.detail || `HTTP ${res.status}`);
+	}
 
-  return json.id || "";
+	return json.id || "";
 }
 
 function initForm(projectId) {
-  const form = $("#add-participant-form");
-  const submit = $("#participant-submit");
-  const status = $("#participant-status");
-  if (!form) return;
+	const form = $("#add-participant-form");
+	const submit = $("#participant-submit");
+	const status = $("#participant-status");
+	if (!form) return;
 
-  form.addEventListener("submit", async (event) => {
-    event.preventDefault();
-    const errors = validate();
-    showErrors(errors);
-    if (errors.length) return;
+	form.addEventListener("submit", async (event) => {
+		event.preventDefault();
+		const errors = validate();
+		showErrors(errors);
+		if (errors.length) return;
 
-    if (submit) submit.setAttribute("disabled", "true");
-    if (status) status.textContent = "Creating participant.";
+		if (submit) submit.setAttribute("disabled", "true");
+		if (status) status.textContent = "Creating participant.";
 
-    try {
-      const participantId = await createParticipant();
-      if (status) status.textContent = "Participant created. Opening study participants page.";
-      const studyId = fieldValue("#study-select");
-      const suffix = participantId ? `#participant-${encodeURIComponent(participantId)}` : "";
-      location.assign(`/pages/study/participants/?pid=${encodeURIComponent(projectId)}&sid=${encodeURIComponent(studyId)}${suffix}`);
-    } catch (err) {
-      showErrors([{ id: "participant-display-name", message: `Could not create participant. ${String(err?.message || err)}` }]);
-      if (status) status.textContent = "";
-    } finally {
-      if (submit) submit.removeAttribute("disabled");
-    }
-  });
+		try {
+			const participantId = await createParticipant(projectId);
+			if (status) status.textContent = "Participant created. Opening study participants page.";
+			const studyId = fieldValue("#study-select");
+			const suffix = participantId ? `#participant-${encodeURIComponent(participantId)}` : "";
+			location.assign(`/pages/study/participants/?pid=${encodeURIComponent(projectId)}&sid=${encodeURIComponent(studyId)}${suffix}`);
+		} catch (err) {
+			showErrors([{ id: "participant-display-name", message: `Could not create participant. ${String(err?.message || err)}` }]);
+			if (status) status.textContent = "";
+		} finally {
+			if (submit) submit.removeAttribute("disabled");
+		}
+	});
 }
 
 (async function bootstrap() {
-  const projectId = projectIdFromUrl();
-  if (!projectId) {
-    showErrors([{ id: "study-select", message: "Missing project id" }]);
-    return;
-  }
+	const projectId = projectIdFromUrl();
+	if (!projectId) {
+		showErrors([{ id: "project-id", message: "Missing project id" }]);
+		return;
+	}
 
-  const [project, studies] = await Promise.all([loadProject(projectId), loadStudies(projectId)]);
-  setProjectLinks(projectId, project);
-  populateStudies(studies);
-  initForm(projectId);
+	const [project, studies] = await Promise.all([loadProject(projectId), loadStudies(projectId)]);
+	setProjectLinks(projectId, project);
+	populateStudies(studies);
+	initForm(projectId);
 })();

--- a/public/pages/study/new/index.html
+++ b/public/pages/study/new/index.html
@@ -9,10 +9,11 @@
 	<title>Add study — ResearchOps</title>
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="modulepreload" href="/pages/study/new/study-new.js" />
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
@@ -29,81 +30,85 @@
 		}'>
 	</x-include>
 
-	<main id="main" class="govuk-body" role="main" data-project-id="">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Projects</span>
-					</a>
-					<meta property="schema:position" content="1" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-					<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-						<span property="schema:name">Project</span>
-					</a>
-					<meta property="schema:position" content="2" />
-				</li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
-					<span property="schema:name">Add study</span>
-					<meta property="schema:position" content="3" />
-				</li>
-			</ol>
-		</nav>
+	<main id="main-content" class="govuk-main-wrapper" role="main" tabindex="-1" data-project-id="">
+		<div class="govuk-width-container">
+			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
+				<ol class="govuk-breadcrumbs__list">
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Projects</span>
+						</a>
+						<meta property="schema:position" content="1" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+							<span property="schema:name">Project</span>
+						</a>
+						<meta property="schema:position" content="2" />
+					</li>
+					<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
+						<span property="schema:name">Add study</span>
+						<meta property="schema:position" content="3" />
+					</li>
+				</ol>
+			</nav>
 
-		<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
+			<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
 
-		<div class="dashboard-hero">
-			<p id="project-eyebrow" class="project-org">Project</p>
-			<h1 class="govuk-heading-l">Add study</h1>
-			<p class="lede">Create a study as a dedicated workflow so method, description and readiness controls can be managed outside the project dashboard.</p>
+			<div class="dashboard-hero">
+				<p id="project-eyebrow" class="project-org">Project</p>
+				<h1 class="govuk-heading-l">Add study</h1>
+				<p class="lede">Create a study as a dedicated workflow so method, description and readiness controls can be managed outside the project dashboard.</p>
+			</div>
+
+			<div id="study-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="study-error-summary-title" hidden>
+				<h2 id="study-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
+				<div class="govuk-error-summary__body">
+					<ul class="govuk-list govuk-error-summary__list" id="study-error-list"></ul>
+				</div>
+			</div>
+
+			<form id="add-study-form" novalidate>
+				<input id="project-id" name="project_airtable_id" type="hidden" value="" />
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="study-title-input">Study title</label>
+					<div id="study-title-hint" class="govuk-hint">Use a short, recognisable title.</div>
+					<input id="study-title-input" name="title" class="govuk-input govuk-!-width-two-thirds" aria-describedby="study-title-hint" />
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="study-method">Research method</label>
+					<select id="study-method" name="method" class="govuk-select" required>
+						<option value="">Choose a research method</option>
+						<option>Card Sort</option>
+						<option>Contextual Inquiry</option>
+						<option>Customer Satisfaction Survey</option>
+						<option>Diary Study</option>
+						<option>Existing Research Analysis</option>
+						<option>Expert Review</option>
+						<option>Stakeholder Interview</option>
+						<option>Survey</option>
+						<option>Tree Test</option>
+						<option>Usability Test</option>
+						<option>User Interview</option>
+					</select>
+				</div>
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="study-notes">Study description</label>
+					<div id="study-notes-hint" class="govuk-hint">Describe the purpose of the study. Do not include participant personal data.</div>
+					<textarea id="study-notes" name="description" class="govuk-textarea govuk-!-width-two-thirds" rows="6" required aria-describedby="study-notes-hint"></textarea>
+				</div>
+
+				<div class="govuk-button-group">
+					<button id="study-submit" class="govuk-button" type="submit">Create study</button>
+					<a id="cancel-study" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
+				</div>
+
+				<p id="study-status" class="hint" role="status" aria-live="polite"></p>
+			</form>
 		</div>
-
-		<div id="study-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="study-error-summary-title" hidden>
-			<h2 id="study-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
-			<div class="govuk-error-summary__body">
-				<ul class="govuk-list govuk-error-summary__list" id="study-error-list"></ul>
-			</div>
-		</div>
-
-		<form id="add-study-form" novalidate>
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="study-title-input">Study title</label>
-				<div id="study-title-hint" class="govuk-hint">Use a short, recognisable title.</div>
-				<input id="study-title-input" name="title" class="govuk-input govuk-!-width-two-thirds" aria-describedby="study-title-hint" />
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="study-method">Research method</label>
-				<select id="study-method" name="method" class="govuk-select" required>
-					<option value="">Choose a research method</option>
-					<option>Card Sort</option>
-					<option>Contextual Inquiry</option>
-					<option>Customer Satisfaction Survey</option>
-					<option>Diary Study</option>
-					<option>Existing Research Analysis</option>
-					<option>Expert Review</option>
-					<option>Stakeholder Interview</option>
-					<option>Survey</option>
-					<option>Tree Test</option>
-					<option>Usability Test</option>
-					<option>User Interview</option>
-				</select>
-			</div>
-
-			<div class="govuk-form-group">
-				<label class="govuk-label" for="study-notes">Study description</label>
-				<div id="study-notes-hint" class="govuk-hint">Describe the purpose of the study. Do not include participant personal data.</div>
-				<textarea id="study-notes" name="description" class="govuk-textarea govuk-!-width-two-thirds" rows="6" required aria-describedby="study-notes-hint"></textarea>
-			</div>
-
-			<div class="govuk-button-group">
-				<button id="study-submit" class="govuk-button" type="submit">Create study</button>
-				<a id="cancel-study" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
-			</div>
-
-			<p id="study-status" class="hint" role="status" aria-live="polite"></p>
-		</form>
 	</main>
 
 	<x-include src="/partials/footer.html"></x-include>

--- a/public/pages/study/new/study-new.js
+++ b/public/pages/study/new/study-new.js
@@ -23,8 +23,11 @@ function setProjectLinks(projectId, project = {}) {
   const dashboardHref = `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
   const projectName = project.name || project.Name || "Project";
 
-  const main = $("#main");
+  const main = $("#main-content");
   if (main) main.dataset.projectId = projectId;
+
+  const projectInput = $("#project-id");
+  if (projectInput) projectInput.value = projectId;
 
   const breadcrumbProject = $("#breadcrumb-project");
   if (breadcrumbProject) {
@@ -66,6 +69,9 @@ function showErrors(errors) {
 
 function validate() {
   const errors = [];
+  if (!fieldValue("#project-id")) {
+    errors.push({ id: "project-id", message: "Missing project id" });
+  }
   if (!fieldValue("#study-method")) {
     errors.push({ id: "study-method", message: "Choose a research method" });
   }
@@ -130,7 +136,7 @@ function initForm(projectId) {
 (async function bootstrap() {
   const projectId = projectIdFromUrl();
   if (!projectId) {
-    showErrors([{ id: "study-title-input", message: "Missing project id" }]);
+    showErrors([{ id: "project-id", message: "Missing project id" }]);
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes the issues identified after merging the Project Dashboard action workflow work.

- Implements the correct GOV.UK page chrome structure on the Project Dashboard:
  - `govuk-page-chrome.css`
  - `govuk-main-wrapper`
  - `main-content` skip-link target
  - `govuk-width-container`
  - no-JavaScript GOV.UK chrome fallback
  - avoids secondary `<header>` elements inside the page body that can break strict landmark smoke checks.
- Keeps Project Dashboard action links project-scoped:
  - Add participant routes with `pid=<projectId>`
  - Import participants routes with `pid=<projectId>`
  - Add study routes with `pid=<projectId>`
- Adds a dashboard context helper to keep action links synced after the dashboard controller renders project data.
- Adds hidden project ID fields to the Add Participant, Import Participants and Add Study workflows.
- Passes/guards `project_airtable_id` through participant creation, participant CSV import and study creation flows.
- Updates Add Participant and Add Study controllers to use the `main-content` project context.

## Files changed

- `public/pages/project-dashboard/index.html`
- `public/js/project-dashboard-context.js`
- `public/js/project-participant-context.js`
- `public/pages/project-dashboard/participants/index.html`
- `public/pages/project-dashboard/participants/participants-project.js`
- `public/pages/project-dashboard/participants/import/index.html`
- `public/pages/study/new/index.html`
- `public/pages/study/new/study-new.js`

## Validation

- Branch is ahead of `main` by 11 commits and behind by 0.
- Static connector inspection confirmed the changed files and branch comparison.
- Full CI should run the release gate on this PR.