### PR TITLE
Refresh GOV.UK header and service navigation

### DIFF
--- a/docs/design-system/govuk-page-chrome-navigation-migration.md
+++ b/docs/design-system/govuk-page-chrome-navigation-migration.md
@@ -1,14 +1,21 @@
 # GOV.UK page chrome and navigation migration
 
-Date: 2026-04-27
-Branch: `design-system/govuk-page-chrome-navigation-all-routes`
-Scope: Shared page chrome, service navigation, skip link, phase banner, footer and main-content targeting.
+Date: 2026-05-05
+Branch: `fix/project-dashboard-action-routes-govuk-chrome`
+Scope: Shared page chrome, refreshed GOV.UK branding, service navigation, skip link, phase banner, footer and main-content targeting.
 
 ## Purpose
 
 This document records the GOV.UK page chrome and navigation migration for ResearchOps.
 
 Page chrome is a shared service frame. It must remain global. Route stylesheets may lay out route content, but they must not define independent header, footer, skip-link or service-navigation systems.
+
+ResearchOps must use the current GOV.UK header and Service navigation relationship:
+
+- the GOV.UK header identifies GOV.UK
+- the service name and service navigation sit in the Service navigation component
+- the GOV.UK header must not contain the service name or service navigation links
+- page-specific navigation, breadcrumbs and content come after the global service frame
 
 ## Component classification
 
@@ -23,7 +30,7 @@ Implemented in:
 
 The skip link points to `#main-content`.
 
-The shared header helper preserves existing route-facing main IDs. If a page already has a main ID such as `main` or `content`, the helper inserts a small `#main-content` target before the main landmark. If a page has an unnamed main landmark, it assigns `id="main-content"` to that landmark.
+The shared header helper preserves existing route-facing main IDs where possible. If a page has an unnamed main landmark, it assigns `id="main-content"` to that landmark. If a page already provides `id="main-content"`, it keeps the existing ID and adds `tabindex="-1"` when needed.
 
 ### Header
 
@@ -34,13 +41,18 @@ Implemented in:
 - `public/partials/header.html`
 - `public/css/govuk/govuk-page-chrome.css`
 
-The shared header now uses GOV.UK-style service header classes:
+The shared header now follows the current GOV.UK header pattern and refreshed GOV.UK branding. The header is intentionally limited to the GOV.UK identity.
+
+The header uses:
 
 - `govuk-header`
 - `govuk-header__container`
-- `govuk-header__service-name`
-- `govuk-header__link`
-- `govuk-header__service-description`
+- `govuk-width-container`
+- `govuk-header__logo`
+- `govuk-header__homepage-link`
+- `govuk-header__logotype`
+
+The service name is not placed in the GOV.UK header.
 
 ### Service navigation
 
@@ -51,15 +63,22 @@ Implemented in:
 - `public/partials/header.html`
 - `public/css/govuk/govuk-page-chrome.css`
 
-The shared service navigation now uses GOV.UK-style service navigation classes:
+The shared service navigation now follows the current GOV.UK Service navigation pattern. It holds the ResearchOps service name and the service-level navigation.
+
+The service navigation uses:
 
 - `govuk-service-navigation`
 - `govuk-service-navigation__container`
+- `govuk-service-navigation__service-name`
+- `govuk-service-navigation__wrapper`
+- `govuk-service-navigation__toggle`
 - `govuk-service-navigation__list`
 - `govuk-service-navigation__item`
+- `govuk-service-navigation__item--active`
 - `govuk-service-navigation__link`
+- `govuk-service-navigation__active-fallback`
 
-The existing `data-active` and `data-nav` contract is preserved so `layout.js` continues to set active navigation state.
+The existing `data-active` and `data-nav` contract is preserved. `layout.js` now applies the GOV.UK active state to the list item and sets `aria-current="true"` on the active link.
 
 ### Phase banner
 
@@ -97,24 +116,39 @@ Base page chrome styling lives in:
 
 Route stylesheets must not recreate shared header, service navigation, skip-link, phase banner or footer behaviour.
 
+The page chrome stylesheet currently provides a static GOV.UK-compatible foundation while ResearchOps does not yet import the full `govuk-frontend` package. A later migration should replace these local approximations with GOV.UK Frontend assets and macro-generated component output.
+
 ## What changed
 
-Changed files:
+Changed files in this migration area:
 
 - `public/css/govuk/govuk-page-chrome.css`
 - `public/partials/header.html`
 - `public/partials/footer.html`
+- `public/components/layout.js`
 - `docs/design-system/govuk-page-chrome-navigation-migration.md`
 - `tests/govuk-page-chrome-navigation-route-state.test.js`
-- `scripts/validate.sh`
 
 ## What did not change
 
-This migration does not rewrite route content.
+This migration does not rewrite every route component.
 
-This migration does not change page controllers, API payloads, Airtable payloads, or dynamic breadcrumb IDs.
+This migration does not replace every local GOV.UK-style component with the upstream GOV.UK Frontend package.
 
-This migration does not rename existing route-facing main IDs such as `main` or `content`.
+This migration does not change API payloads, Airtable payloads, or dynamic breadcrumb IDs.
+
+## Wider GOV.UK Design System migration still required
+
+ResearchOps still needs a fuller GOV.UK Design System refresh across the component set.
+
+Priority areas:
+
+- replace local component approximations with GOV.UK Frontend component output where possible
+- audit all page templates against the current GOV.UK page template, header and Service navigation patterns
+- update form components, error summaries, fieldsets, checkboxes, radios, file upload, summary lists, tables, tags, task lists and notification states against the current examples
+- remove legacy component aliases once route-state tests no longer depend on them
+- add regression coverage for component-level markup, not just route-level presence checks
+- add visual checks for refreshed branding across desktop and mobile
 
 ## Manual checks
 
@@ -124,6 +158,9 @@ Check these routes after merge:
 - `/pages/start/`
 - `/pages/projects/`
 - `/pages/project-dashboard/?id=<project-id>`
+- `/pages/project-dashboard/participants/?pid=<project-id>`
+- `/pages/project-dashboard/participants/import/?pid=<project-id>`
+- `/pages/study/new/?pid=<project-id>`
 - `/pages/study/?pid=<project-id>&sid=<study-id>`
 - `/pages/study/guides/?pid=<project-id>&sid=<study-id>`
 - `/pages/study/participants/?pid=<project-id>&sid=<study-id>`
@@ -133,8 +170,10 @@ Confirm:
 
 - skip link appears on keyboard focus
 - skip link moves focus to main content
-- header and footer are visually consistent
+- header uses the refreshed GOV.UK header treatment
+- service name appears in Service navigation, not the GOV.UK header
 - active service navigation state remains correct
+- mobile service navigation can be expanded and collapsed
 - phase banner appears once
 - route-specific breadcrumbs and dynamic IDs still work
 - no route stylesheet owns shared page chrome styling
@@ -145,6 +184,7 @@ Expected commands:
 
 - `npm run validate`
 - `npm run lint`
+- `npm test`
 
 The application-level route-state test is:
 

--- a/public/components/layout.js
+++ b/public/components/layout.js
@@ -21,7 +21,7 @@
  * - Supported tags: {{key}}, {{{key}}}, {{& key}}, {{#section}}...{{/section}}, {{^section}}...{{/section}}
  * - Dot notation paths are supported (e.g., {{project.name}}). Array item scope is available as {{.}}.
  * - The element injects content directly into itself (no Shadow DOM) so page CSS applies normally.
- * - After render, if a container has [data-active="Name"], any descendant with [data-nav="Name"] gets .active.
+ * - After render, if a container has [data-active="Name"], any descendant with [data-nav="Name"] gets the GOV.UK active service navigation state.
  *
  * optional debug gating, auto-nav activation, queued re-renders, and footer defaults.
  */
@@ -195,8 +195,10 @@ class XInclude extends HTMLElement {
 			if (!target) return;
 			el.querySelectorAll("[data-nav]").forEach(link => {
 				const isMatch = (link.getAttribute("data-nav") || "").trim() === target;
+				const item = link.closest(".govuk-service-navigation__item");
+				if (item) item.classList.toggle("govuk-service-navigation__item--active", isMatch);
 				link.classList.toggle("active", isMatch);
-				if (isMatch) link.setAttribute("aria-current", "page");
+				if (isMatch) link.setAttribute("aria-current", "true");
 				else link.removeAttribute("aria-current");
 			});
 		});

--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -336,7 +336,7 @@
 #back-to-project.govuk-back-link {
 	display: block;
 	width: fit-content;
-	margin: 0 0 24px auto;
+	margin: 0 24px 24px auto;
 	padding: 8px 10px 7px;
 	border: 2px solid transparent;
 	background: #f4f8fb;

--- a/public/css/govuk/govuk-page-chrome.css
+++ b/public/css/govuk/govuk-page-chrome.css
@@ -1,9 +1,12 @@
 /* GOV.UK page chrome foundation */
 
 .govuk-width-container {
+	box-sizing: border-box;
 	max-width: 1200px;
 	margin-right: auto;
 	margin-left: auto;
+	padding-right: 30px;
+	padding-left: 30px;
 	}
 
 .govuk-grid-row {
@@ -64,84 +67,99 @@
 
 .govuk-header {
 	margin: -24px -24px 0;
-	border-bottom: 10px solid #1d70b8;
-	background: #0b0c0c;
+	background: #1d70b8;
 	color: #ffffff;
 	}
 
 .govuk-header__container {
-	padding: 10px 24px;
+	display: flex;
+	align-items: center;
+	min-height: 50px;
+	padding-top: 10px;
+	padding-bottom: 10px;
 	}
 
 .govuk-header__logo {
 	margin: 0;
 	}
 
+.govuk-header__homepage-link,
 .govuk-header__link {
+	display: inline-flex;
+	align-items: center;
 	color: #ffffff;
 	font-weight: 700;
 	text-decoration: none;
 	}
 
+.govuk-header__homepage-link:hover,
 .govuk-header__link:hover {
 	text-decoration: underline;
 	text-decoration-thickness: 3px;
 	text-underline-offset: 0.1em;
 	}
 
+.govuk-header__homepage-link:focus,
 .govuk-header__link:focus {
 	background-color: #ffdd00;
 	color: #0b0c0c;
 	outline: 3px solid #ffdd00;
 	outline-offset: 0;
 	box-shadow: 0 0 0 4px #0b0c0c;
+	text-decoration: none;
 	}
 
 .govuk-header__link--homepage {
-	display: inline-block;
+	display: inline-flex;
 	}
 
 .govuk-header__logotype {
+	display: inline-block;
 	font-size: 30px;
 	line-height: 1;
 	}
 
-.govuk-header__service-name {
-	margin: 0;
-	font-size: 30px;
-	line-height: 1.11111;
-	}
-
+.govuk-header__service-name,
 .govuk-header__service-description {
-	margin: 6px 0 0;
-	color: #ffffff;
-	font-size: 19px;
-	line-height: 1.31579;
+	display: none;
 	}
 
 .govuk-service-navigation {
 	margin: 0 -24px;
-	background: #f3f2f1;
-	border-bottom: 1px solid #b1b4b6;
+	border-bottom: 1px solid #8eb8dc;
+	background: #f4f8fb;
+	color: #0b0c0c;
+	}
+
+.govuk-service-navigation > .govuk-width-container {
+	padding-right: 30px;
+	padding-left: 30px;
 	}
 
 .govuk-service-navigation__container {
 	display: flex;
-	flex-wrap: wrap;
-	align-items: baseline;
-	gap: 0 24px;
-	padding: 0 24px;
+	align-items: stretch;
+	gap: 0 30px;
+	min-height: 50px;
+	padding: 0;
 	}
 
 .govuk-service-navigation__service-name {
-	display: inline-block;
-	margin: 0 24px 0 0;
+	display: inline-flex;
+	align-items: center;
+	margin: 0;
 	font-weight: 700;
 	}
 
 .govuk-service-navigation__service-name .govuk-service-navigation__link {
 	color: #0b0c0c;
 	font-weight: 700;
+	}
+
+.govuk-service-navigation__wrapper {
+	display: flex;
+	flex: 1 1 auto;
+	align-items: stretch;
 	}
 
 .govuk-service-navigation__list {
@@ -155,19 +173,23 @@
 	}
 
 .govuk-service-navigation__item {
+	display: flex;
+	align-items: stretch;
 	margin: 0;
 	padding: 0;
 	}
 
 .govuk-service-navigation__link {
-	display: inline-block;
+	display: inline-flex;
+	align-items: center;
 	padding: 15px 0 12px;
-	border-bottom: 3px solid transparent;
-	color: #1d70b8;
+	border-bottom: 5px solid transparent;
+	color: #1a65a6;
 	text-decoration: none;
 	}
 
 .govuk-service-navigation__link:hover {
+	color: #0f385c;
 	text-decoration: underline;
 	text-decoration-thickness: 3px;
 	text-underline-offset: 0.1em;
@@ -182,6 +204,8 @@
 	text-decoration: none;
 	}
 
+.govuk-service-navigation__item--active .govuk-service-navigation__link,
+.govuk-service-navigation__link[aria-current="true"],
 .govuk-service-navigation__link[aria-current="page"],
 .govuk-service-navigation__link.active {
 	border-bottom-color: #1d70b8;
@@ -189,11 +213,36 @@
 	font-weight: 700;
 	}
 
+.govuk-service-navigation__active-fallback {
+	font-weight: 700;
+	}
+
+.govuk-service-navigation__toggle {
+	display: none;
+	margin: 8px 0;
+	padding: 7px 10px 6px;
+	border: 2px solid #0b0c0c;
+	background: transparent;
+	color: #0b0c0c;
+	font: inherit;
+	font-weight: 700;
+	cursor: pointer;
+	}
+
+.govuk-service-navigation__toggle:focus {
+	background-color: #ffdd00;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 4px #0b0c0c;
+	}
+
 .govuk-phase-banner {
-	max-width: 1200px;
-	margin: 0 auto 24px;
-	padding: 10px 0;
-	border-bottom: 1px solid #b1b4b6;
+	box-sizing: border-box;
+	margin-top: 0;
+	margin-bottom: 24px;
+	padding-top: 10px;
+	padding-bottom: 10px;
+	border-bottom: 1px solid #cecece;
 	}
 
 .govuk-phase-banner__content {
@@ -238,11 +287,11 @@
 	content: "›";
 	display: inline-block;
 	margin: 0 8px;
-	color: #505a5f;
+	color: #484949;
 	}
 
 .govuk-breadcrumbs__link {
-	color: #1d70b8;
+	color: #1a65a6;
 	text-decoration: underline;
 	text-decoration-thickness: 1px;
 	text-underline-offset: 0.1em;
@@ -287,11 +336,11 @@
 #back-to-project.govuk-back-link {
 	display: block;
 	width: fit-content;
-	margin: 0 24px 24px auto;
+	margin: 0 0 24px auto;
 	padding: 8px 10px 7px;
 	border: 2px solid transparent;
-	background: #f3f2f1;
-	box-shadow: 0 2px 0 #929191;
+	background: #f4f8fb;
+	box-shadow: 0 2px 0 #8eb8dc;
 	color: #0b0c0c;
 	font-size: 19px;
 	line-height: 1;
@@ -304,7 +353,7 @@
 	}
 
 #back-to-project.govuk-back-link:hover {
-	background: #dbdad9;
+	background: #d2e2f1;
 	}
 
 #back-to-project.govuk-back-link:focus {
@@ -315,20 +364,24 @@
 
 .govuk-footer {
 	margin: 48px -24px -24px;
-	padding: 32px 24px;
-	border-top: 1px solid #b1b4b6;
-	background: #f3f2f1;
+	padding: 32px 0;
+	border-top: 1px solid #8eb8dc;
+	background: #f4f8fb;
 	color: #0b0c0c;
 	}
 
 .govuk-footer__container {
+	box-sizing: border-box;
 	max-width: 1200px;
-	margin: 0 auto;
+	margin-right: auto;
+	margin-left: auto;
+	padding-right: 30px;
+	padding-left: 30px;
 	}
 
 .govuk-footer__meta {
 	margin: 0;
-	color: #505a5f;
+	color: #484949;
 	font-size: 16px;
 	line-height: 1.25;
 	}
@@ -341,6 +394,13 @@
 	}
 
 @media (max-width: 640px) {
+	.govuk-width-container,
+	.govuk-service-navigation > .govuk-width-container,
+	.govuk-footer__container {
+		padding-right: 16px;
+		padding-left: 16px;
+		}
+
 	.govuk-header,
 	.govuk-service-navigation,
 	.govuk-footer {
@@ -348,38 +408,59 @@
 		margin-left: -24px;
 		}
 
-	.govuk-header__container,
-	.govuk-service-navigation__container,
-	.govuk-footer {
-		padding-right: 16px;
-		padding-left: 16px;
+	.govuk-header__container {
+		min-height: 44px;
+		}
+
+	.govuk-header__logotype {
+		font-size: 24px;
 		}
 
 	.govuk-service-navigation__container {
 		display: block;
+		min-height: 0;
 		}
 
 	.govuk-service-navigation__service-name {
 		display: block;
-		margin-right: 0;
+		padding-top: 12px;
+		padding-bottom: 12px;
+		}
+
+	.govuk-service-navigation__wrapper {
+		display: block;
+		}
+
+	.govuk-service-navigation__toggle {
+		display: inline-block;
 		}
 
 	.govuk-service-navigation__list {
 		display: block;
 		}
 
+	.govuk-service-navigation__list--collapsed {
+		display: none;
+		}
+
 	.govuk-service-navigation__item {
-		border-top: 1px solid #b1b4b6;
+		display: block;
+		border-top: 1px solid #8eb8dc;
 		}
 
 	.govuk-service-navigation__link {
+		display: block;
 		padding-top: 12px;
 		padding-bottom: 9px;
+		border-bottom-width: 0;
 		}
 
-	.govuk-header__service-name,
-	.govuk-header__logotype {
-		font-size: 24px;
+	.govuk-service-navigation__item--active .govuk-service-navigation__link,
+	.govuk-service-navigation__link[aria-current="true"],
+	.govuk-service-navigation__link[aria-current="page"],
+	.govuk-service-navigation__link.active {
+		border-left: 5px solid #1d70b8;
+		padding-left: 10px;
 		}
 
 	.govuk-phase-banner__content {

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,43 +1,47 @@
 <!-- public/partials/header.html -->
 <a class="govuk-skip-link" href="#main-content">Skip to main content</a>
 
-<header class="govuk-header" role="banner">
-	<div class="govuk-header__container">
+<header class="govuk-header" role="banner" data-module="govuk-header">
+	<div class="govuk-header__container govuk-width-container">
 		<div class="govuk-header__logo">
-			<a class="govuk-header__link" href="/" aria-label="GOV.UK home">
-				<span class="govuk-header__logotype">GOV.UK</span>
+			<a href="/" class="govuk-header__homepage-link" aria-label="GOV.UK home">
+				<span class="govuk-header__logotype" aria-hidden="true">GOV.UK</span>
 			</a>
-		</div>
-		<div class="govuk-header__service-name">
-			{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
 		</div>
 	</div>
 </header>
 
-<nav class="govuk-service-navigation" data-active="{{active}}" aria-label="Service navigation">
-	<div class="govuk-service-navigation__container govuk-width-container">
-		<span class="govuk-service-navigation__service-name">
-			<a class="govuk-service-navigation__link" href="/">
-				{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
-			</a>
-		</span>
-		<ul class="govuk-service-navigation__list">
-			<li class="govuk-service-navigation__item">
-				<a class="govuk-service-navigation__link" href="/" data-nav="Home">Home</a>
-			</li>
-			<li class="govuk-service-navigation__item">
-				<a class="govuk-service-navigation__link" href="/pages/start/" data-nav="Start Research Project">Start research project</a>
-			</li>
-			<li class="govuk-service-navigation__item">
-				<a class="govuk-service-navigation__link" href="/pages/projects/" data-nav="Projects">Projects</a>
-			</li>
-		</ul>
+<section aria-label="Service information" class="govuk-service-navigation" data-module="govuk-service-navigation" data-active="{{active}}">
+	<div class="govuk-width-container">
+		<div class="govuk-service-navigation__container">
+			<span class="govuk-service-navigation__service-name">
+				<a class="govuk-service-navigation__link" href="/">
+					{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
+				</a>
+			</span>
+			<nav aria-label="Menu" class="govuk-service-navigation__wrapper">
+				<button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden aria-hidden="true">
+					Menu
+				</button>
+				<ul class="govuk-service-navigation__list" id="navigation">
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/" data-nav="Home">Home</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/start/" data-nav="Start Research Project">Start research project</a>
+					</li>
+					<li class="govuk-service-navigation__item">
+						<a class="govuk-service-navigation__link" href="/pages/projects/" data-nav="Projects">Projects</a>
+					</li>
+				</ul>
+			</nav>
+		</div>
 	</div>
-</nav>
+</section>
 
-<div class="govuk-phase-banner" role="note" aria-label="Service phase">
+<div class="govuk-phase-banner govuk-width-container" role="note" aria-label="Service phase">
 	<p class="govuk-phase-banner__content">
-		<strong class="govuk-tag">Prototype</strong>
+		<strong class="govuk-tag govuk-phase-banner__content__tag">Prototype</strong>
 		<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant personal data.</span>
 	</p>
 </div>
@@ -72,9 +76,30 @@
 			}
 		}
 
+		function initServiceNavigation() {
+			var nav = document.querySelector(".govuk-service-navigation");
+			if (!nav) return;
+
+			var toggle = nav.querySelector(".govuk-js-service-navigation-toggle");
+			var list = nav.querySelector("#navigation");
+			if (!toggle || !list) return;
+
+			toggle.hidden = false;
+			toggle.removeAttribute("aria-hidden");
+			toggle.setAttribute("aria-expanded", "false");
+			list.classList.add("govuk-service-navigation__list--collapsed");
+
+			toggle.addEventListener("click", function () {
+				var expanded = toggle.getAttribute("aria-expanded") === "true";
+				toggle.setAttribute("aria-expanded", String(!expanded));
+				list.classList.toggle("govuk-service-navigation__list--collapsed", expanded);
+			});
+		}
+
 		function init() {
 			ensurePageChromeStylesheet();
 			ensureMainContentTarget();
+			initServiceNavigation();
 		}
 
 		if (document.readyState === "loading") {

--- a/tests/govuk-page-chrome-navigation-route-state.test.js
+++ b/tests/govuk-page-chrome-navigation-route-state.test.js
@@ -8,6 +8,7 @@ const migrationDoc = fs.readFileSync(
   "docs/design-system/govuk-page-chrome-navigation-migration.md",
   "utf8"
 );
+const layoutSource = fs.readFileSync("public/components/layout.js", "utf8");
 
 const pagesUsingSharedChrome = [
   "public/index.html",
@@ -40,36 +41,49 @@ function excludes(source, text, label) {
 includes(pageChromeCss, ".govuk-skip-link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-header", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-header__container", "page chrome stylesheet");
-includes(pageChromeCss, ".govuk-header__service-name", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-header__homepage-link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-service-navigation", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-service-navigation__wrapper", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-service-navigation__toggle", "page chrome stylesheet");
+includes(pageChromeCss, ".govuk-service-navigation__item--active", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-service-navigation__link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-phase-banner", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-back-link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-footer", "page chrome stylesheet");
+includes(pageChromeCss, "background: #1d70b8;", "page chrome stylesheet");
+includes(pageChromeCss, "background: #f4f8fb;", "page chrome stylesheet");
 includes(pageChromeCss, "/* transparency begins in the cascade */", "page chrome stylesheet");
 
 includes(headerPartial, "class=\"govuk-skip-link\" href=\"#main-content\"", "shared header partial");
-includes(headerPartial, "class=\"govuk-header\" role=\"banner\"", "shared header partial");
-includes(headerPartial, "class=\"govuk-header__container\"", "shared header partial");
-includes(headerPartial, "class=\"govuk-header__service-name\"", "shared header partial");
-includes(headerPartial, "class=\"govuk-header__link\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header\" role=\"banner\" data-module=\"govuk-header\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header__container govuk-width-container\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header__homepage-link\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header__logotype\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-service-navigation\"", "shared header partial");
-includes(headerPartial, "aria-label=\"Service navigation\"", "shared header partial");
+includes(headerPartial, "data-module=\"govuk-service-navigation\"", "shared header partial");
+includes(headerPartial, "aria-label=\"Service information\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-service-navigation__service-name\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-service-navigation__wrapper\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-service-navigation__toggle govuk-js-service-navigation-toggle\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-service-navigation__list\"", "shared header partial");
 includes(headerPartial, "data-active=\"{{active}}\"", "shared header partial");
 includes(headerPartial, "data-nav=\"Home\"", "shared header partial");
 includes(headerPartial, "data-nav=\"Start Research Project\"", "shared header partial");
 includes(headerPartial, "data-nav=\"Projects\"", "shared header partial");
-includes(headerPartial, "class=\"govuk-phase-banner\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-phase-banner govuk-width-container\"", "shared header partial");
 includes(headerPartial, "Do not enter real participant personal data", "shared header partial");
 includes(headerPartial, "ensurePageChromeStylesheet", "shared header partial");
 includes(headerPartial, "ensureMainContentTarget", "shared header partial");
+includes(headerPartial, "initServiceNavigation", "shared header partial");
 includes(headerPartial, "main.classList.add(\"govuk-main-wrapper\")", "shared header partial");
 includes(headerPartial, "target.id = \"main-content\"", "shared header partial");
 excludes(headerPartial, "main.setAttribute(\"id\", \"main-content\")", "shared header partial");
-excludes(headerPartial, "aria-hidden", "shared header partial");
 excludes(headerPartial, "class=\"rops-header\"", "shared header partial");
 excludes(headerPartial, "class=\"nav govuk-body\"", "shared header partial");
+
+includes(layoutSource, "govuk-service-navigation__item--active", "layout helper");
+includes(layoutSource, "aria-current", "layout helper");
+includes(layoutSource, "\"true\"", "layout helper");
 
 includes(footerPartial, "class=\"govuk-footer\" role=\"contentinfo\"", "shared footer partial");
 includes(footerPartial, "class=\"govuk-footer__container\"", "shared footer partial");
@@ -77,6 +91,7 @@ includes(footerPartial, "class=\"govuk-footer__meta\"", "shared footer partial")
 excludes(footerPartial, "<hr", "shared footer partial");
 
 includes(migrationDoc, "# GOV.UK page chrome and navigation migration", "page chrome migration doc");
+includes(migrationDoc, "refreshed GOV.UK branding", "page chrome migration doc");
 includes(migrationDoc, "Skip link", "page chrome migration doc");
 includes(migrationDoc, "Service navigation", "page chrome migration doc");
 includes(migrationDoc, "Phase banner", "page chrome migration doc");


### PR DESCRIPTION
## Summary

Updates the shared ResearchOps page chrome to align with the current GOV.UK Design System header and Service navigation relationship.

- Moves the service identity out of the GOV.UK header and into Service navigation.
- Keeps the GOV.UK header focused on GOV.UK identity only.
- Updates Service navigation markup to use the current component structure:
  - `data-module="govuk-service-navigation"`
  - `govuk-service-navigation__wrapper`
  - `govuk-service-navigation__toggle`
  - `govuk-service-navigation__item--active`
  - active link `aria-current="true"`
- Refreshes the page chrome colours and layout foundation to move away from the old black GOV.UK header treatment.
- Updates `layout.js` so active service navigation state is applied to the list item, not just the link.
- Updates route-state coverage and the page chrome migration note.

## Design-system rationale

The current GOV.UK Design System guidance says the GOV.UK header and Service navigation work together. The GOV.UK header should not show the service name or navigation links. The service name and service-level navigation belong in the Service navigation component.

The GOV.UK header and Service navigation components were also updated in June 2025 to support the refreshed GOV.UK brand. This PR updates the ResearchOps shared page chrome foundation towards that refreshed pattern.

## Scope note

This is a foundation update for the global header/service-navigation frame. It does not yet complete the full component-by-component migration to upstream GOV.UK Frontend output.

The migration note now explicitly records the remaining work required across forms, summary lists, tables, tags, task lists, notification states and other GOV.UK components.

## Files changed

- `public/partials/header.html`
- `public/css/govuk/govuk-page-chrome.css`
- `public/components/layout.js`
- `docs/design-system/govuk-page-chrome-navigation-migration.md`
- `tests/govuk-page-chrome-navigation-route-state.test.js`

## Validation

- Branch comparison shows this branch is ahead of `main` by 5 commits.
- Full CI should run the release gate on this PR.