### PR TITLE
Migrate GOV.UK Frontend v6 component contracts

### DIFF
--- a/docs/design-system/govuk-frontend-v6-migration.md
+++ b/docs/design-system/govuk-frontend-v6-migration.md
@@ -1,0 +1,155 @@
+# GOV.UK Frontend v6 migration
+
+Date: 2026-05-05
+Branch: `feature/govuk-frontend-v6-component-migration`
+Scope: Dedicated GOV.UK Frontend v6 component migration contract.
+
+## Purpose
+
+This document records the dedicated GOV.UK Frontend v6 migration contract for ResearchOps.
+
+The migration replaces local approximations for forms, buttons, error summaries, fieldsets, radios, checkboxes, file upload, tables, summary lists, tags and notification states with upstream GOV.UK Frontend-compatible markup and styles.
+
+The goal is not to cosmetically restyle isolated pages. The goal is to move ResearchOps towards a single GOV.UK-compatible component contract that can be applied consistently across the service.
+
+## Migration principle
+
+Use upstream GOV.UK Frontend component names, structure and state classes wherever ResearchOps renders GOV.UK components.
+
+Where the platform still contains legacy ResearchOps aliases, such as `.btn` or `.tag`, those aliases must be temporary compatibility bridges. They must not become a second design system.
+
+## Global contract
+
+The canonical migration layer is:
+
+- `public/css/govuk/govuk-frontend-v6.css`
+
+This file loads after existing local CSS so it can neutralise route-level and legacy approximations without requiring a risky one-shot rewrite of every page and controller.
+
+The compatibility layer covers:
+
+- `govuk-button`
+- `govuk-button--secondary`
+- `govuk-button--warning`
+- `govuk-button--start`
+- `govuk-button-group`
+- `govuk-form-group`
+- `govuk-form-group--error`
+- `govuk-label`
+- `govuk-hint`
+- `govuk-error-message`
+- `govuk-fieldset`
+- `govuk-fieldset__legend`
+- `govuk-fieldset__heading`
+- `govuk-input`
+- `govuk-textarea`
+- `govuk-select`
+- `govuk-file-upload`
+- `govuk-radios`
+- `govuk-radios__item`
+- `govuk-radios__input`
+- `govuk-radios__label`
+- `govuk-checkboxes`
+- `govuk-checkboxes__item`
+- `govuk-checkboxes__input`
+- `govuk-checkboxes__label`
+- `govuk-error-summary`
+- `govuk-error-summary__title`
+- `govuk-error-summary__body`
+- `govuk-error-summary__list`
+- `govuk-table`
+- `govuk-table__caption`
+- `govuk-table__header`
+- `govuk-table__cell`
+- `govuk-summary-list`
+- `govuk-summary-list__row`
+- `govuk-summary-list__key`
+- `govuk-summary-list__value`
+- `govuk-summary-list__actions`
+- `govuk-tag`
+- `govuk-tag--grey`
+- `govuk-tag--green`
+- `govuk-tag--blue`
+- `govuk-tag--red`
+- `govuk-tag--yellow`
+- `govuk-notification-banner`
+- `govuk-notification-banner--success`
+
+## Hard rules
+
+Do not add new route-level component approximations.
+
+Do not add new `.btn`, `.tag`, `.table`, `.panel[role="alert"]`, custom radio, custom checkbox, custom file-upload, or custom notification styling when a GOV.UK component contract exists.
+
+Do not use route CSS to override the base GOV.UK form, button, table, summary list, tag, notification banner, radio, checkbox, error-summary, fieldset, or file-upload contracts.
+
+Route stylesheets may only define page-specific layout, composition, spacing, and workflow affordances.
+
+Do not change field IDs, names, generated payload shapes, URL parameters, or controller selectors as part of this migration unless the relevant controller and route-state tests are updated in the same PR.
+
+## Markup expectations
+
+Buttons should use GOV.UK button classes. JavaScript-enhanced buttons should retain their existing IDs and `type` values.
+
+Error summaries should use `govuk-error-summary`, `govuk-error-summary__title`, `govuk-error-summary__body` and `govuk-error-summary__list`.
+
+Field groups should use `govuk-form-group`. Error states should use `govuk-form-group--error` and the matching control error modifier where needed.
+
+Grouped choices should use `govuk-fieldset` with a meaningful legend. Radios and checkboxes should use GOV.UK item, input and label classes.
+
+File upload controls should use `govuk-file-upload` rather than dropzone-only or route-specific input styling.
+
+Tables should use `govuk-table`, `govuk-table__head`, `govuk-table__body`, `govuk-table__row`, `govuk-table__header` and `govuk-table__cell`.
+
+Summary lists should use `govuk-summary-list`, `govuk-summary-list__row`, `govuk-summary-list__key`, `govuk-summary-list__value` and, when required, `govuk-summary-list__actions`.
+
+Status tags should use `govuk-tag` plus GOV.UK tag colour modifiers instead of bespoke pill classes where the tag is expressing a status.
+
+Notification states should use `govuk-notification-banner`. Success states should use `govuk-notification-banner--success`.
+
+## Implementation strategy
+
+This PR deliberately uses a global compatibility layer first.
+
+That keeps the migration safe because many ResearchOps pages still contain route-specific layouts and JavaScript-generated markup. It avoids changing behaviour while bringing the visible component contract closer to GOV.UK Frontend v6.
+
+The next pass should remove legacy aliases once every page and generated controller has upstream-compatible markup.
+
+## Validation expectations
+
+Every GOV.UK Frontend v6 migration change must preserve:
+
+- route-state tests
+- generated acceptance criteria contracts
+- visual walkthrough registration
+- keyboard interaction
+- existing controller selectors
+- API payload contracts
+
+The release gate should continue to run:
+
+- `npm run validate`
+- `npm run lint`
+- `npm run format:check`
+- `npm test`
+- `npm run audit:performance --if-present`
+- `npm run audit:security`
+
+## Manual review checklist
+
+Review at least one page for each migrated surface:
+
+- Start a new research project: form groups, buttons, error summary and summary list
+- Projects page: cards, tags and project status states
+- Project dashboard: action buttons and notification-style states
+- Add participant: form groups, select, validation and buttons
+- Import participants: file upload, preview table and error summary
+- Study participant consent: fieldsets and checkboxes
+- Reflexive journals: fieldsets and radios
+- Synthesis: tables, controls and disabled states
+
+## Rollback note
+
+If a route breaks, revert the route markup or generated controller first.
+
+Only revert `public/css/govuk/govuk-frontend-v6.css` if the global compatibility layer is the direct cause of the regression.

--- a/public/components/layout.js
+++ b/public/components/layout.js
@@ -26,6 +26,24 @@
  * optional debug gating, auto-nav activation, queued re-renders, and footer defaults.
  */
 
+const GOVUK_FRONTEND_V6_STYLESHEET = "/css/govuk/govuk-frontend-v6.css";
+
+export function ensureGovukFrontendV6Stylesheet(root = document) {
+	const doc = root.ownerDocument || root;
+	const head = doc.head;
+	if (!head) return;
+
+	const existing = head.querySelector(`link[rel="stylesheet"][href="${GOVUK_FRONTEND_V6_STYLESHEET}"]`);
+	if (existing) return;
+
+	const link = doc.createElement("link");
+	link.rel = "stylesheet";
+	link.href = GOVUK_FRONTEND_V6_STYLESHEET;
+	link.media = "screen";
+	link.dataset.govukFrontendV6 = "true";
+	head.appendChild(link);
+}
+
 class XInclude extends HTMLElement {
 	static get observedAttributes() { return ["src", "vars", "debug-only"]; }
 
@@ -222,6 +240,8 @@ class XInclude extends HTMLElement {
 }
 
 if (!customElements.get("x-include")) customElements.define("x-include", XInclude);
+
+ensureGovukFrontendV6Stylesheet();
 
 // Optional helper
 export function whenIncludesReady(root = document) {

--- a/public/css/govuk/govuk-frontend-v6.css
+++ b/public/css/govuk/govuk-frontend-v6.css
@@ -1,0 +1,732 @@
+/* ==========================================================================
+   GOV.UK Frontend v6 compatibility layer
+   Service:    Home Office Biometrics — ResearchOps
+   Scope:      Canonical GOV.UK component contracts loaded after legacy route CSS
+   Repo:       /css/govuk/govuk-frontend-v6.css
+   ========================================================================== */
+
+.govuk-visually-hidden {
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	margin: 0 !important;
+	padding: 0 !important;
+	overflow: hidden !important;
+	clip: rect(0 0 0 0) !important;
+	clip-path: inset(50%) !important;
+	border: 0 !important;
+	white-space: nowrap !important;
+	}
+
+.govuk-button,
+.btn {
+	display: inline-block;
+	position: relative;
+	width: auto;
+	margin: 0 0 22px;
+	padding: 8px 10px 7px;
+	border: 2px solid transparent;
+	border-radius: 0;
+	outline: 1px solid transparent;
+	outline-offset: -1px;
+	box-shadow: 0 2px 0 #002d18;
+	background-color: #00703c;
+	color: #ffffff;
+	font-family: inherit;
+	font-size: 19px;
+	font-weight: 400;
+	line-height: 1.1875;
+	text-align: center;
+	text-decoration: none;
+	vertical-align: top;
+	cursor: pointer;
+	-webkit-appearance: none;
+	}
+
+.govuk-button:link,
+.govuk-button:visited,
+.govuk-button:active,
+.govuk-button:hover,
+.btn:link,
+.btn:visited,
+.btn:active,
+.btn:hover {
+	color: #ffffff;
+	text-decoration: none;
+	}
+
+.govuk-button:hover,
+.btn:hover {
+	background-color: #005a30;
+	}
+
+.govuk-button:active,
+.btn:active {
+	top: 2px;
+	box-shadow: none;
+	}
+
+.govuk-button:focus,
+.btn:focus {
+	border-color: #ffdd00;
+	outline: 3px solid transparent;
+	box-shadow: 0 0 0 3px #ffdd00;
+	}
+
+.govuk-button:focus:not(:active):not(:hover),
+.btn:focus:not(:active):not(:hover) {
+	border-color: #ffdd00;
+	background-color: #ffdd00;
+	box-shadow: 0 2px 0 #0b0c0c;
+	color: #0b0c0c;
+	}
+
+.govuk-button--secondary,
+.btn--secondary,
+.btn--outline {
+	background-color: #f3f2f1;
+	box-shadow: 0 2px 0 #929191;
+	color: #0b0c0c;
+	}
+
+.govuk-button--secondary:link,
+.govuk-button--secondary:visited,
+.govuk-button--secondary:active,
+.govuk-button--secondary:hover,
+.btn--secondary:link,
+.btn--secondary:visited,
+.btn--secondary:active,
+.btn--secondary:hover,
+.btn--outline:link,
+.btn--outline:visited,
+.btn--outline:active,
+.btn--outline:hover {
+	color: #0b0c0c;
+	}
+
+.govuk-button--secondary:hover,
+.btn--secondary:hover,
+.btn--outline:hover {
+	background-color: #dbdad9;
+	}
+
+.govuk-button--warning {
+	background-color: #d4351c;
+	box-shadow: 0 2px 0 #55150b;
+	}
+
+.govuk-button--warning:hover {
+	background-color: #aa2a16;
+	}
+
+.govuk-button--start {
+	min-height: auto;
+	padding-right: 42px;
+	font-weight: 700;
+	background-position: right 10px center;
+	background-repeat: no-repeat;
+	}
+
+.govuk-button[disabled],
+.govuk-button[aria-disabled="true"],
+.btn[disabled],
+.btn[aria-disabled="true"] {
+	top: 0;
+	box-shadow: none;
+	background-color: #b1b4b6;
+	color: #0b0c0c;
+	cursor: default;
+	}
+
+.govuk-button-group {
+	display: flex;
+	gap: 15px;
+	align-items: baseline;
+	flex-wrap: wrap;
+	margin-bottom: 20px;
+	}
+
+.govuk-button-group .govuk-button,
+.govuk-button-group .btn {
+	margin-bottom: 0;
+	}
+
+.govuk-form-group {
+	margin-bottom: 30px;
+	}
+
+.govuk-form-group--error {
+	padding-left: 15px;
+	border-left: 5px solid #d4351c;
+	}
+
+.govuk-label {
+	display: block;
+	margin-bottom: 5px;
+	color: #0b0c0c;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
+.govuk-label--s,
+.govuk-label--m,
+.govuk-label--l,
+.govuk-label--xl {
+	font-weight: 700;
+	}
+
+.govuk-label--s {
+	font-size: 19px;
+	line-height: 1.31579;
+	}
+
+.govuk-label--m {
+	font-size: 24px;
+	line-height: 1.25;
+	}
+
+.govuk-label--l {
+	font-size: 36px;
+	line-height: 1.11111;
+	}
+
+.govuk-label--xl {
+	font-size: 48px;
+	line-height: 1.04167;
+	}
+
+.govuk-hint {
+	display: block;
+	margin-bottom: 15px;
+	color: #505a5f;
+	}
+
+.govuk-error-message {
+	display: block;
+	margin-bottom: 15px;
+	clear: both;
+	color: #d4351c;
+	font-weight: 700;
+	}
+
+.govuk-error-message .govuk-visually-hidden {
+	position: static !important;
+	width: auto !important;
+	height: auto !important;
+	margin: 0 !important;
+	overflow: visible !important;
+	clip: auto !important;
+	clip-path: none !important;
+	white-space: inherit !important;
+	}
+
+.govuk-fieldset {
+	min-width: 0;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	}
+
+.govuk-fieldset::after {
+	content: "";
+	display: block;
+	clear: both;
+	}
+
+.govuk-fieldset__legend {
+	display: table;
+	box-sizing: border-box;
+	max-width: 100%;
+	margin-bottom: 10px;
+	padding: 0;
+	color: #0b0c0c;
+	white-space: normal;
+	}
+
+.govuk-fieldset__legend--s,
+.govuk-fieldset__legend--m,
+.govuk-fieldset__legend--l,
+.govuk-fieldset__legend--xl {
+	font-weight: 700;
+	}
+
+.govuk-fieldset__legend--s {
+	font-size: 19px;
+	line-height: 1.31579;
+	}
+
+.govuk-fieldset__legend--m {
+	font-size: 24px;
+	line-height: 1.25;
+	}
+
+.govuk-fieldset__legend--l {
+	font-size: 36px;
+	line-height: 1.11111;
+	}
+
+.govuk-fieldset__legend--xl {
+	font-size: 48px;
+	line-height: 1.04167;
+	}
+
+.govuk-fieldset__heading {
+	margin: 0;
+	font-size: inherit;
+	font-weight: inherit;
+	}
+
+.govuk-input,
+.govuk-textarea,
+.govuk-select,
+.govuk-file-upload {
+	box-sizing: border-box;
+	border: 2px solid #0b0c0c;
+	border-radius: 0;
+	background-color: #ffffff;
+	color: #0b0c0c;
+	font-family: inherit;
+	font-size: 19px;
+	line-height: 1.25;
+	}
+
+.govuk-input,
+.govuk-textarea {
+	width: 100%;
+	padding: 5px;
+	}
+
+.govuk-input {
+	height: 40px;
+	}
+
+.govuk-textarea {
+	min-height: 40px;
+	resize: vertical;
+	}
+
+.govuk-select {
+	width: auto;
+	max-width: 100%;
+	height: 40px;
+	padding: 5px 30px 5px 5px;
+	}
+
+.govuk-file-upload {
+	max-width: 100%;
+	margin-left: 0;
+	padding: 5px;
+	}
+
+.govuk-input:focus,
+.govuk-textarea:focus,
+.govuk-select:focus,
+.govuk-file-upload:focus {
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: inset 0 0 0 2px #0b0c0c;
+	}
+
+.govuk-input--error,
+.govuk-textarea--error,
+.govuk-select--error,
+.govuk-file-upload--error {
+	border-color: #d4351c;
+	}
+
+.govuk-input--width-30 {
+	max-width: 59ex;
+	}
+
+.govuk-input--width-20 {
+	max-width: 41ex;
+	}
+
+.govuk-input--width-10 {
+	max-width: 23ex;
+	}
+
+.govuk-input--width-5 {
+	max-width: 10.8ex;
+	}
+
+.govuk-input--width-4 {
+	max-width: 9ex;
+	}
+
+.govuk-input--width-3 {
+	max-width: 7.2ex;
+	}
+
+.govuk-input--width-2 {
+	max-width: 5.4ex;
+	}
+
+.govuk-checkboxes,
+.govuk-radios {
+	margin: 0;
+	}
+
+.govuk-checkboxes__item,
+.govuk-radios__item {
+	display: block;
+	position: relative;
+	min-height: 40px;
+	margin-bottom: 10px;
+	padding-left: 50px;
+	clear: left;
+	}
+
+.govuk-checkboxes__input,
+.govuk-radios__input {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 40px;
+	height: 40px;
+	margin: 0;
+	opacity: 0;
+	cursor: pointer;
+	}
+
+.govuk-checkboxes__label,
+.govuk-radios__label {
+	display: inline-block;
+	margin-bottom: 0;
+	padding: 8px 15px 5px 1px;
+	cursor: pointer;
+	}
+
+.govuk-checkboxes__label::before,
+.govuk-radios__label::before {
+	content: "";
+	box-sizing: border-box;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 40px;
+	height: 40px;
+	border: 2px solid #0b0c0c;
+	background: #ffffff;
+	}
+
+.govuk-radios__label::before {
+	border-radius: 50%;
+	}
+
+.govuk-checkboxes__label::after {
+	content: "";
+	position: absolute;
+	top: 11px;
+	left: 9px;
+	width: 18px;
+	height: 7px;
+	transform: rotate(-45deg);
+	border: solid;
+	border-width: 0 0 5px 5px;
+	border-color: #0b0c0c;
+	opacity: 0;
+	}
+
+.govuk-radios__label::after {
+	content: "";
+	position: absolute;
+	top: 10px;
+	left: 10px;
+	width: 0;
+	height: 0;
+	border: 10px solid #0b0c0c;
+	border-radius: 50%;
+	opacity: 0;
+	}
+
+.govuk-checkboxes__input:checked + .govuk-checkboxes__label::after,
+.govuk-radios__input:checked + .govuk-radios__label::after {
+	opacity: 1;
+	}
+
+.govuk-checkboxes__input:focus + .govuk-checkboxes__label::before,
+.govuk-radios__input:focus + .govuk-radios__label::before {
+	border-width: 4px;
+	box-shadow: 0 0 0 3px #ffdd00;
+	}
+
+.govuk-checkboxes__hint,
+.govuk-radios__hint {
+	display: block;
+	padding-right: 15px;
+	padding-left: 1px;
+	color: #505a5f;
+	}
+
+.govuk-error-summary {
+	margin-bottom: 30px;
+	padding: 20px 15px 15px;
+	border: 5px solid #d4351c;
+	color: #0b0c0c;
+	}
+
+.govuk-error-summary:focus {
+	outline: 3px solid #ffdd00;
+	}
+
+.govuk-error-summary__title {
+	margin-top: 0;
+	margin-bottom: 15px;
+	font-size: 24px;
+	font-weight: 700;
+	line-height: 1.25;
+	}
+
+.govuk-error-summary__body {
+	margin-bottom: 0;
+	}
+
+.govuk-error-summary__list {
+	margin-top: 0;
+	margin-bottom: 0;
+	padding-left: 0;
+	list-style-type: none;
+	}
+
+.govuk-error-summary__list a {
+	color: #d4351c;
+	font-weight: 700;
+	}
+
+.govuk-table {
+	width: 100%;
+	margin-bottom: 30px;
+	border-spacing: 0;
+	border-collapse: collapse;
+	}
+
+.govuk-table__caption {
+	display: table-caption;
+	margin-bottom: 15px;
+	text-align: left;
+	font-weight: 700;
+	}
+
+.govuk-table__caption--s {
+	font-size: 19px;
+	line-height: 1.31579;
+	}
+
+.govuk-table__caption--m {
+	font-size: 24px;
+	line-height: 1.25;
+	}
+
+.govuk-table__caption--l {
+	font-size: 36px;
+	line-height: 1.11111;
+	}
+
+.govuk-table__row {
+	border-bottom: 1px solid #b1b4b6;
+	}
+
+.govuk-table .govuk-table__header,
+.govuk-table .govuk-table__cell {
+	padding: 10px 20px 10px 0 !important;
+	border: 0 !important;
+	border-bottom: 1px solid #b1b4b6 !important;
+	background-color: transparent !important;
+	text-align: left;
+	vertical-align: top;
+	}
+
+.govuk-table__header {
+	font-weight: 700;
+	}
+
+.govuk-table__header:last-child,
+.govuk-table__cell:last-child {
+	padding-right: 0 !important;
+	}
+
+.govuk-table__header--numeric,
+.govuk-table__cell--numeric {
+	text-align: right !important;
+	}
+
+.govuk-summary-list {
+	display: table;
+	width: 100%;
+	margin: 0 0 30px;
+	border-collapse: collapse;
+	}
+
+.govuk-summary-list__row {
+	display: table-row;
+	border-bottom: 1px solid #b1b4b6;
+	}
+
+.govuk-summary-list--no-border .govuk-summary-list__row,
+.govuk-summary-list__row--no-border {
+	border-bottom: 0;
+	}
+
+.govuk-summary-list__key,
+.govuk-summary-list__value,
+.govuk-summary-list__actions {
+	display: table-cell;
+	padding: 10px 20px 10px 0;
+	vertical-align: top;
+	}
+
+.govuk-summary-list__key {
+	width: 30%;
+	font-weight: 700;
+	}
+
+.govuk-summary-list__value {
+	width: 50%;
+	}
+
+.govuk-summary-list__actions {
+	width: 20%;
+	padding-right: 0;
+	text-align: right;
+	}
+
+.govuk-summary-list__actions-list {
+	width: 100%;
+	margin: 0;
+	padding: 0;
+	}
+
+.govuk-summary-list__actions-list-item {
+	display: inline-block;
+	margin-right: 10px;
+	padding-right: 10px;
+	}
+
+.govuk-summary-list__actions-list-item:not(:last-child) {
+	border-right: 1px solid #b1b4b6;
+	}
+
+.govuk-tag,
+.tag {
+	display: inline-block;
+	max-width: 160px;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 2px 8px 3px;
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+	background-color: #1d70b8;
+	color: #ffffff;
+	font-size: 16px;
+	font-weight: 700;
+	line-height: 1.25;
+	letter-spacing: 1px;
+	text-decoration: none;
+	text-transform: uppercase;
+	}
+
+.govuk-tag--grey {
+	background-color: #eeefef;
+	color: #383f43;
+	}
+
+.govuk-tag--green {
+	background-color: #cce2d8;
+	color: #005a30;
+	}
+
+.govuk-tag--blue {
+	background-color: #d2e2f1;
+	color: #144e81;
+	}
+
+.govuk-tag--red {
+	background-color: #f6d7d2;
+	color: #942514;
+	}
+
+.govuk-tag--yellow {
+	background-color: #fff7bf;
+	color: #594d00;
+	}
+
+.govuk-notification-banner {
+	margin-bottom: 30px;
+	border: 5px solid #1d70b8;
+	background-color: #1d70b8;
+	}
+
+.govuk-notification-banner:focus {
+	outline: 3px solid #ffdd00;
+	}
+
+.govuk-notification-banner__header {
+	padding: 2px 15px 5px;
+	color: #ffffff;
+	}
+
+.govuk-notification-banner__title {
+	margin: 0;
+	font-size: 19px;
+	font-weight: 700;
+	line-height: 1.31579;
+	}
+
+.govuk-notification-banner__content {
+	padding: 20px;
+	background-color: #ffffff;
+	}
+
+.govuk-notification-banner__content > :last-child {
+	margin-bottom: 0;
+	}
+
+.govuk-notification-banner--success {
+	border-color: #00703c;
+	background-color: #00703c;
+	}
+
+@media (max-width: 640px) {
+	.govuk-label--l,
+	.govuk-fieldset__legend--l {
+		font-size: 27px;
+		line-height: 1.11111;
+		}
+
+	.govuk-label--xl,
+	.govuk-fieldset__legend--xl {
+		font-size: 32px;
+		line-height: 1.09375;
+		}
+
+	.govuk-summary-list,
+	.govuk-summary-list__row,
+	.govuk-summary-list__key,
+	.govuk-summary-list__value,
+	.govuk-summary-list__actions {
+		display: block;
+		width: auto;
+		}
+
+	.govuk-summary-list__row {
+		padding: 10px 0;
+		}
+
+	.govuk-summary-list__key,
+	.govuk-summary-list__value,
+	.govuk-summary-list__actions {
+		padding: 0;
+		}
+
+	.govuk-summary-list__key {
+		margin-bottom: 5px;
+		}
+
+	.govuk-summary-list__actions {
+		margin-top: 10px;
+		text-align: left;
+		}
+	}
+
+/* transparency begins in the cascade */

--- a/public/partials/html-head.html
+++ b/public/partials/html-head.html
@@ -8,6 +8,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-frontend-v6.css" media="screen" />
 	
 	{{#include_css}}
 	<!-- Page specific styles -->

--- a/tests/govuk-design-system-baseline-route-state.test.js
+++ b/tests/govuk-design-system-baseline-route-state.test.js
@@ -6,8 +6,12 @@ const componentInventory = fs.readFileSync("docs/design-system/researchops-compo
 const performanceAudit = fs.readFileSync("docs/performance/initial-load-audit.md", "utf8");
 const buttonMigration = fs.readFileSync("docs/design-system/govuk-button-migration.md", "utf8");
 const formMigration = fs.readFileSync("docs/design-system/govuk-form-migration.md", "utf8");
+const frontendV6Migration = fs.readFileSync("docs/design-system/govuk-frontend-v6-migration.md", "utf8");
 const buttonCss = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 const formCss = fs.readFileSync("public/css/govuk/govuk-forms.css", "utf8");
+const tableCss = fs.readFileSync("public/css/govuk/govuk-tables.css", "utf8");
+const frontendV6Css = fs.readFileSync("public/css/govuk/govuk-frontend-v6.css", "utf8");
+const layoutJs = fs.readFileSync("public/components/layout.js", "utf8");
 const dashboardCss = fs.readFileSync("public/css/project-dashboard.css", "utf8");
 const dashboardPage = fs.readFileSync("public/pages/project-dashboard/index.html", "utf8");
 
@@ -63,6 +67,28 @@ includes(formCss, ".govuk-textarea", "GOV.UK form stylesheet");
 includes(formCss, ".govuk-select", "GOV.UK form stylesheet");
 includes(formCss, ".govuk-error-summary", "GOV.UK form stylesheet");
 includes(formCss, ".govuk-button-group", "GOV.UK form stylesheet");
+
+includes(tableCss, ".govuk-table", "GOV.UK table stylesheet");
+includes(tableCss, ".govuk-summary-list", "GOV.UK table stylesheet");
+includes(tableCss, ".govuk-summary-list__actions", "GOV.UK table stylesheet");
+
+includes(frontendV6Migration, "# GOV.UK Frontend v6 migration", "GOV.UK Frontend v6 migration");
+includes(frontendV6Migration, "forms, buttons, error summaries, fieldsets, radios, checkboxes, file upload, tables, summary lists, tags and notification states", "GOV.UK Frontend v6 migration");
+includes(frontendV6Migration, "Do not add new route-level component approximations", "GOV.UK Frontend v6 migration");
+
+includes(frontendV6Css, ".govuk-file-upload", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, ".govuk-radios__label::before", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, ".govuk-checkboxes__label::before", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, ".govuk-error-summary__list a", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, ".govuk-table .govuk-table__header", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, ".govuk-summary-list__row", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, ".govuk-tag--green", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, ".govuk-notification-banner--success", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, "/* transparency begins in the cascade */", "GOV.UK Frontend v6 stylesheet");
+
+includes(layoutJs, "GOVUK_FRONTEND_V6_STYLESHEET", "layout component");
+includes(layoutJs, "/css/govuk/govuk-frontend-v6.css", "layout component");
+includes(layoutJs, "ensureGovukFrontendV6Stylesheet();", "layout component");
 
 includes(dashboardPage, "class=\"section\"", "project dashboard page");
 includes(dashboardPage, "class=\"section__header\"", "project dashboard page");


### PR DESCRIPTION
## Summary

- Adds a dedicated GOV.UK Frontend v6 compatibility layer for component contracts.
- Brings forms, buttons, error summaries, fieldsets, radios, checkboxes, file upload, tables, summary lists, tags and notification banners under upstream-compatible GOV.UK class and state patterns.
- Wires the v6 stylesheet through the shared head partial and the layout component so routes that load the shared layout receive the migration layer after existing local styles.
- Documents the GOV.UK Frontend v6 migration contract and hard rules against new route-level component approximations.
- Updates the GOV.UK baseline unit-test contract to cover the new migration layer, stylesheet loading and required component states.

## Notes

This PR keeps existing IDs, names, route selectors and controller contracts intact. Legacy `.btn` and `.tag` aliases remain only as compatibility bridges while route markup and generated controller markup are migrated fully.

The branch was created from main while the latest main build was still running. GitHub Actions should run the full repository checks on this PR.

## Validation expected in CI

- `npm run validate`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run audit:performance --if-present`
- `npm run audit:security`