### PR TITLE
Fix GOV.UK v6 stylesheet order and checkbox capture regression

### DIFF
--- a/public/components/layout.js
+++ b/public/components/layout.js
@@ -33,14 +33,26 @@ export function ensureGovukFrontendV6Stylesheet(root = document) {
 	const head = doc.head;
 	if (!head) return;
 
-	const existing = head.querySelector(`link[rel="stylesheet"][href="${GOVUK_FRONTEND_V6_STYLESHEET}"]`);
-	if (existing) return;
+	const selector = `link[rel="stylesheet"][href="${GOVUK_FRONTEND_V6_STYLESHEET}"]`;
+	const existing = head.querySelector(selector);
+	const link = existing || doc.createElement("link");
 
-	const link = doc.createElement("link");
-	link.rel = "stylesheet";
-	link.href = GOVUK_FRONTEND_V6_STYLESHEET;
-	link.media = "screen";
+	if (!existing) {
+		link.rel = "stylesheet";
+		link.href = GOVUK_FRONTEND_V6_STYLESHEET;
+		link.media = "screen";
+	}
+
 	link.dataset.govukFrontendV6 = "true";
+
+	const stylesheets = Array.from(head.querySelectorAll('link[rel="stylesheet"]')).filter((candidate) => candidate !== link);
+	const lastStylesheet = stylesheets[stylesheets.length - 1];
+
+	if (lastStylesheet) {
+		lastStylesheet.after(link);
+		return;
+	}
+
 	head.appendChild(link);
 }
 

--- a/public/css/govuk/govuk-frontend-v6.css
+++ b/public/css/govuk/govuk-frontend-v6.css
@@ -1,9 +1,9 @@
-/* ==========================================================================
+/* ===========================================================================
    GOV.UK Frontend v6 compatibility layer
    Service:    Home Office Biometrics — ResearchOps
    Scope:      Canonical GOV.UK component contracts loaded after legacy route CSS
    Repo:       /css/govuk/govuk-frontend-v6.css
-   ========================================================================== */
+   =========================================================================== */
 
 .govuk-visually-hidden {
 	position: absolute !important;
@@ -209,17 +209,6 @@
 	font-weight: 700;
 	}
 
-.govuk-error-message .govuk-visually-hidden {
-	position: static !important;
-	width: auto !important;
-	height: auto !important;
-	margin: 0 !important;
-	overflow: visible !important;
-	clip: auto !important;
-	clip-path: none !important;
-	white-space: inherit !important;
-	}
-
 .govuk-fieldset {
 	min-width: 0;
 	margin: 0;
@@ -380,6 +369,7 @@
 .govuk-checkboxes__input,
 .govuk-radios__input {
 	position: absolute;
+	z-index: 1;
 	top: 0;
 	left: 0;
 	width: 40px;
@@ -408,6 +398,7 @@
 	height: 40px;
 	border: 2px solid #0b0c0c;
 	background: #ffffff;
+	pointer-events: none;
 	}
 
 .govuk-radios__label::before {
@@ -426,6 +417,7 @@
 	border-width: 0 0 5px 5px;
 	border-color: #0b0c0c;
 	opacity: 0;
+	pointer-events: none;
 	}
 
 .govuk-radios__label::after {
@@ -438,6 +430,7 @@
 	border: 10px solid #0b0c0c;
 	border-radius: 50%;
 	opacity: 0;
+	pointer-events: none;
 	}
 
 .govuk-checkboxes__input:checked + .govuk-checkboxes__label::after,

--- a/public/partials/html-head.html
+++ b/public/partials/html-head.html
@@ -8,12 +8,14 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-frontend-v6.css" media="screen" />
 	
 	{{#include_css}}
 	<!-- Page specific styles -->
 	<link rel="stylesheet" href="{{.}}" />
 	{{/include_css}}
+	
+	<!-- GOV.UK Frontend migration layer -->
+	<link rel="stylesheet" href="/css/govuk/govuk-frontend-v6.css" media="screen" />
 	
 	<!-- Layout + custom elements -->
 	<script type="module" src="/components/layout.js" defer></script>

--- a/tests/govuk-design-system-baseline-route-state.test.js
+++ b/tests/govuk-design-system-baseline-route-state.test.js
@@ -11,6 +11,7 @@ const buttonCss = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 const formCss = fs.readFileSync("public/css/govuk/govuk-forms.css", "utf8");
 const tableCss = fs.readFileSync("public/css/govuk/govuk-tables.css", "utf8");
 const frontendV6Css = fs.readFileSync("public/css/govuk/govuk-frontend-v6.css", "utf8");
+const htmlHead = fs.readFileSync("public/partials/html-head.html", "utf8");
 const layoutJs = fs.readFileSync("public/components/layout.js", "utf8");
 const dashboardCss = fs.readFileSync("public/css/project-dashboard.css", "utf8");
 const dashboardPage = fs.readFileSync("public/pages/project-dashboard/index.html", "utf8");
@@ -21,6 +22,15 @@ function includes(source, text, label) {
 
 function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+function appearsAfter(source, earlier, later, label) {
+  const earlierIndex = source.indexOf(earlier);
+  const laterIndex = source.indexOf(later);
+
+  assert.notEqual(earlierIndex, -1, `Expected ${label} to include earlier text: ${earlier}`);
+  assert.notEqual(laterIndex, -1, `Expected ${label} to include later text: ${later}`);
+  assert.equal(laterIndex > earlierIndex, true, `Expected ${label} to place ${later} after ${earlier}`);
 }
 
 includes(complianceAudit, "# GOV.UK design system compliance audit", "GOV.UK compliance audit");
@@ -84,11 +94,17 @@ includes(frontendV6Css, ".govuk-table .govuk-table__header", "GOV.UK Frontend v6
 includes(frontendV6Css, ".govuk-summary-list__row", "GOV.UK Frontend v6 stylesheet");
 includes(frontendV6Css, ".govuk-tag--green", "GOV.UK Frontend v6 stylesheet");
 includes(frontendV6Css, ".govuk-notification-banner--success", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, "z-index: 1;", "GOV.UK Frontend v6 stylesheet");
+includes(frontendV6Css, "pointer-events: none;", "GOV.UK Frontend v6 stylesheet");
 includes(frontendV6Css, "/* transparency begins in the cascade */", "GOV.UK Frontend v6 stylesheet");
+excludes(frontendV6Css, ".govuk-error-message .govuk-visually-hidden", "GOV.UK Frontend v6 stylesheet");
 
+appearsAfter(htmlHead, "{{/include_css}}", "/css/govuk/govuk-frontend-v6.css", "shared HTML head partial");
 includes(layoutJs, "GOVUK_FRONTEND_V6_STYLESHEET", "layout component");
 includes(layoutJs, "/css/govuk/govuk-frontend-v6.css", "layout component");
+includes(layoutJs, "lastStylesheet.after(link);", "layout component");
 includes(layoutJs, "ensureGovukFrontendV6Stylesheet();", "layout component");
+excludes(layoutJs, "if (existing) return;", "layout component");
 
 includes(dashboardPage, "class=\"section\"", "project dashboard page");
 includes(dashboardPage, "class=\"section__header\"", "project dashboard page");


### PR DESCRIPTION
## Summary

- Fixes the Codex P1 finding by moving the GOV.UK Frontend v6 stylesheet after page-specific `include_css` links in the shared head partial.
- Updates `ensureGovukFrontendV6Stylesheet()` so it no longer exits early when a v6 link already exists. It now moves the link after the last stylesheet, preserving the intended cascade order at runtime.
- Fixes the Codex P2 finding by removing the `.govuk-error-message .govuk-visually-hidden` override, keeping the standard screen-reader-only `Error:` prefix hidden visually.
- Fixes the visual walkthrough failure from the supplied logs by putting GOV.UK checkbox/radio inputs above their label pseudo-elements and making the pseudo-elements non-interactive. This prevents labels intercepting Playwright `locator.check()` on generated synthesis evidence checkboxes.
- Adds unit-test assertions for v6 stylesheet ordering, runtime ordering behavior, hidden prefix contract and checkbox click-target protections.

## Evidence from supplied logs

The walkthrough failed at `synthesize/evidence-added-to-cluster` because Playwright attempted to check `#evidence-ev-confidence-before-start`, but the GOV.UK checkbox label intercepted pointer events. The CSS update addresses that specific failure mode.

## Validation expected in CI

- `npm test`
- `npm run qa:visual-walkthrough`
- Existing validate, lint, format, performance and security gates