### PR TITLE
Surface Wrangler logs when walkthrough publishing fails

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -170,6 +170,7 @@ jobs:
         run: npx --yes wrangler@${WRANGLER_VERSION} --version
 
       - name: Deploy visual walkthrough to Cloudflare Pages reporting site
+        id: deploy_reporting_site
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -179,6 +180,33 @@ jobs:
             --branch=main \
             --commit-hash=${{ github.event.workflow_run.head_sha }} \
             --commit-message="Visual walkthrough ${{ github.event.workflow_run.id }}"
+
+      - name: Show Wrangler failure log
+        if: ${{ always() && steps.deploy_reporting_site.outcome == 'failure' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest="$(ls -t "$HOME/.config/.wrangler/logs"/wrangler-*.log 2>/dev/null | head -n 1 || true)"
+
+          if [ -z "$latest" ]; then
+            echo "No Wrangler log file was found."
+            exit 0
+          fi
+
+          echo "Wrangler log: $latest"
+          echo "::group::Wrangler failure log tail"
+          tail -n 240 "$latest"
+          echo "::endgroup::"
+
+      - name: Upload Wrangler logs
+        if: ${{ always() && steps.deploy_reporting_site.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wrangler-pages-deploy-logs
+          path: ~/.config/.wrangler/logs/*.log
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Verify reporting site was updated
         shell: bash


### PR DESCRIPTION
## Summary

- Adds explicit Wrangler failure-log output to the Publish Walkthrough workflow.
- Uploads Wrangler log files as a workflow artifact named `wrangler-pages-deploy-logs` when Cloudflare Pages deployment fails.
- Keeps the existing Cloudflare Pages access preflight and reporting-site verification checks intact.

## Context

The latest supplied message showed only Wrangler's local log path:

`/home/runner/.config/.wrangler/logs/wrangler-2026-05-05_09-31-02_780.log`

That path exists only inside the GitHub Actions runner and is not available after the job unless the workflow prints or uploads it. This PR makes the next failure actionable by surfacing the log tail directly in the Actions output and preserving the full log as an artifact.

## Current walkthrough status

The application visual walkthrough itself now appears to have captured all states successfully after the checkbox/radio fix. The current `reports-site/manifest.json` on `main` records `failureCount: 0`. This PR targets the remaining Cloudflare Pages publish/debuggability issue rather than the screenshot capture logic.

## Validation expected in CI

- Workflow syntax validation through GitHub Actions
- Next publish failure should expose Wrangler diagnostics in logs and as an artifact