### PR TITLE
Add Wrangler diagnostics to manual walkthrough publishing

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -301,6 +301,7 @@ jobs:
         run: npx --yes wrangler@${WRANGLER_VERSION} --version
 
       - name: Deploy visual walkthrough to Cloudflare Pages reporting site
+        id: deploy_reporting_site
         if: >-
           ${{
             steps.detect_site.outputs.present == 'true' &&
@@ -316,6 +317,41 @@ jobs:
             --branch=main \
             --commit-hash=${GITHUB_SHA} \
             --commit-message="Visual walkthrough ${GITHUB_RUN_ID}"
+
+      - name: Show Wrangler failure log
+        if: >-
+          ${{
+            always() &&
+            steps.deploy_reporting_site.outcome == 'failure'
+          }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest="$(ls -t "$HOME/.config/.wrangler/logs"/wrangler-*.log 2>/dev/null | head -n 1 || true)"
+
+          if [ -z "$latest" ]; then
+            echo "No Wrangler log file was found."
+            exit 0
+          fi
+
+          echo "Wrangler log: $latest"
+          echo "::group::Wrangler failure log tail"
+          tail -n 240 "$latest"
+          echo "::endgroup::"
+
+      - name: Upload Wrangler logs
+        if: >-
+          ${{
+            always() &&
+            steps.deploy_reporting_site.outcome == 'failure'
+          }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wrangler-pages-deploy-logs
+          path: ~/.config/.wrangler/logs/*.log
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Verify reporting site was updated
         if: >-


### PR DESCRIPTION
## Summary

- Adds the same Wrangler failure diagnostics to the `qa-bdd` workflow-dispatch publish path.
- Gives the manual Cloudflare Pages deploy step an explicit `id` so the workflow can detect failed deployment.
- Prints the latest Wrangler log tail and uploads all Wrangler logs as `wrangler-pages-deploy-logs` when the manual publish fails.

## Context

The latest failure still only exposed this local runner path:

`/home/runner/.config/.wrangler/logs/wrangler-2026-05-05_09-58-08_536.log`

That indicates the failing run is the `qa-bdd` workflow-dispatch publish path, not the separate `Publish Walkthrough (Pages)` workflow patched in PR #173. This PR patches the remaining deploy path.

## Expected outcome

The next manual walkthrough publish failure should expose the Cloudflare/Wrangler error directly in the GitHub Actions logs and keep the full Wrangler logs as a downloadable artifact.