### PR TITLE
Fix Cloudflare Pages preflight Node stdin invocation

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -135,7 +135,9 @@ jobs:
             --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             --header "Content-Type: application/json" || true)"
 
-          node <<'NODE' "$response_file" "$status" "$REPORTING_PAGES_PROJECT"
+          echo "Cloudflare Pages access check HTTP status: ${status}"
+
+          node - "$response_file" "$status" "$REPORTING_PAGES_PROJECT" <<'NODE'
           const fs = require('node:fs');
 
           const [, , responsePath, status, projectName] = process.argv;


### PR DESCRIPTION
## Summary

This PR replaces the diverged corrective branch with a clean branch from current `main`.

It fixes the Cloudflare Pages access preflight step in `.github/workflows/publish-walkthrough.yml` by using the correct Node stdin invocation:

```bash
node - "$response_file" "$status" "$REPORTING_PAGES_PROJECT" <<'NODE'
```

The previous form passed the heredoc body and arguments in the wrong order for Node stdin execution.

## Diamond GitHub compliance

- Created a clean branch from current `main`.
- Did not force-push.
- Did not rewrite branch history.
- Left the previous diverged branch untouched.
- Kept the change scoped to the failing workflow command.

## Verification

- Compared `fix/pages-preflight-node-stdin-clean` against `main`.
- Result: branch is ahead by 1 commit and behind by 0 commits.
- Changed files: `.github/workflows/publish-walkthrough.yml` only.

Workflow execution will verify the change in GitHub Actions.