### PR TITLE
Improve walkthrough publish failure handling

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -109,6 +109,15 @@ jobs:
             exit 1
           fi
 
+      - name: Upload reporting site publish candidate
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-walkthrough-site-publish-candidate
+          path: reports-site
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Verify Cloudflare Pages project access
         shell: bash
         env:
@@ -264,8 +273,8 @@ jobs:
           echo "Reporting site did not show the generated run timestamp after deployment."
           exit 1
 
-      - name: Add job summary
-        if: always()
+      - name: Add successful publication job summary
+        if: success()
         shell: bash
         run: |
           echo "## Application visual walkthrough" >> "$GITHUB_STEP_SUMMARY"
@@ -279,3 +288,17 @@ jobs:
           echo "[Open raw Cucumber HTML report](${REPORTING_PAGES_URL}cucumber/cucumber-report.html)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "> The gallery shows registered application pages and interaction states across desktop and mobile screenshots, with source-derived Gherkin criteria inside each state card." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Add failed publication job summary
+        if: failure()
+        shell: bash
+        run: |
+          echo "## Application visual walkthrough" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The visual walkthrough publish job did not update the Cloudflare Pages reporting site." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The generated publish candidate was uploaded as the \\`visual-walkthrough-site-publish-candidate\\` workflow artifact before deployment." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "If the failure point is the Cloudflare Pages access check, replace \\`CF_API_TOKEN\\` with a token from the same Cloudflare account as \\`CF_ACCOUNT_ID\\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Required token scope: Account > Cloudflare Pages > Edit for the account that owns \\`${REPORTING_PAGES_PROJECT}\\`." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The latest workflow failure is no longer the Node stdin invocation. That part is now executing correctly.

The current failure is an authenticated Cloudflare API response:

```text
HTTP status: 403
Cloudflare error: Authentication error [code: 10000]
```

That points to a repository secret/account configuration issue rather than an application code issue.

This PR improves the workflow around that failure mode so the publish candidate is preserved and the job summary does not falsely say the reporting site was published when the Cloudflare step fails.

## Changes

- Uploads `reports-site` as `visual-walkthrough-site-publish-candidate` before the Cloudflare Pages access check.
- Splits the job summary into success and failure summaries.
- Keeps the existing fail-fast Cloudflare Pages preflight check.
- Leaves the Cloudflare deployment failure as a hard failure.

## Required non-code action

Update GitHub repository secrets:

- `CF_API_TOKEN` must be a Cloudflare API token from the same account as `CF_ACCOUNT_ID`.
- The token needs `Account > Cloudflare Pages > Edit` for the account that owns `reopsreporting`.
- `CF_ACCOUNT_ID` must be the account ID that owns the `reopsreporting` Pages project.

## Verification

- Created from current `main`.
- Compared branch against `main`: ahead by 1, behind by 0.
- Changed file: `.github/workflows/publish-walkthrough.yml` only.
- The remaining fix requires updating GitHub secrets, which cannot be verified in code without a valid Cloudflare token.