### PR TITLE
Fix walkthrough failure summary backticks

### DIFF
--- a/.github/workflows/publish-walkthrough.yml
+++ b/.github/workflows/publish-walkthrough.yml
@@ -293,12 +293,14 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          echo "## Application visual walkthrough" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "The visual walkthrough publish job did not update the Cloudflare Pages reporting site." >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "The generated publish candidate was uploaded as the \\`visual-walkthrough-site-publish-candidate\\` workflow artifact before deployment." >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "If the failure point is the Cloudflare Pages access check, replace \\`CF_API_TOKEN\\` with a token from the same Cloudflare account as \\`CF_ACCOUNT_ID\\`." >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Required token scope: Account > Cloudflare Pages > Edit for the account that owns \\`${REPORTING_PAGES_PROJECT}\\`." >> "$GITHUB_STEP_SUMMARY"
+          {
+            printf '%s\n' '## Application visual walkthrough'
+            printf '%s\n' ''
+            printf '%s\n' 'The visual walkthrough publish job did not update the Cloudflare Pages reporting site.'
+            printf '%s\n' ''
+            printf '%s\n' 'The generated publish candidate was uploaded as the `visual-walkthrough-site-publish-candidate` workflow artifact before deployment.'
+            printf '%s\n' ''
+            printf '%s\n' 'If the failure point is the Cloudflare Pages access check, replace `CF_API_TOKEN` with a token from the same Cloudflare account as `CF_ACCOUNT_ID`.'
+            printf '%s\n' ''
+            printf 'Required token scope: Account > Cloudflare Pages > Edit for the account that owns `%s`.\n' "${REPORTING_PAGES_PROJECT}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The latest pasted workflow failure is still the Cloudflare Pages access preflight failure:

```text
HTTP status: 403
Cloudflare error: Authentication error [code: 10000]
```

That remains a GitHub secret / Cloudflare account-token issue rather than an application-code failure.

However, the previously merged failure-summary change introduced a small shell quoting defect identified by Codex. This PR corrects that defect so a future failure summary can render Markdown inline code spans without Bash command substitution.

## Changes

- Rewrites the failed publication summary step to use a `printf` block.
- Emits literal Markdown backticks safely for:
  - `visual-walkthrough-site-publish-candidate`
  - `CF_API_TOKEN`
  - `CF_ACCOUNT_ID`
  - the configured reporting Pages project name
- Keeps the Cloudflare Pages access preflight as a hard failure.
- Does not change deployment logic or secrets handling.

## Verification

- Created from current `main`.
- Compared branch against `main`: ahead by 1, behind by 0.
- Changed file: `.github/workflows/publish-walkthrough.yml` only.

## Remaining action outside code

The workflow will continue to fail at the Cloudflare access preflight until repository secrets are corrected:

- `CF_API_TOKEN` must belong to the same Cloudflare account as `CF_ACCOUNT_ID`.
- The token needs `Account > Cloudflare Pages > Edit` for the account that owns `reopsreporting`.
- `CF_ACCOUNT_ID` must identify the Cloudflare account that owns `reopsreporting`.