### PR TITLE
Fix GOV.UK header service brand placement

### DIFF
--- a/public/css/govuk/govuk-header-service-brand.css
+++ b/public/css/govuk/govuk-header-service-brand.css
@@ -1,0 +1,81 @@
+/* GOV.UK header service brand alignment */
+
+.govuk-header .govuk-header__homepage-link,
+.govuk-header .govuk-header__homepage-link:visited,
+.govuk-header .govuk-header__link,
+.govuk-header .govuk-header__link:visited {
+	color: #ffffff;
+	text-decoration: none;
+	}
+
+.govuk-header .govuk-header__homepage-link:hover,
+.govuk-header .govuk-header__link:hover {
+	box-shadow: 0 3px 0 #ffffff;
+	color: #ffffff;
+	text-decoration: none;
+	}
+
+.govuk-header .govuk-header__homepage-link:focus,
+.govuk-header .govuk-header__link:focus {
+	background-color: #ffdd00;
+	color: #0b0c0c;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 0 0 4px #0b0c0c;
+	text-decoration: none;
+	}
+
+.govuk-header .govuk-header__logotype {
+	display: inline-block;
+	width: 162px;
+	height: 30px;
+	vertical-align: middle;
+	}
+
+.govuk-header .govuk-header__service-name {
+	display: inline-block;
+	margin-left: 15px;
+	color: inherit;
+	font-size: 30px;
+	font-weight: 400;
+	line-height: 1;
+	white-space: nowrap;
+	}
+
+.govuk-service-navigation .govuk-service-navigation__link:visited {
+	color: #1a65a6;
+	}
+
+.govuk-service-navigation .govuk-service-navigation__link:focus {
+	background-color: #ffdd00;
+	color: #0b0c0c;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+	text-decoration: none;
+	}
+
+.govuk-service-navigation__item--active .govuk-service-navigation__link:visited,
+.govuk-service-navigation__link[aria-current="true"]:visited,
+.govuk-service-navigation__link[aria-current="page"]:visited,
+.govuk-service-navigation__link.active:visited {
+	color: #0b0c0c;
+	}
+
+@media (max-width: 640px) {
+	.govuk-header .govuk-header__homepage-link,
+	.govuk-header .govuk-header__link {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 8px;
+		}
+
+	.govuk-header .govuk-header__service-name {
+		margin-left: 0;
+		font-size: 24px;
+		line-height: 1.1;
+		white-space: normal;
+		}
+	}
+
+/* transparency begins in the cascade */

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,10 +1,11 @@
 <!-- public/partials/header.html -->
 <a class="govuk-skip-link" href="#main-content">Skip to main content</a>
+<link rel="stylesheet" href="/css/govuk/govuk-header-service-brand.css" media="screen">
 
 <header class="govuk-header" role="banner" data-module="govuk-header">
 	<div class="govuk-header__container govuk-width-container">
 		<div class="govuk-header__logo">
-			<a href="/" class="govuk-header__homepage-link" aria-label="GOV.UK home">
+			<a href="/" class="govuk-header__homepage-link">
 				<svg
 					focusable="false"
 					role="img"
@@ -30,6 +31,7 @@
 					<circle class="govuk-logo-dot" cx="226" cy="36" r="7.3" />
 					<path d="M93.94 41.25c.4 1.81 1.2 3.21 2.21 4.62 1 1.4 2.21 2.41 3.61 3.21s3.21 1.2 5.22 1.2 3.61-.4 4.82-1c1.4-.6 2.41-1.4 3.21-2.41.8-1 1.4-2.01 1.61-3.01s.4-2.01.4-3.01v.14h-10.86v-7.02h20.07v24.08h-8.03v-5.56c-.6.8-1.38 1.61-2.19 2.41-.8.8-1.81 1.2-2.81 1.81-1 .4-2.21.8-3.41 1.2s-2.41.4-3.81.4a18.56 18.56 0 0 1-14.65-6.63c-1.6-2.01-3.01-4.41-3.81-7.02s-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83a20.45 20.45 0 0 1 19.46-13.65c3.21 0 4.01.2 5.82.8 1.81.4 3.61 1.2 5.02 2.01 1.61.8 2.81 2.01 4.01 3.21s2.21 2.61 2.81 4.21l-7.63 4.41c-.4-1-1-1.81-1.61-2.61-.6-.8-1.4-1.4-2.21-2.01-.8-.6-1.81-1-2.81-1.4-1-.4-2.21-.4-3.61-.4-2.01 0-3.81.4-5.22 1.2-1.4.8-2.61 1.81-3.61 3.21s-1.61 2.81-2.21 4.62c-.4 1.81-.6 3.71-.6 5.42s.8 5.22.8 5.22Zm57.8-27.9c3.21 0 6.22.6 8.63 1.81 2.41 1.2 4.82 2.81 6.62 4.82S170.2 24.39 171 27s1.4 5.62 1.4 8.83-.4 6.02-1.4 8.83-2.41 5.02-4.01 7.02-4.01 3.61-6.62 4.82-5.42 1.81-8.63 1.81-6.22-.6-8.63-1.81-4.82-2.81-6.42-4.82-3.21-4.41-4.01-7.02-1.4-5.62-1.4-8.83.4-6.02 1.4-8.83 2.41-5.02 4.01-7.02 4.01-3.61 6.42-4.82 5.42-1.81 8.63-1.81Zm0 36.73c1.81 0 3.61-.4 5.02-1s2.61-1.81 3.61-3.01 1.81-2.81 2.21-4.41c.4-1.81.8-3.61.8-5.62 0-2.21-.2-4.21-.8-6.02s-1.2-3.21-2.21-4.62c-1-1.2-2.21-2.21-3.61-3.01s-3.21-1-5.02-1-3.61.4-5.02 1c-1.4.8-2.61 1.81-3.61 3.01s-1.81 2.81-2.21 4.62c-.4 1.81-.8 3.61-.8 5.62 0 2.41.2 4.21.8 6.02.4 1.81 1.2 3.21 2.21 4.41s2.21 2.21 3.61 3.01c1.4.8 3.21 1 5.02 1Zm36.32 7.96-12.24-44.15h9.83l8.43 32.77h.4l8.23-32.77h9.83L200.3 58.04h-12.24Zm74.14-7.96c2.18 0 3.51-.6 3.51-.6 1.2-.6 2.01-1 2.81-1.81s1.4-1.81 1.81-2.81a13 13 0 0 0 .8-4.01V13.9h8.63v28.15c0 2.41-.4 4.62-1.4 6.62-.8 2.01-2.21 3.61-3.61 5.02s-3.41 2.41-5.62 3.21-4.62 1.2-7.02 1.2-5.02-.4-7.02-1.2c-2.21-.8-4.01-1.81-5.62-3.21s-2.81-3.01-3.61-5.02-1.4-4.21-1.4-6.62V13.9h8.63v26.95c0 1.61.2 3.01.8 4.01.4 1.2 1.2 2.21 2.01 2.81.8.8 1.81 1.4 2.81 1.81 0 0 1.34.6 3.51.6Zm34.22-36.18v18.92l15.65-18.92h10.82l-15.03 17.32 16.03 26.83h-10.21l-11.44-20.21-5.62 6.22v13.99h-8.83V13.9" />
 				</svg>
+				<span class="govuk-header__service-name">ResearchOps Demo Suite</span>
 			</a>
 		</div>
 	</div>
@@ -38,11 +40,6 @@
 <section aria-label="Service information" class="govuk-service-navigation" data-module="govuk-service-navigation" data-active="{{active}}">
 	<div class="govuk-width-container">
 		<div class="govuk-service-navigation__container">
-			<span class="govuk-service-navigation__service-name">
-				<a class="govuk-service-navigation__link" href="/">
-					{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}
-				</a>
-			</span>
 			<nav aria-label="Menu" class="govuk-service-navigation__wrapper">
 				<button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden aria-hidden="true">
 					Menu

--- a/tests/govuk-page-chrome-navigation-route-state.test.js
+++ b/tests/govuk-page-chrome-navigation-route-state.test.js
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const pageChromeCss = fs.readFileSync("public/css/govuk/govuk-page-chrome.css", "utf8");
+const headerServiceBrandCss = fs.readFileSync(
+  "public/css/govuk/govuk-header-service-brand.css",
+  "utf8"
+);
 const headerPartial = fs.readFileSync("public/partials/header.html", "utf8");
 const footerPartial = fs.readFileSync("public/partials/footer.html", "utf8");
 const migrationDoc = fs.readFileSync(
@@ -53,7 +57,6 @@ includes(pageChromeCss, ".govuk-service-navigation__item--active", "page chrome 
 includes(pageChromeCss, ".govuk-service-navigation__link", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-service-navigation .govuk-service-navigation__link:visited", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-service-navigation .govuk-service-navigation__link:focus", "page chrome stylesheet");
-includes(pageChromeCss, ".govuk-service-navigation__service-name .govuk-service-navigation__link:visited", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-service-navigation__link[aria-current=\"page\"]:visited", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-phase-banner", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-back-link", "page chrome stylesheet");
@@ -62,7 +65,18 @@ includes(pageChromeCss, "background: #1d70b8;", "page chrome stylesheet");
 includes(pageChromeCss, "background: #f4f8fb;", "page chrome stylesheet");
 includes(pageChromeCss, "/* transparency begins in the cascade */", "page chrome stylesheet");
 
+includes(headerServiceBrandCss, "GOV.UK header service brand alignment", "header service brand stylesheet");
+includes(headerServiceBrandCss, ".govuk-header .govuk-header__homepage-link:hover", "header service brand stylesheet");
+includes(headerServiceBrandCss, "box-shadow: 0 3px 0 #ffffff;", "header service brand stylesheet");
+includes(headerServiceBrandCss, "color: #ffffff;", "header service brand stylesheet");
+includes(headerServiceBrandCss, ".govuk-header .govuk-header__service-name", "header service brand stylesheet");
+includes(headerServiceBrandCss, "font-size: 30px;", "header service brand stylesheet");
+includes(headerServiceBrandCss, ".govuk-service-navigation .govuk-service-navigation__link:visited", "header service brand stylesheet");
+includes(headerServiceBrandCss, ".govuk-service-navigation__link[aria-current=\"page\"]:visited", "header service brand stylesheet");
+includes(headerServiceBrandCss, "/* transparency begins in the cascade */", "header service brand stylesheet");
+
 includes(headerPartial, "class=\"govuk-skip-link\" href=\"#main-content\"", "shared header partial");
+includes(headerPartial, "href=\"/css/govuk/govuk-header-service-brand.css\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-header\" role=\"banner\" data-module=\"govuk-header\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-header__container govuk-width-container\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-header__homepage-link\"", "shared header partial");
@@ -76,11 +90,14 @@ includes(headerPartial, "class=\"govuk-header__logotype\"", "shared header parti
 includes(headerPartial, "aria-label=\"GOV.UK\"", "shared header partial");
 includes(headerPartial, "<title>GOV.UK</title>", "shared header partial");
 includes(headerPartial, "class=\"govuk-logo-dot\"", "shared header partial");
+includes(headerPartial, "class=\"govuk-header__service-name\"", "shared header partial");
+includes(headerPartial, "ResearchOps Demo Suite", "shared header partial");
 excludes(headerPartial, "<span class=\"govuk-header__logotype\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-service-navigation\"", "shared header partial");
 includes(headerPartial, "data-module=\"govuk-service-navigation\"", "shared header partial");
 includes(headerPartial, "aria-label=\"Service information\"", "shared header partial");
-includes(headerPartial, "class=\"govuk-service-navigation__service-name\"", "shared header partial");
+excludes(headerPartial, "class=\"govuk-service-navigation__service-name\"", "shared header partial");
+excludes(headerPartial, "{{#title}}{{title}}{{/title}}{{^title}}ResearchOps Demo Suite{{/title}}", "shared header partial");
 includes(headerPartial, "class=\"govuk-service-navigation__wrapper\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-service-navigation__toggle govuk-js-service-navigation-toggle\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-service-navigation__list\"", "shared header partial");


### PR DESCRIPTION
Summary

This PR updates the shared ResearchOps page chrome so the GOV.UK header carries the service name and the service navigation contains only navigation items.

Changes

- Moves ResearchOps Demo Suite into the GOV.UK header brand link after the SVG logotype.
- Removes ResearchOps Demo Suite from the service navigation area.
- Adds a dedicated header service brand stylesheet.
- Keeps the header brand hover state white with a white underline treatment.
- Prevents component links in the header and service navigation from inheriting the global visited-link colour.
- Updates route-state unit tests for the corrected header and navigation contract.

Validation

- Branch created from current main.
- Compared branch to main: 3 files changed and 0 commits behind.
- Test coverage updated in tests/govuk-page-chrome-navigation-route-state.test.js.