### PR TITLE
Fix GOV.UK header brand metrics from latest main

### DIFF
--- a/public/css/govuk/govuk-header-service-brand.css
+++ b/public/css/govuk/govuk-header-service-brand.css
@@ -9,7 +9,7 @@
 	}
 
 .govuk-header .govuk-header__homepage-link {
-	display: inline;
+	display: inline-block;
 	margin-right: 10px;
 	font-size: 30px;
 	line-height: 1;
@@ -47,7 +47,7 @@
 	top: -3px;
 	width: 162px;
 	height: 30px;
-	margin-right: 0.4375rem;
+	margin-right: 7px;
 	margin-bottom: 2px;
 	fill: currentcolor;
 	vertical-align: top;
@@ -60,9 +60,9 @@
 .govuk-header .govuk-header__product-name,
 .govuk-header .govuk-header__service-name {
 	display: inline-table;
-	margin-bottom: -0.0625rem;
+	margin-bottom: -1px;
 	color: inherit;
-	font-size: 1.9375rem;
+	font-size: 31px;
 	font-weight: 400;
 	line-height: 1;
 	letter-spacing: -0.015em;

--- a/tests/govuk-page-chrome-navigation-route-state.test.js
+++ b/tests/govuk-page-chrome-navigation-route-state.test.js
@@ -67,16 +67,17 @@ includes(pageChromeCss, "/* transparency begins in the cascade */", "page chrome
 
 includes(headerServiceBrandCss, "GOV.UK header product-name alignment", "header product-name stylesheet");
 includes(headerServiceBrandCss, ".govuk-header .govuk-header__homepage-link:hover", "header product-name stylesheet");
+includes(headerServiceBrandCss, "display: inline-block;", "header product-name stylesheet");
 includes(headerServiceBrandCss, "margin-bottom: -3px;", "header product-name stylesheet");
 includes(headerServiceBrandCss, "border-bottom: 3px solid;", "header product-name stylesheet");
 includes(headerServiceBrandCss, "word-spacing: -6px;", "header product-name stylesheet");
 includes(headerServiceBrandCss, "top: -3px;", "header product-name stylesheet");
-includes(headerServiceBrandCss, "margin-right: 0.4375rem;", "header product-name stylesheet");
+includes(headerServiceBrandCss, "margin-right: 7px;", "header product-name stylesheet");
 includes(headerServiceBrandCss, "margin-bottom: 2px;", "header product-name stylesheet");
 includes(headerServiceBrandCss, ".govuk-header .govuk-header__product-name", "header product-name stylesheet");
 includes(headerServiceBrandCss, "display: inline-table;", "header product-name stylesheet");
-includes(headerServiceBrandCss, "margin-bottom: -0.0625rem;", "header product-name stylesheet");
-includes(headerServiceBrandCss, "font-size: 1.9375rem;", "header product-name stylesheet");
+includes(headerServiceBrandCss, "margin-bottom: -1px;", "header product-name stylesheet");
+includes(headerServiceBrandCss, "font-size: 31px;", "header product-name stylesheet");
 includes(headerServiceBrandCss, "letter-spacing: -0.015em;", "header product-name stylesheet");
 includes(headerServiceBrandCss, "vertical-align: top;", "header product-name stylesheet");
 includes(headerServiceBrandCss, ".govuk-service-navigation .govuk-service-navigation__link:visited", "header product-name stylesheet");


### PR DESCRIPTION
Summary

This PR applies the corrected GOV.UK Header brand metrics from a fresh branch created from the current `main` branch after PR #181 had already been merged.

Changes

- Keeps the GOV.UK header homepage link as `inline-block`, not `inline`, so the hover underline contract can apply the `margin-bottom: -3px` compensation without layout shift.
- Replaces rem-derived GOV.UK header metric values with the direct pixel values used by the GOV.UK Header product-name contract in this codebase context:
  - product-name font size: `31px`
  - logotype/product-name gap: `7px`
  - product-name bottom margin: `-1px`
- Updates the GOV.UK page chrome route-state assertions so the regression test checks the corrected header metric contract.

Diamond workflow evidence

- Confirmed PR #181 is merged and closed.
- Checked latest `main`: `b99041a5581ff74b43a57b44c647e67694957ee6`.
- Created this branch from that latest `main` SHA.
- Compared branch to `main`: 2 commits ahead, 0 commits behind.
- Did not force-push or mutate the merged PR branch.

Validation

- Static route-state assertions updated for the changed CSS contract.
- CI should run the full repository checks on this PR.