### PR TITLE
Improve reporting site walkthrough evidence and design-risk notes

### DIFF
--- a/scripts/researchops-state-acceptance.mjs
+++ b/scripts/researchops-state-acceptance.mjs
@@ -34,6 +34,24 @@ const PAGE_STORIES = {
 		want: 'review the status, evidence and next actions for a research project',
 		so: 'I can coordinate research activity across the team',
 	},
+	'project-dashboard-add-study': {
+		feature: 'Add a study to a research project',
+		context: 'add study journey',
+		want: 'add a study to the correct project',
+		so: 'study planning remains traceable to the project context',
+	},
+	'project-dashboard-add-participant': {
+		feature: 'Add a participant to a research project',
+		context: 'add participant journey',
+		want: 'add a participant from the correct project context',
+		so: 'recruitment records are connected to the right research work',
+	},
+	'project-dashboard-import-participants': {
+		feature: 'Import participants for a research project',
+		context: 'import participants journey',
+		want: 'import participant records with clear project context and safe guidance',
+		so: 'bulk participant setup does not weaken privacy, consent or traceability',
+	},
 	outcomes: {
 		feature: 'Manage project outcomes',
 		context: 'project outcomes page',
@@ -237,15 +255,15 @@ function buildActionScenario(sourceActions = []) {
 
 	if (relevantActions.length === 0) {
 		return [
-			'Scenario: Use the default view',
+			'Scenario: Understand the default view',
 			'  Then I should understand what ResearchOps task this page supports',
-			'  And I should be able to choose an appropriate next action',
+			'  And I should be able to choose an appropriate next action for my work',
 		];
 	}
 
 	return [
-		'Scenario: Complete the interaction needed for this state',
-		'  Given I am ready to work with this ResearchOps state',
+		'Scenario: Complete the interaction needed for this ResearchOps task',
+		'  Given I am ready to continue this ResearchOps journey',
 		...relevantActions.map(buildActionStep),
 		'  Then I should be able to continue the ResearchOps journey with confidence',
 	];
@@ -259,7 +277,7 @@ export function buildStateAcceptanceGherkin(page = {}, state = {}, sourceState =
 	const story = storyForPage(page);
 	const statePurpose = state.description
 		? truncateForGherkin(state.description, 220)
-		: `the ${lowerFirst(state.title || 'current')} state`;
+		: `the ${lowerFirst(state.title || 'current view')}`;
 	const sourceActions = Array.isArray(sourceState?.actions) ? sourceState.actions : [];
 
 	return [
@@ -277,14 +295,14 @@ export function buildStateAcceptanceGherkin(page = {}, state = {}, sourceState =
 		`    Then I should see content that supports ${lowerFirst(page.description || story.want)}`,
 		'    And I should understand what ResearchOps task I can complete from this page',
 		'',
-		`  Scenario: Work with the "${quoteGherkin(state.title || 'Default')}" state`,
+		`  Scenario: Use "${quoteGherkin(state.title || 'Default view')}" in the ResearchOps journey`,
 		`    Given I am using the ${story.context}`,
-		`    Then the interface should make it clear that this state is for ${lowerFirst(statePurpose)}`,
-		'    And I should be given enough context to decide what to do next',
+		`    Then I should understand how ${lowerFirst(statePurpose)} supports my research work`,
+		'    And I should be given enough service context to decide what to do next',
 		'',
 		...buildActionScenario(sourceActions).map((line) => `  ${line}`),
 		'',
-		'  Scenario: Use the state accessibly',
+		'  Scenario: Use this part of the journey accessibly',
 		'    Then the page should have one clear main heading',
 		'    And headings, labels and controls should be exposed in a logical reading order',
 		'    And I should be able to move through the available controls using a keyboard',

--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -3,6 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
 import {
+	operationalMockRoutes,
+	operationalPaths,
+	operationalProjectId,
+	operationalStudyId,
+} from '../visual-walkthrough.operational-fixtures.mjs';
+import {
 	participantConsentDefaultState,
 	participantConsentVisualStates,
 } from '../visual-walkthrough.participant-consent-states.mjs';
@@ -64,6 +70,16 @@ function actionSelectorValues(stateId) {
 		.map((action) => action.selector);
 }
 
+function pageById(pageId) {
+	return visualWalkthroughConfig.pages.find((page) => page.id === pageId);
+}
+
+function assertDefaultStatePath(pageId, expectedPath, message) {
+	const page = pageById(pageId);
+	assert.equal(Boolean(page?.defaultState?.path), true, `Expected ${pageId} to define a default state path`);
+	assert.equal(page.defaultState.path, expectedPath, message);
+}
+
 const discoveredRoutes = listHtmlFiles(visualWalkthroughConfig.publicRoot)
 	.map(routeFromPublicFile)
 	.filter((route) => !visualWalkthroughConfig.excludedRoutes.includes(route));
@@ -74,6 +90,7 @@ const profileIds = visualWalkthroughConfig.profiles.map((profile) => profile.id)
 const synthesisStateIds = synthesisVisualStates.map((state) => state.id);
 const participantConsentStateIds = participantConsentVisualStates.map((state) => state.id);
 const visualWalkthroughSource = fs.readFileSync('scripts/visual-walkthrough.mjs', 'utf8');
+const stateAcceptanceSource = fs.readFileSync('scripts/researchops-state-acceptance.mjs', 'utf8');
 
 for (const route of discoveredRoutes) {
 	assert.ok(
@@ -90,6 +107,18 @@ for (const page of visualWalkthroughConfig.pages) {
 	);
 	assert.equal(Boolean(page.title), true, `Expected registered page to have a title: ${page.id}`);
 	assert.equal(Boolean(page.group), true, `Expected registered page to have a group: ${page.id}`);
+	assert.equal(Boolean(page.designRisk?.risk), true, `Expected page to define a design risk: ${page.id}`);
+	assert.equal(Boolean(page.designRisk?.impact), true, `Expected page to define design risk impact: ${page.id}`);
+	assert.equal(
+		Boolean(page.designRisk?.recommendedChange),
+		true,
+		`Expected page to define design risk recommendation: ${page.id}`
+	);
+	assert.doesNotMatch(
+		`${page.designRisk.risk} ${page.designRisk.impact} ${page.designRisk.recommendedChange}`,
+		/No specific design risk recorded|No additional impact has been identified|Review this state during the next design critique/,
+		`Expected page to use a route-specific design-risk assessment: ${page.id}`
+	);
 }
 
 assert.equal(
@@ -115,6 +144,90 @@ for (const profile of visualWalkthroughConfig.profiles) {
 		Boolean(profile.contextOptions?.viewport?.height),
 		true,
 		`Expected profile to define viewport height: ${profile.id}`
+	);
+}
+
+assert.equal(
+	operationalMockRoutes().length >= 7,
+	true,
+	'Expected operational walkthrough fixtures to cover project, study, participant, guide, consent and session APIs'
+);
+
+assertDefaultStatePath(
+	'project-dashboard',
+	operationalPaths.projectDashboard,
+	'Expected project dashboard walkthrough to capture a real project-scoped URL'
+);
+assertDefaultStatePath(
+	'project-dashboard-add-study',
+	operationalPaths.addStudy,
+	'Expected add-study walkthrough to keep the parent project ID in the URL'
+);
+assertDefaultStatePath(
+	'project-dashboard-add-participant',
+	operationalPaths.addParticipant,
+	'Expected add-participant walkthrough to keep the parent project ID in the URL'
+);
+assertDefaultStatePath(
+	'project-dashboard-import-participants',
+	operationalPaths.importParticipants,
+	'Expected import-participants walkthrough to keep the parent project ID in the URL'
+);
+assertDefaultStatePath(
+	'study',
+	operationalPaths.study,
+	'Expected study overview walkthrough to capture a project and study scoped URL'
+);
+assertDefaultStatePath(
+	'study-guides',
+	operationalPaths.studyGuides,
+	'Expected discussion guides walkthrough to capture a project and study scoped URL'
+);
+assertDefaultStatePath(
+	'study-participants',
+	operationalPaths.studyParticipants,
+	'Expected study participants walkthrough to capture a project and study scoped URL'
+);
+assertDefaultStatePath(
+	'study-session',
+	operationalPaths.studySession,
+	'Expected study session walkthrough to capture a project and study scoped URL'
+);
+assertDefaultStatePath(
+	'study-consent-forms',
+	operationalPaths.studyConsentForms,
+	'Expected consent forms walkthrough to capture a project and study scoped URL'
+);
+
+for (const pageId of [
+	'project-dashboard',
+	'project-dashboard-add-study',
+	'project-dashboard-add-participant',
+	'project-dashboard-import-participants',
+	'study',
+	'study-guides',
+	'study-participants',
+	'study-session',
+	'study-consent-forms',
+]) {
+	const page = pageById(pageId);
+	assert.ok(
+		page.defaultState.path.includes(operationalProjectId),
+		`Expected ${pageId} walkthrough path to include the operational project ID`
+	);
+}
+
+for (const pageId of [
+	'study',
+	'study-guides',
+	'study-participants',
+	'study-session',
+	'study-consent-forms',
+]) {
+	const page = pageById(pageId);
+	assert.ok(
+		page.defaultState.path.includes(operationalStudyId),
+		`Expected ${pageId} walkthrough path to include the operational study ID`
 	);
 }
 
@@ -152,6 +265,36 @@ assert.doesNotMatch(
 	visualWalkthroughSource,
 	/Gherkin acceptance criteria for this state/,
 	'Expected state-level details panels not to use delivery-tooling wording as the summary label'
+);
+
+assert.match(
+	stateAcceptanceSource,
+	/ResearchOps journey/,
+	'Expected generated Gherkin criteria to be framed around the user journey rather than the report artefact'
+);
+
+assert.match(
+	stateAcceptanceSource,
+	/Add a study to a research project/,
+	'Expected generated Gherkin criteria to include project-dashboard action journeys'
+);
+
+assert.doesNotMatch(
+	stateAcceptanceSource,
+	/ready to work with this ResearchOps state/,
+	'Expected generated Gherkin criteria not to describe the reporting site state as the user task'
+);
+
+assert.doesNotMatch(
+	stateAcceptanceSource,
+	/Use the state accessibly/,
+	'Expected generated Gherkin criteria to avoid reporting-site state language in accessibility scenarios'
+);
+
+assert.doesNotMatch(
+	stateAcceptanceSource,
+	/Work with the "/,
+	'Expected generated Gherkin criteria to avoid generic state wording in scenario titles'
 );
 
 assert.match(

--- a/tests/visual-walkthrough-registry.test.js
+++ b/tests/visual-walkthrough-registry.test.js
@@ -76,7 +76,11 @@ function pageById(pageId) {
 
 function assertDefaultStatePath(pageId, expectedPath, message) {
 	const page = pageById(pageId);
-	assert.equal(Boolean(page?.defaultState?.path), true, `Expected ${pageId} to define a default state path`);
+	assert.equal(
+		Boolean(page?.defaultState?.path),
+		true,
+		`Expected ${pageId} to define a default state path`
+	);
 	assert.equal(page.defaultState.path, expectedPath, message);
 }
 
@@ -107,8 +111,16 @@ for (const page of visualWalkthroughConfig.pages) {
 	);
 	assert.equal(Boolean(page.title), true, `Expected registered page to have a title: ${page.id}`);
 	assert.equal(Boolean(page.group), true, `Expected registered page to have a group: ${page.id}`);
-	assert.equal(Boolean(page.designRisk?.risk), true, `Expected page to define a design risk: ${page.id}`);
-	assert.equal(Boolean(page.designRisk?.impact), true, `Expected page to define design risk impact: ${page.id}`);
+	assert.equal(
+		Boolean(page.designRisk?.risk),
+		true,
+		`Expected page to define a design risk: ${page.id}`
+	);
+	assert.equal(
+		Boolean(page.designRisk?.impact),
+		true,
+		`Expected page to define design risk impact: ${page.id}`
+	);
 	assert.equal(
 		Boolean(page.designRisk?.recommendedChange),
 		true,

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -1,6 +1,11 @@
 /* eslint-env node */
 
 import {
+	operationalDefaultState,
+	operationalDesignRisks,
+	operationalPaths,
+} from './visual-walkthrough.operational-fixtures.mjs';
+import {
 	participantConsentDefaultState,
 	participantConsentVisualStates,
 } from './visual-walkthrough.participant-consent-states.mjs';
@@ -171,6 +176,7 @@ export const visualWalkthroughConfig = {
 			group: 'Core',
 			path: '/',
 			description: 'ResearchOps landing page.',
+			designRisk: operationalDesignRisks.home,
 		},
 		{
 			id: 'start',
@@ -178,6 +184,7 @@ export const visualWalkthroughConfig = {
 			group: 'Core',
 			path: '/pages/start/index.html',
 			description: 'Start page for creating or beginning research project work.',
+			designRisk: operationalDesignRisks.start,
 			states: [
 				{
 					id: 'step-1-filled',
@@ -273,6 +280,7 @@ export const visualWalkthroughConfig = {
 			group: 'Projects',
 			path: '/pages/projects/index.html',
 			description: 'Project list page.',
+			designRisk: operationalDesignRisks.projects,
 		},
 		{
 			id: 'project-dashboard',
@@ -280,6 +288,14 @@ export const visualWalkthroughConfig = {
 			group: 'Projects',
 			path: '/pages/project-dashboard/index.html',
 			description: 'Project dashboard page.',
+			designRisk: operationalDesignRisks.projectDashboard,
+			defaultState: operationalDefaultState({
+				title: 'Project dashboard with operational project context',
+				description:
+					'Dashboard captured with a deterministic project ID, project metadata, linked stakeholders and study context.',
+				path: operationalPaths.projectDashboard,
+				waitForText: 'Assisted Digital Support Discovery',
+			}),
 		},
 		{
 			id: 'project-dashboard-add-study',
@@ -287,6 +303,14 @@ export const visualWalkthroughConfig = {
 			group: 'Projects',
 			path: '/pages/study/new/index.html',
 			description: 'Create a study from the project dashboard action workflow.',
+			designRisk: operationalDesignRisks.addStudy,
+			defaultState: operationalDefaultState({
+				title: 'Add study with parent project context',
+				description:
+					'Add-study workflow captured with the parent project ID present in the URL so project relationship and return routes can be reviewed.',
+				path: operationalPaths.addStudy,
+				waitForText: 'Add study',
+			}),
 		},
 		{
 			id: 'project-dashboard-add-participant',
@@ -294,6 +318,14 @@ export const visualWalkthroughConfig = {
 			group: 'Projects',
 			path: '/pages/project-dashboard/participants/index.html',
 			description: 'Add a study-linked participant from the project dashboard action workflow.',
+			designRisk: operationalDesignRisks.addParticipant,
+			defaultState: operationalDefaultState({
+				title: 'Add participant with parent project context',
+				description:
+					'Participant workflow captured with the project ID present so privacy copy, project ownership and study-linking context can be evaluated.',
+				path: operationalPaths.addParticipant,
+				waitForText: 'Add participant',
+			}),
 		},
 		{
 			id: 'project-dashboard-import-participants',
@@ -302,6 +334,14 @@ export const visualWalkthroughConfig = {
 			path: '/pages/project-dashboard/participants/import/index.html',
 			description:
 				'Import study-linked participants from CSV from the project dashboard action workflow.',
+			designRisk: operationalDesignRisks.importParticipants,
+			defaultState: operationalDefaultState({
+				title: 'Import participants with parent project context',
+				description:
+					'CSV import workflow captured with the project ID present so file-upload guidance, privacy warnings and bulk-error recovery can be reviewed.',
+				path: operationalPaths.importParticipants,
+				waitForText: 'Import participants',
+			}),
 		},
 		{
 			id: 'outcomes',
@@ -309,6 +349,14 @@ export const visualWalkthroughConfig = {
 			group: 'Projects',
 			path: '/pages/projects/outcomes/index.html',
 			description: 'Outcomes page for project-level findings and outputs.',
+			designRisk: operationalDesignRisks.outcomes,
+			defaultState: operationalDefaultState({
+				title: 'Project outcomes with project context',
+				description:
+					'Outcomes page captured with a deterministic project ID so traceability from evidence to recommendations can be evaluated.',
+				path: operationalPaths.outcomes,
+				waitForText: 'Project outcomes',
+			}),
 		},
 		{
 			id: 'journals',
@@ -316,6 +364,14 @@ export const visualWalkthroughConfig = {
 			group: 'Projects',
 			path: '/pages/projects/journals/index.html',
 			description: 'Reflexive journal page.',
+			designRisk: operationalDesignRisks.journals,
+			defaultState: operationalDefaultState({
+				title: 'Project journals with project context',
+				description:
+					'Reflexive journal page captured with project context so assumptions, decisions and researcher influence can be reviewed against project work.',
+				path: operationalPaths.journals,
+				waitForText: 'Project journals',
+			}),
 		},
 		{
 			id: 'study',
@@ -323,6 +379,14 @@ export const visualWalkthroughConfig = {
 			group: 'Study',
 			path: '/pages/study/index.html',
 			description: 'Study overview and readiness controls.',
+			designRisk: operationalDesignRisks.study,
+			defaultState: operationalDefaultState({
+				title: 'Study overview with readiness context',
+				description:
+					'Study overview captured with project and study IDs, participants, guides, consent forms and consent records present.',
+				path: operationalPaths.study,
+				waitForText: 'Assisted digital support interview round 1',
+			}),
 		},
 		{
 			id: 'study-guides',
@@ -330,6 +394,14 @@ export const visualWalkthroughConfig = {
 			group: 'Study',
 			path: '/pages/study/guides/index.html',
 			description: 'Discussion guide list and editor page.',
+			designRisk: operationalDesignRisks.studyGuides,
+			defaultState: operationalDefaultState({
+				title: 'Discussion guides with study context',
+				description:
+					'Discussion guides page captured with project and study IDs so list, editor and publication context can be reviewed.',
+				path: operationalPaths.studyGuides,
+				waitForText: 'Discussion guides',
+			}),
 		},
 		{
 			id: 'study-participants',
@@ -337,6 +409,14 @@ export const visualWalkthroughConfig = {
 			group: 'Study',
 			path: '/pages/study/participants/index.html',
 			description: 'Participants page for a study.',
+			designRisk: operationalDesignRisks.studyParticipants,
+			defaultState: operationalDefaultState({
+				title: 'Study participants with participant records',
+				description:
+					'Participants page captured with study-scoped participant records so recruitment, scheduling and consent readiness can be reviewed.',
+				path: operationalPaths.studyParticipants,
+				waitForText: 'Participants',
+			}),
 		},
 		{
 			id: 'study-session',
@@ -344,6 +424,14 @@ export const visualWalkthroughConfig = {
 			group: 'Study',
 			path: '/pages/study/session/index.html',
 			description: 'Session running and note capture page.',
+			designRisk: operationalDesignRisks.studySession,
+			defaultState: operationalDefaultState({
+				title: 'Study session with project and study context',
+				description:
+					'Session workspace captured with project and study IDs so participant, consent and note-capture readiness can be reviewed.',
+				path: operationalPaths.studySession,
+				waitForText: 'Study session',
+			}),
 		},
 		{
 			id: 'study-consent-forms',
@@ -351,6 +439,14 @@ export const visualWalkthroughConfig = {
 			group: 'Study',
 			path: '/pages/study/consent-forms/index.html',
 			description: 'Study-specific consent form configuration page.',
+			designRisk: operationalDesignRisks.studyConsentForms,
+			defaultState: operationalDefaultState({
+				title: 'Study consent forms with study context',
+				description:
+					'Consent form configuration captured with project and study IDs so publishing state and consent wording can be reviewed.',
+				path: operationalPaths.studyConsentForms,
+				waitForText: 'Consent forms',
+			}),
 		},
 		{
 			id: 'study-participant-consent',
@@ -358,6 +454,7 @@ export const visualWalkthroughConfig = {
 			group: 'Study',
 			path: '/pages/study/participant-consent/index.html',
 			description: 'Study-scoped participant consent recording and review page.',
+			designRisk: operationalDesignRisks.participantConsent,
 			defaultState: participantConsentDefaultState,
 			states: participantConsentVisualStates,
 		},
@@ -367,6 +464,7 @@ export const visualWalkthroughConfig = {
 			group: 'Utilities',
 			path: '/pages/search/index.html',
 			description: 'Search page.',
+			designRisk: operationalDesignRisks.search,
 		},
 		{
 			id: 'notes',
@@ -374,6 +472,7 @@ export const visualWalkthroughConfig = {
 			group: 'Utilities',
 			path: '/pages/notes/index.html',
 			description: 'Notes page.',
+			designRisk: operationalDesignRisks.notes,
 		},
 		{
 			id: 'consent',
@@ -381,6 +480,7 @@ export const visualWalkthroughConfig = {
 			group: 'Utilities',
 			path: '/pages/consent/index.html',
 			description: 'Consent page.',
+			designRisk: operationalDesignRisks.consent,
 		},
 		{
 			id: 'sessions',
@@ -388,6 +488,7 @@ export const visualWalkthroughConfig = {
 			group: 'Utilities',
 			path: '/pages/sessions/index.html',
 			description: 'Sessions list page.',
+			designRisk: operationalDesignRisks.sessions,
 		},
 		{
 			id: 'synthesize',
@@ -395,6 +496,7 @@ export const visualWalkthroughConfig = {
 			group: 'Analysis',
 			path: '/pages/synthesize/index.html',
 			description: 'Synthesis page.',
+			designRisk: operationalDesignRisks.synthesize,
 		},
 	],
 };

--- a/visual-walkthrough.operational-fixtures.mjs
+++ b/visual-walkthrough.operational-fixtures.mjs
@@ -1,0 +1,348 @@
+/* eslint-env node */
+
+/**
+ * @file visual-walkthrough.operational-fixtures.mjs
+ * @summary Deterministic operational context for visual walkthrough states that need project or study scope.
+ */
+
+export const operationalProjectId = 'recVisualProject001';
+export const operationalStudyId = 'recVisualStudy001';
+export const operationalParticipantId = 'recVisualParticipant001';
+
+export const operationalPaths = {
+	projectDashboard: `/pages/project-dashboard/?id=${operationalProjectId}`,
+	addStudy: `/pages/study/new/?pid=${operationalProjectId}`,
+	addParticipant: `/pages/project-dashboard/participants/?id=${operationalProjectId}`,
+	importParticipants: `/pages/project-dashboard/participants/import/?id=${operationalProjectId}`,
+	outcomes: `/pages/projects/outcomes/?id=${operationalProjectId}`,
+	journals: `/pages/projects/journals/?id=${operationalProjectId}`,
+	study: `/pages/study/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
+	studyGuides: `/pages/study/guides/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
+	studyParticipants: `/pages/study/participants/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
+	studySession: `/pages/study/session/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
+	studyConsentForms: `/pages/study/consent-forms/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
+};
+
+export const operationalProject = {
+	id: operationalProjectId,
+	LocalId: operationalProjectId,
+	localId: operationalProjectId,
+	name: 'Assisted Digital Support Discovery',
+	Name: 'Assisted Digital Support Discovery',
+	description:
+		'This discovery examines how caseworkers and support staff help people who cannot complete a digital application without assistance.',
+	Description:
+		'This discovery examines how caseworkers and support staff help people who cannot complete a digital application without assistance.',
+	Org: 'Home Office Biometrics',
+	org: 'Home Office Biometrics',
+	Phase: 'Discovery',
+	Status: 'Planning research',
+	'rops:servicePhase': 'Discovery',
+	'rops:projectStatus': 'Planning research',
+	objectives: [
+		'Understand where users need assisted digital support before, during and after the application journey.',
+		'Identify operational signals for accessibility, safeguarding, language support and confidence-related needs.',
+		'Assess whether content and contact routes help users decide what to do next.',
+	],
+	user_groups: [
+		'Applicants with low digital confidence',
+		'Support workers',
+		'Caseworkers',
+		'Users with accessibility needs',
+	],
+	stakeholders: [
+		{
+			name: 'Priya Shah',
+			role: 'Service owner',
+			email: 'priya.shah@example.gov.uk',
+		},
+		{
+			name: 'Mark Evans',
+			role: 'Operations lead',
+			email: 'mark.evans@example.gov.uk',
+		},
+	],
+	createdAt: '2026-04-21T09:30:00.000Z',
+	lead_researcher: 'Alex Morgan',
+	lead_researcher_email: 'alex.morgan@example.gov.uk',
+};
+
+export const operationalStudy = {
+	id: operationalStudyId,
+	studyId: 'STUDY-ADS-001',
+	projectId: operationalProjectId,
+	projectName: operationalProject.name,
+	title: 'Assisted digital support interview round 1',
+	Title: 'Assisted digital support interview round 1',
+	method: 'Moderated interview',
+	status: 'Planning',
+	description:
+		'Round 1 interviews exploring confidence, evidence expectations, assisted digital handoffs and support routes before users begin a high-stakes application.',
+	createdAt: '2026-04-24T10:00:00.000Z',
+};
+
+export const operationalParticipants = [
+	{
+		id: operationalParticipantId,
+		participantId: 'P-ADS-001',
+		studyId: operationalStudyId,
+		pseudonym: 'Participant A',
+		name: 'Participant A',
+		userType: 'Applicant with low digital confidence',
+		status: 'Scheduled',
+		consentStatus: 'Ready for session',
+		sessionDate: '2026-05-14',
+		sessionTime: '10:30',
+	},
+	{
+		id: 'recVisualParticipant002',
+		participantId: 'P-ADS-002',
+		studyId: operationalStudyId,
+		pseudonym: 'Participant B',
+		name: 'Participant B',
+		userType: 'Support worker',
+		status: 'Screening',
+		consentStatus: 'Consent outstanding',
+		sessionDate: '2026-05-16',
+		sessionTime: '14:00',
+	},
+];
+
+export const operationalGuides = [
+	{
+		id: 'recVisualGuide001',
+		studyId: operationalStudyId,
+		title: 'Assisted digital support discussion guide',
+		status: 'Published',
+		updatedAt: '2026-04-26T11:00:00.000Z',
+	},
+];
+
+export const operationalConsentForms = [
+	{
+		id: 'recVisualConsentForm001',
+		studyId: operationalStudyId,
+		title: 'Assisted digital support consent form',
+		status: 'Published',
+		statements: [
+			'I understand what the research is about.',
+			'I understand that taking part is voluntary.',
+			'I agree that anonymous notes may be used for synthesis.',
+		],
+	},
+];
+
+export const operationalParticipantConsentRecords = [
+	{
+		id: 'recVisualParticipantConsent001',
+		studyId: operationalStudyId,
+		participantId: operationalParticipantId,
+		status: 'Ready for session',
+		withdrawn: false,
+		updatedAt: '2026-05-01T09:45:00.000Z',
+	},
+];
+
+export const operationalSessions = [
+	{
+		id: 'recVisualSession001',
+		studyId: operationalStudyId,
+		participantId: operationalParticipantId,
+		startsAt: '2026-05-14T09:30:00.000Z',
+		status: 'Scheduled',
+		type: 'Remote',
+	},
+];
+
+export function operationalMockRoutes() {
+	return [
+		{
+			url: /\/api\/projects(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				projects: [operationalProject],
+			},
+		},
+		{
+			url: /\/api\/studies(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				studies: [operationalStudy],
+			},
+		},
+		{
+			url: /\/api\/participants(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				participants: operationalParticipants,
+			},
+		},
+		{
+			url: /\/api\/guides(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				guides: operationalGuides,
+			},
+		},
+		{
+			url: /\/api\/consent-forms(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				consentForms: operationalConsentForms,
+			},
+		},
+		{
+			url: /\/api\/participant-consent(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				participantConsentRecords: operationalParticipantConsentRecords,
+			},
+		},
+		{
+			url: /\/api\/sessions(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				sessions: operationalSessions,
+			},
+		},
+	];
+}
+
+export function operationalDefaultState({ title, description, path, waitForText }) {
+	const actions = waitForText
+		? [
+				{
+					type: 'waitForText',
+					text: waitForText,
+				},
+			]
+		: [];
+
+	return {
+		id: 'default',
+		title,
+		description,
+		path,
+		mockRoutes: operationalMockRoutes(),
+		actions,
+	};
+}
+
+function risk(riskText, impact, recommendedChange, owner = 'UCD team') {
+	return {
+		risk: riskText,
+		impact,
+		recommendedChange,
+		owner,
+		status: 'Needs UCD review',
+	};
+}
+
+export const operationalDesignRisks = {
+	home: risk(
+		'The landing page may look visually complete while failing to explain the safest route into research setup, evidence review or synthesis work.',
+		'User researchers could choose the wrong workflow, duplicate records or miss the intended evidence-to-insight traceability model.',
+		'Review the page against GOV.UK start-point conventions, link purpose, visible service identity and keyboard-accessible navigation.'
+	),
+	start: risk(
+		'The guided project setup could collect plausible project metadata without making privacy boundaries, required fields and AI-assistance disclosure clear enough.',
+		'Poor framing at project creation can create weak objectives, unsafe notes or project records that are difficult to use later.',
+		'Evaluate the journey against GOV.UK form, error-summary, hint, button and check-answers patterns before accepting the walkthrough state.'
+	),
+	projects: risk(
+		'The project list may not make project status, ownership and next actions clear enough for a user researcher returning to active work.',
+		'Users may open the wrong project or miss whether a project is ready for study, participant or synthesis activity.',
+		'Check that the list uses GOV.UK table/list conventions, meaningful link text, visible status language and realistic project records.'
+	),
+	projectDashboard: risk(
+		'The dashboard can appear operational while actions, study readiness and project context are not grounded in a real project ID.',
+		'Users may create studies, participants or outcomes against the wrong project or lose confidence in the platform state.',
+		'Capture this page with a deterministic project ID, linked studies and operational content, then review action routing and GOV.UK component use.'
+	),
+	addStudy: risk(
+		'The add-study workflow may not preserve the parent project context clearly enough through the form.',
+		'A study could be created without a traceable project relationship, weakening downstream planning and synthesis.',
+		'Validate the form with a project-scoped URL, clear heading context, GOV.UK form groups, accessible errors and a safe return route.'
+	),
+	addParticipant: risk(
+		'The participant workflow may invite participant data entry without enough study and project context.',
+		'Participant records could be attached to the wrong research activity or collect more personal data than the prototype stance allows.',
+		'Capture with a project-scoped URL and review labels, privacy copy, required-field errors and navigation back to the owning project.'
+	),
+	importParticipants: risk(
+		'The import workflow may make bulk participant upload look safer or more complete than it is.',
+		'Bulk upload mistakes can create consent, scheduling and data-minimisation risks at scale.',
+		'Review file-upload markup, CSV guidance, error recovery, privacy warnings and project context before treating the state as acceptable.'
+	),
+	outcomes: risk(
+		'Outcomes can be presented as conclusions without enough visible connection to evidence, insights and recommendations.',
+		'Teams may over-trust weak findings or lose the audit trail between evidence and delivery decisions.',
+		'Evaluate whether outcomes use GOV.UK summary/list patterns and make evidence provenance, status and next actions visible.'
+	),
+	journals: risk(
+		'Reflexive journal states may look like generic notes rather than a deliberate record of assumptions, decisions and researcher influence.',
+		'The team may miss bias, decision provenance or safeguarding reflections that should inform synthesis.',
+		'Review category labels, empty states, entry creation, privacy guidance and traceability back to project context.'
+	),
+	study: risk(
+		'The study overview may show readiness controls without enough realistic setup data to prove the session gate works.',
+		'Researchers could start sessions before guides, consent materials, participants or participant consent are ready.',
+		'Capture with project and study IDs, mocked readiness data and visible links to guides, participants, consent and synthesis.'
+	),
+	studyGuides: risk(
+		'Discussion guide management may not make draft, published and reusable guide states clear enough.',
+		'Inconsistent or unapproved guides can affect research quality and comparability across sessions.',
+		'Review editor/list structure, heading hierarchy, save/publish affordances and GOV.UK button/link treatment.'
+	),
+	studyParticipants: risk(
+		'The participants view may not distinguish recruitment, scheduling and consent readiness clearly.',
+		'Research teams may invite or schedule participants before consent or safeguarding requirements are understood.',
+		'Capture with study-scoped participant fixtures and review table/list semantics, status tags, filters and keyboard access.'
+	),
+	studySession: risk(
+		'The session workspace may imply that a session can start without clear participant, consent and study readiness context.',
+		'Unsafe session starts can create consent, safeguarding and evidence-quality risks.',
+		'Review session controls, timing, note structure, consent visibility and keyboard operation against GOV.UK and WCAG expectations.'
+	),
+	studyConsentForms: risk(
+		'Consent form configuration may not make publishing status, wording and participant comprehension clear enough.',
+		'Researchers may rely on incomplete consent statements before participant activity begins.',
+		'Review fieldsets, checkboxes, summary content, publication state and error handling using GOV.UK form patterns.'
+	),
+	participantConsent: risk(
+		'Participant consent screens may not separate setup blockers, participant selection and auditable consent recording clearly enough.',
+		'Research may proceed without clear, current and reviewable consent evidence.',
+		'Capture both blocker and ready states with deterministic study fixtures and review accessible status messaging.'
+	),
+	search: risk(
+		'Search may return visually plausible results without making scope, result type and relevance clear.',
+		'Users may treat weak or unrelated results as evidence for a project decision.',
+		'Review search input labelling, result summaries, empty states, keyboard access and provenance cues.'
+	),
+	notes: risk(
+		'Notes may be captured without enough context about session, study, source and later synthesis use.',
+		'Evidence can become hard to trace, compare or safely reuse.',
+		'Review note metadata, source context, privacy guidance, save feedback and accessible form behaviour.'
+	),
+	consent: risk(
+		'Generic consent information may not be clearly connected to the specific study and participant workflow.',
+		'Users may misunderstand what consent must be configured, recorded or reviewed before a session.',
+		'Review the content against informed consent, plain English, GOV.UK typography and accessible link behaviour.'
+	),
+	sessions: risk(
+		'Sessions may look schedulable without showing readiness, consent and follow-up obligations.',
+		'Research activity could be coordinated from incomplete or misleading operational data.',
+		'Review status language, date/time presentation, participant context, and links into the session workspace.'
+	),
+	synthesize: risk(
+		'Synthesis states may make clusters and themes look authoritative before evidence quantity, provenance and confidence are clear.',
+		'Insights and recommendations could be accepted without sufficient traceability to source evidence.',
+		'Review evidence grouping, theme creation, disabled states, provenance details and GOV.UK component conformance.'
+	),
+};

--- a/visual-walkthrough.operational-fixtures.mjs
+++ b/visual-walkthrough.operational-fixtures.mjs
@@ -164,6 +164,11 @@ export function operationalMockRoutes() {
 			},
 		},
 		{
+			url: /\/api\/projects\/[^/?]+(?:\?.*)?$/,
+			method: 'GET',
+			body: operationalProject,
+		},
+		{
 			url: /\/api\/studies(?:\?.*)?$/,
 			method: 'GET',
 			body: {


### PR DESCRIPTION
## Summary

This PR improves the reporting-site visual walkthrough evidence so it is more useful for reviewing the ResearchOps platform, rather than just proving that the reporting site can render screenshots.

Changes made:

- Added deterministic operational walkthrough fixtures for a project, study, participants, guides, consent forms, consent records and sessions.
- Updated project and study routes in the visual walkthrough registry so dashboard, add-study, add-participant, import-participants, outcomes, journals, study overview, guides, participants, session and consent-form captures use realistic project/study scope where appropriate.
- Reframed generated user-scoped Gherkin criteria around ResearchOps user journeys and operational tasks, rather than wording them as though the reporting-site state itself is the thing being evaluated.
- Added route-specific design-risk notes covering ResearchOps intent, GOV.UK Design System conformance, accessibility, UX, traceability, consent, privacy and evidence-quality risks.
- Extended registry tests so operationally scoped routes and non-generic design-risk notes are enforced.

## Validation

- Confirmed branch is based on current `main` and is ahead by 5 commits with no divergence.
- Updated the visual walkthrough registry contract tests to assert scoped operational routes and route-specific design-risk notes.

I could not run the npm test suite locally in this environment because the repository cannot be checked out from GitHub here. The PR should run the repository CI checks, including unit tests and the visual walkthrough workflow, as the source of truth.