### PR TITLE
Fix walkthrough wait text from current main

### DIFF
--- a/scripts/researchops-state-acceptance.mjs
+++ b/scripts/researchops-state-acceptance.mjs
@@ -184,6 +184,10 @@ function lowerFirst(value = '') {
 	return `${text.charAt(0).toLowerCase()}${text.slice(1)}`;
 }
 
+function sentenceFragment(value = '') {
+	return lowerFirst(normaliseText(value)).replace(/[.?!:;]+$/u, '');
+}
+
 function storyForPage(page = {}) {
 	return (
 		PAGE_STORIES[page.id] || {
@@ -275,9 +279,12 @@ export function buildStateAcceptanceGherkin(page = {}, state = {}, sourceState =
 	if (page.id === 'projects') return buildProjectsAcceptanceCriteriaFromSource();
 
 	const story = storyForPage(page);
-	const statePurpose = state.description
-		? truncateForGherkin(state.description, 220)
-		: `the ${lowerFirst(state.title || 'current view')}`;
+	const statePurpose = sentenceFragment(
+		state.description
+			? truncateForGherkin(state.description, 220)
+			: `the ${lowerFirst(state.title || 'current view')}`
+	);
+	const pagePurpose = sentenceFragment(page.description || story.want);
 	const sourceActions = Array.isArray(sourceState?.actions) ? sourceState.actions : [];
 
 	return [
@@ -292,12 +299,13 @@ export function buildStateAcceptanceGherkin(page = {}, state = {}, sourceState =
 		`    When I visit the ${story.context}`,
 		'',
 		'  Scenario: Understand the page purpose',
-		`    Then I should see content that supports ${lowerFirst(page.description || story.want)}`,
+		`    Then I should see content that supports ${pagePurpose}`,
 		'    And I should understand what ResearchOps task I can complete from this page',
 		'',
 		`  Scenario: Use "${quoteGherkin(state.title || 'Default view')}" in the ResearchOps journey`,
 		`    Given I am using the ${story.context}`,
-		`    Then I should understand how ${lowerFirst(statePurpose)} supports my research work`,
+		'    Then I should understand the research value of this part of the journey',
+		`    And I should see that ${statePurpose}`,
 		'    And I should be given enough service context to decide what to do next',
 		'',
 		...buildActionScenario(sourceActions).map((line) => `  ${line}`),

--- a/tests/cucumber-reporting.test.js
+++ b/tests/cucumber-reporting.test.js
@@ -177,7 +177,7 @@ test('buildStateAcceptanceGherkin derives user-centred criteria from state actio
 	assert.match(gherkin, /Feature: Synthesize research evidence/);
 	assert.match(gherkin, /When I enter "Confidence and support needs" into the "Theme label" field/);
 	assert.match(gherkin, /And I select "Create theme"/);
-	assert.match(gherkin, /Scenario: Use the state accessibly/);
+	assert.match(gherkin, /Scenario: Use this part of the journey accessibly/);
 	assert.doesNotMatch(gherkin, /Given the route/);
 });
 

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -355,7 +355,7 @@ export const visualWalkthroughConfig = {
 				description:
 					'Outcomes page captured with a deterministic project ID so traceability from evidence to recommendations can be evaluated.',
 				path: operationalPaths.outcomes,
-				waitForText: 'Project outcomes',
+				waitForText: 'Impact & ROI',
 			}),
 		},
 		{
@@ -370,7 +370,7 @@ export const visualWalkthroughConfig = {
 				description:
 					'Reflexive journal page captured with project context so assumptions, decisions and researcher influence can be reviewed against project work.',
 				path: operationalPaths.journals,
-				waitForText: 'Project journals',
+				waitForText: 'Reflexive Journal & Analysis',
 			}),
 		},
 		{
@@ -400,7 +400,7 @@ export const visualWalkthroughConfig = {
 				description:
 					'Discussion guides page captured with project and study IDs so list, editor and publication context can be reviewed.',
 				path: operationalPaths.studyGuides,
-				waitForText: 'Discussion guides',
+				waitForText: 'Guides for this study',
 			}),
 		},
 		{
@@ -430,7 +430,7 @@ export const visualWalkthroughConfig = {
 				description:
 					'Session workspace captured with project and study IDs so participant, consent and note-capture readiness can be reviewed.',
 				path: operationalPaths.studySession,
-				waitForText: 'Study session',
+				waitForText: 'Begin a session',
 			}),
 		},
 		{


### PR DESCRIPTION
## Summary

This PR corrects the visual-walkthrough wait text for scoped reporting-site states and fixes the unit-test failure from the generated Gherkin wording introduced after PR #183 was merged.

## PR state check

Before updating this work, I checked the repository PR state:

- PR #183 is closed and merged.
- PR #184 is open.
- Because PR #184 is open and covers the active corrective work, the additional fix has been committed to PR #184 instead of opening another PR.
- Current `main` includes merge commit `e3ca7a1a294ee469c0685c019411f43cb678233e`.

## Changes

### Visual walkthrough wait text

The failing walkthrough captures were waiting for labels that do not exist in the rendered pages. This updates the wait text to match the actual current page copy:

- `outcomes/default`: `Project outcomes` → `Impact & ROI`
- `journals/default`: `Project journals` → `Reflexive Journal & Analysis`
- `study-guides/default`: `Discussion guides` → `Guides for this study`
- `study-session/default`: `Study session` → `Begin a session`

### Generated Gherkin acceptance criteria

The release-gate log showed one blocking unit-test failure in `tests/cucumber-reporting.test.js`:

- old test expectation: `Scenario: Use the state accessibly`
- current journey-focused wording: `Scenario: Use this part of the journey accessibly`

This PR updates the unit test to assert the new journey-focused wording and refines the generated state-purpose sentence so it does not produce awkward text such as `A theme has been created from grouped evidence. supports my research work`.

## Validation

- Reviewed the supplied release-gate log.
- Confirmed the blocking failure was the single unit-test mismatch in `buildStateAcceptanceGherkin derives user-centred criteria from state actions for generic pages`.
- Confirmed PR #184 is open before committing the additional fix to its branch.
- Confirmed no new PR was opened for this correction.

Expected result: the release gate should no longer fail on the Gherkin scenario-title mismatch, and the visual walkthrough should no longer timeout on the four scoped states across desktop and mobile.