### PR TITLE
Add reporting review model for grouped criteria and design-risk notes

### DIFF
--- a/config/reporting-review-overrides.json
+++ b/config/reporting-review-overrides.json
@@ -1,0 +1,287 @@
+{
+  "groups": {
+    "start": {
+      "title": "Start research project",
+      "acceptanceStatus": "needs-review",
+      "designRiskStatus": "needs-review",
+      "acceptanceCriteria": [
+        "As a user researcher, I can start a new research project from a guided process that explains what information is needed before I commit anything.",
+        "I can provide the minimum viable project context, including name, purpose, expected research activity and governance context, without being forced into irrelevant fields.",
+        "I can review the information I have entered before creating the project so that incorrect research records are not created accidentally.",
+        "I can understand when AI-assisted wording has been suggested and I remain in control of whether it is used.",
+        "I can recover from missing or invalid information through GOV.UK-compatible validation messages, focus management and error summaries.",
+        "I can complete the journey using keyboard, screen reader, zoom and reflow without losing context or progress."
+      ],
+      "designRiskNotes": [
+        "The start-project journey is a commitment point for the ResearchOps evidence model. Weak context capture risks downstream ambiguity across studies, participants, analysis and reporting.",
+        "The guided process must preserve user control over AI-assisted copy. Suggestions should not become opaque defaults or create false confidence in project framing.",
+        "Validation should follow GOV.UK error-summary, field-level error and focus-management patterns. Failing this creates avoidable friction at the first high-value task in the service.",
+        "The journey should make the relationship between project, study and evidence traceability explicit enough for researchers to understand what they are creating."
+      ],
+      "states": {
+        "default": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can understand the purpose of the guided process before entering project information.",
+            "I can identify the first action and the expected level of detail needed to continue."
+          ],
+          "designRiskNotes": [
+            "The initial state should not overload the user before they understand the project record being created."
+          ]
+        },
+        "step-1-filled": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can see that the core project details I entered have been retained and are ready to support the next step.",
+            "I can continue without losing orientation in the guided process."
+          ],
+          "designRiskNotes": [
+            "The completed first step must make progress visible without implying that the full project context is already complete."
+          ]
+        },
+        "step-2-default": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can understand what additional research context is needed before I choose whether to use AI assistance.",
+            "I can proceed manually without being nudged into AI-supported wording."
+          ],
+          "designRiskNotes": [
+            "The state must avoid making AI assistance appear mandatory or more authoritative than researcher-authored context."
+          ]
+        },
+        "step-2-filled-no-ai": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can continue with researcher-authored project context without using AI-generated wording.",
+            "I can see that the service accepts manual input as a complete and valid path."
+          ],
+          "designRiskNotes": [
+            "Manual completion must remain a first-class journey so researchers are not indirectly coerced into AI use."
+          ]
+        },
+        "step-2-ai-rewrite-shown": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can distinguish AI-suggested text from my original wording before deciding whether to use it.",
+            "I can reject, amend or ignore the suggestion without losing my original project context."
+          ],
+          "designRiskNotes": [
+            "AI-suggested wording creates provenance and accountability risk unless the suggestion is clearly attributable and under user control."
+          ]
+        },
+        "step-3-default": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can understand what governance, delivery or research-planning information is needed at this stage.",
+            "I can provide the information without needing knowledge of internal data structures."
+          ],
+          "designRiskNotes": [
+            "The form should not expose implementation concepts that are meaningful to Airtable or APIs but not to user researchers."
+          ]
+        },
+        "step-3-filled": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can see the information entered for this step and understand that it will be included in the project record.",
+            "I can continue toward review without losing the ability to correct earlier answers."
+          ],
+          "designRiskNotes": [
+            "Progressive disclosure must keep correction routes available because project setup mistakes propagate into later ResearchOps journeys."
+          ]
+        },
+        "step-4-check-answers": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can check the full project information before creating the project.",
+            "I can identify and correct inaccurate answers before submission."
+          ],
+          "designRiskNotes": [
+            "The check-answers state is the final safeguard against creating weak or incorrect project records. It should follow GOV.UK summary-list and change-link conventions."
+          ]
+        }
+      }
+    },
+    "participant-consent": {
+      "title": "Participant consent",
+      "acceptanceStatus": "needs-review",
+      "designRiskStatus": "needs-review",
+      "acceptanceCriteria": [
+        "As a user researcher, I can capture or review participant consent within the correct project and study context.",
+        "I can distinguish missing project, study, participant and published-consent-form conditions from valid consent capture states.",
+        "I can select a participant and understand which consent items apply before recording or reviewing consent.",
+        "I can recover from missing context through clear GOV.UK-compatible error messaging rather than silent failure.",
+        "I can use the journey accessibly, with labels, grouped controls, focus order and validation semantics exposed correctly.",
+        "I can trust that consent records remain tied to the correct participant, study and consent form."
+      ],
+      "designRiskNotes": [
+        "Participant consent is a high-trust research governance activity. Ambiguity about participant, study or consent-form context creates ethical, operational and evidence-integrity risk.",
+        "The journey must avoid presenting an empty state as a successful state. Missing participants, missing forms and missing IDs need different recovery paths.",
+        "Consent options must be semantically grouped and labelled so assistive technology users understand the scope and consequence of each choice.",
+        "The reporting walkthrough should show realistic consent states, not generic screenshots, so reviewers can assess whether the service supports ethical consent practice."
+      ],
+      "states": {
+        "default": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can see the participant consent journey in a valid project and study context.",
+            "I can identify the next action needed to review or capture consent."
+          ],
+          "designRiskNotes": [
+            "The default state must make the selected study context visible enough to prevent accidental consent capture against the wrong study."
+          ]
+        },
+        "missing-context-error": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I am told when the service cannot continue because project or study context is missing.",
+            "I am given a clear recovery route rather than an empty or broken consent screen."
+          ],
+          "designRiskNotes": [
+            "Missing-context states should be treated as controlled error states. They should not resemble valid empty states."
+          ]
+        },
+        "no-published-consent-form": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can understand that participant consent cannot be captured until a consent form is published for the study.",
+            "I can identify what needs to happen next to make the journey usable."
+          ],
+          "designRiskNotes": [
+            "Capturing consent without a published consent form would weaken consent provenance. The blocked state should be explicit and actionable."
+          ]
+        },
+        "no-participants": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can understand that there are no eligible participants available for consent capture.",
+            "I can identify how to add or schedule participants before returning to consent capture."
+          ],
+          "designRiskNotes": [
+            "The state should distinguish between no participant records and a participant-loading failure to avoid incorrect operational decisions."
+          ]
+        },
+        "participant-selected": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can see which participant is selected before reviewing or recording consent.",
+            "I can understand the consent options that apply to that participant and study."
+          ],
+          "designRiskNotes": [
+            "The selected-participant state carries the highest risk of misattribution. Participant identity, pseudonym and consent scope must be unambiguous."
+          ]
+        }
+      }
+    },
+    "analysis": {
+      "title": "Analysis",
+      "acceptanceStatus": "needs-review",
+      "designRiskStatus": "needs-review",
+      "acceptanceCriteria": [
+        "As a user researcher, I can synthesize research evidence within a specific study context.",
+        "I can see when evidence is missing, loaded, grouped into a working cluster, added to a cluster, blocked from theme creation or converted into a theme.",
+        "I can maintain traceability between source evidence, clusters, themes, insights and recommendations.",
+        "I can recover from blocked states without losing evidence selections or misunderstanding why the action is unavailable.",
+        "I can use the analysis workflow accessibly with keyboard-operable controls, clear headings, clear labels and meaningful status updates.",
+        "I can trust that the synthesis UI supports research judgement rather than hiding analytical decisions behind automation."
+      ],
+      "designRiskNotes": [
+        "The analysis journey is central to ResearchOps traceability. If the UI weakens the evidence-to-theme chain, the service can produce recommendations that appear stronger than the underlying evidence supports.",
+        "Blocked theme creation, empty evidence and missing study context are materially different analytical states and should not be collapsed into generic errors.",
+        "The interface must support human analytical judgement and should avoid suggesting that clustering or theme creation is mechanically correct by default.",
+        "Accessibility risks are higher in synthesis workflows because multi-step selection, grouping and status changes can be hard to perceive without robust semantic feedback."
+      ],
+      "states": {
+        "missing-sid-error": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I am told when study context is missing and synthesis cannot start.",
+            "I can recover by returning to a valid study context."
+          ],
+          "designRiskNotes": [
+            "This state should remain an explicit error state and should not be included in the concern about scoped operational screenshots."
+          ]
+        },
+        "empty-evidence": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can understand that no evidence is currently available for synthesis in this study.",
+            "I can identify what needs to happen before themes or recommendations can be produced."
+          ],
+          "designRiskNotes": [
+            "The empty-evidence state must not imply that analysis is complete or that absence of evidence is itself an insight."
+          ]
+        },
+        "evidence-loaded": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can review loaded evidence before grouping it.",
+            "I can understand enough source context to make a defensible analytical decision."
+          ],
+          "designRiskNotes": [
+            "Loaded evidence should preserve provenance cues. Removing source context makes later themes harder to audit."
+          ]
+        },
+        "working-cluster-created": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can see that a working cluster has been created before it becomes a theme.",
+            "I can continue refining the cluster rather than treating it as a finished insight."
+          ],
+          "designRiskNotes": [
+            "Working clusters are provisional. The UI should avoid presenting them with the same authority as validated themes."
+          ]
+        },
+        "evidence-added-to-cluster": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can see that selected evidence has been added to the working cluster.",
+            "I can understand how the added evidence changes the analytical grouping."
+          ],
+          "designRiskNotes": [
+            "The state should make evidence movement auditable so that cluster membership can be challenged or corrected later."
+          ]
+        },
+        "theme-blocked-without-evidence": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I am prevented from creating a theme without supporting evidence.",
+            "I can understand why the action is blocked and what evidence action is needed next."
+          ],
+          "designRiskNotes": [
+            "Blocking unsupported theme creation is a core evidence-integrity safeguard. The recovery route should be explicit and keyboard accessible."
+          ]
+        },
+        "theme-created": {
+          "acceptanceStatus": "needs-review",
+          "designRiskStatus": "needs-review",
+          "acceptanceCriteria": [
+            "I can see that a theme has been created from grouped evidence.",
+            "I can understand how that theme remains connected to its source evidence."
+          ],
+          "designRiskNotes": [
+            "The created-theme state must show enough provenance to stop themes becoming detached claims."
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/devops/reporting-review-content-recovery.md
+++ b/docs/devops/reporting-review-content-recovery.md
@@ -1,0 +1,117 @@
+# Reporting review content recovery
+
+This note records the evidence recovered from the generated visual walkthrough report before changing the reporting review model.
+
+## Evidence source
+
+The recovery source is the generated PDF export supplied during review:
+
+```text
+ResearchOps application visual walkthrough.pdf
+Generated: 2026-05-05T17:41:16.070Z
+Base URL: https://researchops.pages.dev/
+Coverage: 20 pages, 37 states, 74 screenshots, 0 failures
+```
+
+The PDF contains the rendered reporting-site content, including route-level Gherkin acceptance criteria, state cards, design-risk notes and screenshot evidence. It should be treated as the recovery source for the current report state when the live reporting site is not accessible from automation or tooling.
+
+## Recovery status
+
+| Area | Gherkin recovered | Design-risk recovered | Notes |
+| --- | --- | --- | --- |
+| Home | Yes | Yes | Bespoke route-level criteria and design-risk notes are present in the default state. |
+| Start research project | Yes | Yes | Full route-level criteria are present in the default state. The same design-risk note is repeated across step states. |
+| Projects | Yes | Yes | Full route-level criteria and page-level design-risk notes are present. |
+| Project dashboard | Yes | Yes | Criteria are generic and state-derived, but operational project context is present. |
+| Add study | No route-level Gherkin visible in the recovered text | Yes | Design-risk note is present for parent-project context. |
+| Add participant | Yes | Yes | Criteria are generic and state-derived. |
+| Import participants | Yes | Yes | Criteria are generic and state-derived. |
+| Project outcomes | Yes | Yes | Criteria are generic and state-derived. |
+| Project journals | Yes | Yes | Criteria are generic and state-derived. |
+| Study overview | Yes | Yes | Criteria are generic and state-derived. |
+| Discussion guides | Yes | Yes | Criteria are generic and state-derived. |
+| Participants | Yes | Yes | Criteria are generic and state-derived. |
+| Study session | Yes | Yes | Criteria are generic and state-derived. |
+| Study consent forms | Yes | Yes | Criteria are generic and state-derived. |
+| Participant consent | Yes | Yes | Full route-level criteria are present in the loaded state. The same design-risk note is repeated across blocker and selected-participant states. |
+| Search | Yes | Yes | Criteria are generic and state-derived. |
+| Notes | Yes | Yes | Criteria are generic and state-derived. |
+| Consent | Yes | Yes | Criteria are generic and state-derived. |
+| Sessions | Yes | Yes | Criteria are generic and state-derived. |
+| Study synthesis / Analysis | Yes | Yes | Full route-level criteria are present for the missing-study-ID state. The same design-risk note is repeated across the synthesis states. |
+
+## Duplicated content observed
+
+### Start research project
+
+The recovered report places the full `Feature: Start a new research project` criteria in the default state. Later states then repeat the same design-risk note rather than supplying state-specific risk evaluation.
+
+Repeated design-risk note:
+
+```text
+Design risk: The guided project setup could collect plausible project metadata without making privacy boundaries, required fields and AI-assistance disclosure clear enough.
+Impact: Poor framing at project creation can create weak objectives, unsafe notes or project records that are difficult to use later.
+Recommended change: Evaluate the journey against GOV.UK form, error-summary, hint, button and check-answers patterns before accepting the walkthrough state.
+Owner: UCD team
+Status: Needs UCD review
+```
+
+The group-level model should hold the journey-level criteria and this journey-level risk once. State-level records should only describe the relevant scenario, for example step 1 completed, AI rewrite shown, or check answers.
+
+### Participant consent
+
+The recovered report places the full `Feature: Record participant consent` criteria in the loaded consent workspace state. The same design-risk note is repeated across missing-context, no-published-consent-form, no-participants and participant-selected states.
+
+Repeated design-risk note:
+
+```text
+Design risk: Participant consent screens may not separate setup blockers, participant selection and auditable consent recording clearly enough.
+Impact: Research may proceed without clear, current and reviewable consent evidence.
+Recommended change: Capture both blocker and ready states with deterministic study fixtures and review accessible status messaging.
+Owner: UCD team
+Status: Needs UCD review
+```
+
+The group-level model should hold the consent journey criteria and shared ethical risk once. State-level records should describe specific blockers and recovery paths.
+
+### Study synthesis / Analysis
+
+The recovered report places `Feature: Synthesize research evidence` criteria in the missing-study-ID state. The same design-risk note is repeated across empty evidence, evidence available, working cluster, evidence added, theme blocked and theme-created states.
+
+Repeated design-risk note:
+
+```text
+Design risk: Synthesis states may make clusters and themes look authoritative before evidence quantity, provenance and confidence are clear.
+Impact: Insights and recommendations could be accepted without sufficient traceability to source evidence.
+Recommended change: Review evidence grouping, theme creation, disabled states, provenance details and GOV.UK component conformance.
+Owner: UCD team
+Status: Needs UCD review
+```
+
+The group-level model should hold synthesis journey criteria and shared evidence-integrity risk once. State-level records should focus on the particular analytical state: empty evidence, evidence loaded, working cluster, evidence added, blocked theme creation or theme created.
+
+## Implementation implication
+
+The reporting review model must not treat the generated report HTML as the source of truth for manual review decisions.
+
+The corrected approach is:
+
+1. Preserve recovered group-level Gherkin and design-risk content as the starting evidence.
+2. Move repeated journey-level content to the group level.
+3. Keep state-level content specific to the screenshot state.
+4. Persist manual edits and status changes in the repository, not in generated HTML.
+5. Render review statuses from repo-backed data so `Needs review`, `Approved`, `Rejected`, `Draft` and `Superseded` are controlled through PR review.
+6. Validate that group-level content is not copied into state-level records.
+
+## Reporting obligation for future iterations
+
+When generating or changing the reporting model, the PR must state:
+
+- whether live reporting-site content was fetched successfully;
+- whether repository `reports-site` content was used as a fallback;
+- whether an uploaded report export was used as recovery evidence;
+- which sections were recovered exactly;
+- which sections were rewritten or seeded;
+- which tests were run.
+
+This prevents the review model from drifting into plausible but unevidenced acceptance criteria or design-risk notes.

--- a/docs/devops/reporting-review-model.md
+++ b/docs/devops/reporting-review-model.md
@@ -1,0 +1,66 @@
+# Reporting review model
+
+The visual walkthrough reporting site separates review evidence into two levels.
+
+## Group-level review evidence
+
+Use group-level review evidence for the acceptance criteria and design-risk notes that apply to the whole journey area.
+
+Examples:
+
+- `start`: the full guided process for starting a research project.
+- `participant-consent`: all states involved in consent capture and recovery.
+- `analysis`: evidence loading, grouping, clustering, theme creation and blocked analysis states.
+
+Group-level content should explain the whole ResearchOps user need, the expected GOV.UK Design System and accessibility behaviour, and the service risk being evaluated.
+
+## State-level review evidence
+
+Use state-level review evidence only for what is specific to that screen state.
+
+State-level content must not duplicate the group-level acceptance criteria or design-risk notes. It should describe the scenario shown by the screenshot, such as a missing-context error, a participant-selected state, or a blocked theme-creation state.
+
+## Status values
+
+The supported review statuses are:
+
+- `draft`
+- `needs-review`
+- `approved`
+- `rejected`
+- `superseded`
+
+These statuses are deliberately repo-backed. They should be changed in `config/reporting-review-overrides.json`, reviewed through a PR, and then picked up by the next report generation.
+
+## Manual editing approach
+
+Do not make generated report HTML the source of truth.
+
+Generated reports can expose review state and make it easier to identify weak criteria, but persistent edits should live in the repository. This keeps review history auditable, avoids browser-only changes being lost, and keeps the generated report reproducible.
+
+The current source of truth for manual review overrides is:
+
+```text
+config/reporting-review-overrides.json
+```
+
+The utility module that normalises, merges and validates review content is:
+
+```text
+scripts/reporting-review-model.mjs
+```
+
+The model supports a generated base review model plus repo-backed overrides. Overrides can change titles, acceptance criteria, design-risk notes and statuses at either group or state level.
+
+## Duplication rule
+
+Group-level acceptance criteria and design-risk notes should not be copied into each state.
+
+The validation utility flags:
+
+- `duplicated-group-acceptance-criteria`
+- `duplicated-group-design-risk-notes`
+- `missing-group-acceptance-criteria`
+- `missing-group-design-risk-notes`
+
+This is intended to prevent the Start research project, Participant consent and Analysis sections from repeating the same evidence across every screenshot state.

--- a/scripts/reporting-review-model.mjs
+++ b/scripts/reporting-review-model.mjs
@@ -1,0 +1,262 @@
+const REVIEW_STATUS_VALUES = new Set([
+  'draft',
+  'needs-review',
+  'approved',
+  'rejected',
+  'superseded',
+]);
+
+export const REVIEW_STATUSES = Object.freeze([...REVIEW_STATUS_VALUES]);
+
+function clonePlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return { ...value };
+}
+
+export function normaliseReviewStatus(value, fallback = 'needs-review') {
+  if (REVIEW_STATUS_VALUES.has(value)) {
+    return value;
+  }
+
+  if (REVIEW_STATUS_VALUES.has(fallback)) {
+    return fallback;
+  }
+
+  return 'needs-review';
+}
+
+export function normaliseReviewText(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => String(item || '').trim())
+      .filter(Boolean);
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function normaliseStateReview(stateId, stateReview = {}, groupReview = {}) {
+  const review = clonePlainObject(stateReview);
+
+  return {
+    id: stateId,
+    title: review.title || stateId,
+    acceptanceCriteria: normaliseReviewText(review.acceptanceCriteria),
+    acceptanceStatus: normaliseReviewStatus(
+      review.acceptanceStatus || review.gherkinStatus,
+      groupReview.acceptanceStatus,
+    ),
+    designRiskNotes: normaliseReviewText(review.designRiskNotes),
+    designRiskStatus: normaliseReviewStatus(
+      review.designRiskStatus,
+      groupReview.designRiskStatus,
+    ),
+  };
+}
+
+function normaliseGroupReview(groupId, groupReview = {}) {
+  const review = clonePlainObject(groupReview);
+  const states = clonePlainObject(review.states);
+  const acceptanceStatus = normaliseReviewStatus(
+    review.acceptanceStatus || review.gherkinStatus,
+  );
+  const designRiskStatus = normaliseReviewStatus(review.designRiskStatus);
+
+  return {
+    id: groupId,
+    title: review.title || groupId,
+    acceptanceCriteria: normaliseReviewText(review.acceptanceCriteria),
+    acceptanceStatus,
+    designRiskNotes: normaliseReviewText(review.designRiskNotes),
+    designRiskStatus,
+    states: Object.fromEntries(
+      Object.entries(states).map(([stateId, stateReview]) => [
+        stateId,
+        normaliseStateReview(stateId, stateReview, {
+          acceptanceStatus,
+          designRiskStatus,
+        }),
+      ]),
+    ),
+  };
+}
+
+function mergeReviewText(baseValue, overrideValue) {
+  const overrideText = normaliseReviewText(overrideValue);
+
+  if (overrideText.length > 0) {
+    return overrideText;
+  }
+
+  return normaliseReviewText(baseValue);
+}
+
+function mergeStateReview(baseState, overrideState = {}, groupReview = {}) {
+  const base = normaliseStateReview(baseState.id, baseState, groupReview);
+  const override = clonePlainObject(overrideState);
+
+  return {
+    ...base,
+    title: override.title || base.title,
+    acceptanceCriteria: mergeReviewText(
+      base.acceptanceCriteria,
+      override.acceptanceCriteria,
+    ),
+    acceptanceStatus: normaliseReviewStatus(
+      override.acceptanceStatus || override.gherkinStatus,
+      base.acceptanceStatus,
+    ),
+    designRiskNotes: mergeReviewText(
+      base.designRiskNotes,
+      override.designRiskNotes,
+    ),
+    designRiskStatus: normaliseReviewStatus(
+      override.designRiskStatus,
+      base.designRiskStatus,
+    ),
+  };
+}
+
+function mergeGroupReview(baseGroup, overrideGroup = {}) {
+  const base = normaliseGroupReview(baseGroup.id, baseGroup);
+  const override = clonePlainObject(overrideGroup);
+  const overrideStates = clonePlainObject(override.states);
+  const stateIds = new Set([
+    ...Object.keys(base.states),
+    ...Object.keys(overrideStates),
+  ]);
+  const acceptanceStatus = normaliseReviewStatus(
+    override.acceptanceStatus || override.gherkinStatus,
+    base.acceptanceStatus,
+  );
+  const designRiskStatus = normaliseReviewStatus(
+    override.designRiskStatus,
+    base.designRiskStatus,
+  );
+
+  const group = {
+    ...base,
+    title: override.title || base.title,
+    acceptanceCriteria: mergeReviewText(
+      base.acceptanceCriteria,
+      override.acceptanceCriteria,
+    ),
+    acceptanceStatus,
+    designRiskNotes: mergeReviewText(base.designRiskNotes, override.designRiskNotes),
+    designRiskStatus,
+    states: {},
+  };
+
+  for (const stateId of stateIds) {
+    const baseState = base.states[stateId] || { id: stateId, title: stateId };
+
+    group.states[stateId] = mergeStateReview(baseState, overrideStates[stateId], {
+      acceptanceStatus,
+      designRiskStatus,
+    });
+  }
+
+  return group;
+}
+
+export function buildReportingReviewModel(baseReview = {}, overrides = {}) {
+  const baseGroups = clonePlainObject(baseReview.groups || baseReview);
+  const overrideGroups = clonePlainObject(overrides.groups || overrides);
+  const groupIds = new Set([
+    ...Object.keys(baseGroups),
+    ...Object.keys(overrideGroups),
+  ]);
+
+  return {
+    groups: Object.fromEntries(
+      [...groupIds].map((groupId) => [
+        groupId,
+        mergeGroupReview(
+          { id: groupId, ...clonePlainObject(baseGroups[groupId]) },
+          overrideGroups[groupId],
+        ),
+      ]),
+    ),
+  };
+}
+
+function sameReviewText(left, right) {
+  const leftText = normaliseReviewText(left).join('\n');
+  const rightText = normaliseReviewText(right).join('\n');
+
+  return leftText.length > 0 && leftText === rightText;
+}
+
+export function validateReportingReviewModel(model = {}) {
+  const reviewModel = buildReportingReviewModel(model);
+  const issues = [];
+
+  for (const group of Object.values(reviewModel.groups)) {
+    if (group.acceptanceCriteria.length === 0) {
+      issues.push({
+        code: 'missing-group-acceptance-criteria',
+        groupId: group.id,
+      });
+    }
+
+    if (group.designRiskNotes.length === 0) {
+      issues.push({
+        code: 'missing-group-design-risk-notes',
+        groupId: group.id,
+      });
+    }
+
+    for (const state of Object.values(group.states)) {
+      if (sameReviewText(group.acceptanceCriteria, state.acceptanceCriteria)) {
+        issues.push({
+          code: 'duplicated-group-acceptance-criteria',
+          groupId: group.id,
+          stateId: state.id,
+        });
+      }
+
+      if (sameReviewText(group.designRiskNotes, state.designRiskNotes)) {
+        issues.push({
+          code: 'duplicated-group-design-risk-notes',
+          groupId: group.id,
+          stateId: state.id,
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function summariseReportingReviewModel(model = {}) {
+  const reviewModel = buildReportingReviewModel(model);
+  const summary = {
+    groups: 0,
+    states: 0,
+    statuses: Object.fromEntries(REVIEW_STATUSES.map((status) => [status, 0])),
+  };
+
+  for (const group of Object.values(reviewModel.groups)) {
+    summary.groups += 1;
+    summary.statuses[group.acceptanceStatus] += 1;
+    summary.statuses[group.designRiskStatus] += 1;
+
+    for (const state of Object.values(group.states)) {
+      summary.states += 1;
+      summary.statuses[state.acceptanceStatus] += 1;
+      summary.statuses[state.designRiskStatus] += 1;
+    }
+  }
+
+  return summary;
+}

--- a/tests/reporting-review-model.test.js
+++ b/tests/reporting-review-model.test.js
@@ -2,150 +2,132 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  buildReportingReviewModel,
-  normaliseReviewStatus,
-  summariseReportingReviewModel,
-  validateReportingReviewModel,
+	buildReportingReviewModel,
+	normaliseReviewStatus,
+	summariseReportingReviewModel,
+	validateReportingReviewModel,
 } from '../scripts/reporting-review-model.mjs';
 
 test('buildReportingReviewModel keeps group criteria separate from state criteria', () => {
-  const model = buildReportingReviewModel({
-    groups: {
-      start: {
-        title: 'Start research project',
-        acceptanceCriteria: [
-          'As a user researcher, I can start a project using a guided process.',
-        ],
-        designRiskNotes: [
-          'Project setup errors create downstream traceability risk.',
-        ],
-        states: {
-          'step-1-filled': {
-            acceptanceCriteria: [
-              'I can see the project details I entered have been retained.',
-            ],
-            designRiskNotes: [
-              'The completed first step must make progress visible.',
-            ],
-          },
-        },
-      },
-    },
-  });
+	const model = buildReportingReviewModel({
+		groups: {
+			start: {
+				title: 'Start research project',
+				acceptanceCriteria: ['As a user researcher, I can start a project using a guided process.'],
+				designRiskNotes: ['Project setup errors create downstream traceability risk.'],
+				states: {
+					'step-1-filled': {
+						acceptanceCriteria: ['I can see the project details I entered have been retained.'],
+						designRiskNotes: ['The completed first step must make progress visible.'],
+					},
+				},
+			},
+		},
+	});
 
-  assert.deepEqual(model.groups.start.acceptanceCriteria, [
-    'As a user researcher, I can start a project using a guided process.',
-  ]);
-  assert.deepEqual(model.groups.start.states['step-1-filled'].acceptanceCriteria, [
-    'I can see the project details I entered have been retained.',
-  ]);
-  assert.equal(validateReportingReviewModel(model).length, 0);
+	assert.deepEqual(model.groups.start.acceptanceCriteria, [
+		'As a user researcher, I can start a project using a guided process.',
+	]);
+	assert.deepEqual(model.groups.start.states['step-1-filled'].acceptanceCriteria, [
+		'I can see the project details I entered have been retained.',
+	]);
+	assert.equal(validateReportingReviewModel(model).length, 0);
 });
 
 test('buildReportingReviewModel applies repo-backed review overrides', () => {
-  const model = buildReportingReviewModel(
-    {
-      groups: {
-        analysis: {
-          acceptanceStatus: 'needs-review',
-          designRiskStatus: 'needs-review',
-          acceptanceCriteria: ['Group-level analysis criteria.'],
-          designRiskNotes: ['Group-level analysis risk.'],
-          states: {
-            'theme-created': {
-              acceptanceCriteria: ['Original state criteria.'],
-              designRiskNotes: ['Original state risk.'],
-            },
-          },
-        },
-      },
-    },
-    {
-      groups: {
-        analysis: {
-          acceptanceStatus: 'approved',
-          states: {
-            'theme-created': {
-              acceptanceStatus: 'approved',
-              designRiskStatus: 'draft',
-              acceptanceCriteria: ['Curated theme-created state criteria.'],
-            },
-          },
-        },
-      },
-    },
-  );
+	const model = buildReportingReviewModel(
+		{
+			groups: {
+				analysis: {
+					acceptanceStatus: 'needs-review',
+					designRiskStatus: 'needs-review',
+					acceptanceCriteria: ['Group-level analysis criteria.'],
+					designRiskNotes: ['Group-level analysis risk.'],
+					states: {
+						'theme-created': {
+							acceptanceCriteria: ['Original state criteria.'],
+							designRiskNotes: ['Original state risk.'],
+						},
+					},
+				},
+			},
+		},
+		{
+			groups: {
+				analysis: {
+					acceptanceStatus: 'approved',
+					states: {
+						'theme-created': {
+							acceptanceStatus: 'approved',
+							designRiskStatus: 'draft',
+							acceptanceCriteria: ['Curated theme-created state criteria.'],
+						},
+					},
+				},
+			},
+		}
+	);
 
-  assert.equal(model.groups.analysis.acceptanceStatus, 'approved');
-  assert.equal(
-    model.groups.analysis.states['theme-created'].acceptanceStatus,
-    'approved',
-  );
-  assert.equal(
-    model.groups.analysis.states['theme-created'].designRiskStatus,
-    'draft',
-  );
-  assert.deepEqual(
-    model.groups.analysis.states['theme-created'].acceptanceCriteria,
-    ['Curated theme-created state criteria.'],
-  );
-  assert.deepEqual(model.groups.analysis.states['theme-created'].designRiskNotes, [
-    'Original state risk.',
-  ]);
+	assert.equal(model.groups.analysis.acceptanceStatus, 'approved');
+	assert.equal(model.groups.analysis.states['theme-created'].acceptanceStatus, 'approved');
+	assert.equal(model.groups.analysis.states['theme-created'].designRiskStatus, 'draft');
+	assert.deepEqual(model.groups.analysis.states['theme-created'].acceptanceCriteria, [
+		'Curated theme-created state criteria.',
+	]);
+	assert.deepEqual(model.groups.analysis.states['theme-created'].designRiskNotes, [
+		'Original state risk.',
+	]);
 });
 
 test('validateReportingReviewModel flags duplicated group content at state level', () => {
-  const issues = validateReportingReviewModel({
-    groups: {
-      consent: {
-        acceptanceCriteria: ['Shared consent criteria.'],
-        designRiskNotes: ['Shared consent risk.'],
-        states: {
-          default: {
-            acceptanceCriteria: ['Shared consent criteria.'],
-            designRiskNotes: ['Shared consent risk.'],
-          },
-        },
-      },
-    },
-  });
+	const issues = validateReportingReviewModel({
+		groups: {
+			consent: {
+				acceptanceCriteria: ['Shared consent criteria.'],
+				designRiskNotes: ['Shared consent risk.'],
+				states: {
+					default: {
+						acceptanceCriteria: ['Shared consent criteria.'],
+						designRiskNotes: ['Shared consent risk.'],
+					},
+				},
+			},
+		},
+	});
 
-  assert.deepEqual(
-    issues.map((issue) => issue.code),
-    [
-      'duplicated-group-acceptance-criteria',
-      'duplicated-group-design-risk-notes',
-    ],
-  );
+	assert.deepEqual(
+		issues.map((issue) => issue.code),
+		['duplicated-group-acceptance-criteria', 'duplicated-group-design-risk-notes']
+	);
 });
 
 test('review statuses are normalised and summarised', () => {
-  assert.equal(normaliseReviewStatus('approved'), 'approved');
-  assert.equal(normaliseReviewStatus('unknown'), 'needs-review');
+	assert.equal(normaliseReviewStatus('approved'), 'approved');
+	assert.equal(normaliseReviewStatus('unknown'), 'needs-review');
 
-  const summary = summariseReportingReviewModel({
-    groups: {
-      start: {
-        acceptanceStatus: 'approved',
-        designRiskStatus: 'needs-review',
-        acceptanceCriteria: ['Group criteria.'],
-        designRiskNotes: ['Group risk.'],
-        states: {
-          default: {
-            acceptanceStatus: 'draft',
-            designRiskStatus: 'superseded',
-            acceptanceCriteria: ['State criteria.'],
-            designRiskNotes: ['State risk.'],
-          },
-        },
-      },
-    },
-  });
+	const summary = summariseReportingReviewModel({
+		groups: {
+			start: {
+				acceptanceStatus: 'approved',
+				designRiskStatus: 'needs-review',
+				acceptanceCriteria: ['Group criteria.'],
+				designRiskNotes: ['Group risk.'],
+				states: {
+					default: {
+						acceptanceStatus: 'draft',
+						designRiskStatus: 'superseded',
+						acceptanceCriteria: ['State criteria.'],
+						designRiskNotes: ['State risk.'],
+					},
+				},
+			},
+		},
+	});
 
-  assert.equal(summary.groups, 1);
-  assert.equal(summary.states, 1);
-  assert.equal(summary.statuses.approved, 1);
-  assert.equal(summary.statuses['needs-review'], 1);
-  assert.equal(summary.statuses.draft, 1);
-  assert.equal(summary.statuses.superseded, 1);
+	assert.equal(summary.groups, 1);
+	assert.equal(summary.states, 1);
+	assert.equal(summary.statuses.approved, 1);
+	assert.equal(summary.statuses['needs-review'], 1);
+	assert.equal(summary.statuses.draft, 1);
+	assert.equal(summary.statuses.superseded, 1);
 });

--- a/tests/reporting-review-model.test.js
+++ b/tests/reporting-review-model.test.js
@@ -1,0 +1,151 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildReportingReviewModel,
+  normaliseReviewStatus,
+  summariseReportingReviewModel,
+  validateReportingReviewModel,
+} from '../scripts/reporting-review-model.mjs';
+
+test('buildReportingReviewModel keeps group criteria separate from state criteria', () => {
+  const model = buildReportingReviewModel({
+    groups: {
+      start: {
+        title: 'Start research project',
+        acceptanceCriteria: [
+          'As a user researcher, I can start a project using a guided process.',
+        ],
+        designRiskNotes: [
+          'Project setup errors create downstream traceability risk.',
+        ],
+        states: {
+          'step-1-filled': {
+            acceptanceCriteria: [
+              'I can see the project details I entered have been retained.',
+            ],
+            designRiskNotes: [
+              'The completed first step must make progress visible.',
+            ],
+          },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(model.groups.start.acceptanceCriteria, [
+    'As a user researcher, I can start a project using a guided process.',
+  ]);
+  assert.deepEqual(model.groups.start.states['step-1-filled'].acceptanceCriteria, [
+    'I can see the project details I entered have been retained.',
+  ]);
+  assert.equal(validateReportingReviewModel(model).length, 0);
+});
+
+test('buildReportingReviewModel applies repo-backed review overrides', () => {
+  const model = buildReportingReviewModel(
+    {
+      groups: {
+        analysis: {
+          acceptanceStatus: 'needs-review',
+          designRiskStatus: 'needs-review',
+          acceptanceCriteria: ['Group-level analysis criteria.'],
+          designRiskNotes: ['Group-level analysis risk.'],
+          states: {
+            'theme-created': {
+              acceptanceCriteria: ['Original state criteria.'],
+              designRiskNotes: ['Original state risk.'],
+            },
+          },
+        },
+      },
+    },
+    {
+      groups: {
+        analysis: {
+          acceptanceStatus: 'approved',
+          states: {
+            'theme-created': {
+              acceptanceStatus: 'approved',
+              designRiskStatus: 'draft',
+              acceptanceCriteria: ['Curated theme-created state criteria.'],
+            },
+          },
+        },
+      },
+    },
+  );
+
+  assert.equal(model.groups.analysis.acceptanceStatus, 'approved');
+  assert.equal(
+    model.groups.analysis.states['theme-created'].acceptanceStatus,
+    'approved',
+  );
+  assert.equal(
+    model.groups.analysis.states['theme-created'].designRiskStatus,
+    'draft',
+  );
+  assert.deepEqual(
+    model.groups.analysis.states['theme-created'].acceptanceCriteria,
+    ['Curated theme-created state criteria.'],
+  );
+  assert.deepEqual(model.groups.analysis.states['theme-created'].designRiskNotes, [
+    'Original state risk.',
+  ]);
+});
+
+test('validateReportingReviewModel flags duplicated group content at state level', () => {
+  const issues = validateReportingReviewModel({
+    groups: {
+      consent: {
+        acceptanceCriteria: ['Shared consent criteria.'],
+        designRiskNotes: ['Shared consent risk.'],
+        states: {
+          default: {
+            acceptanceCriteria: ['Shared consent criteria.'],
+            designRiskNotes: ['Shared consent risk.'],
+          },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(
+    issues.map((issue) => issue.code),
+    [
+      'duplicated-group-acceptance-criteria',
+      'duplicated-group-design-risk-notes',
+    ],
+  );
+});
+
+test('review statuses are normalised and summarised', () => {
+  assert.equal(normaliseReviewStatus('approved'), 'approved');
+  assert.equal(normaliseReviewStatus('unknown'), 'needs-review');
+
+  const summary = summariseReportingReviewModel({
+    groups: {
+      start: {
+        acceptanceStatus: 'approved',
+        designRiskStatus: 'needs-review',
+        acceptanceCriteria: ['Group criteria.'],
+        designRiskNotes: ['Group risk.'],
+        states: {
+          default: {
+            acceptanceStatus: 'draft',
+            designRiskStatus: 'superseded',
+            acceptanceCriteria: ['State criteria.'],
+            designRiskNotes: ['State risk.'],
+          },
+        },
+      },
+    },
+  });
+
+  assert.equal(summary.groups, 1);
+  assert.equal(summary.states, 1);
+  assert.equal(summary.statuses.approved, 1);
+  assert.equal(summary.statuses['needs-review'], 1);
+  assert.equal(summary.statuses.draft, 1);
+  assert.equal(summary.statuses.superseded, 1);
+});


### PR DESCRIPTION
## Summary

This PR creates the repo-backed reporting review model needed to reduce duplicated Gherkin acceptance criteria and duplicated design-risk notes across the visual walkthrough reporting site.

It sets up the structure agreed in the chat:

- group-level review evidence for whole journey areas
- state-level review evidence only for the specific screenshot state
- repo-backed manual review overrides rather than editing generated report HTML
- review statuses for Gherkin and design-risk notes
- validation to flag duplicated group content copied into state content

## PR state and branch discipline

Before creating this branch and PR, I checked the repository PR state:

- No open PRs were present for `kevinrapley/ResearchOps`.
- The previous reporting-site PRs were closed and merged.
- This branch was created from current `main` at `e0899c3c840704fd239cf5cb91f8334bd34b28d3`.
- The branch is 4 commits ahead and 0 commits behind `main`.
- No previous PR branch was force-updated or reused.

## Changes

### Reporting review model utility

Adds `scripts/reporting-review-model.mjs` with functions to:

- normalise supported statuses: `draft`, `needs-review`, `approved`, `rejected`, `superseded`
- normalise group-level and state-level acceptance criteria
- normalise group-level and state-level design-risk notes
- merge generated base review evidence with repo-backed overrides
- validate duplicated group content copied into state content
- summarise review-status counts

### Repo-backed override source of truth

Adds `config/reporting-review-overrides.json` containing curated group-level and state-level review evidence for:

- Start research project
- Participant consent
- Analysis

This gives the reporting site a persistent, reviewable source of truth for manual changes and status updates.

### Tests

Adds `tests/reporting-review-model.test.js` covering:

- group criteria remaining separate from state criteria
- overrides replacing generated values where present
- duplicated group content being flagged at state level
- status normalisation and status summary counts

### Documentation

Adds `docs/devops/reporting-review-model.md` explaining:

- group-level vs state-level review evidence
- status values
- why generated HTML is not the source of truth
- how manual edits should be persisted through the repo
- duplication validation rules

## Validation

I ran the new review-model unit tests locally in isolation with Node's built-in test runner against the same module content:

```text
node --test reporting-review-model.test.mjs
```

Result:

```text
4 tests passed
0 failed
```

I could not run the full repository suite locally in this environment because the repository cannot be checked out from GitHub here. CI should run the repository validation, lint and full unit-test suite as the source of truth.

## Follow-on integration

This PR deliberately creates the model, override source and tests first. The next integration step is to wire `scripts/visual-walkthrough.mjs` and the report renderer to read `config/reporting-review-overrides.json`, render group-level panels once per group, and render only state-specific criteria and design-risk notes inside each state card.