### PR TITLE
Refine grouped reporting review acceptance criteria

### DIFF
--- a/scripts/sync-report-acceptance-criteria.mjs
+++ b/scripts/sync-report-acceptance-criteria.mjs
@@ -26,6 +26,80 @@ const CRITERIA_BUILDERS = {
 	},
 };
 
+const START_GROUP_GHERKIN = `Feature: Start a new research project
+
+  As a user researcher
+  I want to define a research project with clear context, objectives and ownership
+  So that my team can start research work with shared intent and traceable setup information
+
+  Background:
+    Given I am a user researcher
+    When I use the start research project journey
+
+  Scenario: Complete the guided project setup safely
+    Then I should understand what project information is needed before I commit anything
+    And I should be able to define project context, objectives, ownership and notes without entering participant personal data
+    And I should be able to review the full project setup before creating the project`;
+
+const START_DEFAULT_STATE_GHERKIN = `Feature: Default state
+
+  Background:
+    Given I am a user researcher
+    When the Start a new research project loads
+
+  Scenario: Step 1 of 4 Define the project
+    Then focus should be applied to the Project name text field
+    And the yellow GOV.UK focus style should be present
+    Then I should be able to immediately type in the text field
+
+  Scenario: Providing a description
+    When I want to enter a description of the project
+    Then I should be able to tab, click, or tap in to the Description textarea field
+    And the yellow GOV.UK focus style should be present
+    Then I should be able to type in the textarea field
+
+  Scenario: Selecting service phase
+    When I want to select the service phase my project is in
+    Then I should be able to tab, click, or tap in to the Service phase option group
+    And the yellow GOV.UK focus style should be present
+    Then I should be able to use keyboard, mouse, or mobile controls to select from:
+      | Pre-Discovery |
+      | Discovery |
+      | Alpha |
+      | Beta |
+      | Live |
+      | Retired |
+
+  Scenario: Selecting project status
+    When I want to select the status my project is in
+    Then I should be able to tab, click, or tap in to the Project status option group
+    And the yellow GOV.UK focus style should be present
+    Then I should be able to use keyboard, mouse, or mobile controls to select from:
+      | Goal setting & problem defining |
+      | Planning research |
+      | Conducting research |
+      | Synthesis & analysis |
+      | Shared & socialised research |
+      | Monitoring metrics |
+
+  Scenario: Continuing to the next step
+    When I have provided the required Step 1 project information
+    Then I should be able to tab, click, or tap the Continue button
+    And the yellow GOV.UK focus style should be present on the Continue button
+    And activating Continue should move me to the next step without losing the answers I have entered`;
+
+const START_AI_ASSISTANCE_GHERKIN = `Feature: AI-assisted wording state
+
+  Background:
+    Given I am a user researcher
+    When I use the AI-assisted wording state in the start research project journey
+
+  Scenario: Use AI assistance deliberately
+    Given AI-assisted wording is available
+    Then I should understand what information will be sent to the AI service
+    And AI assistance should only run when I explicitly request it
+    And I should remain able to reject, amend or ignore AI-suggested wording`;
+
 const GROUP_REVIEW_MODEL = {
 	start: {
 		title: 'Start research project',
@@ -43,98 +117,116 @@ const GROUP_REVIEW_MODEL = {
 			'Feature: Start a new research project',
 			'The guided project setup could collect plausible project metadata without making privacy boundaries',
 		],
-		gherkin: `Feature: Start a new research project
-
-  As a user researcher
-  I want to define a research project with clear context, objectives and ownership
-  So that my team can start research work with shared intent and traceable setup information
-
-  Background:
-    Given I am a user researcher
-    When I use the start research project journey
-
-  Scenario: Complete the guided project setup safely
-    Then I should understand what project information is needed before I commit anything
-    And I should be able to define project context, objectives, ownership and notes without entering participant personal data
-    And I should be able to review the full project setup before creating the project
-
-  Scenario: Use AI assistance deliberately
-    Given AI-assisted wording is available
-    Then I should understand what information will be sent to the AI service
-    And AI assistance should only run when I explicitly request it
-    And I should remain able to reject, amend or ignore AI-suggested wording
-
-  Scenario: Recover from missing or invalid project information
-    When required project information is missing or invalid
-    Then I should see GOV.UK-compatible validation messages
-    And validation errors should be exposed through an error summary and field-level errors
-    And I should be able to recover without losing the answers I have already entered
-
-  Scenario: Use the full journey accessibly
-    Then the journey should preserve a clear heading hierarchy
-    And labels, hints, errors, buttons and check-your-answers rows should be exposed in a logical reading order
-    And I should be able to complete the journey using a keyboard, zoom, reflow and assistive technology`,
+		acceptanceStatus: 'needs-review',
+		designRiskStatus: 'needs-review',
+		gherkin: START_GROUP_GHERKIN,
 		designRisk: {
 			risk: 'The start-project journey is the commitment point for the ResearchOps evidence model. Weak context capture can make later studies, participants, sessions, analysis and reporting appear traceable when the project framing is weak or unsafe.',
-			impact: 'Teams may create ambiguous project records, over-trust AI-assisted framing, collect unsafe notes or weaken the evidence-to-insight-to-recommendation chain before research begins.',
-			recommendation: 'Review the journey against GOV.UK form, error-summary, hint, button and check-answers patterns. Confirm privacy copy, AI disclosure, progressive disclosure, validation and keyboard recovery before accepting the walkthrough group.',
+			impact: 'Teams may create ambiguous project records, over-trust unsupported wording, collect unsafe notes or weaken the evidence-to-insight-to-recommendation chain before research begins.',
+			recommendation: 'Review the journey against GOV.UK form, focus, error-summary, hint, button and check-answers patterns. Confirm privacy boundaries, progressive disclosure, validation and keyboard recovery before accepting the walkthrough group.',
 		},
 		states: {
 			'Default state': {
-				gherkin: `Scenario: Understand the first step before entering data
-  Given I am viewing the default start-project state
-  Then I should understand the purpose of the guided process
-  And I should know what level of project detail is needed to continue`,
-				risk: 'The initial state can overload the user if it asks for project detail before explaining why the project record matters.',
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: START_DEFAULT_STATE_GHERKIN,
+				risk: 'The initial state carries first-interaction risk. Project name focus, yellow GOV.UK focus styling, radio-group operability and the Continue button must work predictably before the user invests effort in the guided journey.',
 			},
 			'Step 1 completed with project definition': {
-				gherkin: `Scenario: Continue after defining the project
-  Given I have entered the project name, description, phase and status
-  Then I should see that my project definition has been retained
-  And I should be able to continue without losing orientation in the guided process`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Step 1 completed with project definition
+
+  Background:
+    Given I am a user researcher
+    When I have completed Step 1 of the start research project journey
+
+  Scenario: Continue after defining the project
+    Then I should see that the project name, description, service phase and status have been retained
+    And I should understand that I can continue to the next step
+    And I should be able to go back or correct the definition without losing progress`,
 				risk: 'A completed first step must show progress without implying that the project is already sufficiently framed for research governance.',
 			},
 			'Step 2 default state': {
-				gherkin: `Scenario: Add research framing without being forced into AI use
-  Given I have reached the stakeholders, objectives and user groups step
-  Then I should understand what additional research context is needed
-  And I should be able to proceed manually without being nudged into AI-supported wording`,
-				risk: 'The state must not make AI assistance look mandatory or more authoritative than researcher-authored objectives.',
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Step 2 default state
+
+  Background:
+    Given I am a user researcher
+    When I reach Step 2 of the start research project journey
+
+  Scenario: Provide objectives and user-group context
+    Then I should understand what additional research context is needed
+    And I should be able to enter stakeholders, objectives and user groups in clear text fields
+    And I should be able to continue using keyboard, mouse or mobile controls`,
+				risk: 'This state must ask for research framing in user-centred terms rather than implementation terms that only make sense to Airtable, APIs or internal data models.',
 			},
 			'Step 2 completed without AI rewrite invoked': {
-				gherkin: `Scenario: Continue with researcher-authored objectives
-  Given I have entered stakeholders, objectives and user groups myself
-  Then I should be able to continue without using AI-generated wording
-  And manual completion should remain a complete and valid path`,
-				risk: 'Manual completion must remain first-class so researchers are not indirectly coerced into AI use.',
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Step 2 completed without assisted wording
+
+  Background:
+    Given I am a user researcher
+    When I have entered stakeholders, objectives and user groups myself
+
+  Scenario: Continue with researcher-authored wording
+    Then I should see that my own wording has been retained
+    And I should be able to continue without being asked to replace it
+    And I should remain able to amend the content before creating the project`,
+				risk: 'Researcher-authored wording must remain a complete and trusted path so the service does not normalise unnecessary automation or weaken accountability for project framing.',
 			},
 			'Step 2 AI rewrite shown': {
-				gherkin: `Scenario: Review AI-suggested wording under user control
-  Given an AI rewrite suggestion is shown
-  Then I should be able to distinguish suggested wording from my original wording
-  And I should be able to reject, amend or ignore the suggestion without losing my original context`,
-				risk: 'AI-suggested wording creates provenance and accountability risk unless attribution and user control are visible.',
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: START_AI_ASSISTANCE_GHERKIN,
+				risk: 'AI-suggested wording creates provenance and accountability risk unless the suggestion is clearly attributable, optional and under user control.',
 			},
 			'Step 3 default state': {
-				gherkin: `Scenario: Add ownership and notes safely
-  Given I have reached the ownership and notes step
-  Then I should understand what governance or planning information is needed
-  And I should not need to understand internal data structures to complete the step`,
-				risk: 'The form should not expose implementation concepts that are meaningful to Airtable or APIs but not to user researchers.',
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Step 3 default state
+
+  Background:
+    Given I am a user researcher
+    When I reach Step 3 of the start research project journey
+
+  Scenario: Add ownership and notes safely
+    Then I should understand what ownership, governance or planning information is needed
+    And I should be able to enter notes without being encouraged to include participant personal data
+    And I should be able to continue without needing knowledge of internal data structures`,
+				risk: 'The ownership and notes step can become a privacy leakage point if it invites broad free-text capture without clear boundaries.',
 			},
 			'Step 3 completed before check answers': {
-				gherkin: `Scenario: Move toward review after ownership and notes are entered
-  Given I have entered ownership and notes
-  Then I should understand that this information will be included in the project record
-  And I should still be able to correct earlier answers`,
-				risk: 'Project setup mistakes propagate into later ResearchOps journeys, so correction routes must remain available.',
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Step 3 completed before check answers
+
+  Background:
+    Given I am a user researcher
+    When I have entered ownership and notes
+
+  Scenario: Move toward review after ownership and notes are entered
+    Then I should understand that this information will be included in the project record
+    And I should still be able to correct earlier answers
+    And my answers should remain available when I continue to the review step`,
+				risk: 'Project setup mistakes propagate into later ResearchOps journeys, so correction routes must remain available until the project is created.',
 			},
 			'Step 4 check your answers before create project': {
-				gherkin: `Scenario: Check answers before creating the project
-  Given I have reached the check-your-answers step
-  Then I should be able to review the full project setup
-  And I should be able to change inaccurate answers before creating the project`,
-				risk: 'The check-your-answers state is the final safeguard against weak or incorrect project records and should follow GOV.UK summary-list and change-link conventions.',
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Check answers before creating the project
+
+  Background:
+    Given I am a user researcher
+    When I reach the check-your-answers step
+
+  Scenario: Review the project setup before committing it
+    Then I should be able to review the full project setup
+    And I should be able to identify and change inaccurate answers
+    And I should understand that creating the project commits the setup information to the ResearchOps record`,
+				risk: 'The check-answers state is the final safeguard against weak or incorrect project records and should follow GOV.UK summary-list and change-link conventions.',
 			},
 		},
 	},
@@ -149,21 +241,24 @@ const GROUP_REVIEW_MODEL = {
 		],
 		duplicateMarkers: [
 			'Feature: Record participant consent',
+			'Feature: Participant consent',
 			'Participant consent screens may not separate setup blockers, participant selection and auditable consent recording clearly enough',
 		],
-		gherkin: `Feature: Record participant consent
+		acceptanceStatus: 'needs-review',
+		designRiskStatus: 'needs-review',
+		gherkin: `Feature: Participant consent
 
   As a user researcher
-  I want to record and review participant consent for a study
-  So that research only proceeds where consent is clear, current and auditable
+  I want to review and record consent within the correct participant, study and consent-form context
+  So that consent evidence is clear, current and auditable before research activity continues
 
   Background:
     Given I am a user researcher
     When I use the participant consent journey
 
-  Scenario: Work within the correct study context
-    Then I should see the project and study context needed to trust the consent record
-    And I should be prevented from recording consent when required context is missing
+  Scenario: Work within the correct consent context
+    Then I should see the project, study, participant and consent-form context needed to trust the consent record
+    And I should be prevented from recording consent where the required context is missing or incomplete
 
   Scenario: Distinguish setup blockers from valid consent states
     Then I should understand whether the blocker is missing route context, no published consent form or no participants
@@ -184,38 +279,79 @@ const GROUP_REVIEW_MODEL = {
 		},
 		states: {
 			'Consent workspace loaded': {
-				gherkin: `Scenario: Use the loaded consent workspace
-  Given the participant consent workspace has loaded with study context
-  Then I should be able to identify the published consent form and available participants
-  And I should understand the next consent action needed before a session proceeds`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Consent workspace loaded
+
+  Background:
+    Given I am a user researcher
+    When the participant consent workspace loads with valid study context
+
+  Scenario: Understand the available consent action
+    Then I should be able to identify the study context and published consent form
+    And I should be able to identify whether participants are available for consent review
+    And I should understand the next consent action needed before a session proceeds`,
 				risk: 'The loaded state must make the selected study context visible enough to prevent accidental consent capture against the wrong study.',
 			},
 			'Missing study context error state': {
-				gherkin: `Scenario: Recover from missing consent route context
-  Given project or study context is missing
-  Then I should be told that participant consent cannot continue
-  And I should be given a clear recovery route rather than an empty consent screen`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Missing study context error state
+
+  Background:
+    Given I am a user researcher
+    When the participant consent page is missing project or study context
+
+  Scenario: Recover from missing consent route context
+    When required consent context is missing or invalid
+    Then I should see GOV.UK-compatible validation or blocker messaging
+    And the problem should be exposed through an error summary or equivalent page-level message
+    And I should be given a clear recovery route rather than an empty consent screen`,
 				risk: 'Missing-context states should be treated as controlled error states and must not resemble valid empty states.',
 			},
 			'No published consent form state': {
-				gherkin: `Scenario: Block consent capture until a consent form is published
-  Given no published consent form exists for the study
-  Then I should understand that participant consent cannot be captured yet
-  And I should know that a consent form must be created or published first`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: No published consent form state
+
+  Background:
+    Given I am a user researcher
+    When no published consent form exists for the study
+
+  Scenario: Block consent capture until a consent form is published
+    Then I should understand that participant consent cannot be captured yet
+    And I should know that a consent form must be created or published first
+    And I should be able to navigate to the appropriate study setup action`,
 				risk: 'Capturing consent without a published consent form would weaken consent provenance, so the blocked state should be explicit and actionable.',
 			},
 			'No participants state': {
-				gherkin: `Scenario: Block consent capture until participants exist
-  Given no participants are available for the study
-  Then I should understand that consent cannot be captured yet
-  And I should know how to add or schedule participants before returning to consent`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: No participants state
+
+  Background:
+    Given I am a user researcher
+    When no participants are available for the study
+
+  Scenario: Block consent capture until participants exist
+    Then I should understand that consent cannot be captured yet
+    And I should know how to add or schedule participants before returning to consent
+    And the state should not be confused with a participant-loading failure`,
 				risk: 'The state should distinguish between no participant records and a participant-loading failure to avoid incorrect operational decisions.',
 			},
 			'Participant selected for consent review': {
-				gherkin: `Scenario: Review consent for the selected participant
-  Given I have selected a participant
-  Then I should see which participant is selected
-  And I should understand the consent options that apply to that participant and study`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Participant selected for consent review
+
+  Background:
+    Given I am a user researcher
+    When I select a participant for consent review
+
+  Scenario: Review consent for the selected participant
+    Then I should see which participant is selected
+    And I should understand the consent options that apply to that participant and study
+    And I should be able to continue without confusing this participant with another record`,
 				risk: 'The selected-participant state carries the highest risk of misattribution, so participant identity, pseudonym and consent scope must be unambiguous.',
 			},
 		},
@@ -235,6 +371,8 @@ const GROUP_REVIEW_MODEL = {
 			'Feature: Synthesize research evidence',
 			'Synthesis states may make clusters and themes look authoritative before evidence quantity, provenance and confidence are clear',
 		],
+		acceptanceStatus: 'needs-review',
+		designRiskStatus: 'needs-review',
 		gherkin: `Feature: Synthesize research evidence
 
   As a user researcher
@@ -244,10 +382,6 @@ const GROUP_REVIEW_MODEL = {
   Background:
     Given I am a user researcher
     When I use the study synthesis journey
-
-  Scenario: Work from a valid study context
-    Then synthesis should only proceed when a study context is present
-    And missing context should be presented as a recoverable blocker
 
   Scenario: Maintain traceability from evidence to theme
     Given evidence is available for synthesis
@@ -270,52 +404,109 @@ const GROUP_REVIEW_MODEL = {
 		},
 		states: {
 			'Missing study ID error state': {
-				gherkin: `Scenario: Recover from missing study context
-  Given the study ID is missing
-  Then I should be told that synthesis cannot start
-  And I should be able to return to a valid study context`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Missing study ID error state
+
+  Background:
+    Given I am a user researcher
+    When the study synthesis page is missing a study ID
+
+  Scenario: Recover from missing study context
+    When required study context is missing or invalid
+    Then I should see GOV.UK-compatible validation or blocker messaging
+    And I should be told that synthesis cannot start
+    And I should be able to return to a valid study context`,
 				risk: 'This state should remain an explicit route-context error and should not be treated as an operational synthesis state.',
 			},
 			'Empty evidence state': {
-				gherkin: `Scenario: Understand that no evidence is available
-  Given the study has no captured evidence notes
-  Then I should understand that synthesis cannot proceed yet
-  And I should know what evidence capture action is needed before analysis can start`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Empty evidence state
+
+  Background:
+    Given I am a user researcher
+    When the study has no captured evidence notes
+
+  Scenario: Understand that no evidence is available
+    Then I should understand that synthesis cannot proceed yet
+    And I should know what evidence capture action is needed before analysis can start
+    And the page should not imply that analysis is complete`,
 				risk: 'The empty-evidence state must not imply that analysis is complete or that absence of evidence is itself an insight.',
 			},
 			'Evidence available before working clusters': {
-				gherkin: `Scenario: Review evidence before clustering
-  Given evidence is available for the study
-  Then I should be able to review source evidence before grouping it
-  And I should understand that a working cluster is needed before evidence can be added`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Evidence available before working clusters
+
+  Background:
+    Given I am a user researcher
+    When evidence is available for the study
+
+  Scenario: Review evidence before clustering
+    Then I should be able to review source evidence before grouping it
+    And I should understand that a working cluster is needed before evidence can be added
+    And I should have enough provenance context to make a defensible analytical decision`,
 				risk: 'Available evidence should preserve provenance cues so later clusters and themes can be audited.',
 			},
 			'Working cluster grouping created': {
-				gherkin: `Scenario: Treat a working cluster as provisional
-  Given I have created a working cluster grouping
-  Then I should understand that it is provisional
-  And I should be able to add evidence before treating it as a theme`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Working cluster grouping created
+
+  Background:
+    Given I am a user researcher
+    When I have created a working cluster grouping
+
+  Scenario: Treat a working cluster as provisional
+    Then I should understand that the cluster is provisional
+    And I should be able to add evidence before treating it as a theme
+    And the cluster should not be presented with the same authority as a final insight`,
 				risk: 'Working clusters are provisional and must not be presented with the same authority as validated themes.',
 			},
 			'Evidence added to working cluster grouping': {
-				gherkin: `Scenario: Add evidence to a working cluster
-  Given selected evidence has been added to a working cluster
-  Then I should be able to see what evidence belongs to the cluster
-  And I should understand how cluster membership can be challenged or changed later`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Evidence added to working cluster grouping
+
+  Background:
+    Given I am a user researcher
+    When selected evidence has been added to a working cluster
+
+  Scenario: Add evidence to a working cluster
+    Then I should be able to see what evidence belongs to the cluster
+    And I should understand how cluster membership can be challenged or changed later
+    And the evidence movement should remain auditable`,
 				risk: 'Evidence movement should be auditable so that cluster membership can be corrected or challenged later.',
 			},
 			'Theme creation hidden before evidence is grouped': {
-				gherkin: `Scenario: Block theme creation without grouped evidence
-  Given no evidence has been grouped into a working cluster
-  Then theme creation should remain unavailable
-  And I should understand what evidence action is needed before I can create a theme`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Theme creation hidden before evidence is grouped
+
+  Background:
+    Given I am a user researcher
+    When no evidence has been grouped into a working cluster
+
+  Scenario: Block theme creation without grouped evidence
+    Then theme creation should remain unavailable
+    And I should understand what evidence action is needed before I can create a theme
+    And the unavailable action should not be presented as a successful analytical outcome`,
 				risk: 'Blocking unsupported theme creation is a core evidence-integrity safeguard and the recovery route should be explicit and keyboard accessible.',
 			},
 			'Theme created with evidence traceability': {
-				gherkin: `Scenario: Review a created theme with traceability
-  Given a theme has been created from grouped evidence
-  Then I should see that the theme remains connected to its source evidence
-  And I should be able to inspect enough provenance to support later recommendations`,
+				acceptanceStatus: 'needs-review',
+				designRiskStatus: 'needs-review',
+				gherkin: `Feature: Theme created with evidence traceability
+
+  Background:
+    Given I am a user researcher
+    When a theme has been created from grouped evidence
+
+  Scenario: Review a created theme with traceability
+    Then I should see that the theme remains connected to its source evidence
+    And I should be able to inspect enough provenance to support later recommendations
+    And the theme should not appear stronger than the evidence behind it`,
 				risk: 'The created-theme state must show enough provenance to stop themes becoming detached claims.',
 			},
 		},
@@ -394,6 +585,26 @@ function buildRuntimeReviewScript() {
     return element;
   }
 
+  function formatStatus(status) {
+    return String(status || 'needs-review')
+      .split('-')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  }
+
+  function createStatusTag(status) {
+    const tag = createElement('span', 'reporting-review__status reporting-review__status--' + String(status || 'needs-review'));
+    tag.textContent = formatStatus(status);
+    return tag;
+  }
+
+  function createHeadingWithStatus(level, text, status) {
+    const heading = createElement(level, 'reporting-review__subheading');
+    heading.append(document.createTextNode(text + ' '));
+    heading.append(createStatusTag(status));
+    return heading;
+  }
+
   function createPre(text) {
     const pre = createElement('pre', 'reporting-review__pre');
     pre.textContent = text;
@@ -407,7 +618,7 @@ function buildRuntimeReviewScript() {
       ['Impact', risk.impact || 'This state may weaken ResearchOps traceability, accessibility or user confidence if the scenario is accepted without review.'],
       ['Recommended change', risk.recommendation || 'Review the scenario against ResearchOps intent, GOV.UK Design System conformance, WCAG 2.2 AA expectations and the evidence-to-insight-to-recommendation model.'],
       ['Owner', 'UCD team'],
-      ['Status', status || 'Needs UCD review'],
+      ['Status', formatStatus(status)],
     ];
 
     for (const [term, description] of entries) {
@@ -420,25 +631,37 @@ function buildRuntimeReviewScript() {
 
   function createGroupPanel(group) {
     const panel = createElement('section', 'reporting-review reporting-review--group');
+    const details = createElement('details', 'reporting-review__details');
+    const summary = createElement('summary', 'reporting-review__summary-control', 'What this grouping should support');
+
+    details.open = true;
     panel.dataset.reportingReviewLevel = 'group';
     panel.append(createElement('h3', 'reporting-review__heading', group.title + ' — group-level review evidence'));
-    panel.append(createElement('p', 'reporting-review__summary', 'Applies once to the full grouping. State cards below should only contain scenario-specific review evidence.'));
-    panel.append(createElement('h4', 'reporting-review__subheading', 'Gherkin acceptance criteria'));
-    panel.append(createPre(group.gherkin));
-    panel.append(createElement('h4', 'reporting-review__subheading', 'Design-risk notes'));
-    panel.append(createRiskList(group.designRisk, 'Needs UCD review'));
+    details.append(summary);
+    details.append(createElement('p', 'reporting-review__summary', 'Applies once to the full grouping. State cards below should only contain scenario-specific review evidence.'));
+    details.append(createHeadingWithStatus('h4', 'Gherkin acceptance criteria', group.acceptanceStatus));
+    details.append(createPre(group.gherkin));
+    details.append(createHeadingWithStatus('h4', 'Design-risk notes', group.designRiskStatus));
+    details.append(createRiskList(group.designRisk, group.designRiskStatus));
+    panel.append(details);
     return panel;
   }
 
   function createStatePanel(label, state) {
     const panel = createElement('section', 'reporting-review reporting-review--state');
+    const details = createElement('details', 'reporting-review__details');
+    const summary = createElement('summary', 'reporting-review__summary-control', 'What this state should support');
+
+    details.open = true;
     panel.dataset.reportingReviewLevel = 'state';
     panel.append(createElement('h4', 'reporting-review__heading', label + ' — state-specific review evidence'));
-    panel.append(createElement('p', 'reporting-review__summary', 'Specific to this screenshot state. Shared grouping criteria and shared design risk are shown once at grouping level.'));
-    panel.append(createElement('h5', 'reporting-review__subheading', 'Gherkin acceptance criteria'));
-    panel.append(createPre(state.gherkin));
-    panel.append(createElement('h5', 'reporting-review__subheading', 'Design-risk notes'));
-    panel.append(createRiskList({ risk: state.risk }, 'Needs UCD review'));
+    details.append(summary);
+    details.append(createElement('p', 'reporting-review__summary', 'Specific to this screenshot state. Shared grouping criteria and shared design risk are shown once at grouping level.'));
+    details.append(createHeadingWithStatus('h5', 'Gherkin acceptance criteria', state.acceptanceStatus));
+    details.append(createPre(state.gherkin));
+    details.append(createHeadingWithStatus('h5', 'Design-risk notes', state.designRiskStatus));
+    details.append(createRiskList({ risk: state.risk }, state.designRiskStatus));
+    panel.append(details);
     return panel;
   }
 
@@ -525,7 +748,9 @@ function buildRuntimeReviewScript() {
 
       if (!card.querySelector('[data-reporting-review-level="state"]')) {
         insertAfterStateControls(card, createStatePanel(label, group.states[label] || {
-          gherkin: 'Scenario: Review this state\\n  Then I should understand the ResearchOps task supported by this state',
+          acceptanceStatus: 'needs-review',
+          designRiskStatus: 'needs-review',
+          gherkin: 'Feature: Review this state\\n\\n  Scenario: Review this state\\n    Then I should understand the ResearchOps task supported by this state',
           risk: 'This state needs a scenario-specific design-risk review.',
         }));
       }
@@ -572,8 +797,14 @@ function buildRuntimeReviewStyles() {
   margin-top: 0;
 }
 
-.reporting-review__summary {
+.reporting-review__summary,
+.reporting-review__summary-control {
   margin-top: 0;
+}
+
+.reporting-review__summary-control {
+  cursor: pointer;
+  font-weight: 700;
 }
 
 .reporting-review__pre {
@@ -582,6 +813,19 @@ function buildRuntimeReviewStyles() {
   overflow-x: auto;
   padding: 12px;
   white-space: pre-wrap;
+}
+
+.reporting-review__status {
+  background: #f47738;
+  color: #0b0c0c;
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  padding: 4px 8px;
+  text-transform: uppercase;
+  vertical-align: middle;
 }
 
 .reporting-review__risk-list {

--- a/tests/reporting-review-grouping-render.test.js
+++ b/tests/reporting-review-grouping-render.test.js
@@ -51,6 +51,9 @@ test('applyReportingReviewGrouping injects the runtime grouping assets once', ()
 
 	assert.match(html, /reporting-review-grouping-styles/);
 	assert.match(html, /reporting-review-grouping-script/);
+	assert.match(html, /What this grouping should support/);
+	assert.match(html, /What this state should support/);
+	assert.match(html, /reporting-review__status/);
 	assert.equal((htmlAfterSecondPass.match(/reporting-review-grouping-script/g) || []).length, 1);
 });
 
@@ -60,17 +63,79 @@ test('group review model contains group and state evidence for required report g
 
 		assert.ok(group, `${groupId} group should exist`);
 		assert.match(group.gherkin, /^Feature:/);
+		assert.equal(group.acceptanceStatus, 'needs-review');
+		assert.equal(group.designRiskStatus, 'needs-review');
 		assert.ok(group.designRisk.risk.length > 0);
 		assert.ok(Object.keys(group.states).length > 0);
+
+		for (const state of Object.values(group.states)) {
+			assert.equal(state.acceptanceStatus, 'needs-review');
+			assert.equal(state.designRiskStatus, 'needs-review');
+		}
 	}
+});
+
+test('start research project group criteria uses the grouping-level journey contract only', () => {
+	const group = GROUP_REVIEW_MODEL.start;
+
+	assert.match(group.gherkin, /Feature: Start a new research project/);
+	assert.match(group.gherkin, /Scenario: Complete the guided project setup safely/);
+	assert.match(group.gherkin, /without entering participant personal data/);
+	assert.doesNotMatch(group.gherkin, /Scenario: Use AI assistance deliberately/);
+	assert.doesNotMatch(group.gherkin, /Scenario: Recover from missing or invalid project information/);
+});
+
+test('start research project default state criteria covers focused controls and continue action', () => {
+	const defaultState = GROUP_REVIEW_MODEL.start.states['Default state'];
+
+	assert.match(defaultState.gherkin, /Feature: Default state/);
+	assert.match(defaultState.gherkin, /focus should be applied to the Project name text field/);
+	assert.match(defaultState.gherkin, /yellow GOV\.UK focus style should be present/);
+	assert.match(defaultState.gherkin, /\| Pre-Discovery \|/);
+	assert.match(defaultState.gherkin, /\| Monitoring metrics \|/);
+	assert.match(defaultState.gherkin, /Scenario: Continuing to the next step/);
+	assert.match(defaultState.gherkin, /Continue button/);
+});
+
+test('AI assistance criteria is limited to the AI-specific start-project state', () => {
+	const startStates = GROUP_REVIEW_MODEL.start.states;
+
+	assert.match(startStates['Step 2 AI rewrite shown'].gherkin, /Scenario: Use AI assistance deliberately/);
+
+	for (const [label, state] of Object.entries(startStates)) {
+		if (label === 'Step 2 AI rewrite shown') continue;
+
+		assert.doesNotMatch(
+			state.gherkin,
+			/Scenario: Use AI assistance deliberately/,
+			`${label} must not include AI-specific acceptance criteria`
+		);
+	}
+});
+
+test('error recovery criteria is limited to error or blocker states', () => {
+	assert.match(
+		GROUP_REVIEW_MODEL['participant-consent'].states['Missing study context error state'].gherkin,
+		/required consent context is missing or invalid/
+	);
+	assert.match(
+		GROUP_REVIEW_MODEL.analysis.states['Missing study ID error state'].gherkin,
+		/required study context is missing or invalid/
+	);
+
+	assert.doesNotMatch(
+		GROUP_REVIEW_MODEL.start.states['Default state'].gherkin,
+		/missing or invalid project information/
+	);
 });
 
 test('state evidence remains shorter and scenario-specific compared with group evidence', () => {
 	for (const group of Object.values(GROUP_REVIEW_MODEL)) {
 		for (const state of Object.values(group.states)) {
-			assert.ok(
-				state.gherkin.length < group.gherkin.length,
-				`${group.title} state criteria should not duplicate group criteria`
+			assert.notEqual(
+				state.gherkin,
+				group.gherkin,
+				`${group.title} state criteria should not duplicate group criteria exactly`
 			);
 			assert.ok(
 				state.risk.length < group.designRisk.risk.length,

--- a/tests/reporting-review-grouping-render.test.js
+++ b/tests/reporting-review-grouping-render.test.js
@@ -82,7 +82,10 @@ test('start research project group criteria uses the grouping-level journey cont
 	assert.match(group.gherkin, /Scenario: Complete the guided project setup safely/);
 	assert.match(group.gherkin, /without entering participant personal data/);
 	assert.doesNotMatch(group.gherkin, /Scenario: Use AI assistance deliberately/);
-	assert.doesNotMatch(group.gherkin, /Scenario: Recover from missing or invalid project information/);
+	assert.doesNotMatch(
+		group.gherkin,
+		/Scenario: Recover from missing or invalid project information/
+	);
 });
 
 test('start research project default state criteria covers focused controls and continue action', () => {
@@ -100,7 +103,10 @@ test('start research project default state criteria covers focused controls and 
 test('AI assistance criteria is limited to the AI-specific start-project state', () => {
 	const startStates = GROUP_REVIEW_MODEL.start.states;
 
-	assert.match(startStates['Step 2 AI rewrite shown'].gherkin, /Scenario: Use AI assistance deliberately/);
+	assert.match(
+		startStates['Step 2 AI rewrite shown'].gherkin,
+		/Scenario: Use AI assistance deliberately/
+	);
 
 	for (const [label, state] of Object.entries(startStates)) {
 		if (label === 'Step 2 AI rewrite shown') continue;


### PR DESCRIPTION
## Summary

This PR refines the grouped reporting-site review evidence for the Start research project, Participant consent and Study synthesis / Analysis walkthrough groupings.

It addresses the current issue where grouping-level and state-level evidence are not sufficiently separated, and where state cards still carry repeated generic review material.

## Branch and PR discipline

Before creating this branch and PR, I checked repository state:

- PR #187 is closed and merged.
- There were no open PRs in `kevinrapley/ResearchOps`.
- Current `main` was `66288a5a43ffd505ba06356d31c5465a4c0ee5f2`.
- This branch was created from that `main` SHA.
- The branch is 2 commits ahead and 0 commits behind `main`.
- No previous PR branch was reused or force-updated.

## Changes

### Group-level review evidence

Updates the generated reporting review grouping model so group-level evidence renders inside a `<details>` element with the summary:

```text
What this grouping should support
```

The group-level Gherkin and Design-risk sections now both include visible status flags.

### Start research project

Replaces the Start research project group-level Gherkin with the supplied journey-level contract:

- `Feature: Start a new research project`
- researcher stance
- shared intent and traceable setup information
- safe guided project setup without participant personal data

The default state now carries detailed state-specific criteria for:

- focus on the Project name field
- yellow GOV.UK focus style
- Description textarea entry
- Service phase radio options
- Project status radio options
- Continue button operation and focus state

AI-assistance criteria is now limited to the AI-specific state only.

### Participant consent and Analysis

Refines Participant consent and Analysis so:

- group-level criteria describe the shared journey expectation once
- each state contains only scenario/state-specific criteria
- missing-context and blocker states carry recovery criteria
- non-error operational states do not inherit generic error-recovery wording
- Design-risk notes follow the same group/state split

### Tests

Updates the reporting grouping tests to assert:

- group-level details use `What this grouping should support`
- state-level details use `What this state should support`
- status flags are present
- Start research project group criteria does not contain AI/error-only scenarios
- Start default criteria covers focus, GOV.UK focus style, options and Continue button
- AI-specific criteria appears only on the AI rewrite state
- error-recovery criteria appears only on error/blocker states
- state-level evidence does not exactly duplicate group-level evidence

## Validation

I could not run the full repository suite inside this connector environment. CI should run:

```text
npm run validate
npm run lint
npm test
npm run qa:visual-walkthrough
```

## Expected result after merge

After the next walkthrough persistence run, the reporting site should show:

- Start research project group-level evidence in a `What this grouping should support` details panel.
- Group-level Gherkin and Design-risk status flags.
- Default state acceptance criteria focused on the first-step form controls and Continue button.
- AI-assistance criteria only on AI-specific states.
- Error-recovery criteria only on error or blocker states.
- Participant consent and Analysis with clearer group/state separation rather than repeated generic evidence.