### PR TITLE
Move reporting review evidence into generation model

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -211,14 +211,8 @@ jobs:
       - name: Run application visual walkthrough
         run: npm run qa:visual-walkthrough
 
-      - name: Sync source-derived acceptance criteria
-        run: node scripts/sync-report-acceptance-criteria.mjs reports-site
-
-      - name: Apply reporting review repetition pass
-        run: node scripts/apply-reporting-review-repetition-pass.mjs reports-site
-
-      - name: Finalise reporting review repetition pass
-        run: node scripts/finalise-reporting-review-repetition-pass.mjs reports-site
+      - name: Render reporting review site from manifest evidence
+        run: node scripts/render-reporting-review-site.mjs reports-site
 
       - name: Detect visual walkthrough site
         id: detect_site

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -79,12 +79,20 @@ function renderCriteriaMaturity(state = {}) {
 	return `<strong class="criteria-tag criteria-tag--${escapeHtml(maturity.slug)}">${escapeHtml(maturity.label)}</strong>`;
 }
 
+function criteriaSourceForState(state = {}) {
+	return state.acceptanceCriteriaSource || state.criteriaSource?.type || 'generated';
+}
+
 function renderStateAcceptanceCriteria(state = {}) {
-	if (!state.acceptanceCriteria || state.suppressGeneratedStateCriteria !== true) return '';
+	if (!state.acceptanceCriteria) return '';
+
+	const summary = state.suppressGeneratedStateCriteria === true
+		? 'What this state should support'
+		: 'What this screen state should support';
 
 	return `
-					<details class="state-acceptance-criteria" data-acceptance-criteria-source="${escapeHtml(state.acceptanceCriteriaSource || 'generated')}">
-						<summary>What this state should support</summary>
+					<details class="state-acceptance-criteria" data-acceptance-criteria-source="${escapeHtml(criteriaSourceForState(state))}">
+						<summary>${summary}</summary>
 						<div class="state-acceptance-criteria__meta">
 							${renderCriteriaMaturity(state)}
 							<span>Format: Gherkin acceptance criteria</span>
@@ -94,7 +102,7 @@ function renderStateAcceptanceCriteria(state = {}) {
 }
 
 function renderDesignRisk(state = {}) {
-	if (!state.designRisk || state.suppressGeneratedStateCriteria !== true) return '';
+	if (!state.designRisk) return '';
 
 	return `
 					<section class="design-risk" aria-label="Design-risk notes">
@@ -158,8 +166,7 @@ function renderPage(page = {}) {
 					${(page.states || []).map((state) => renderState(page, state)).join('')}
 				</div>
 			</article>`;
-}
-
+}\n
 function renderJourneyNavigation(manifest = {}) {
 	const pagesById = new Map((manifest.pages || []).map((page) => [page.id, page]));
 	const journeys = manifest.journeys || [];

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -2,7 +2,7 @@
 
 /**
  * @file scripts/render-reporting-review-site.mjs
- * @summary Render the visual walkthrough report from manifest evidence without runtime DOM patching.
+ * @summary Render the visual walkthrough report from explicit manifest evidence.
  */
 
 import fs from 'node:fs';
@@ -21,21 +21,13 @@ function escapeHtml(value = '') {
 		.replaceAll("'", '&#39;');
 }
 
-function readJson(filePath) {
-	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-}
-
-function writeJson(filePath, value) {
-	fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
-}
-
 function groupPages(pages = []) {
 	const groups = new Map();
 
 	for (const page of pages) {
-		const group = page.group || 'Application';
-		if (!groups.has(group)) groups.set(group, []);
-		groups.get(group).push(page);
+		const groupName = page.group || 'Application';
+		if (!groups.has(groupName)) groups.set(groupName, []);
+		groups.get(groupName).push(page);
 	}
 
 	return [...groups.entries()];
@@ -47,31 +39,31 @@ function renderStatus(status = 'needs-review') {
 
 function renderRiskList(designRisk = {}) {
 	return `
-			<dl class="review-risk-list">
-				<div><dt>Design risk</dt><dd>${escapeHtml(designRisk.risk)}</dd></div>
-				<div><dt>Impact</dt><dd>${escapeHtml(designRisk.impact)}</dd></div>
-				<div><dt>Recommended change</dt><dd>${escapeHtml(designRisk.recommendedChange)}</dd></div>
-				<div><dt>Owner</dt><dd>${escapeHtml(designRisk.owner)}</dd></div>
-				<div><dt>Status</dt><dd>${escapeHtml(designRisk.status)}</dd></div>
-			</dl>`;
+		<dl class="review-risk-list">
+			<div><dt>Design risk</dt><dd>${escapeHtml(designRisk.risk)}</dd></div>
+			<div><dt>Impact</dt><dd>${escapeHtml(designRisk.impact)}</dd></div>
+			<div><dt>Recommended change</dt><dd>${escapeHtml(designRisk.recommendedChange)}</dd></div>
+			<div><dt>Owner</dt><dd>${escapeHtml(designRisk.owner)}</dd></div>
+			<div><dt>Status</dt><dd>${escapeHtml(designRisk.status)}</dd></div>
+		</dl>`;
 }
 
-function renderGroupReviewEvidence(page = {}) {
+function renderGroupEvidence(page = {}) {
 	const evidence = page.reviewEvidence;
 	if (!evidence) return '';
 
 	return `
-			<section class="review-evidence review-evidence--group" data-review-group-id="${escapeHtml(page.reviewGroupId)}" data-review-evidence-level="group">
-				<h4>${escapeHtml(evidence.title)} — group-level review evidence</h4>
-				<details open>
-					<summary>What this grouping should support</summary>
-					<p>Applies once to the full grouping. State cards below contain only scenario-specific review evidence.</p>
-					<h5>Gherkin acceptance criteria ${renderStatus(evidence.acceptanceStatus)}</h5>
-					<pre class="gherkin-criteria"><code>${escapeHtml(evidence.gherkin)}</code></pre>
-					<h5>Design-risk notes ${renderStatus(evidence.designRiskStatus)}</h5>
-					${renderRiskList(evidence.designRisk)}
-				</details>
-			</section>`;
+		<section class="review-evidence review-evidence--group" data-review-group-id="${escapeHtml(page.reviewGroupId)}" data-review-evidence-level="group">
+			<h4>${escapeHtml(evidence.title)} — group-level review evidence</h4>
+			<details open>
+				<summary>What this grouping should support</summary>
+				<p>Applies once to the full grouping. State cards below contain only scenario-specific review evidence.</p>
+				<h5>Gherkin acceptance criteria ${renderStatus(evidence.acceptanceStatus)}</h5>
+				<pre class="gherkin-criteria"><code>${escapeHtml(evidence.gherkin)}</code></pre>
+				<h5>Design-risk notes ${renderStatus(evidence.designRiskStatus)}</h5>
+				${renderRiskList(evidence.designRisk)}
+			</details>
+		</section>`;
 }
 
 function renderCriteriaMaturity(state = {}) {
@@ -79,112 +71,87 @@ function renderCriteriaMaturity(state = {}) {
 	return `<strong class="criteria-tag criteria-tag--${escapeHtml(maturity.slug)}">${escapeHtml(maturity.label)}</strong>`;
 }
 
-function criteriaSourceForState(state = {}) {
-	return state.acceptanceCriteriaSource || state.criteriaSource?.type || 'generated';
-}
-
-function renderStateAcceptanceCriteria(state = {}) {
+function renderAcceptanceCriteria(state = {}) {
 	if (!state.acceptanceCriteria) return '';
 
 	const summary = state.suppressGeneratedStateCriteria === true
 		? 'What this state should support'
 		: 'What this screen state should support';
+	const source = state.acceptanceCriteriaSource || state.criteriaSource?.type || 'generated';
 
 	return `
-					<details class="state-acceptance-criteria" data-acceptance-criteria-source="${escapeHtml(criteriaSourceForState(state))}">
-						<summary>${summary}</summary>
-						<div class="state-acceptance-criteria__meta">
-							${renderCriteriaMaturity(state)}
-							<span>Format: Gherkin acceptance criteria</span>
-						</div>
-						<pre class="gherkin-criteria"><code>${escapeHtml(state.acceptanceCriteria)}</code></pre>
-					</details>`;
+		<details class="state-acceptance-criteria" data-acceptance-criteria-source="${escapeHtml(source)}">
+			<summary>${escapeHtml(summary)}</summary>
+			<div class="state-acceptance-criteria__meta">
+				${renderCriteriaMaturity(state)}
+				<span>Format: Gherkin acceptance criteria</span>
+			</div>
+			<pre class="gherkin-criteria"><code>${escapeHtml(state.acceptanceCriteria)}</code></pre>
+		</details>`;
 }
 
 function renderDesignRisk(state = {}) {
 	if (!state.designRisk) return '';
 
 	return `
-					<section class="design-risk" aria-label="Design-risk notes">
-						<h5>Design-risk notes</h5>
-						${renderRiskList(state.designRisk)}
-					</section>`;
+		<section class="design-risk" aria-label="Design-risk notes">
+			<h5>Design-risk notes</h5>
+			${renderRiskList(state.designRisk)}
+		</section>`;
 }
 
 function renderEvidenceTypes(state = {}) {
-	const types = state.evidenceTypes || [];
-	if (types.length === 0) return '';
-
 	return `
-					<div class="evidence-types" aria-label="Evidence types for this state">
-						${types.map((type) => `<span>${escapeHtml(type)}</span>`).join('')}
-					</div>`;
+		<div class="evidence-types" aria-label="Evidence types for this state">
+			${(state.evidenceTypes || []).map((type) => `<span>${escapeHtml(type)}</span>`).join('')}
+		</div>`;
 }
 
 function renderCapture(page = {}, state = {}, capture = {}) {
-	const failedClass = capture.status === 'failed' ? ' failed' : '';
 	const alt = `Screenshot of ${page.title} in the ${state.title} state for ${capture.profileTitle || capture.profile}.`;
+	const image = capture.screenshot
+		? `<figure class="capture__figure"><a href="${escapeHtml(capture.screenshot)}"><img loading="lazy" src="${escapeHtml(capture.screenshot)}" alt="${escapeHtml(alt)}" /></a><figcaption>${escapeHtml(page.title)} — ${escapeHtml(state.title)} — ${escapeHtml(capture.profileTitle || capture.profile)}</figcaption></figure>`
+		: '';
 
 	return `
-					<section class="capture${failedClass}" data-profile="${escapeHtml(capture.profile)}">
-						<div class="capture__header">
-							<h5>Screenshot evidence</h5>
-							<p class="meta">${escapeHtml(capture.profileTitle || capture.profile)} · ${escapeHtml(capture.status)} · ${escapeHtml(capture.url)}</p>
-							${capture.error ? `<p>${escapeHtml(capture.error)}</p>` : ''}
-						</div>
-						${capture.screenshot ? `<figure class="capture__figure"><a href="${escapeHtml(capture.screenshot)}"><img loading="lazy" src="${escapeHtml(capture.screenshot)}" alt="${escapeHtml(alt)}" /></a><figcaption>${escapeHtml(page.title)} — ${escapeHtml(state.title)} — ${escapeHtml(capture.profileTitle || capture.profile)}</figcaption></figure>` : ''}
-					</section>`;
+		<section class="capture${capture.status === 'failed' ? ' failed' : ''}" data-profile="${escapeHtml(capture.profile)}">
+			<h5>Screenshot evidence</h5>
+			<p class="meta">${escapeHtml(capture.profileTitle || capture.profile)} · ${escapeHtml(capture.status)} · ${escapeHtml(capture.url)}</p>
+			${capture.error ? `<p>${escapeHtml(capture.error)}</p>` : ''}
+			${image}
+		</section>`;
 }
 
 function renderState(page = {}, state = {}) {
 	return `
-				<article class="state" id="${escapeHtml(page.id)}-${escapeHtml(state.id)}" data-review-group-id="${escapeHtml(state.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(state.reviewEvidenceLevel || 'generated')}" data-suppress-generated-state-criteria="${state.suppressGeneratedStateCriteria === true ? 'true' : 'false'}">
-					<div class="state__header">
-						<h4>${escapeHtml(state.title)}</h4>
-						<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
-						${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
-						${renderEvidenceTypes(state)}
-					</div>
-					${renderStateAcceptanceCriteria(state)}
-					${renderDesignRisk(state)}
-					<div class="state__captures">
-						${(state.captures || []).map((capture) => renderCapture(page, state, capture)).join('')}
-					</div>
-				</article>`;
+	<article class="state" id="${escapeHtml(page.id)}-${escapeHtml(state.id)}" data-review-group-id="${escapeHtml(state.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(state.reviewEvidenceLevel || 'generated')}" data-suppress-generated-state-criteria="${state.suppressGeneratedStateCriteria === true ? 'true' : 'false'}">
+		<div class="state__header">
+			<h4>${escapeHtml(state.title)}</h4>
+			<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
+			${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
+			${renderEvidenceTypes(state)}
+		</div>
+		${renderAcceptanceCriteria(state)}
+		${renderDesignRisk(state)}
+		<div class="state__captures">
+			${(state.captures || []).map((capture) => renderCapture(page, state, capture)).join('')}
+		</div>
+	</article>`;
 }
 
 function renderPage(page = {}) {
 	return `
-			<article class="page-card" id="${escapeHtml(page.id)}" data-review-group-id="${escapeHtml(page.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(page.reviewEvidenceLevel || 'generated')}">
-				<div class="page-card__header">
-					<h3>${escapeHtml(page.title)}</h3>
-					<p class="meta">${escapeHtml(page.path)}</p>
-					<p>${escapeHtml(page.description)}</p>
-					${renderGroupReviewEvidence(page)}
-				</div>
-				<div class="states">
-					${(page.states || []).map((state) => renderState(page, state)).join('')}
-				</div>
-			</article>`;
-}\n
-function renderJourneyNavigation(manifest = {}) {
-	const pagesById = new Map((manifest.pages || []).map((page) => [page.id, page]));
-	const journeys = manifest.journeys || [];
-	if (journeys.length === 0) return '';
-
-	return `
-	<section class="journey-nav" aria-labelledby="journey-nav-title">
-		<h2 id="journey-nav-title">ResearchOps journeys</h2>
-		<p class="meta">Review the visual evidence by workflow, not only by page.</p>
-		<div class="journey-nav__grid">
-			${journeys.map((journey) => `
-			<article class="journey-card" id="journey-${escapeHtml(journey.id)}">
-				<h3>${escapeHtml(journey.title)}</h3>
-				<p>${escapeHtml(journey.description)}</p>
-				<ul>${(journey.pageIds || []).map((pageId) => pagesById.get(pageId)).filter(Boolean).map((page) => `<li><a href="#${escapeHtml(page.id)}">${escapeHtml(page.title)}</a></li>`).join('')}</ul>
-			</article>`).join('')}
+	<article class="page-card" id="${escapeHtml(page.id)}" data-review-group-id="${escapeHtml(page.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(page.reviewEvidenceLevel || 'generated')}">
+		<div class="page-card__header">
+			<h3>${escapeHtml(page.title)}</h3>
+			<p class="meta">${escapeHtml(page.path)}</p>
+			<p>${escapeHtml(page.description)}</p>
+			${renderGroupEvidence(page)}
 		</div>
-	</section>`;
+		<div class="states">
+			${(page.states || []).map((state) => renderState(page, state)).join('')}
+		</div>
+	</article>`;
 }
 
 function renderStyles() {
@@ -193,12 +160,9 @@ header { display: flex; justify-content: space-between; align-items: flex-start;
 h1 { margin: 0 0 8px; }
 h2 { margin-top: 32px; border-bottom: 1px solid #e5e5e5; padding-bottom: 8px; }
 h3, h4, h5 { margin: 0 0 6px; }
-.badge { background: #eef; border: 1px solid #99c; border-radius: 6px; display: inline-block; padding: 6px 10px; }
 .meta { color: #444; margin: 0; }
+.badge { background: #eef; border: 1px solid #99c; border-radius: 6px; display: inline-block; padding: 6px 10px; }
 .group { margin-bottom: 40px; }
-.journey-nav { border-bottom: 1px solid #d8d8d8; margin: 0 0 24px; padding: 0 0 24px; }
-.journey-nav__grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); margin-top: 16px; }
-.journey-card { border-left: 5px solid #1d70b8; background: #f3f2f1; padding: 12px 16px; }
 .page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 18px 0; overflow: hidden; }
 .page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
 .states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
@@ -213,7 +177,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 .criteria-tag--curated { border-color: #00703c; color: #00703c; }
 .state-acceptance-criteria, .design-risk { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
 .gherkin-criteria { background: #f3f2f1; border: 1px solid #b1b4b6; overflow-x: auto; padding: 12px; white-space: pre-wrap; }
-.review-risk-list, .design-risk .review-risk-list { margin: 0; }
+.review-risk-list { margin: 0; }
 .review-risk-list div { display: grid; gap: 4px; grid-template-columns: minmax(120px, 0.35fr) 1fr; margin: 0 0 6px; }
 .review-risk-list dt { font-weight: 700; }
 .review-risk-list dd { margin: 0; }
@@ -244,7 +208,6 @@ export function renderReportingReviewHtml(manifest = {}) {
 		<p class="badge">${escapeHtml(reviewedManifest.failureCount)} failures</p>
 	</header>
 	<main>
-		${renderJourneyNavigation(reviewedManifest)}
 		${groups.map(([group, pages]) => `
 		<section class="group" aria-labelledby="group-${escapeHtml(group)}">
 			<h2 id="group-${escapeHtml(group)}">${escapeHtml(group)}</h2>
@@ -259,11 +222,11 @@ export function renderReportingReviewSite(options = {}) {
 	const siteDir = typeof options === 'string' ? options : options.siteDir || DEFAULT_SITE_DIR;
 	const manifestPath = path.join(siteDir, 'manifest.json');
 	const indexPath = path.join(siteDir, 'index.html');
-	const manifest = applyReportingReviewEvidenceToManifest(readJson(manifestPath));
+	const manifest = applyReportingReviewEvidenceToManifest(JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
 	const html = renderReportingReviewHtml(manifest);
 
-	writeJson(manifestPath, manifest);
 	fs.writeFileSync(indexPath, html, 'utf8');
+	fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
 
 	return { indexPath, manifestPath };
 }
@@ -271,6 +234,5 @@ export function renderReportingReviewSite(options = {}) {
 const currentFile = fileURLToPath(import.meta.url);
 
 if (process.argv[1] === currentFile) {
-	const result = renderReportingReviewSite({ siteDir: process.argv[2] || DEFAULT_SITE_DIR });
-	console.log(JSON.stringify(result, null, 2));
+	console.log(JSON.stringify(renderReportingReviewSite({ siteDir: process.argv[2] || DEFAULT_SITE_DIR }), null, 2));
 }

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -1,0 +1,269 @@
+/* eslint-env node */
+
+/**
+ * @file scripts/render-reporting-review-site.mjs
+ * @summary Render the visual walkthrough report from manifest evidence without runtime DOM patching.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyReportingReviewEvidenceToManifest } from './reporting-review-evidence.mjs';
+
+const DEFAULT_SITE_DIR = 'reports-site';
+
+function escapeHtml(value = '') {
+	return String(value)
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;');
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+	fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function groupPages(pages = []) {
+	const groups = new Map();
+
+	for (const page of pages) {
+		const group = page.group || 'Application';
+		if (!groups.has(group)) groups.set(group, []);
+		groups.get(group).push(page);
+	}
+
+	return [...groups.entries()];
+}
+
+function renderStatus(status = 'needs-review') {
+	return `<strong class="review-status review-status--${escapeHtml(status)}">${escapeHtml(status.replaceAll('-', ' '))}</strong>`;
+}
+
+function renderRiskList(designRisk = {}) {
+	return `
+			<dl class="review-risk-list">
+				<div><dt>Design risk</dt><dd>${escapeHtml(designRisk.risk)}</dd></div>
+				<div><dt>Impact</dt><dd>${escapeHtml(designRisk.impact)}</dd></div>
+				<div><dt>Recommended change</dt><dd>${escapeHtml(designRisk.recommendedChange)}</dd></div>
+				<div><dt>Owner</dt><dd>${escapeHtml(designRisk.owner)}</dd></div>
+				<div><dt>Status</dt><dd>${escapeHtml(designRisk.status)}</dd></div>
+			</dl>`;
+}
+
+function renderGroupReviewEvidence(page = {}) {
+	const evidence = page.reviewEvidence;
+	if (!evidence) return '';
+
+	return `
+			<section class="review-evidence review-evidence--group" data-review-group-id="${escapeHtml(page.reviewGroupId)}" data-review-evidence-level="group">
+				<h4>${escapeHtml(evidence.title)} — group-level review evidence</h4>
+				<details open>
+					<summary>What this grouping should support</summary>
+					<p>Applies once to the full grouping. State cards below contain only scenario-specific review evidence.</p>
+					<h5>Gherkin acceptance criteria ${renderStatus(evidence.acceptanceStatus)}</h5>
+					<pre class="gherkin-criteria"><code>${escapeHtml(evidence.gherkin)}</code></pre>
+					<h5>Design-risk notes ${renderStatus(evidence.designRiskStatus)}</h5>
+					${renderRiskList(evidence.designRisk)}
+				</details>
+			</section>`;
+}
+
+function renderCriteriaMaturity(state = {}) {
+	const maturity = state.criteriaMaturity || { label: 'Needs review', slug: 'needs-review' };
+	return `<strong class="criteria-tag criteria-tag--${escapeHtml(maturity.slug)}">${escapeHtml(maturity.label)}</strong>`;
+}
+
+function renderStateAcceptanceCriteria(state = {}) {
+	if (!state.acceptanceCriteria || state.suppressGeneratedStateCriteria !== true) return '';
+
+	return `
+					<details class="state-acceptance-criteria" data-acceptance-criteria-source="${escapeHtml(state.acceptanceCriteriaSource || 'generated')}">
+						<summary>What this state should support</summary>
+						<div class="state-acceptance-criteria__meta">
+							${renderCriteriaMaturity(state)}
+							<span>Format: Gherkin acceptance criteria</span>
+						</div>
+						<pre class="gherkin-criteria"><code>${escapeHtml(state.acceptanceCriteria)}</code></pre>
+					</details>`;
+}
+
+function renderDesignRisk(state = {}) {
+	if (!state.designRisk || state.suppressGeneratedStateCriteria !== true) return '';
+
+	return `
+					<section class="design-risk" aria-label="Design-risk notes">
+						<h5>Design-risk notes</h5>
+						${renderRiskList(state.designRisk)}
+					</section>`;
+}
+
+function renderEvidenceTypes(state = {}) {
+	const types = state.evidenceTypes || [];
+	if (types.length === 0) return '';
+
+	return `
+					<div class="evidence-types" aria-label="Evidence types for this state">
+						${types.map((type) => `<span>${escapeHtml(type)}</span>`).join('')}
+					</div>`;
+}
+
+function renderCapture(page = {}, state = {}, capture = {}) {
+	const failedClass = capture.status === 'failed' ? ' failed' : '';
+	const alt = `Screenshot of ${page.title} in the ${state.title} state for ${capture.profileTitle || capture.profile}.`;
+
+	return `
+					<section class="capture${failedClass}" data-profile="${escapeHtml(capture.profile)}">
+						<div class="capture__header">
+							<h5>Screenshot evidence</h5>
+							<p class="meta">${escapeHtml(capture.profileTitle || capture.profile)} · ${escapeHtml(capture.status)} · ${escapeHtml(capture.url)}</p>
+							${capture.error ? `<p>${escapeHtml(capture.error)}</p>` : ''}
+						</div>
+						${capture.screenshot ? `<figure class="capture__figure"><a href="${escapeHtml(capture.screenshot)}"><img loading="lazy" src="${escapeHtml(capture.screenshot)}" alt="${escapeHtml(alt)}" /></a><figcaption>${escapeHtml(page.title)} — ${escapeHtml(state.title)} — ${escapeHtml(capture.profileTitle || capture.profile)}</figcaption></figure>` : ''}
+					</section>`;
+}
+
+function renderState(page = {}, state = {}) {
+	return `
+				<article class="state" id="${escapeHtml(page.id)}-${escapeHtml(state.id)}" data-review-group-id="${escapeHtml(state.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(state.reviewEvidenceLevel || 'generated')}" data-suppress-generated-state-criteria="${state.suppressGeneratedStateCriteria === true ? 'true' : 'false'}">
+					<div class="state__header">
+						<h4>${escapeHtml(state.title)}</h4>
+						<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
+						${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
+						${renderEvidenceTypes(state)}
+					</div>
+					${renderStateAcceptanceCriteria(state)}
+					${renderDesignRisk(state)}
+					<div class="state__captures">
+						${(state.captures || []).map((capture) => renderCapture(page, state, capture)).join('')}
+					</div>
+				</article>`;
+}
+
+function renderPage(page = {}) {
+	return `
+			<article class="page-card" id="${escapeHtml(page.id)}" data-review-group-id="${escapeHtml(page.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(page.reviewEvidenceLevel || 'generated')}">
+				<div class="page-card__header">
+					<h3>${escapeHtml(page.title)}</h3>
+					<p class="meta">${escapeHtml(page.path)}</p>
+					<p>${escapeHtml(page.description)}</p>
+					${renderGroupReviewEvidence(page)}
+				</div>
+				<div class="states">
+					${(page.states || []).map((state) => renderState(page, state)).join('')}
+				</div>
+			</article>`;
+}
+
+function renderJourneyNavigation(manifest = {}) {
+	const pagesById = new Map((manifest.pages || []).map((page) => [page.id, page]));
+	const journeys = manifest.journeys || [];
+	if (journeys.length === 0) return '';
+
+	return `
+	<section class="journey-nav" aria-labelledby="journey-nav-title">
+		<h2 id="journey-nav-title">ResearchOps journeys</h2>
+		<p class="meta">Review the visual evidence by workflow, not only by page.</p>
+		<div class="journey-nav__grid">
+			${journeys.map((journey) => `
+			<article class="journey-card" id="journey-${escapeHtml(journey.id)}">
+				<h3>${escapeHtml(journey.title)}</h3>
+				<p>${escapeHtml(journey.description)}</p>
+				<ul>${(journey.pageIds || []).map((pageId) => pagesById.get(pageId)).filter(Boolean).map((page) => `<li><a href="#${escapeHtml(page.id)}">${escapeHtml(page.title)}</a></li>`).join('')}</ul>
+			</article>`).join('')}
+		</div>
+	</section>`;
+}
+
+function renderStyles() {
+	return `body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 24px; line-height: 1.45; color: #111; background: #fff; }
+header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; border-bottom: 1px solid #d8d8d8; margin-bottom: 24px; padding-bottom: 16px; }
+h1 { margin: 0 0 8px; }
+h2 { margin-top: 32px; border-bottom: 1px solid #e5e5e5; padding-bottom: 8px; }
+h3, h4, h5 { margin: 0 0 6px; }
+.badge { background: #eef; border: 1px solid #99c; border-radius: 6px; display: inline-block; padding: 6px 10px; }
+.meta { color: #444; margin: 0; }
+.group { margin-bottom: 40px; }
+.journey-nav { border-bottom: 1px solid #d8d8d8; margin: 0 0 24px; padding: 0 0 24px; }
+.journey-nav__grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); margin-top: 16px; }
+.journey-card { border-left: 5px solid #1d70b8; background: #f3f2f1; padding: 12px 16px; }
+.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 18px 0; overflow: hidden; }
+.page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
+.states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
+.state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }
+.state__header { padding: 10px 12px; border-bottom: 1px solid #e5e5e5; }
+.evidence-types { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 0; }
+.evidence-types span { background: #f3f2f1; border: 1px solid #b1b4b6; display: inline-block; font-size: 0.875rem; padding: 3px 6px; }
+.review-evidence { border: 2px solid #1d70b8; margin: 16px 0 0; padding: 16px; background: #fff; }
+.review-evidence--group { background: #f3f2f1; }
+.review-status { background: #f47738; display: inline-block; font-size: 0.875rem; padding: 4px 8px; text-transform: uppercase; }
+.criteria-tag { border: 2px solid #0b0c0c; display: inline-block; font-size: 0.875rem; line-height: 1; padding: 4px 6px; }
+.criteria-tag--curated { border-color: #00703c; color: #00703c; }
+.state-acceptance-criteria, .design-risk { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
+.gherkin-criteria { background: #f3f2f1; border: 1px solid #b1b4b6; overflow-x: auto; padding: 12px; white-space: pre-wrap; }
+.review-risk-list, .design-risk .review-risk-list { margin: 0; }
+.review-risk-list div { display: grid; gap: 4px; grid-template-columns: minmax(120px, 0.35fr) 1fr; margin: 0 0 6px; }
+.review-risk-list dt { font-weight: 700; }
+.review-risk-list dd { margin: 0; }
+.capture { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
+.capture__figure { margin: 10px 0 0; }
+.capture__figure img { border: 1px solid #d8d8d8; height: auto; max-width: 100%; }`;
+}
+
+export function renderReportingReviewHtml(manifest = {}) {
+	const reviewedManifest = applyReportingReviewEvidenceToManifest(manifest);
+	const groups = groupPages(reviewedManifest.pages);
+
+	return `<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8" />
+	<title>${escapeHtml(reviewedManifest.title)}</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<style>${renderStyles()}</style>
+</head>
+<body>
+	<header>
+		<div>
+			<h1>${escapeHtml(reviewedManifest.title)}</h1>
+			<p>${escapeHtml(reviewedManifest.description)}</p>
+			<p class="meta">Run started: ${escapeHtml(reviewedManifest.startedAt)} · Base URL: ${escapeHtml(reviewedManifest.baseURL)}</p>
+		</div>
+		<p class="badge">${escapeHtml(reviewedManifest.failureCount)} failures</p>
+	</header>
+	<main>
+		${renderJourneyNavigation(reviewedManifest)}
+		${groups.map(([group, pages]) => `
+		<section class="group" aria-labelledby="group-${escapeHtml(group)}">
+			<h2 id="group-${escapeHtml(group)}">${escapeHtml(group)}</h2>
+			${pages.map(renderPage).join('')}
+		</section>`).join('')}
+	</main>
+</body>
+</html>`;
+}
+
+export function renderReportingReviewSite(options = {}) {
+	const siteDir = typeof options === 'string' ? options : options.siteDir || DEFAULT_SITE_DIR;
+	const manifestPath = path.join(siteDir, 'manifest.json');
+	const indexPath = path.join(siteDir, 'index.html');
+	const manifest = applyReportingReviewEvidenceToManifest(readJson(manifestPath));
+	const html = renderReportingReviewHtml(manifest);
+
+	writeJson(manifestPath, manifest);
+	fs.writeFileSync(indexPath, html, 'utf8');
+
+	return { indexPath, manifestPath };
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+
+if (process.argv[1] === currentFile) {
+	const result = renderReportingReviewSite({ siteDir: process.argv[2] || DEFAULT_SITE_DIR });
+	console.log(JSON.stringify(result, null, 2));
+}

--- a/scripts/reporting-review-evidence.mjs
+++ b/scripts/reporting-review-evidence.mjs
@@ -1,0 +1,171 @@
+/* eslint-env node */
+
+/**
+ * @file scripts/reporting-review-evidence.mjs
+ * @summary Explicit group and state evidence for the reporting-site walkthrough.
+ */
+
+function risk(text) {
+	return {
+		risk: text,
+		impact: 'If this is accepted without review, ResearchOps traceability, accessibility or user confidence may be weakened.',
+		recommendedChange: 'Review this evidence against ResearchOps intent, GOV.UK component conventions and WCAG 2.2 AA expectations.',
+		owner: 'UCD team',
+		status: 'Needs review',
+	};
+}
+
+function state(title, gherkin, riskText) {
+	return {
+		title,
+		acceptanceStatus: 'needs-review',
+		designRiskStatus: 'needs-review',
+		gherkin,
+		designRisk: risk(riskText),
+	};
+}
+
+const START_GROUP = `Feature: Start a new research project
+
+  As a user researcher
+  I want to define a project with clear context, objectives and ownership
+  So that my team can start research work with shared intent and traceable setup information
+
+  Scenario: Complete the guided project setup safely
+    Then I should understand what project information is needed before I commit anything
+    And I should be able to review the full setup before creating the project
+
+  Scenario: Understand the guided process
+    Then I should be guided through project definition, research framing, ownership and check-your-answers steps`;
+
+const CONSENT_GROUP = `Feature: Participant consent
+
+  As a user researcher
+  I want to review and record consent within the correct participant, study and consent-form context
+  So that consent evidence is clear, current and auditable
+
+  Scenario: Work within the correct consent context
+    Then I should see the project, study, participant and consent-form context needed to trust the record
+    And I should be blocked where required context is missing or incomplete`;
+
+const ANALYSIS_GROUP = `Feature: Synthesize research evidence
+
+  As a user researcher
+  I want to group evidence and create traceable themes
+  So that insights and recommendations remain connected to source evidence
+
+  Scenario: Maintain traceability from evidence to theme
+    Then I should be able to review evidence provenance before grouping it
+    And created themes should remain connected to their source evidence
+
+  Scenario: Prevent unsupported theme creation
+    Then I should be prevented from creating a theme until evidence has been grouped`;
+
+export const REPORTING_REVIEW_GROUPS = Object.freeze({
+	start: {
+		id: 'start',
+		pageId: 'start',
+		title: 'Start research project',
+		acceptanceStatus: 'needs-review',
+		designRiskStatus: 'needs-review',
+		gherkin: START_GROUP,
+		designRisk: risk('The start-project journey is the commitment point for the ResearchOps evidence model. Weak framing can make later work appear traceable when the project context is weak.'),
+		states: {
+			default: state('Default state', 'Feature: Start project default state\n\n  Scenario: Complete Step 1 controls\n    Then I should be able to enter the project name\n    And I should be able to enter the project description\n    And I should be able to select the service phase and project status\n    And I should be able to continue without losing my answers', 'The first state must make the core form controls clear and operable.'),
+			'step-1-filled': state('Step 1 completed with project definition', 'Feature: Step 1 completed\n\n  Scenario: Continue after defining the project\n    Then my project definition should be retained\n    And I should be able to go back or correct it without losing progress', 'A completed first step must show progress without implying that the project is fully governed.'),
+			'step-2-default': state('Step 2 default state', 'Feature: Step 2 default state\n\n  Scenario: Provide research framing context\n    Then I should be able to enter stakeholders, objectives and user groups\n    And each field should explain the planning information expected', 'This state must ask for research framing in user-centred terms.'),
+			'step-2-filled-no-ai': state('Step 2 completed with researcher-authored context', 'Feature: Step 2 completed with researcher-authored context\n\n  Scenario: Continue with researcher-authored wording\n    Then my wording should be retained\n    And the service should not imply that automated rewriting is required', 'Researcher-authored wording must remain a complete and trusted path.'),
+			'step-2-ai-rewrite-shown': state('Step 2 assisted rewrite shown', 'Feature: Step 2 assisted rewrite shown\n\n  Scenario: Use assisted wording deliberately\n    Then assistance should only run after an explicit user action\n    And I should remain able to reject, amend or ignore suggested wording', 'Assisted wording creates provenance and accountability risk unless suggestions are optional and under user control.'),
+			'step-3-default': state('Step 3 default state', 'Feature: Step 3 default state\n\n  Scenario: Add ownership and notes safely\n    Then I should be able to enter ownership and planning notes\n    And the service should not encourage unnecessary personal data capture', 'The notes step can become a privacy leakage point if broad free-text capture is not bounded.'),
+			'step-3-filled': state('Step 3 completed before check answers', 'Feature: Step 3 completed before check answers\n\n  Scenario: Move toward review\n    Then my answers should remain available on the review step\n    And I should still be able to correct earlier answers', 'Correction routes must remain available until the project is created.'),
+			'step-4-check-answers': state('Step 4 check answers before creating the project', 'Feature: Check answers before creating the project\n\n  Scenario: Review before committing\n    Then I should be able to identify and change inaccurate answers\n    And I should understand that creating the project commits the setup information', 'The check-answers state is the final safeguard against weak or incorrect project records.'),
+		},
+	},
+	'participant-consent': {
+		id: 'participant-consent',
+		pageId: 'study-participant-consent',
+		title: 'Participant consent',
+		acceptanceStatus: 'needs-review',
+		designRiskStatus: 'needs-review',
+		gherkin: CONSENT_GROUP,
+		designRisk: risk('Consent is a high-trust research governance activity. Ambiguity about participant, study or consent-form context creates evidence-integrity risk.'),
+		states: {
+			default: state('Consent workspace loaded', 'Feature: Consent workspace loaded\n\n  Scenario: Understand the available consent action\n    Then I should identify the study context and published consent form\n    And I should understand the next consent action needed', 'The loaded state must make the selected study context visible enough to prevent accidental misattribution.'),
+			'missing-context-error': state('Missing study context error state', 'Feature: Missing study context error state\n\n  Scenario: Recover from missing consent route context\n    Then I should be told that participant consent cannot continue\n    And I should be given a recovery route rather than an empty consent screen', 'Missing context must be treated as a controlled error state.'),
+			'no-published-consent-form': state('No published consent form state', 'Feature: No published consent form state\n\n  Scenario: Block consent capture until a form is published\n    Then I should understand that consent cannot be captured yet\n    And I should know that a consent form must be created or published first', 'Capturing consent without a published form would weaken provenance.'),
+			'no-participants': state('No participants state', 'Feature: No participants state\n\n  Scenario: Block consent capture until participants exist\n    Then I should understand that consent cannot be captured yet\n    And this should not be confused with a loading failure', 'The state must distinguish no records from a technical loading problem.'),
+			'participant-selected': state('Participant selected for consent review', 'Feature: Participant selected for consent review\n\n  Scenario: Review consent for the selected participant\n    Then I should see which participant is selected\n    And I should understand the consent options that apply to that participant and study', 'The selected-participant state carries misattribution risk.'),
+		},
+	},
+	analysis: {
+		id: 'analysis',
+		pageId: 'synthesize',
+		title: 'Study synthesis',
+		acceptanceStatus: 'needs-review',
+		designRiskStatus: 'needs-review',
+		gherkin: ANALYSIS_GROUP,
+		designRisk: risk('The analysis journey is central to ResearchOps traceability. Weak evidence-to-theme links can make recommendations appear stronger than the evidence supports.'),
+		states: {
+			'missing-sid-error': state('Missing study ID error state', 'Feature: Missing study ID error state\n\n  Scenario: Recover from missing study context\n    Then I should be told that synthesis cannot start\n    And I should be able to return to a valid study context', 'This should remain an explicit route-context error.'),
+			'empty-evidence': state('Empty evidence state', 'Feature: Empty evidence state\n\n  Scenario: Understand that no evidence is available\n    Then I should understand that synthesis cannot proceed yet\n    And the page should not imply that analysis is complete', 'Absence of evidence must not be presented as an insight.'),
+			'evidence-loaded': state('Evidence available before working clusters', 'Feature: Evidence available before working clusters\n\n  Scenario: Review evidence before clustering\n    Then I should review source evidence before grouping it\n    And I should have enough provenance context to make a defensible analytical decision', 'Available evidence should preserve provenance cues.'),
+			'working-cluster-created': state('Working cluster grouping created', 'Feature: Working cluster grouping created\n\n  Scenario: Treat a working cluster as provisional\n    Then I should understand that the cluster is provisional\n    And it should not be presented with the same authority as a final insight', 'Working clusters must remain visibly provisional.'),
+			'evidence-added-to-cluster': state('Evidence added to working cluster grouping', 'Feature: Evidence added to working cluster grouping\n\n  Scenario: Add evidence to a working cluster\n    Then I should see what evidence belongs to the cluster\n    And evidence movement should remain auditable', 'Evidence movement should be auditable.'),
+			'theme-blocked-without-evidence': state('Theme creation hidden before evidence is grouped', 'Feature: Theme creation hidden before evidence is grouped\n\n  Scenario: Block theme creation without grouped evidence\n    Then theme creation should remain unavailable\n    And I should understand what evidence action is needed', 'Blocking unsupported theme creation is an evidence-integrity safeguard.'),
+			'theme-created': state('Theme created with evidence traceability', 'Feature: Theme created with evidence traceability\n\n  Scenario: Review a created theme with traceability\n    Then the theme should remain connected to source evidence\n    And it should not appear stronger than the evidence behind it', 'Created themes must show enough provenance to stop themes becoming detached claims.'),
+		},
+	},
+});
+
+const GROUPS_BY_PAGE_ID = Object.freeze(Object.fromEntries(Object.values(REPORTING_REVIEW_GROUPS).map((group) => [group.pageId, group])));
+
+export function reportingReviewGroupForPage(page = {}) {
+	return GROUPS_BY_PAGE_ID[page.id] || null;
+}
+
+export function reportingReviewStateFor(page = {}, state = {}) {
+	const group = reportingReviewGroupForPage(page);
+	if (!group) return null;
+	return group.states[state.id] || null;
+}
+
+export function applyReportingReviewEvidenceToManifest(manifest = {}) {
+	return {
+		...manifest,
+		pages: (manifest.pages || []).map((page) => {
+			const group = reportingReviewGroupForPage(page);
+			if (!group) return page;
+
+			return {
+				...page,
+				reviewGroupId: group.id,
+				reviewEvidenceLevel: 'group',
+				reviewEvidence: group,
+				states: (page.states || []).map((item) => {
+					const evidence = reportingReviewStateFor(page, item);
+					if (!evidence) return item;
+
+					return {
+						...item,
+						reviewGroupId: group.id,
+						reviewEvidenceLevel: 'state',
+						acceptanceCriteriaSource: 'repo-curated',
+						suppressGeneratedStateCriteria: true,
+						acceptanceCriteria: evidence.gherkin,
+						criteriaMaturity: {
+							label: 'Curated criteria',
+							slug: 'curated',
+							description: 'Explicit repo-backed review evidence replaces generated full-page criteria for this state.',
+						},
+						designRisk: evidence.designRisk,
+						evidenceTypes: [
+							'Screenshot evidence',
+							'State-level curated acceptance criteria',
+							'State-level curated design-risk notes',
+						],
+					};
+				}),
+			};
+		}),
+	};
+}

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -103,7 +103,7 @@ test('curated start states replace old full-page generated criteria', () => {
 	assert.doesNotMatch(defaultState.acceptanceCriteria, /Navigate using the primary navigation/);
 	assert.match(researcherAuthoredState.acceptanceCriteria, /Feature: Step 2 completed with researcher-authored context/);
 	assert.doesNotMatch(researcherAuthoredState.acceptanceCriteria, /AI description assistance/);
-	assert.doesNotMatch(researcherAuthoredState.acceptanceCriteria, /automated rewriting is required/);
+	assert.match(researcherAuthoredState.acceptanceCriteria, /should not imply that automated rewriting is required/);
 });
 
 test('rendered report emits group evidence above states without runtime grouping script', () => {

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyReportingReviewEvidenceToManifest } from '../scripts/reporting-review-evidence.mjs';
+import { renderReportingReviewHtml } from '../scripts/render-reporting-review-site.mjs';
+
+function stateFixture(id, title, acceptanceCriteria = 'Generated full-page criteria') {
+	return {
+		id,
+		title,
+		description: `${title} description`,
+		status: 'captured',
+		url: `https://researchops.pages.dev/${id}`,
+		acceptanceCriteria,
+		criteriaMaturity: {
+			label: 'Needs review',
+			slug: 'needs-review',
+			description: 'Generated criteria.',
+		},
+		designRisk: {
+			risk: 'Generated risk',
+			impact: 'Generated impact',
+			recommendedChange: 'Generated recommendation',
+			owner: 'UCD team',
+			status: 'Needs review',
+		},
+		evidenceTypes: ['Screenshot evidence', 'State-level acceptance criteria'],
+		captures: [],
+	};
+}
+
+function manifestFixture() {
+	return {
+		title: 'ResearchOps application visual walkthrough',
+		description: 'Fixture manifest',
+		startedAt: '2026-05-06T00:00:00.000Z',
+		baseURL: 'https://researchops.pages.dev/',
+		failureCount: 0,
+		pages: [
+			{
+				id: 'home',
+				title: 'Home',
+				group: 'Core',
+				path: '/',
+				description: 'Home page',
+				states: [stateFixture('default', 'Default state')],
+			},
+			{
+				id: 'start',
+				title: 'Start research project',
+				group: 'Core',
+				path: '/pages/start/index.html',
+				description: 'Start page',
+				states: [
+					stateFixture('default', 'Default state', 'Feature: Start a new research project\nScenario: Navigate using the primary navigation'),
+					stateFixture('step-2-filled-no-ai', 'Step 2 completed with researcher-authored context', 'Feature: Start a new research project\nScenario: Use AI description assistance'),
+				],
+			},
+			{
+				id: 'study-participant-consent',
+				title: 'Participant consent',
+				group: 'Study',
+				path: '/pages/study/participant-consent/index.html',
+				description: 'Consent page',
+				states: [stateFixture('default', 'Consent workspace loaded')],
+			},
+			{
+				id: 'synthesize',
+				title: 'Study synthesis',
+				group: 'Analysis',
+				path: '/pages/synthesize/index.html',
+				description: 'Synthesis page',
+				states: [stateFixture('missing-sid-error', 'Missing study ID error state')],
+			},
+		],
+	};
+}
+
+test('reporting review evidence is applied by page and state id rather than text matching', () => {
+	const manifest = applyReportingReviewEvidenceToManifest(manifestFixture());
+	const homePage = manifest.pages.find((page) => page.id === 'home');
+	const startPage = manifest.pages.find((page) => page.id === 'start');
+	const consentPage = manifest.pages.find((page) => page.id === 'study-participant-consent');
+	const analysisPage = manifest.pages.find((page) => page.id === 'synthesize');
+
+	assert.equal(homePage.reviewGroupId, undefined);
+	assert.equal(startPage.reviewGroupId, 'start');
+	assert.equal(consentPage.reviewGroupId, 'participant-consent');
+	assert.equal(analysisPage.reviewGroupId, 'analysis');
+	assert.equal(startPage.states[0].acceptanceCriteriaSource, 'repo-curated');
+	assert.equal(startPage.states[0].suppressGeneratedStateCriteria, true);
+	assert.equal(consentPage.states[0].suppressGeneratedStateCriteria, true);
+	assert.equal(analysisPage.states[0].suppressGeneratedStateCriteria, true);
+});
+
+test('curated start states replace old full-page generated criteria', () => {
+	const manifest = applyReportingReviewEvidenceToManifest(manifestFixture());
+	const startPage = manifest.pages.find((page) => page.id === 'start');
+	const defaultState = startPage.states.find((state) => state.id === 'default');
+	const researcherAuthoredState = startPage.states.find((state) => state.id === 'step-2-filled-no-ai');
+
+	assert.match(defaultState.acceptanceCriteria, /Feature: Start project default state/);
+	assert.doesNotMatch(defaultState.acceptanceCriteria, /Navigate using the primary navigation/);
+	assert.match(researcherAuthoredState.acceptanceCriteria, /Feature: Step 2 completed with researcher-authored context/);
+	assert.doesNotMatch(researcherAuthoredState.acceptanceCriteria, /AI description assistance/);
+	assert.doesNotMatch(researcherAuthoredState.acceptanceCriteria, /automated rewriting is required/);
+});
+
+test('rendered report emits group evidence above states without runtime grouping script', () => {
+	const html = renderReportingReviewHtml(manifestFixture());
+	const startPageHeaderIndex = html.indexOf('Start research project — group-level review evidence');
+	const startStatesIndex = html.indexOf('<div class="states">', startPageHeaderIndex);
+
+	assert.ok(startPageHeaderIndex > -1);
+	assert.ok(startStatesIndex > startPageHeaderIndex);
+	assert.match(html, /data-review-group-id="start"/);
+	assert.match(html, /data-review-evidence-level="group"/);
+	assert.match(html, /data-suppress-generated-state-criteria="true"/);
+	assert.match(html, /What this grouping should support/);
+	assert.match(html, /What this state should support/);
+	assert.doesNotMatch(html, /reporting-review-grouping-script/);
+	assert.doesNotMatch(html, /insertAdjacentElement/);
+});
+
+test('non-curated pages keep generated screen-state criteria', () => {
+	const html = renderReportingReviewHtml(manifestFixture());
+	const homeIndex = html.indexOf('Home page');
+	const startIndex = html.indexOf('Start research project — group-level review evidence');
+	const homeFragment = html.slice(homeIndex, startIndex);
+
+	assert.match(homeFragment, /What this screen state should support/);
+	assert.match(homeFragment, /Generated full-page criteria/);
+});

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -52,8 +52,16 @@ function manifestFixture() {
 				path: '/pages/start/index.html',
 				description: 'Start page',
 				states: [
-					stateFixture('default', 'Default state', 'Feature: Start a new research project\nScenario: Navigate using the primary navigation'),
-					stateFixture('step-2-filled-no-ai', 'Step 2 completed with researcher-authored context', 'Feature: Start a new research project\nScenario: Use AI description assistance'),
+					stateFixture(
+						'default',
+						'Default state',
+						'Feature: Start a new research project\nScenario: Navigate using the primary navigation'
+					),
+					stateFixture(
+						'step-2-filled-no-ai',
+						'Step 2 completed with researcher-authored context',
+						'Feature: Start a new research project\nScenario: Use AI description assistance'
+					),
 				],
 			},
 			{
@@ -97,13 +105,21 @@ test('curated start states replace old full-page generated criteria', () => {
 	const manifest = applyReportingReviewEvidenceToManifest(manifestFixture());
 	const startPage = manifest.pages.find((page) => page.id === 'start');
 	const defaultState = startPage.states.find((state) => state.id === 'default');
-	const researcherAuthoredState = startPage.states.find((state) => state.id === 'step-2-filled-no-ai');
+	const researcherAuthoredState = startPage.states.find(
+		(state) => state.id === 'step-2-filled-no-ai'
+	);
 
 	assert.match(defaultState.acceptanceCriteria, /Feature: Start project default state/);
 	assert.doesNotMatch(defaultState.acceptanceCriteria, /Navigate using the primary navigation/);
-	assert.match(researcherAuthoredState.acceptanceCriteria, /Feature: Step 2 completed with researcher-authored context/);
+	assert.match(
+		researcherAuthoredState.acceptanceCriteria,
+		/Feature: Step 2 completed with researcher-authored context/
+	);
 	assert.doesNotMatch(researcherAuthoredState.acceptanceCriteria, /AI description assistance/);
-	assert.match(researcherAuthoredState.acceptanceCriteria, /should not imply that automated rewriting is required/);
+	assert.match(
+		researcherAuthoredState.acceptanceCriteria,
+		/should not imply that automated rewriting is required/
+	);
 });
 
 test('rendered report emits group evidence above states without runtime grouping script', () => {


### PR DESCRIPTION
## Summary

Moves the reporting-review correction out of runtime DOM patching and into an explicit generation model.

The latest reporting-site evidence showed that the previous approach remained brittle:

- Start research project group-level evidence could be inserted against the wrong `Default state` card.
- Start state cards still carried old full-page generated acceptance criteria.
- Non-AI Start states still carried AI-related generated criteria.
- Participant consent and Analysis still had additive evidence rather than replacement/suppression of old generated state evidence.
- The report depended on browser-side text matching and hiding after generation.

## Changes

### Explicit review evidence model

Adds `scripts/reporting-review-evidence.mjs` with repo-backed metadata for the curated groups:

- `reviewGroupId`
- `reviewEvidenceLevel`
- `acceptanceCriteriaSource`
- `suppressGeneratedStateCriteria`
- group-level Gherkin and design-risk notes
- state-level curated Gherkin and design-risk notes

The model applies evidence by stable page and state IDs, not by text matching labels such as `Default state`.

### Static manifest renderer

Adds `scripts/render-reporting-review-site.mjs`.

The renderer:

- reads `reports-site/manifest.json`
- applies the explicit review evidence model
- writes the updated manifest back to disk
- renders `reports-site/index.html` directly from manifest evidence
- emits group evidence in the `.page-card__header`
- emits curated state evidence inside each state card
- preserves generated evidence for non-curated pages
- does not emit `reporting-review-grouping-script`
- does not use `insertAdjacentElement` or runtime DOM matching

### Workflow

Updates `.github/workflows/qa-bdd.yml` so the walkthrough job now runs:

```text
npm run qa:visual-walkthrough
node scripts/render-reporting-review-site.mjs reports-site
```

It removes the old reporting path from the workflow:

```text
node scripts/sync-report-acceptance-criteria.mjs reports-site
node scripts/apply-reporting-review-repetition-pass.mjs reports-site
node scripts/finalise-reporting-review-repetition-pass.mjs reports-site
```

### Tests

Adds `tests/reporting-review-generation-model.test.js` to assert:

- review evidence is applied by page and state ID rather than text matching
- Start, Participant consent and Analysis states receive `suppressGeneratedStateCriteria: true`
- old full-page Start criteria are replaced
- non-AI Start states do not retain old AI-generated criteria
- group evidence is rendered above the states grid
- no runtime grouping script or `insertAdjacentElement` is present
- non-curated pages keep generated screen-state criteria

## Validation

I could not run the repository suite inside this connector environment. CI should run:

```text
npm run validate
npm run lint
npm test
npm run qa:visual-walkthrough
node scripts/render-reporting-review-site.mjs reports-site
```

## Expected result after publish

The next reporting-site publish should show:

- Start research project group-level evidence in the Start page header, not after Home or inside the states grid.
- Start state cards showing only curated state-specific evidence.
- No old repeated Start full-page criteria inside each Start state.
- No AI-related criteria in the researcher-authored non-AI Start state.
- Participant consent and Analysis group evidence acting as the source of truth for their groups, with state cards showing curated state-specific evidence only.
- No browser-side hiding or post-render DOM patching.