### PR TITLE
Restore reporting sync and profile filtering

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -211,6 +211,9 @@ jobs:
       - name: Run application visual walkthrough
         run: npm run qa:visual-walkthrough
 
+      - name: Sync source-derived acceptance criteria
+        run: node scripts/sync-report-acceptance-criteria.mjs reports-site
+
       - name: Render reporting review site from manifest evidence
         run: node scripts/render-reporting-review-site.mjs reports-site
 

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -154,6 +154,68 @@ function renderPage(page = {}) {
 	</article>`;
 }
 
+function renderProfileSwitcher(profiles = []) {
+	if (!Array.isArray(profiles) || profiles.length === 0) return '';
+
+	const compareButton = profiles.length > 1
+		? `
+			<button type="button" class="profile-switcher__button" data-profile-filter="compare" aria-pressed="false">
+				Compare
+			</button>`
+		: '';
+
+	return `
+	<nav class="profile-switcher" aria-label="Screenshot profile">
+		<p class="profile-switcher__label">View</p>
+		<div class="profile-switcher__controls">
+			${profiles
+				.map(
+					(profile, index) => `
+			<button type="button" class="profile-switcher__button" data-profile-filter="${escapeHtml(profile.id)}" aria-pressed="${index === 0 ? 'true' : 'false'}">
+				${escapeHtml(profile.title || profile.id)}
+			</button>`
+				)
+				.join('')}${compareButton}
+		</div>
+	</nav>`;
+}
+
+function renderProfileSwitcherScript(profiles = []) {
+	if (!Array.isArray(profiles) || profiles.length === 0) return '';
+
+	const defaultProfile = profiles[0]?.id || '';
+
+	return `
+	<script>
+	(function () {
+		const defaultProfile = ${JSON.stringify(defaultProfile)};
+		const buttons = Array.from(document.querySelectorAll('[data-profile-filter]'));
+		const captures = Array.from(document.querySelectorAll('.capture[data-profile]'));
+
+		function applyProfileFilter(profile) {
+			const activeProfile = profile || defaultProfile;
+			const showAll = activeProfile === 'compare';
+
+			document.documentElement.dataset.profileFilter = activeProfile;
+
+			for (const button of buttons) {
+				button.setAttribute('aria-pressed', button.dataset.profileFilter === activeProfile ? 'true' : 'false');
+			}
+
+			for (const capture of captures) {
+				capture.hidden = !showAll && capture.dataset.profile !== activeProfile;
+			}
+		}
+
+		for (const button of buttons) {
+			button.addEventListener('click', () => applyProfileFilter(button.dataset.profileFilter));
+		}
+
+		applyProfileFilter(defaultProfile);
+	})();
+	</script>`;
+}
+
 function renderStyles() {
 	return `body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 24px; line-height: 1.45; color: #111; background: #fff; }
 header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; border-bottom: 1px solid #d8d8d8; margin-bottom: 24px; padding-bottom: 16px; }
@@ -162,6 +224,12 @@ h2 { margin-top: 32px; border-bottom: 1px solid #e5e5e5; padding-bottom: 8px; }
 h3, h4, h5 { margin: 0 0 6px; }
 .meta { color: #444; margin: 0; }
 .badge { background: #eef; border: 1px solid #99c; border-radius: 6px; display: inline-block; padding: 6px 10px; }
+.profile-switcher { align-items: center; display: flex; flex-wrap: wrap; gap: 12px; margin: 0 0 24px; }
+.profile-switcher__label { font-weight: 700; margin: 0; }
+.profile-switcher__controls { display: flex; flex-wrap: wrap; gap: 8px; }
+.profile-switcher__button { background: #f3f2f1; border: 2px solid #0b0c0c; border-radius: 0; cursor: pointer; font: inherit; padding: 8px 12px; }
+.profile-switcher__button[aria-pressed="true"] { background: #1d70b8; color: #fff; }
+.profile-switcher__button:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 .group { margin-bottom: 40px; }
 .page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 18px 0; overflow: hidden; }
 .page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
@@ -207,6 +275,7 @@ export function renderReportingReviewHtml(manifest = {}) {
 		</div>
 		<p class="badge">${escapeHtml(reviewedManifest.failureCount)} failures</p>
 	</header>
+	${renderProfileSwitcher(reviewedManifest.profiles)}
 	<main>
 		${groups.map(([group, pages]) => `
 		<section class="group" aria-labelledby="group-${escapeHtml(group)}">
@@ -214,6 +283,7 @@ export function renderReportingReviewHtml(manifest = {}) {
 			${pages.map(renderPage).join('')}
 		</section>`).join('')}
 	</main>
+	${renderProfileSwitcherScript(reviewedManifest.profiles)}
 </body>
 </html>`;
 }

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -174,8 +174,12 @@ test('non-curated pages keep generated screen-state criteria', () => {
 test('walkthrough workflow restores source-derived criteria sync before rendering', () => {
 	const workflow = fs.readFileSync('.github/workflows/qa-bdd.yml', 'utf8');
 	const walkthroughIndex = workflow.indexOf('npm run qa:visual-walkthrough');
-	const syncIndex = workflow.indexOf('node scripts/sync-report-acceptance-criteria.mjs reports-site');
-	const renderIndex = workflow.indexOf('node scripts/render-reporting-review-site.mjs reports-site');
+	const syncIndex = workflow.indexOf(
+		'node scripts/sync-report-acceptance-criteria.mjs reports-site'
+	);
+	const renderIndex = workflow.indexOf(
+		'node scripts/render-reporting-review-site.mjs reports-site'
+	);
 
 	assert.ok(walkthroughIndex > -1);
 	assert.ok(syncIndex > walkthroughIndex);

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -1,8 +1,19 @@
+import fs from 'node:fs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { applyReportingReviewEvidenceToManifest } from '../scripts/reporting-review-evidence.mjs';
 import { renderReportingReviewHtml } from '../scripts/render-reporting-review-site.mjs';
+
+function captureFixture(profile, title) {
+	return {
+		profile,
+		profileTitle: title,
+		status: 'captured',
+		url: `https://researchops.pages.dev/${profile}`,
+		screenshot: `screenshots/${profile}/fixture.png`,
+	};
+}
 
 function stateFixture(id, title, acceptanceCriteria = 'Generated full-page criteria') {
 	return {
@@ -25,7 +36,7 @@ function stateFixture(id, title, acceptanceCriteria = 'Generated full-page crite
 			status: 'Needs review',
 		},
 		evidenceTypes: ['Screenshot evidence', 'State-level acceptance criteria'],
-		captures: [],
+		captures: [captureFixture('desktop', 'Desktop'), captureFixture('mobile', 'Mobile')],
 	};
 }
 
@@ -36,6 +47,18 @@ function manifestFixture() {
 		startedAt: '2026-05-06T00:00:00.000Z',
 		baseURL: 'https://researchops.pages.dev/',
 		failureCount: 0,
+		profiles: [
+			{
+				id: 'desktop',
+				title: 'Desktop',
+				description: 'Desktop Chromium viewport.',
+			},
+			{
+				id: 'mobile',
+				title: 'Mobile',
+				description: 'Mobile Chromium viewport.',
+			},
+		],
 		pages: [
 			{
 				id: 'home',
@@ -146,4 +169,29 @@ test('non-curated pages keep generated screen-state criteria', () => {
 
 	assert.match(homeFragment, /What this screen state should support/);
 	assert.match(homeFragment, /Generated full-page criteria/);
+});
+
+test('walkthrough workflow restores source-derived criteria sync before rendering', () => {
+	const workflow = fs.readFileSync('.github/workflows/qa-bdd.yml', 'utf8');
+	const walkthroughIndex = workflow.indexOf('npm run qa:visual-walkthrough');
+	const syncIndex = workflow.indexOf('node scripts/sync-report-acceptance-criteria.mjs reports-site');
+	const renderIndex = workflow.indexOf('node scripts/render-reporting-review-site.mjs reports-site');
+
+	assert.ok(walkthroughIndex > -1);
+	assert.ok(syncIndex > walkthroughIndex);
+	assert.ok(renderIndex > syncIndex);
+});
+
+test('rendered report preserves profile filtering controls and capture targets', () => {
+	const html = renderReportingReviewHtml(manifestFixture());
+
+	assert.match(html, /class="profile-switcher"/);
+	assert.match(html, /aria-label="Screenshot profile"/);
+	assert.match(html, /data-profile-filter="desktop" aria-pressed="true"/);
+	assert.match(html, /data-profile-filter="mobile" aria-pressed="false"/);
+	assert.match(html, /data-profile-filter="compare" aria-pressed="false"/);
+	assert.match(html, /class="capture" data-profile="desktop"/);
+	assert.match(html, /class="capture" data-profile="mobile"/);
+	assert.match(html, /document\.documentElement\.dataset\.profileFilter = activeProfile/);
+	assert.match(html, /capture\.hidden = !showAll && capture\.dataset\.profile !== activeProfile/);
 });


### PR DESCRIPTION
## Summary

Follow-up to merged PR #190.

This addresses the two bot review findings raised after the generation-model change was merged:

1. Restore the source-derived Home and Projects acceptance criteria sync before rendering the reporting site.
2. Restore profile filtering for desktop/mobile visual captures in the generated report.

## Changes

### Restore source-derived criteria sync

Updates `.github/workflows/qa-bdd.yml` so the walkthrough job now runs:

```text
npm run qa:visual-walkthrough
node scripts/sync-report-acceptance-criteria.mjs reports-site
node scripts/render-reporting-review-site.mjs reports-site
```

This preserves the source-derived Home and Projects criteria traceability from:

- `public/index.html`
- `public/pages/projects/index.html`

The new manifest renderer still runs after sync, so the curated Start, Participant consent and Analysis group/state model remains the final reporting-site render path.

### Restore profile filtering

Updates `scripts/render-reporting-review-site.mjs` to render a profile switcher from `reviewedManifest.profiles`.

The renderer now emits:

- profile switcher navigation with `aria-label="Screenshot profile"`
- desktop/mobile profile buttons
- a Compare button when more than one profile exists
- `aria-pressed` state management
- capture filtering by `.capture[data-profile]`
- `document.documentElement.dataset.profileFilter` for the active profile

This restores the ability to review one profile at a time or compare profiles together without reintroducing the old grouping DOM patch.

### Regression tests

Updates `tests/reporting-review-generation-model.test.js` to assert:

- the workflow runs source-derived sync after `qa:visual-walkthrough` and before the renderer
- generated HTML contains the profile switcher
- desktop and mobile capture targets are present
- profile filtering hides non-selected captures
- the Compare button is rendered for multi-profile reports

## Validation

I could not run the repository suite inside this connector environment. CI should run:

```text
npm run validate
npm run lint
npm test
npm run qa:visual-walkthrough
node scripts/sync-report-acceptance-criteria.mjs reports-site
node scripts/render-reporting-review-site.mjs reports-site
```

## Scope control

This PR does not reopen the broader reporting-evidence model. It is limited to the two post-merge review findings from PR #190.