### PR TITLE
Correct platform heading hierarchy and sentence case

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8" />
 	<base href="/" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>ResearchOps Demo Suite</title>
+	<title>ResearchOps demo suite</title>
 	
 	<!-- Global styles -->
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
@@ -70,7 +70,7 @@
 			<header class="page-intro">
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
-						<h1 class="govuk-heading-xl" id="home-title">ResearchOps Demo Suite</h1>
+						<h1 class="govuk-heading-xl" id="home-title">ResearchOps demo suite</h1>
 						<p class="lede">Objective orientated applied user research done well.</p>
 						<p class="govuk-body">Use ResearchOps to structure applied user research with operations, governance and accessibility baked in.</p>
 					</div>

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -6,7 +6,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Project Dashboard — ResearchOps</title>
+	<title>Project dashboard — ResearchOps</title>
 
 	<meta name="project:name" content="">
 
@@ -25,7 +25,7 @@
 </head>
 
 <body typeof="schema:WebPage" resource="#page" about="#page" vocab="https://schema.org/">
-	<meta property="schema:name" content="Project Dashboard — ResearchOps" />
+	<meta property="schema:name" content="Project dashboard — ResearchOps" />
 	<meta property="schema:creator" content="Home Office ResearchOps Platform" />
 	<meta property="schema:dateModified" content="2026-05-05" />
 	<meta property="dcterms:language" content="en-GB" />
@@ -109,33 +109,33 @@
 			<section class="kv" typeof="schema:ResearchProject" aria-label="Project key information">
 				<dl class="govuk-summary-list">
 					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">Service Stage</dt>
+						<dt class="govuk-summary-list__key">Service stage</dt>
 						<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
 					</div>
 					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">Project Stage</dt>
+						<dt class="govuk-summary-list__key">Project stage</dt>
 						<dd class="govuk-summary-list__value" id="kv-project-stage" property="schema:projectStatus">–</dd>
 					</div>
 					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">Client Name</dt>
+						<dt class="govuk-summary-list__key">Client name</dt>
 						<dd class="govuk-summary-list__value" id="kv-client-name" property="schema:client">–</dd>
 					</div>
 					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">Lead Researcher</dt>
+						<dt class="govuk-summary-list__key">Lead researcher</dt>
 						<dd class="govuk-summary-list__value" id="kv-lead-researcher" property="schema:author" typeof="schema:Person"></dd>
 					</div>
 					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">Lead Researcher Email</dt>
+						<dt class="govuk-summary-list__key">Lead researcher email</dt>
 						<dd class="govuk-summary-list__value"><a id="kv-lead-email" property="schema:email" href="mailto:">–</a></dd>
 					</div>
 				</dl>
 			</section>
 
 			<nav class="board" typeof="schema:SiteNavigationElement">
-				<a href="/pages/projects/journals/?id=" id="journal-link" class="board__item" property="schema:relatedLink">Reflexive Journal</a>
-				<a href="#stakeholders" class="board__item" property="schema:relatedLink">Stakeholder Management</a>
-				<a href="#planning" class="board__item" property="schema:relatedLink">Research Planning</a>
-				<a href="/pages/projects/outcomes/?id=" id="outcomes-link" class="board__item" property="schema:relatedLink">Research Outcomes</a>
+				<a href="/pages/projects/journals/?id=" id="journal-link" class="board__item" property="schema:relatedLink">Reflexive journal</a>
+				<a href="#stakeholders" class="board__item" property="schema:relatedLink">Stakeholder management</a>
+				<a href="#planning" class="board__item" property="schema:relatedLink">Research planning</a>
+				<a href="/pages/projects/outcomes/?id=" id="outcomes-link" class="board__item" property="schema:relatedLink">Research outcomes</a>
 			</nav>
 
 			<section id="mural-integration" class="card">
@@ -152,7 +152,7 @@
 
 			<section id="stakeholders" class="section">
 				<div class="section__header">
-					<h2 class="section__title govuk-heading-m">Stakeholder Management</h2>
+					<h2 class="section__title govuk-heading-m">Stakeholder management</h2>
 					<button id="add-stakeholder-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-stakeholder-panel">Add stakeholder</button>
 				</div>
 				<div class="section__body section__grid">
@@ -208,11 +208,11 @@
 
 			<section id="planning" class="section">
 				<div class="section__header">
-					<h2 class="section__title govuk-heading-m">Research Planning</h2>
+					<h2 class="section__title govuk-heading-m">Research planning</h2>
 				</div>
 				<div class="section__body section__grid">
 					<div>
-						<h3 class="govuk-heading-s">User Groups</h3>
+						<h3 class="govuk-heading-s">User groups</h3>
 						<ul class="list-unstyled list-divided" id="user-groups-list"><li>No user groups yet.</li></ul>
 						<button id="add-user-group-toggle" type="button" class="govuk-button govuk-button--secondary" aria-expanded="false" aria-controls="add-user-group-panel">Add user group</button>
 						<div id="add-user-group-panel" class="dashboard-action-panel" hidden>
@@ -245,7 +245,7 @@
 
 			<section id="outcomes" class="section">
 				<div class="section__header">
-					<h2 class="section__title govuk-heading-m">Research Outcomes</h2>
+					<h2 class="section__title govuk-heading-m">Research outcomes</h2>
 				</div>
 				<div class="section__body section__grid">
 					<div>

--- a/tests/platform-heading-hierarchy-sentence-case.test.js
+++ b/tests/platform-heading-hierarchy-sentence-case.test.js
@@ -1,13 +1,19 @@
-import assert from "node:assert/strict";
-import fs from "node:fs";
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
 
-const homePage = fs.readFileSync("public/index.html", "utf8");
-const projectDashboardPage = fs.readFileSync("public/pages/project-dashboard/index.html", "utf8");
+const homePage = fs.readFileSync('public/index.html', 'utf8');
+const projectDashboardPage = fs.readFileSync('public/pages/project-dashboard/index.html', 'utf8');
 
 function headingText(source, level) {
-	const pattern = new RegExp(`<h${level}\\b[^>]*>([\\s\\S]*?)<\\/h${level}>`, "gi");
+	const pattern = new RegExp(`<h${level}\\b[^>]*>([\\s\\S]*?)<\\/h${level}>`, 'gi');
 	return [...source.matchAll(pattern)]
-		.map((match) => match[1].replace(/<[^>]+>/g, " ").replace(/&amp;/g, "&").replace(/\s+/g, " ").trim())
+		.map((match) =>
+			match[1]
+				.replace(/<[^>]+>/g, ' ')
+				.replace(/&amp;/g, '&')
+				.replace(/\s+/g, ' ')
+				.trim()
+		)
 		.filter(Boolean);
 }
 
@@ -16,22 +22,22 @@ function assertHasOneStaticH1(source, label) {
 	assert.equal(h1s.length, 1, `${label} should expose exactly one static h1`);
 }
 
-assertHasOneStaticH1(homePage, "Home page");
-assert.equal(headingText(homePage, 1)[0], "ResearchOps demo suite");
-assert.equal(homePage.includes(">ResearchOps Demo Suite</h1>"), false);
+assertHasOneStaticH1(homePage, 'Home page');
+assert.equal(headingText(homePage, 1)[0], 'ResearchOps demo suite');
+assert.equal(homePage.includes('>ResearchOps Demo Suite</h1>'), false);
 
-assertHasOneStaticH1(projectDashboardPage, "Project dashboard page");
+assertHasOneStaticH1(projectDashboardPage, 'Project dashboard page');
 
 for (const forbiddenHeading of [
-	"Service Stage",
-	"Project Stage",
-	"Client Name",
-	"Lead Researcher",
-	"Lead Researcher Email",
-	"Stakeholder Management",
-	"Research Planning",
-	"Research Outcomes",
-	"User Groups",
+	'Service Stage',
+	'Project Stage',
+	'Client Name',
+	'Lead Researcher',
+	'Lead Researcher Email',
+	'Stakeholder Management',
+	'Research Planning',
+	'Research Outcomes',
+	'User Groups',
 ]) {
 	assert.equal(
 		projectDashboardPage.includes(forbiddenHeading),
@@ -41,10 +47,10 @@ for (const forbiddenHeading of [
 }
 
 for (const expectedHeading of [
-	"Stakeholder management",
-	"Research planning",
-	"Research outcomes",
-	"User groups",
+	'Stakeholder management',
+	'Research planning',
+	'Research outcomes',
+	'User groups',
 ]) {
 	assert.equal(
 		projectDashboardPage.includes(`>${expectedHeading}<`),

--- a/tests/platform-heading-hierarchy-sentence-case.test.js
+++ b/tests/platform-heading-hierarchy-sentence-case.test.js
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const homePage = fs.readFileSync("public/index.html", "utf8");
+const projectDashboardPage = fs.readFileSync("public/pages/project-dashboard/index.html", "utf8");
+
+function headingText(source, level) {
+	const pattern = new RegExp(`<h${level}\\b[^>]*>([\\s\\S]*?)<\\/h${level}>`, "gi");
+	return [...source.matchAll(pattern)]
+		.map((match) => match[1].replace(/<[^>]+>/g, " ").replace(/&amp;/g, "&").replace(/\s+/g, " ").trim())
+		.filter(Boolean);
+}
+
+function assertHasOneStaticH1(source, label) {
+	const h1s = headingText(source, 1);
+	assert.equal(h1s.length, 1, `${label} should expose exactly one static h1`);
+}
+
+assertHasOneStaticH1(homePage, "Home page");
+assert.equal(headingText(homePage, 1)[0], "ResearchOps demo suite");
+assert.equal(homePage.includes(">ResearchOps Demo Suite</h1>"), false);
+
+assertHasOneStaticH1(projectDashboardPage, "Project dashboard page");
+
+for (const forbiddenHeading of [
+	"Service Stage",
+	"Project Stage",
+	"Client Name",
+	"Lead Researcher",
+	"Lead Researcher Email",
+	"Stakeholder Management",
+	"Research Planning",
+	"Research Outcomes",
+	"User Groups",
+]) {
+	assert.equal(
+		projectDashboardPage.includes(forbiddenHeading),
+		false,
+		`Project dashboard should not use title case heading or key text: ${forbiddenHeading}`
+	);
+}
+
+for (const expectedHeading of [
+	"Stakeholder management",
+	"Research planning",
+	"Research outcomes",
+	"User groups",
+]) {
+	assert.equal(
+		projectDashboardPage.includes(`>${expectedHeading}<`),
+		true,
+		`Project dashboard should use sentence case heading: ${expectedHeading}`
+	);
+}


### PR DESCRIPTION
## Summary

Implements the P1 heading/sentence-case backlog item for the ResearchOps platform routes touched by the design critique.

This targets the live platform under `public/`. It does not update `reports-site/`.

## Changes

- Updates the home page title and visible page heading from `ResearchOps Demo Suite` to `ResearchOps demo suite`.
- Updates the project dashboard document title and schema name to sentence case.
- Converts project dashboard key labels and navigation/section headings to sentence case:
  - `Service stage`
  - `Project stage`
  - `Client name`
  - `Lead researcher`
  - `Lead researcher email`
  - `Reflexive journal`
  - `Stakeholder management`
  - `Research planning`
  - `Research outcomes`
  - `User groups`
- Adds regression coverage in `tests/platform-heading-hierarchy-sentence-case.test.js` for:
  - one static `<h1>` on the home page
  - one static `<h1>` on the project dashboard page
  - home page sentence-case `<h1>`
  - removal of known title-case dashboard headings and key labels
  - presence of sentence-case dashboard headings

## GOV.UK basis

The change follows the GOV.UK heading contract used in the bundle:

- use heading tags to define page structure
- keep heading hierarchy ordered
- use one clear page-level `<h1>`
- write headings in sentence case

## ResearchOps/GitHub management

- Branch created from current `main`: `fix/platform-heading-hierarchy-sentence-case-current-main`
- Scope kept to application source and route-state tests
- No changes made to the generated reporting site

## Validation

I could not run the repository suite in this connector environment. CI should run:

```text
npm run validate
npm run lint
npm test
npm run qa:visual-walkthrough
```

## Notes

This PR corrects the high-confidence authored headings and key labels surfaced by the P1 critique. Follow-up work should extend the same audit to lower-priority routes and dynamically generated headings where needed.