### PR TITLE
Fix project dashboard static heading fallback

### DIFF
--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -102,7 +102,7 @@
 
 			<div class="dashboard-hero">
 				<p id="eyebrow-org" class="project-org" property="schema:sourceOrganization" typeof="schema:Organization"></p>
-				<h1 id="project-title" class="govuk-heading-l" property="schema:name"></h1>
+				<h1 id="project-title" class="govuk-heading-l" property="schema:name">Project dashboard</h1>
 				<p id="project-subtitle" class="lede" property="schema:description"></p>
 			</div>
 

--- a/tests/platform-heading-hierarchy-sentence-case.test.js
+++ b/tests/platform-heading-hierarchy-sentence-case.test.js
@@ -20,13 +20,13 @@ function headingText(source, level) {
 function assertHasOneStaticH1(source, label) {
 	const h1s = headingText(source, 1);
 	assert.equal(h1s.length, 1, `${label} should expose exactly one static h1`);
+	return h1s[0];
 }
 
-assertHasOneStaticH1(homePage, 'Home page');
-assert.equal(headingText(homePage, 1)[0], 'ResearchOps demo suite');
+assert.equal(assertHasOneStaticH1(homePage, 'Home page'), 'ResearchOps demo suite');
 assert.equal(homePage.includes('>ResearchOps Demo Suite</h1>'), false);
 
-assertHasOneStaticH1(projectDashboardPage, 'Project dashboard page');
+assert.equal(assertHasOneStaticH1(projectDashboardPage, 'Project dashboard page'), 'Project dashboard');
 
 for (const forbiddenHeading of [
 	'Service Stage',

--- a/tests/platform-heading-hierarchy-sentence-case.test.js
+++ b/tests/platform-heading-hierarchy-sentence-case.test.js
@@ -26,7 +26,10 @@ function assertHasOneStaticH1(source, label) {
 assert.equal(assertHasOneStaticH1(homePage, 'Home page'), 'ResearchOps demo suite');
 assert.equal(homePage.includes('>ResearchOps Demo Suite</h1>'), false);
 
-assert.equal(assertHasOneStaticH1(projectDashboardPage, 'Project dashboard page'), 'Project dashboard');
+assert.equal(
+	assertHasOneStaticH1(projectDashboardPage, 'Project dashboard page'),
+	'Project dashboard'
+);
 
 for (const forbiddenHeading of [
 	'Service Stage',


### PR DESCRIPTION
## Summary

Fixes the release-gate failure introduced by PR #192.

The failing test was correct to expect one static page-level `<h1>` on the project dashboard. The dashboard route had an empty source-level `<h1>` that is populated by JavaScript, so the static heading audit counted zero headings.

## Changes

- Adds a static sentence-case fallback heading to `public/pages/project-dashboard/index.html`:

```html
<h1 id="project-title" class="govuk-heading-l" property="schema:name">Project dashboard</h1>
```

- Keeps the existing `id="project-title"` hook so the dashboard controller can still replace the fallback with the loaded project name.
- Updates `tests/platform-heading-hierarchy-sentence-case.test.js` to assert the exact static fallback heading.

## Validation

From the attached release-gate logs, the failure was:

```text
AssertionError [ERR_ASSERTION]: Project dashboard page should expose exactly one static h1
0 !== 1
```

This PR addresses that assertion directly by adding a non-empty static `<h1>`.

I could not run the full repository suite in this connector environment. CI should run:

```text
npm test
npm run validate
npm run lint
npm run qa:visual-walkthrough
```

## Risk

Low. This is a one-line application fallback plus a matching assertion update. It improves no-JavaScript and pre-hydration accessibility while preserving the JavaScript update hook.