### PR TITLE
Update home Gherkin test for sentence case

### DIFF
--- a/tests/cucumber-reporting.test.js
+++ b/tests/cucumber-reporting.test.js
@@ -88,7 +88,8 @@ test('buildStateAcceptanceGherkin writes ResearchOps home criteria from a user r
 	assert.match(gherkin, /I want to access the ResearchOps home page/);
 	assert.match(gherkin, /So that I can choose the right ResearchOps journey for my work/);
 	assert.match(gherkin, /Scenario: View the ResearchOps service identity/);
-	assert.match(gherkin, /ResearchOps Demo Suite/);
+	assert.match(gherkin, /ResearchOps demo suite/);
+	assert.doesNotMatch(gherkin, /ResearchOps Demo Suite/);
 	assert.match(gherkin, /Objective orientated applied user research done well\./);
 	assert.match(gherkin, /Scenario: Navigate using the primary navigation/);
 	assert.match(gherkin, /Start research project/);


### PR DESCRIPTION
## Summary

Fixes the latest release-gate failure after the platform heading sentence-case change.

The generated source-derived home-page Gherkin now correctly says:

```text
ResearchOps demo suite
```

But `tests/cucumber-reporting.test.js` still expected the old title-case string:

```text
ResearchOps Demo Suite
```

## Changes

- Updates the home-page Gherkin regression assertion to expect `ResearchOps demo suite`.
- Adds a negative assertion so the test rejects the old `ResearchOps Demo Suite` string.

## Validation from attached logs

The failing assertion was:

```text
The input did not match the regular expression /ResearchOps Demo Suite/.
```

The actual generated Gherkin already contained the correct sentence-case text:

```text
Then I should see the service name "ResearchOps demo suite"
And I should see the page heading "ResearchOps demo suite"
```

## Risk

Low. This updates a stale test expectation to match the deliberate heading/content change from PR #192 and preserves coverage by asserting that the old title-case string is absent.

I could not run the full suite in this connector environment. CI should run:

```text
npm test
npm run validate
npm run lint
npm run qa:visual-walkthrough
```