### PR TITLE
Remove visual focus treatment from main content target

### DIFF
--- a/public/css/govuk/govuk-main-content-focus.css
+++ b/public/css/govuk/govuk-main-content-focus.css
@@ -1,0 +1,9 @@
+/* GOV.UK main content focus target */
+
+main#main-content.govuk-main-wrapper:focus,
+main#main-content.govuk-main-wrapper:focus-visible {
+	outline: none;
+	box-shadow: none;
+	}
+
+/* transparency begins in the cascade */

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,6 +1,7 @@
 <!-- public/partials/header.html -->
 <a class="govuk-skip-link" href="#main-content">Skip to main content</a>
 <link rel="stylesheet" href="/css/govuk/govuk-header-service-brand.css" media="screen">
+<link rel="stylesheet" href="/css/govuk/govuk-main-content-focus.css" media="screen">
 
 <header class="govuk-header" role="banner" data-module="govuk-header">
 	<div class="govuk-header__container govuk-width-container">

--- a/tests/main-content-focus-route-state.test.js
+++ b/tests/main-content-focus-route-state.test.js
@@ -1,45 +1,45 @@
-import assert from "node:assert/strict";
-import fs from "node:fs";
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
 
-const headerPartial = fs.readFileSync("public/partials/header.html", "utf8");
+const headerPartial = fs.readFileSync('public/partials/header.html', 'utf8');
 const mainContentFocusCss = fs.readFileSync(
-  "public/css/govuk/govuk-main-content-focus.css",
-  "utf8"
+	'public/css/govuk/govuk-main-content-focus.css',
+	'utf8'
 );
 
 function includes(source, text, label) {
-  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
 }
 
 function excludes(source, text, label) {
-  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
 includes(
-  headerPartial,
-  "href=\"/css/govuk/govuk-main-content-focus.css\"",
-  "shared header partial"
+	headerPartial,
+	'href="/css/govuk/govuk-main-content-focus.css"',
+	'shared header partial'
 );
 includes(
-  mainContentFocusCss,
-  "main#main-content.govuk-main-wrapper:focus",
-  "main content focus stylesheet"
+	mainContentFocusCss,
+	'main#main-content.govuk-main-wrapper:focus',
+	'main content focus stylesheet'
 );
 includes(
-  mainContentFocusCss,
-  "main#main-content.govuk-main-wrapper:focus-visible",
-  "main content focus stylesheet"
+	mainContentFocusCss,
+	'main#main-content.govuk-main-wrapper:focus-visible',
+	'main content focus stylesheet'
 );
-includes(mainContentFocusCss, "outline: none;", "main content focus stylesheet");
-includes(mainContentFocusCss, "box-shadow: none;", "main content focus stylesheet");
+includes(mainContentFocusCss, 'outline: none;', 'main content focus stylesheet');
+includes(mainContentFocusCss, 'box-shadow: none;', 'main content focus stylesheet');
 includes(
-  mainContentFocusCss,
-  "/* transparency begins in the cascade */",
-  "main content focus stylesheet"
+	mainContentFocusCss,
+	'/* transparency begins in the cascade */',
+	'main content focus stylesheet'
 );
 
-excludes(mainContentFocusCss, "background:", "main content focus stylesheet");
-excludes(mainContentFocusCss, "background-color:", "main content focus stylesheet");
-excludes(mainContentFocusCss, "color:", "main content focus stylesheet");
-excludes(mainContentFocusCss, "#ffbf47", "main content focus stylesheet");
-excludes(mainContentFocusCss, "#ffdd00", "main content focus stylesheet");
+excludes(mainContentFocusCss, 'background:', 'main content focus stylesheet');
+excludes(mainContentFocusCss, 'background-color:', 'main content focus stylesheet');
+excludes(mainContentFocusCss, 'color:', 'main content focus stylesheet');
+excludes(mainContentFocusCss, '#ffbf47', 'main content focus stylesheet');
+excludes(mainContentFocusCss, '#ffdd00', 'main content focus stylesheet');

--- a/tests/main-content-focus-route-state.test.js
+++ b/tests/main-content-focus-route-state.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const headerPartial = fs.readFileSync("public/partials/header.html", "utf8");
+const mainContentFocusCss = fs.readFileSync(
+  "public/css/govuk/govuk-main-content-focus.css",
+  "utf8"
+);
+
+function includes(source, text, label) {
+  assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+  assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(
+  headerPartial,
+  "href=\"/css/govuk/govuk-main-content-focus.css\"",
+  "shared header partial"
+);
+includes(
+  mainContentFocusCss,
+  "main#main-content.govuk-main-wrapper:focus",
+  "main content focus stylesheet"
+);
+includes(
+  mainContentFocusCss,
+  "main#main-content.govuk-main-wrapper:focus-visible",
+  "main content focus stylesheet"
+);
+includes(mainContentFocusCss, "outline: none;", "main content focus stylesheet");
+includes(mainContentFocusCss, "box-shadow: none;", "main content focus stylesheet");
+includes(
+  mainContentFocusCss,
+  "/* transparency begins in the cascade */",
+  "main content focus stylesheet"
+);
+
+excludes(mainContentFocusCss, "background:", "main content focus stylesheet");
+excludes(mainContentFocusCss, "background-color:", "main content focus stylesheet");
+excludes(mainContentFocusCss, "color:", "main content focus stylesheet");
+excludes(mainContentFocusCss, "#ffbf47", "main content focus stylesheet");
+excludes(mainContentFocusCss, "#ffdd00", "main content focus stylesheet");


### PR DESCRIPTION
## Summary

Prevents `main#main-content.govuk-main-wrapper` from showing visual focus colour treatment when it receives focus as the skip-link target.

The main content region remains programmatically focusable for skip-link behaviour. Interactive elements inside the page keep their own focus styles.

## Changes

- Adds `public/css/govuk/govuk-main-content-focus.css`.
- Loads the stylesheet from `public/partials/header.html` with the existing page chrome styles.
- Adds a regression test in `tests/main-content-focus-route-state.test.js`.

## Focus behaviour

The new stylesheet only targets:

```css
main#main-content.govuk-main-wrapper:focus,
main#main-content.govuk-main-wrapper:focus-visible
```

It sets:

```css
outline: none;
box-shadow: none;
```

It does not set `background`, `background-color`, `color`, or GOV.UK yellow focus colours on the main content target.

## Validation

I could not run the suite in this connector environment. CI should run:

```text
npm test
npm run validate
npm run lint
npm run qa:visual-walkthrough
```

## Risk

Low. This is scoped to the main content skip-link target only. It does not remove focus styles from links, buttons, form controls, service navigation, breadcrumbs, or other interactive elements.