### PR TITLE
Source control Agent Gateway audit schema

### DIFF
--- a/infra/cloudflare/agent-gateway/migrations/0001_agent_gateway_audit.sql
+++ b/infra/cloudflare/agent-gateway/migrations/0001_agent_gateway_audit.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS agent_gateway_audit (
+	row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	id TEXT NOT NULL,
+	tool TEXT NOT NULL,
+	environment TEXT NOT NULL,
+	actor TEXT NOT NULL,
+	reason TEXT NOT NULL,
+	phase TEXT NOT NULL,
+	ok INTEGER NOT NULL,
+	message TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	fixture_name TEXT,
+	request_id TEXT,
+	target_resource_type TEXT,
+	target_resource_id TEXT,
+	operation_class TEXT,
+	ip_hash TEXT,
+	user_agent_hash TEXT,
+	commit_sha TEXT,
+	workflow_run_id TEXT,
+	input_hash TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_created_at
+ON agent_gateway_audit (created_at);
+
+CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_actor
+ON agent_gateway_audit (actor);
+
+CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_tool
+ON agent_gateway_audit (tool);
+
+CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_phase
+ON agent_gateway_audit (phase);
+
+CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_operation_class
+ON agent_gateway_audit (operation_class);
+
+CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_target_resource
+ON agent_gateway_audit (target_resource_type, target_resource_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_request_id
+ON agent_gateway_audit (request_id);

--- a/infra/cloudflare/agent-gateway/src/audit/log.ts
+++ b/infra/cloudflare/agent-gateway/src/audit/log.ts
@@ -10,6 +10,16 @@ export type AuditRecord = {
   ok: boolean;
   message: string;
   createdAt: string;
+  fixtureName: string;
+  requestId: string;
+  targetResourceType: string;
+  targetResourceId: string;
+  operationClass: "read" | "write";
+  ipHash: string;
+  userAgentHash: string;
+  commitSha: string;
+  workflowRunId: string;
+  inputHash: string;
 };
 
 export type AuditBinding = {
@@ -24,8 +34,87 @@ export type AuditEnv = {
   AUDIT_DB?: AuditBinding;
 };
 
+const WRITE_TOOLS = new Set([
+  "cloudflare.d1.seedApprovedFixture",
+  "cloudflare.kv.putJsonUnderPrefix",
+]);
+
+const AUDIT_TABLE_SQL = `CREATE TABLE IF NOT EXISTS agent_gateway_audit (
+	row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	id TEXT NOT NULL,
+	tool TEXT NOT NULL,
+	environment TEXT NOT NULL,
+	actor TEXT NOT NULL,
+	reason TEXT NOT NULL,
+	phase TEXT NOT NULL,
+	ok INTEGER NOT NULL,
+	message TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	fixture_name TEXT,
+	request_id TEXT,
+	target_resource_type TEXT,
+	target_resource_id TEXT,
+	operation_class TEXT,
+	ip_hash TEXT,
+	user_agent_hash TEXT,
+	commit_sha TEXT,
+	workflow_run_id TEXT,
+	input_hash TEXT
+)`;
+
+const AUDIT_INDEX_SQL = [
+  "CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_created_at ON agent_gateway_audit (created_at)",
+  "CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_actor ON agent_gateway_audit (actor)",
+  "CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_tool ON agent_gateway_audit (tool)",
+  "CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_phase ON agent_gateway_audit (phase)",
+  "CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_operation_class ON agent_gateway_audit (operation_class)",
+  "CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_target_resource ON agent_gateway_audit (target_resource_type, target_resource_id)",
+  "CREATE INDEX IF NOT EXISTS idx_agent_gateway_audit_request_id ON agent_gateway_audit (request_id)",
+];
+
 export function createAuditId(): string {
   return `agw_${crypto.randomUUID()}`;
+}
+
+function auditString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function targetResourceType(request: ToolRequest): string {
+  if (request.tool.startsWith("cloudflare.d1.")) return "d1";
+  if (request.tool.startsWith("cloudflare.kv.")) return "kv";
+  if (request.tool.startsWith("cloudflare.durableObjects.")) return "durable-object";
+  if (request.tool.startsWith("cloudflare.workers.")) return "worker";
+  return "cloudflare";
+}
+
+function targetResourceId(request: ToolRequest): string {
+  return (
+    auditString(request.input?.databaseId) ||
+    auditString(request.input?.namespaceId) ||
+    auditString(request.input?.scriptName) ||
+    auditString(request.input?.key) ||
+    auditString(request.input?.path)
+  );
+}
+
+function operationClass(request: ToolRequest): "read" | "write" {
+  return WRITE_TOOLS.has(request.tool) ? "write" : "read";
+}
+
+async function hashInput(input: unknown): Promise<string> {
+  const value = JSON.stringify(input || {});
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function ensureAuditSchema(db: AuditBinding): Promise<void> {
+  await db.prepare(AUDIT_TABLE_SQL).bind().run();
+
+  for (const sql of AUDIT_INDEX_SQL) {
+    await db.prepare(sql).bind().run();
+  }
 }
 
 export async function persistAudit(
@@ -46,20 +135,26 @@ export async function persistAudit(
     ok,
     message,
     createdAt: new Date().toISOString(),
+    fixtureName: auditString(request.input?.fixtureName),
+    requestId: auditString(request.input?.requestId),
+    targetResourceType: targetResourceType(request),
+    targetResourceId: targetResourceId(request),
+    operationClass: operationClass(request),
+    ipHash: auditString(request.input?.ipHash),
+    userAgentHash: auditString(request.input?.userAgentHash),
+    commitSha: auditString(request.input?.commitSha),
+    workflowRunId: auditString(request.input?.workflowRunId),
+    inputHash: await hashInput(request.input),
   };
 
   if (!env.AUDIT_DB) {
     throw new Error("AUDIT_DB binding is required so agent gateway activity is persisted.");
   }
 
-  await env.AUDIT_DB.prepare(
-    "CREATE TABLE IF NOT EXISTS agent_gateway_audit (id TEXT NOT NULL, tool TEXT NOT NULL, environment TEXT NOT NULL, actor TEXT NOT NULL, reason TEXT NOT NULL, phase TEXT NOT NULL, ok INTEGER NOT NULL, message TEXT NOT NULL, created_at TEXT NOT NULL)",
-  )
-    .bind()
-    .run();
+  await ensureAuditSchema(env.AUDIT_DB);
 
   await env.AUDIT_DB.prepare(
-    "INSERT INTO agent_gateway_audit (id, tool, environment, actor, reason, phase, ok, message, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO agent_gateway_audit (id, tool, environment, actor, reason, phase, ok, message, created_at, fixture_name, request_id, target_resource_type, target_resource_id, operation_class, ip_hash, user_agent_hash, commit_sha, workflow_run_id, input_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
   )
     .bind(
       record.id,
@@ -71,6 +166,16 @@ export async function persistAudit(
       record.ok ? 1 : 0,
       record.message,
       record.createdAt,
+      record.fixtureName,
+      record.requestId,
+      record.targetResourceType,
+      record.targetResourceId,
+      record.operationClass,
+      record.ipHash,
+      record.userAgentHash,
+      record.commitSha,
+      record.workflowRunId,
+      record.inputHash,
     )
     .run();
 

--- a/tests/agent-gateway-capability-layer-contract.test.js
+++ b/tests/agent-gateway-capability-layer-contract.test.js
@@ -15,6 +15,7 @@ const files = {
 	client: `${gatewayRoot}/src/cloudflare/client.ts`,
 	wrangler: `${gatewayRoot}/wrangler.toml`,
 	readme: `${gatewayRoot}/README.md`,
+	migration: `${gatewayRoot}/migrations/0001_agent_gateway_audit.sql`,
 	workerCi: ".github/workflows/worker-ci.yml",
 	deployGateway: ".github/workflows/deploy-agent-gateway.yml",
 	deploymentToolchain: "deployment-toolchain.yaml",
@@ -63,6 +64,49 @@ for (const tool of expectedTools) {
 	includes("index", `"${tool}"`, "agent gateway router");
 }
 
+const auditColumns = [
+	"row_id INTEGER PRIMARY KEY AUTOINCREMENT",
+	"id TEXT NOT NULL",
+	"tool TEXT NOT NULL",
+	"environment TEXT NOT NULL",
+	"actor TEXT NOT NULL",
+	"reason TEXT NOT NULL",
+	"phase TEXT NOT NULL",
+	"ok INTEGER NOT NULL",
+	"message TEXT NOT NULL",
+	"created_at TEXT NOT NULL",
+	"fixture_name TEXT",
+	"request_id TEXT",
+	"target_resource_type TEXT",
+	"target_resource_id TEXT",
+	"operation_class TEXT",
+	"ip_hash TEXT",
+	"user_agent_hash TEXT",
+	"commit_sha TEXT",
+	"workflow_run_id TEXT",
+	"input_hash TEXT",
+];
+
+for (const column of auditColumns) {
+	includes("migration", column, "agent gateway audit migration");
+	includes("audit", column, "agent gateway defensive audit schema");
+}
+
+const auditIndexes = [
+	"idx_agent_gateway_audit_created_at",
+	"idx_agent_gateway_audit_actor",
+	"idx_agent_gateway_audit_tool",
+	"idx_agent_gateway_audit_phase",
+	"idx_agent_gateway_audit_operation_class",
+	"idx_agent_gateway_audit_target_resource",
+	"idx_agent_gateway_audit_request_id",
+];
+
+for (const indexName of auditIndexes) {
+	includes("migration", indexName, "agent gateway audit migration");
+	includes("audit", indexName, "agent gateway defensive audit schema");
+}
+
 const includeChecks = [
 	["schemas", 'environment: "production";', "agent gateway schemas"],
 	["schemas", "actor: string;", "agent gateway schemas"],
@@ -97,6 +141,9 @@ const includeChecks = [
 	["audit", "completed", "agent gateway audit log"],
 	["audit", "failed", "agent gateway audit log"],
 	["audit", "blocked", "agent gateway audit log"],
+	["audit", "inputHash: await hashInput", "agent gateway audit log"],
+	["audit", "operationClass: operationClass", "agent gateway audit log"],
+	["audit", "targetResourceType: targetResourceType", "agent gateway audit log"],
 	["index", "AGENT_GATEWAY_TOKEN", "agent gateway router"],
 	["index", "authorization", "agent gateway router"],
 	["index", "assertAuthorized", "agent gateway router"],
@@ -136,7 +183,7 @@ const includeChecks = [
 	["wrangler", "AUDIT_DB", "agent gateway Wrangler config"],
 	[
 		"wrangler",
-		"00000000-0000-0000-0000-000000000000",
+		"75196021-d2a9-435f-a0ac-654baeb111d4",
 		"agent gateway Wrangler config",
 	],
 	["readme", "production-safe capability layer", "agent gateway README"],
@@ -197,3 +244,5 @@ for (const [key, text, label] of includeChecks) {
 
 excludes("client", "X-Auth-Key", "Cloudflare API client");
 excludes("client", "X-Auth-Email", "Cloudflare API client");
+excludes("audit", "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", "agent gateway audit log");
+excludes("wrangler", "00000000-0000-0000-0000-000000000000", "agent gateway Wrangler config");


### PR DESCRIPTION
## Summary

Adds source-controlled schema governance for the production Agent Gateway audit database.

This PR makes the repository match the stronger D1 audit schema that is already operational in production.

## Changes

- Adds `infra/cloudflare/agent-gateway/migrations/0001_agent_gateway_audit.sql`.
- Aligns the defensive runtime audit table creation in `src/audit/log.ts` with the production schema.
- Extends audit persistence to write the additional traceability columns:
  - `fixture_name`
  - `request_id`
  - `target_resource_type`
  - `target_resource_id`
  - `operation_class`
  - `ip_hash`
  - `user_agent_hash`
  - `commit_sha`
  - `workflow_run_id`
  - `input_hash`
- Adds index creation for the source-controlled schema.
- Updates the existing Agent Gateway contract test to require the migration, runtime schema and insert path to stay aligned.

## Why

The live D1 database has the stronger audit schema, but `main` still had only the minimal runtime table creation statement.

That created schema drift. If the audit database had to be recreated or promoted in another environment, the repository would not recreate the production schema.

## Safety

The change does not add new Agent Gateway tools or broaden access.

It strengthens audit persistence and traceability only.

## Validation

CI should run:

```text
npm run validate
npm run lint
npm test
```

The Agent Gateway contract test is named with the repository's `*-contract.test.js` pattern, so it remains in `npm test` while avoiding the known Prettier formatting issue for generated-style contract assertions.