### PR TITLE
Add Agent Gateway OpenAPI connector contract

### DIFF
--- a/docs/deployment/agent-gateway-openapi-connector.md
+++ b/docs/deployment/agent-gateway-openapi-connector.md
@@ -45,6 +45,8 @@ Do not paste the token into chat.
 
 Do not commit the token to GitHub.
 
+Do not configure the connector with `CF_API_TOKEN`.
+
 Do not expose the Cloudflare API token to the connector.
 
 ## Required connector configuration

--- a/docs/deployment/agent-gateway-openapi-connector.md
+++ b/docs/deployment/agent-gateway-openapi-connector.md
@@ -1,0 +1,218 @@
+# Agent Gateway OpenAPI connector setup
+
+This document explains how to expose the ResearchOps Cloudflare Agent Gateway to an AI agent as a secured API tool connector.
+
+The gateway remains the only runtime that can call Cloudflare production resources. The connector does not receive raw Cloudflare credentials. It only receives a bearer token for the Agent Gateway.
+
+## Source contract
+
+The OpenAPI contract is source-controlled at:
+
+```text
+infra/cloudflare/agent-gateway/openapi.yaml
+```
+
+The production gateway origin is:
+
+```text
+https://researchops-agent-gateway.digikev-kevin-rapley.workers.dev
+```
+
+The contract exposes:
+
+```text
+GET /health
+POST /tools
+```
+
+`POST /tools` is the only privileged operation. It accepts one named tool request and returns an audited response with an `auditId`.
+
+## Authentication model
+
+Store this value as a connector secret:
+
+```text
+AGENT_GATEWAY_TOKEN
+```
+
+The connector must send it as:
+
+```text
+Authorization: Bearer <AGENT_GATEWAY_TOKEN>
+```
+
+Do not paste the token into chat.
+
+Do not commit the token to GitHub.
+
+Do not expose the Cloudflare API token to the connector.
+
+## Required connector configuration
+
+When creating the secured API connector, use:
+
+```text
+OpenAPI file: infra/cloudflare/agent-gateway/openapi.yaml
+Authentication: HTTP bearer token
+Bearer token source: connector secret
+Secret value: AGENT_GATEWAY_TOKEN
+Base URL: https://researchops-agent-gateway.digikev-kevin-rapley.workers.dev
+```
+
+The connector should make only HTTPS requests.
+
+The connector should not allow arbitrary URL override.
+
+The connector should not expose request headers, bearer tokens or Cloudflare API tokens in model-visible output.
+
+## Tool request shape
+
+Example read-only request:
+
+```json
+{
+	"tool": "cloudflare.d1.inspectSchema",
+	"environment": "production",
+	"actor": "agent:chatgpt",
+	"reason": "Inspect the schema before debugging a production issue.",
+	"input": {
+		"databaseId": "75196021-d2a9-435f-a0ac-654baeb111d4"
+	}
+}
+```
+
+Example read-only D1 query:
+
+```json
+{
+	"tool": "cloudflare.d1.runReadOnlyQuery",
+	"environment": "production",
+	"actor": "agent:chatgpt",
+	"reason": "Check recent audit rows after a gateway operation.",
+	"input": {
+		"databaseId": "75196021-d2a9-435f-a0ac-654baeb111d4",
+		"sql": "SELECT id, tool, actor, phase, ok, created_at FROM agent_gateway_audit ORDER BY row_id DESC LIMIT 10",
+		"params": []
+	}
+}
+```
+
+Example write request shape:
+
+```json
+{
+	"tool": "cloudflare.kv.putJsonUnderPrefix",
+	"environment": "production",
+	"actor": "agent:chatgpt",
+	"reason": "Seed an approved test automation fixture under an approved prefix.",
+	"input": {
+		"namespaceId": "example-kv-namespace-id",
+		"key": "researchops:test-automation:example",
+		"value": {
+			"ok": true
+		}
+	}
+}
+```
+
+Write requests remain controlled server-side by the Agent Gateway allowlist. The OpenAPI contract describes the request shape, but the Worker remains the policy enforcement point.
+
+## Available tools
+
+```text
+cloudflare.d1.inspectSchema
+cloudflare.d1.runReadOnlyQuery
+cloudflare.d1.seedApprovedFixture
+cloudflare.kv.listKeys
+cloudflare.kv.getJson
+cloudflare.kv.putJsonUnderPrefix
+cloudflare.durableObjects.listNamespaces
+cloudflare.durableObjects.listObjects
+cloudflare.durableObjects.inspectViaAdminRoute
+cloudflare.workers.tailRecentErrors
+```
+
+## Audit expectations
+
+Every authorised request should create audit rows in:
+
+```text
+researchops-agent-gateway-audit.agent_gateway_audit
+```
+
+Expected successful read-only phases:
+
+```text
+accepted
+completed
+```
+
+Expected blocked write phases:
+
+```text
+blocked
+```
+
+Each response includes:
+
+```text
+auditId
+```
+
+Use that value to find the audit trail for the request.
+
+## Acceptance checks
+
+After configuring the connector, run these checks.
+
+1. Call `getAgentGatewayHealth`.
+
+Expected result:
+
+```json
+{
+	"ok": true,
+	"service": "ResearchOps Cloudflare agent gateway"
+}
+```
+
+2. Call `runAgentGatewayTool` with `cloudflare.d1.inspectSchema` against the audit database.
+
+Expected result:
+
+```text
+ok = true
+auditId present
+result includes agent_gateway_audit schema rows
+```
+
+3. Query the audit table for the returned `auditId`.
+
+Expected phases:
+
+```text
+accepted
+completed
+```
+
+4. Attempt a write without a required reason.
+
+Expected result:
+
+```text
+ok = false
+error.message explains the write was blocked
+blocked audit row exists
+```
+
+## Safety rules
+
+The connector must not be configured with a Cloudflare API token.
+
+The connector must not expose arbitrary Cloudflare HTTP endpoints.
+
+The connector must not allow raw SQL mutation. D1 read-only enforcement remains in the Agent Gateway policy.
+
+The connector must not allow unaudited requests.
+
+If the OpenAPI contract and gateway implementation disagree, the gateway implementation is the source of enforcement and the OpenAPI file must be updated.

--- a/infra/cloudflare/agent-gateway/README.md
+++ b/infra/cloudflare/agent-gateway/README.md
@@ -25,10 +25,11 @@ The gateway is intended for agent-facing operations such as:
 ## Endpoint
 
 ```text
+GET /health
 POST /tools
 ```
 
-Every request must include:
+Every `/tools` request must include:
 
 ```text
 Authorization: Bearer <AGENT_GATEWAY_TOKEN>
@@ -46,6 +47,34 @@ Example request:
 		"databaseId": "<production-d1-database-id>"
 	}
 }
+```
+
+## OpenAPI connector contract
+
+The secured API connector contract is source-controlled at:
+
+```text
+infra/cloudflare/agent-gateway/openapi.yaml
+```
+
+Use it to expose the gateway as an API tool connector without exposing raw Cloudflare credentials.
+
+Connector authentication must use an HTTP bearer token secret:
+
+```text
+AGENT_GATEWAY_TOKEN
+```
+
+Do not paste this token into chat.
+
+Do not commit this token to GitHub.
+
+Do not configure the connector with `CF_API_TOKEN`.
+
+Connector setup instructions are documented at:
+
+```text
+docs/deployment/agent-gateway-openapi-connector.md
 ```
 
 ## Production write rules
@@ -113,7 +142,7 @@ npx --yes wrangler@${WRANGLER_VERSION} secret put CF_ACCOUNT_ID --config infra/c
 
 ## Deployment
 
-Replace the audit D1 database ID in `infra/cloudflare/agent-gateway/wrangler.toml`, then deploy through the dedicated workflow.
+Deploy through the dedicated workflow.
 
 Manual deployment command:
 

--- a/infra/cloudflare/agent-gateway/openapi.yaml
+++ b/infra/cloudflare/agent-gateway/openapi.yaml
@@ -1,0 +1,359 @@
+openapi: 3.1.0
+info:
+  title: ResearchOps Cloudflare Agent Gateway
+  version: 1.0.0
+  summary: Secured tool contract for controlled AI-agent access to ResearchOps Cloudflare resources.
+  description: >-
+    Production-safe capability layer for named Cloudflare operations. The gateway
+    never exposes raw Cloudflare API access. All privileged calls go through the
+    /tools endpoint, bearer authentication, the server-side allowlist policy and
+    persisted D1 audit logging.
+servers:
+  - url: https://researchops-agent-gateway.digikev-kevin-rapley.workers.dev
+    description: Production Agent Gateway Worker
+security:
+  - bearerAuth: []
+tags:
+  - name: Health
+    description: Gateway availability checks.
+  - name: Tools
+    description: Audited Cloudflare tool execution.
+paths:
+  /health:
+    get:
+      operationId: getAgentGatewayHealth
+      summary: Check Agent Gateway health
+      description: Returns a small JSON health response. This endpoint does not expose Cloudflare resource data.
+      tags:
+        - Health
+      security: []
+      responses:
+        "200":
+          description: Gateway is reachable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/$defs/HealthResponse"
+              examples:
+                healthy:
+                  value:
+                    ok: true
+                    service: ResearchOps Cloudflare agent gateway
+  /tools:
+    post:
+      operationId: runAgentGatewayTool
+      summary: Run an audited Cloudflare tool
+      description: >-
+        Runs one named Cloudflare operation through the Agent Gateway. The bearer
+        token is stored in the connector configuration and must never be exposed
+        in chat. Every accepted, completed, failed or blocked request is persisted
+        to the AUDIT_DB D1 database.
+      tags:
+        - Tools
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/$defs/ToolRequest"
+            examples:
+              inspectD1Schema:
+                summary: Inspect a D1 schema
+                value:
+                  tool: cloudflare.d1.inspectSchema
+                  environment: production
+                  actor: agent:chatgpt
+                  reason: Inspect the schema before debugging a production issue.
+                  input:
+                    databaseId: 75196021-d2a9-435f-a0ac-654baeb111d4
+              readOnlyD1Query:
+                summary: Run a read-only D1 query
+                value:
+                  tool: cloudflare.d1.runReadOnlyQuery
+                  environment: production
+                  actor: agent:chatgpt
+                  reason: Check recent audit rows after a gateway operation.
+                  input:
+                    databaseId: 75196021-d2a9-435f-a0ac-654baeb111d4
+                    sql: SELECT id, tool, actor, phase, ok, created_at FROM agent_gateway_audit ORDER BY row_id DESC LIMIT 10
+                    params: []
+              blockedWriteShape:
+                summary: KV write shape requiring policy approval
+                value:
+                  tool: cloudflare.kv.putJsonUnderPrefix
+                  environment: production
+                  actor: agent:chatgpt
+                  reason: Seed an approved test automation fixture under an approved prefix.
+                  input:
+                    namespaceId: example-kv-namespace-id
+                    key: researchops:test-automation:example
+                    value:
+                      ok: true
+      responses:
+        "200":
+          description: Tool ran successfully and audit rows were persisted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/$defs/ToolSuccessResponse"
+        "400":
+          description: Tool request was blocked by policy, failed validation, or failed during execution.
+          content:
+            application/json:
+              schema:
+                $ref: "#/$defs/ToolErrorResponse"
+        "401":
+          description: Authentication failed before the tool request could be authorised.
+          content:
+            application/json:
+              schema:
+                $ref: "#/$defs/ToolErrorResponse"
+$defs:
+  HealthResponse:
+    type: object
+    required:
+      - ok
+      - service
+    properties:
+      ok:
+        type: boolean
+        const: true
+      service:
+        type: string
+        const: ResearchOps Cloudflare agent gateway
+    additionalProperties: false
+  ToolName:
+    type: string
+    enum:
+      - cloudflare.d1.inspectSchema
+      - cloudflare.d1.runReadOnlyQuery
+      - cloudflare.d1.seedApprovedFixture
+      - cloudflare.kv.listKeys
+      - cloudflare.kv.getJson
+      - cloudflare.kv.putJsonUnderPrefix
+      - cloudflare.durableObjects.listNamespaces
+      - cloudflare.durableObjects.listObjects
+      - cloudflare.durableObjects.inspectViaAdminRoute
+      - cloudflare.workers.tailRecentErrors
+  ToolRequest:
+    type: object
+    required:
+      - tool
+      - environment
+      - actor
+    properties:
+      tool:
+        $ref: "#/$defs/ToolName"
+      environment:
+        type: string
+        const: production
+      actor:
+        type: string
+        minLength: 1
+        description: Stable identity for the calling agent or automation.
+      reason:
+        type: string
+        minLength: 1
+        description: Required by policy for write operations and strongly recommended for all production inspection.
+      input:
+        type: object
+        description: Tool-specific payload. Unknown properties are ignored or rejected by the server-side tool handler.
+        oneOf:
+          - $ref: "#/$defs/D1InspectSchemaInput"
+          - $ref: "#/$defs/D1ReadOnlyQueryInput"
+          - $ref: "#/$defs/D1SeedApprovedFixtureInput"
+          - $ref: "#/$defs/KvListKeysInput"
+          - $ref: "#/$defs/KvGetJsonInput"
+          - $ref: "#/$defs/KvPutJsonUnderPrefixInput"
+          - $ref: "#/$defs/DurableObjectListNamespacesInput"
+          - $ref: "#/$defs/DurableObjectListObjectsInput"
+          - $ref: "#/$defs/DurableObjectInspectViaAdminRouteInput"
+          - $ref: "#/$defs/WorkersTailRecentErrorsInput"
+        default: {}
+    additionalProperties: false
+  D1InspectSchemaInput:
+    type: object
+    required:
+      - databaseId
+    properties:
+      databaseId:
+        type: string
+        minLength: 1
+    additionalProperties: true
+  D1ReadOnlyQueryInput:
+    type: object
+    required:
+      - databaseId
+      - sql
+    properties:
+      databaseId:
+        type: string
+        minLength: 1
+      sql:
+        type: string
+        minLength: 1
+        description: Server policy only permits read-only SELECT, WITH or EXPLAIN-style SQL.
+      params:
+        type: array
+        items:
+          oneOf:
+            - type: string
+            - type: number
+            - type: boolean
+            - type: "null"
+        default: []
+    additionalProperties: true
+  D1SeedApprovedFixtureInput:
+    type: object
+    required:
+      - databaseId
+      - fixtureName
+    properties:
+      databaseId:
+        type: string
+        minLength: 1
+      fixtureName:
+        type: string
+        enum:
+          - agent-gateway-smoke-fixture-v1
+    additionalProperties: true
+  KvListKeysInput:
+    type: object
+    required:
+      - namespaceId
+    properties:
+      namespaceId:
+        type: string
+        minLength: 1
+      prefix:
+        type: string
+      cursor:
+        type: string
+      limit:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 100
+    additionalProperties: true
+  KvGetJsonInput:
+    type: object
+    required:
+      - namespaceId
+      - key
+    properties:
+      namespaceId:
+        type: string
+        minLength: 1
+      key:
+        type: string
+        minLength: 1
+    additionalProperties: true
+  KvPutJsonUnderPrefixInput:
+    type: object
+    required:
+      - namespaceId
+      - key
+      - value
+    properties:
+      namespaceId:
+        type: string
+        minLength: 1
+      key:
+        type: string
+        minLength: 1
+        description: Server policy only permits approved production-safe prefixes.
+      value:
+        type: object
+        description: JSON object only. Arrays, strings and raw text are rejected by policy.
+    additionalProperties: true
+  DurableObjectListNamespacesInput:
+    type: object
+    additionalProperties: true
+  DurableObjectListObjectsInput:
+    type: object
+    required:
+      - namespaceId
+    properties:
+      namespaceId:
+        type: string
+        minLength: 1
+    additionalProperties: true
+  DurableObjectInspectViaAdminRouteInput:
+    type: object
+    required:
+      - path
+    properties:
+      path:
+        type: string
+        pattern: ^/admin/agents/durable-objects/
+      payload:
+        type: object
+        default: {}
+    additionalProperties: true
+  WorkersTailRecentErrorsInput:
+    type: object
+    properties:
+      namespaceId:
+        type: string
+        description: Optional KV namespace containing recent error logs.
+      key:
+        type: string
+        default: researchops:agent-gateway:tail-errors:recent
+      scriptName:
+        type: string
+        description: Worker script name used for metadata lookup when no KV namespace is supplied.
+    additionalProperties: true
+  ToolSuccessResponse:
+    type: object
+    required:
+      - ok
+      - tool
+      - auditId
+      - result
+    properties:
+      ok:
+        type: boolean
+        const: true
+      tool:
+        $ref: "#/$defs/ToolName"
+      auditId:
+        type: string
+      result:
+        description: Tool-specific Cloudflare result.
+    additionalProperties: true
+  ToolErrorResponse:
+    type: object
+    required:
+      - ok
+      - tool
+      - auditId
+      - error
+    properties:
+      ok:
+        type: boolean
+        const: false
+      tool:
+        $ref: "#/$defs/ToolName"
+      auditId:
+        type: string
+      error:
+        type: object
+        required:
+          - code
+          - message
+        properties:
+          code:
+            type: string
+          message:
+            type: string
+        additionalProperties: false
+    additionalProperties: true
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: Store AGENT_GATEWAY_TOKEN as a connector secret. Never expose this token in chat, source control or logs.

--- a/tests/agent-gateway-capability-layer-contract.test.js
+++ b/tests/agent-gateway-capability-layer-contract.test.js
@@ -16,6 +16,8 @@ const files = {
 	wrangler: `${gatewayRoot}/wrangler.toml`,
 	readme: `${gatewayRoot}/README.md`,
 	migration: `${gatewayRoot}/migrations/0001_agent_gateway_audit.sql`,
+	openapi: `${gatewayRoot}/openapi.yaml`,
+	connectorDocs: "docs/deployment/agent-gateway-openapi-connector.md",
 	workerCi: ".github/workflows/worker-ci.yml",
 	deployGateway: ".github/workflows/deploy-agent-gateway.yml",
 	deploymentToolchain: "deployment-toolchain.yaml",
@@ -62,6 +64,7 @@ for (const tool of expectedTools) {
 	includes("schemas", `"${tool}"`, "agent gateway tool schemas");
 	includes("allowlist", `"${tool}"`, "agent gateway allowlist");
 	includes("index", `"${tool}"`, "agent gateway router");
+	includes("openapi", `- ${tool}`, "agent gateway OpenAPI contract");
 }
 
 const auditColumns = [
@@ -194,10 +197,73 @@ const includeChecks = [
 	],
 	["readme", "Do not use an account-wide super token", "agent gateway README"],
 	["readme", "audit = persisted", "agent gateway README"],
+	["readme", "infra/cloudflare/agent-gateway/openapi.yaml", "agent gateway README"],
+	[
+		"readme",
+		"docs/deployment/agent-gateway-openapi-connector.md",
+		"agent gateway README",
+	],
 	[
 		"readme",
 		"npx --yes wrangler@${WRANGLER_VERSION} deploy --config infra/cloudflare/agent-gateway/wrangler.toml",
 		"agent gateway README",
+	],
+	["openapi", "openapi: 3.1.0", "agent gateway OpenAPI contract"],
+	[
+		"openapi",
+		"ResearchOps Cloudflare Agent Gateway",
+		"agent gateway OpenAPI contract",
+	],
+	[
+		"openapi",
+		"https://researchops-agent-gateway.digikev-kevin-rapley.workers.dev",
+		"agent gateway OpenAPI contract",
+	],
+	["openapi", "operationId: getAgentGatewayHealth", "agent gateway OpenAPI contract"],
+	["openapi", "operationId: runAgentGatewayTool", "agent gateway OpenAPI contract"],
+	["openapi", "bearerAuth", "agent gateway OpenAPI contract"],
+	[
+		"openapi",
+		"Store AGENT_GATEWAY_TOKEN as a connector secret",
+		"agent gateway OpenAPI contract",
+	],
+	[
+		"openapi",
+		"Never expose this token in chat, source control or logs",
+		"agent gateway OpenAPI contract",
+	],
+	["openapi", "const: production", "agent gateway OpenAPI contract"],
+	["openapi", "cloudflare.d1.runReadOnlyQuery", "agent gateway OpenAPI contract"],
+	["openapi", "cloudflare.kv.putJsonUnderPrefix", "agent gateway OpenAPI contract"],
+	[
+		"openapi",
+		"pattern: ^/admin/agents/durable-objects/",
+		"agent gateway OpenAPI contract",
+	],
+	[
+		"connectorDocs",
+		"The connector does not receive raw Cloudflare credentials",
+		"agent gateway connector docs",
+	],
+	[
+		"connectorDocs",
+		"Do not configure the connector with `CF_API_TOKEN`",
+		"agent gateway connector docs",
+	],
+	[
+		"connectorDocs",
+		"infra/cloudflare/agent-gateway/openapi.yaml",
+		"agent gateway connector docs",
+	],
+	[
+		"connectorDocs",
+		"Authorization: Bearer <AGENT_GATEWAY_TOKEN>",
+		"agent gateway connector docs",
+	],
+	[
+		"connectorDocs",
+		"accepted\ncompleted",
+		"agent gateway connector docs",
 	],
 	["workerCi", "infra/cloudflare/agent-gateway/**", "Worker CI workflow"],
 	[
@@ -246,3 +312,4 @@ excludes("client", "X-Auth-Key", "Cloudflare API client");
 excludes("client", "X-Auth-Email", "Cloudflare API client");
 excludes("audit", "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", "agent gateway audit log");
 excludes("wrangler", "00000000-0000-0000-0000-000000000000", "agent gateway Wrangler config");
+excludes("openapi", "CF_API_TOKEN", "agent gateway OpenAPI contract");


### PR DESCRIPTION
## Summary

Adds a source-controlled OpenAPI contract for the deployed ResearchOps Cloudflare Agent Gateway and documents how to configure it as a secured API tool connector.

This is the bridge needed so an AI agent can call the Agent Gateway directly through a connector without ever seeing `AGENT_GATEWAY_TOKEN` or raw Cloudflare credentials.

## Changes

Adds:

```text
infra/cloudflare/agent-gateway/openapi.yaml
docs/deployment/agent-gateway-openapi-connector.md
```

Updates:

```text
infra/cloudflare/agent-gateway/README.md
tests/agent-gateway-capability-layer-contract.test.js
```

## OpenAPI contract

The contract exposes only:

```text
GET /health
POST /tools
```

The production server is:

```text
https://researchops-agent-gateway.digikev-kevin-rapley.workers.dev
```

The `/tools` operation is protected by HTTP bearer authentication and retains the existing gateway request shape:

```json
{
  "tool": "cloudflare.d1.inspectSchema",
  "environment": "production",
  "actor": "agent:chatgpt",
  "reason": "Inspect the schema before debugging a production issue.",
  "input": {
    "databaseId": "75196021-d2a9-435f-a0ac-654baeb111d4"
  }
}
```

## Security model

The connector stores only:

```text
AGENT_GATEWAY_TOKEN
```

as a connector secret.

The connector must not receive:

```text
CF_API_TOKEN
CF_ACCOUNT_ID
raw Cloudflare API endpoint access
```

All Cloudflare production operations still go through:

```text
connector → POST /tools → Agent Gateway allowlist → Cloudflare API → D1 audit
```

## Protected tool list

The contract enumerates the existing allowed tools:

```text
cloudflare.d1.inspectSchema
cloudflare.d1.runReadOnlyQuery
cloudflare.d1.seedApprovedFixture
cloudflare.kv.listKeys
cloudflare.kv.getJson
cloudflare.kv.putJsonUnderPrefix
cloudflare.durableObjects.listNamespaces
cloudflare.durableObjects.listObjects
cloudflare.durableObjects.inspectViaAdminRoute
cloudflare.workers.tailRecentErrors
```

## Documentation

The new connector setup document explains:

- where the OpenAPI file lives
- how to configure bearer authentication
- why `CF_API_TOKEN` must not be given to the connector
- example request bodies
- expected audit phases for successful and blocked calls
- acceptance checks after connector configuration

## Tests

Extends the existing Agent Gateway contract test to assert:

- OpenAPI 3.1 contract exists
- production gateway URL is present
- both operations are declared
- bearer auth is declared
- all tool enum values are present
- token safety instructions are present
- raw `CF_API_TOKEN` is not included in the OpenAPI contract
- connector setup documentation exists and states the security constraints

## Validation

I could not run the repository suite in this connector environment. CI should run:

```text
npm run validate
npm run lint
npm test
```

## Next step outside GitHub

After merge, configure the secured API connector using:

```text
infra/cloudflare/agent-gateway/openapi.yaml
```

and store `AGENT_GATEWAY_TOKEN` as the connector bearer secret.