### PR TITLE
Add robust agent audit trace control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage/
 .tmp/
 .logs/
 *.log
+.agent-traces/
 
 # === Lockfiles & caches ===
 package-lock.json

--- a/docs/agent-audit/reasoning/README.md
+++ b/docs/agent-audit/reasoning/README.md
@@ -1,0 +1,66 @@
+# Agent audit trace
+
+The agent audit trace is an engineering control for repository-affecting AI work.
+
+It is not a transcript of private chain-of-thought. It is a structured record of what the agent did, which operating-model rules it applied, what evidence it consulted, what decisions it made, what commands it ran, what changed, what failed and how it pivoted.
+
+## Trace model
+
+Raw trace events are written as append-only JSONL under `.agent-traces/raw/`.
+
+Human-readable reports can be rendered under this directory when a task includes `[reasoning]` or when an operator promotes a trace for review.
+
+Each event records:
+
+- a trace ID
+- an event ID
+- timestamp
+- event type
+- actor metadata
+- trace layer
+- redaction metadata
+- previous event hash
+- event hash
+
+The previous hash and event hash form a tamper-evident event chain.
+
+## Required decision boundaries
+
+Repository-affecting agent work should use traced boundaries for:
+
+- prompt and trigger capture
+- bundle detection and application
+- file reads
+- file writes
+- shell commands
+- decisions
+- assumptions
+- risks
+- issues
+- pivots
+- report rendering
+- validation completion
+
+This prevents the final report being a reconstruction from memory.
+
+## Privacy boundary
+
+Trace events must not include raw secrets, bearer tokens, API keys or unnecessary personal data.
+
+Sensitive parameters should be redacted or represented by a hash where the exact value is not needed for review.
+
+## Commands
+
+Validate raw traces when present:
+
+```bash
+npm run trace:validate
+```
+
+Run the regression suite:
+
+```bash
+npm test
+```
+
+The regression test proves redaction, bundle recording, file boundaries, report rendering and hash-chain validation.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "audit:performance": "bash ./scripts/performance-audit.sh",
     "audit:performance:write": "bash ./scripts/performance-audit.sh --write docs/performance/performance-inventory.md",
     "audit:security": "bash ./scripts/security-audit-policy.sh",
+    "trace:validate": "node scripts/agent-trace/validate-traces.mjs",
     "test": "node --test",
     "test:e2e": "playwright test",
     "qa:browsers": "playwright install chromium",

--- a/schemas/agent-trace-event.schema.json
+++ b/schemas/agent-trace-event.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://researchops.local/schemas/agent-trace-event.schema.json",
+  "title": "ResearchOps Agent Trace Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "actor",
+    "eventHash",
+    "eventId",
+    "eventType",
+    "payload",
+    "previousEventHash",
+    "redaction",
+    "schemaVersion",
+    "severity",
+    "timestamp",
+    "traceId",
+    "traceLayer"
+  ],
+  "properties": {
+    "actor": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "kind"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["agent", "system", "tool", "user", "validator"]
+        },
+        "model": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        }
+      }
+    },
+    "eventHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "eventId": {
+      "type": "string",
+      "pattern": "^evt-[a-z0-9-]+$"
+    },
+    "eventType": {
+      "type": "string"
+    },
+    "hashes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "parentEventId": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "previousEventHash": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      ]
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["containsSensitiveMaterial", "redacted", "redactionReasons"],
+      "properties": {
+        "containsSensitiveMaterial": {
+          "type": "boolean"
+        },
+        "redacted": {
+          "type": "boolean"
+        },
+        "redactionReasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["debug", "error", "info", "notice", "warning"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "traceId": {
+      "type": "string",
+      "pattern": "^atrace-[0-9]{8}-[0-9]{6}-[a-z0-9-]+$"
+    },
+    "traceLayer": {
+      "type": "string",
+      "enum": ["behavioural", "mechanistic", "operational", "training"]
+    }
+  }
+}

--- a/scripts/agent-trace/bundle-recorder.mjs
+++ b/scripts/agent-trace/bundle-recorder.mjs
@@ -1,0 +1,95 @@
+/**
+ * @file bundle-recorder.mjs
+ * @module BundleRecorder
+ * @summary Records bundle detection, application, conflicts and precedence decisions.
+ */
+
+/**
+ * Recorder for multi-bundle orchestration events.
+ */
+export class BundleRecorder {
+  /**
+   * Create a bundle recorder.
+   * @param {object} trace Trace writer.
+   */
+  constructor(trace) {
+    this.trace = trace;
+  }
+
+  /**
+   * Record that a bundle was detected as potentially relevant.
+   * @param {Record<string, unknown>} bundle Bundle metadata.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  detect(bundle) {
+    return this.trace.event("bundle.detected", {
+      bundleId: bundle.id,
+      name: bundle.name,
+      reason: bundle.reason,
+      relevance: bundle.relevance,
+      version: bundle.version
+    });
+  }
+
+  /**
+   * Record that a bundle file was loaded.
+   * @param {Record<string, unknown>} bundle Bundle metadata.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  load(bundle) {
+    return this.trace.event("bundle.loaded", {
+      bundleId: bundle.id,
+      name: bundle.name,
+      path: bundle.path,
+      version: bundle.version
+    });
+  }
+
+  /**
+   * Record that bundle rules were applied.
+   * @param {Record<string, unknown>} bundle Bundle metadata.
+   * @param {Record<string, unknown>} [payload] Application metadata.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  apply(bundle, payload = {}) {
+    return this.trace.event("bundle.applied", {
+      appliedRules: payload.appliedRules || [],
+      bundleId: bundle.id,
+      evidence: payload.evidence || [],
+      name: bundle.name,
+      notAppliedRules: payload.notAppliedRules || [],
+      version: bundle.version
+    });
+  }
+
+  /**
+   * Record a bundle conflict.
+   * @param {Record<string, unknown>} payload Conflict metadata.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  conflict(payload) {
+    return this.trace.event(
+      "bundle.conflict",
+      {
+        affectedDecision: payload.affectedDecision,
+        bundles: payload.bundles || [],
+        conflict: payload.conflict
+      },
+      { severity: "warning" }
+    );
+  }
+
+  /**
+   * Record a precedence decision between bundle rules.
+   * @param {Record<string, unknown>} payload Precedence metadata.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  precedence(payload) {
+    return this.trace.event("bundle.precedence_decided", {
+      decisionImpact: payload.decisionImpact,
+      rationale: payload.rationale,
+      supersededBundles: payload.supersededBundles || [],
+      winningBundle: payload.winningBundle
+    });
+  }
+}

--- a/scripts/agent-trace/trace-redactor.mjs
+++ b/scripts/agent-trace/trace-redactor.mjs
@@ -1,0 +1,153 @@
+/**
+ * @file trace-redactor.mjs
+ * @module AgentTraceRedactor
+ * @summary Redacts sensitive material before trace events are persisted.
+ */
+
+import crypto from "node:crypto";
+
+const SECRET_PATTERNS = [
+  /(Authorization:\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi,
+  /(api[_-]?key["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]+/gi,
+  /(token["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]+/gi,
+  /(secret["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]+/gi,
+  /(password["']?\s*[:=]\s*["']?)[^"',\s]+/gi
+];
+
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+
+/**
+ * Create a stable SHA-256 hash for a value.
+ * @param {unknown} value Value to hash.
+ * @returns {string} Prefixed SHA-256 hash.
+ */
+export function hashValue(value) {
+  const serialised = typeof value === "string" ? value : JSON.stringify(value);
+  const hash = crypto.createHash("sha256").update(serialised || "").digest("hex");
+
+  return `sha256:${hash}`;
+}
+
+function redactString(value) {
+  let output = value;
+  let redacted = false;
+  const reasons = [];
+
+  for (const pattern of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+
+    if (pattern.test(output)) {
+      pattern.lastIndex = 0;
+      output = output.replace(pattern, "$1[REDACTED]");
+      redacted = true;
+      reasons.push("secret-like value");
+    }
+  }
+
+  EMAIL_PATTERN.lastIndex = 0;
+
+  if (EMAIL_PATTERN.test(output)) {
+    EMAIL_PATTERN.lastIndex = 0;
+    output = output.replace(EMAIL_PATTERN, "[REDACTED_EMAIL]");
+    redacted = true;
+    reasons.push("email address");
+  }
+
+  return {
+    reasons,
+    redacted,
+    value: output
+  };
+}
+
+function redactObject(value) {
+  let redacted = false;
+  const reasons = [];
+  const output = {};
+
+  for (const [key, item] of Object.entries(value)) {
+    const lowerKey = key.toLowerCase();
+
+    if (
+      lowerKey.includes("authorization") ||
+      lowerKey.includes("password") ||
+      lowerKey.includes("secret") ||
+      lowerKey.includes("token")
+    ) {
+      output[key] = "[REDACTED]";
+      redacted = true;
+      reasons.push(`sensitive key: ${key}`);
+      continue;
+    }
+
+    const result = redactAny(item);
+    output[key] = result.value;
+    redacted = redacted || result.redacted;
+    reasons.push(...result.reasons);
+  }
+
+  return {
+    reasons: [...new Set(reasons)],
+    redacted,
+    value: output
+  };
+}
+
+function redactAny(value) {
+  if (value === null || value === undefined) {
+    return {
+      reasons: [],
+      redacted: false,
+      value
+    };
+  }
+
+  if (typeof value === "string") {
+    return redactString(value);
+  }
+
+  if (Array.isArray(value)) {
+    let redacted = false;
+    const reasons = [];
+    const output = value.map((item) => {
+      const result = redactAny(item);
+      redacted = redacted || result.redacted;
+      reasons.push(...result.reasons);
+      return result.value;
+    });
+
+    return {
+      reasons: [...new Set(reasons)],
+      redacted,
+      value: output
+    };
+  }
+
+  if (typeof value === "object") {
+    return redactObject(value);
+  }
+
+  return {
+    reasons: [],
+    redacted: false,
+    value
+  };
+}
+
+/**
+ * Redact sensitive material from an event payload.
+ * @param {Record<string, unknown>} payload Trace event payload.
+ * @returns {{ payload: Record<string, unknown>, redaction: object }} Redacted payload and redaction metadata.
+ */
+export function redactPayload(payload) {
+  const result = redactAny(payload || {});
+
+  return {
+    payload: result.value,
+    redaction: {
+      containsSensitiveMaterial: result.redacted,
+      redacted: result.redacted,
+      redactionReasons: result.reasons
+    }
+  };
+}

--- a/scripts/agent-trace/trace-redactor.mjs
+++ b/scripts/agent-trace/trace-redactor.mjs
@@ -60,6 +60,10 @@ function redactString(value) {
   };
 }
 
+function isSafeControlValue(value) {
+  return typeof value === "string" && /^\[[a-z0-9-]+\]$/i.test(value);
+}
+
 function redactObject(value) {
   let redacted = false;
   const reasons = [];
@@ -69,10 +73,11 @@ function redactObject(value) {
     const lowerKey = key.toLowerCase();
 
     if (
-      lowerKey.includes("authorization") ||
-      lowerKey.includes("password") ||
-      lowerKey.includes("secret") ||
-      lowerKey.includes("token")
+      !isSafeControlValue(item) &&
+      (lowerKey.includes("authorization") ||
+        lowerKey.includes("password") ||
+        lowerKey.includes("secret") ||
+        lowerKey.includes("token"))
     ) {
       output[key] = "[REDACTED]";
       redacted = true;

--- a/scripts/agent-trace/trace-renderer.mjs
+++ b/scripts/agent-trace/trace-renderer.mjs
@@ -1,0 +1,275 @@
+/**
+ * @file trace-renderer.mjs
+ * @module AgentTraceRenderer
+ * @summary Renders raw agent trace events into a user-readable audit report.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function byType(events, eventType) {
+  return events.filter((event) => event.eventType === eventType);
+}
+
+function safe(value) {
+  if (value === undefined || value === null || value === "") {
+    return "Not recorded";
+  }
+
+  return String(value);
+}
+
+function list(items, fallback = "None recorded.") {
+  if (!items.length) {
+    return fallback;
+  }
+
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+/**
+ * Read a JSONL trace event file.
+ * @param {string} eventPath Raw event path.
+ * @returns {Promise<Array<Record<string, unknown>>>} Parsed events.
+ */
+export async function readTraceEvents(eventPath) {
+  const text = await fs.readFile(eventPath, "utf8");
+
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+/**
+ * Build a compact machine-readable summary from events.
+ * @param {Array<Record<string, unknown>>} events Trace events.
+ * @returns {Record<string, unknown>} Summary object.
+ */
+export function buildTraceSummary(events) {
+  const first = events[0] || {};
+  const last = events.at(-1) || {};
+
+  return {
+    completedAt: last.timestamp,
+    eventCount: events.length,
+    redactedEventCount: events.filter((event) => event.redaction?.redacted).length,
+    startedAt: first.timestamp,
+    traceId: first.traceId,
+    types: [...new Set(events.map((event) => event.eventType))]
+  };
+}
+
+/**
+ * Render trace events as Markdown.
+ * @param {Array<Record<string, unknown>>} events Trace events.
+ * @returns {string} Markdown report.
+ */
+export function renderMarkdown(events) {
+  const first = events[0] || {};
+  const last = events.at(-1) || {};
+  const run = byType(events, "run.started")[0];
+  const prompt = byType(events, "prompt.received")[0];
+  const trigger = byType(events, "trigger.detected")[0];
+  const bundles = byType(events, "bundle.applied");
+  const conflicts = byType(events, "bundle.conflict");
+  const precedence = byType(events, "bundle.precedence_decided");
+  const reads = byType(events, "file.read");
+  const writes = byType(events, "file.write.completed");
+  const commands = byType(events, "command.completed");
+  const decisions = byType(events, "decision.recorded");
+  const assumptions = byType(events, "assumption.recorded");
+  const issues = byType(events, "issue.detected");
+  const pivots = byType(events, "pivot.recorded");
+  const risks = byType(events, "risk.recorded");
+  const title = run?.payload?.title || "Agent audit trace";
+  const lines = [];
+
+  lines.push(`# ${title}`);
+  lines.push("");
+  lines.push(
+    "> This is an auditable agent trace generated from structured events. It records task interpretation, bundle orchestration, context use, actions, decisions, issues, pivots and residual risks. It does not expose private chain-of-thought."
+  );
+  lines.push("");
+  lines.push("## Run metadata");
+  lines.push("");
+  lines.push(`- Trace ID: \`${safe(first.traceId)}\``);
+  lines.push(`- Started: ${safe(first.timestamp)}`);
+  lines.push(`- Completed: ${safe(last.timestamp)}`);
+  lines.push(`- Repository: ${safe(run?.payload?.repository)}`);
+  lines.push(`- Branch: ${safe(run?.payload?.branch)}`);
+  lines.push(`- Agent: ${safe(first.actor?.id)}`);
+  lines.push(`- Model: ${safe(first.actor?.model)}`);
+  lines.push("");
+  lines.push("## Trigger and task interpretation");
+  lines.push("");
+  lines.push(`- Reasoning trigger detected: ${trigger ? "Yes" : "No"}`);
+  lines.push(`- Trigger token: ${safe(trigger?.payload?.token)}`);
+  lines.push(`- Prompt hash: ${safe(prompt?.payload?.promptHash)}`);
+  lines.push("");
+  lines.push("### Safe prompt excerpt");
+  lines.push("");
+  lines.push("```text");
+  lines.push(safe(prompt?.payload?.safeExcerpt));
+  lines.push("```");
+  lines.push("");
+  lines.push("### Interpreted task");
+  lines.push("");
+  lines.push(safe(run?.payload?.interpretedTask));
+  lines.push("");
+  lines.push("## Bundle orchestration");
+  lines.push("");
+  lines.push(
+    list(
+      bundles.map((event) => {
+        const payload = event.payload || {};
+        return `\`${safe(payload.bundleId)}\` — ${safe(payload.name)}. Rules applied: ${
+          payload.appliedRules?.length || 0
+        }.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("### Bundle conflicts");
+  lines.push("");
+  lines.push(
+    list(
+      conflicts.map((event) => {
+        const payload = event.payload || {};
+        return `${safe(payload.conflict)} Impact: ${safe(payload.affectedDecision)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("### Precedence decisions");
+  lines.push("");
+  lines.push(
+    list(
+      precedence.map((event) => {
+        const payload = event.payload || {};
+        return `Winning bundle: \`${safe(payload.winningBundle)}\`. Rationale: ${safe(payload.rationale)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("## Context consulted");
+  lines.push("");
+  lines.push(
+    list(
+      reads.map((event) => {
+        const payload = event.payload || {};
+        return `\`${safe(payload.path)}\` — ${safe(payload.purpose)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("## Decisions and assumptions");
+  lines.push("");
+  lines.push("### Decisions");
+  lines.push("");
+  lines.push(
+    list(
+      decisions.map((event) => {
+        const payload = event.payload || {};
+        return `${safe(payload.decision)} Rationale: ${safe(payload.rationale)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("### Assumptions");
+  lines.push("");
+  lines.push(
+    list(
+      assumptions.map((event) => {
+        const payload = event.payload || {};
+        return `${safe(payload.assumption)} Basis: ${safe(payload.basis)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("## Actions taken");
+  lines.push("");
+  lines.push("### Files written");
+  lines.push("");
+  lines.push(
+    list(
+      writes.map((event) => {
+        const payload = event.payload || {};
+        return `\`${safe(payload.path)}\` — ${safe(payload.purpose)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("### Commands completed");
+  lines.push("");
+  lines.push(
+    list(
+      commands.map((event) => {
+        const payload = event.payload || {};
+        return `\`${safe(payload.command)}\` exited with ${safe(payload.exitCode)} — ${safe(payload.purpose)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("## Issues and pivots");
+  lines.push("");
+  lines.push(
+    list([
+      ...issues.map((event) => {
+        const payload = event.payload || {};
+        return `Issue: ${safe(payload.issue)} Cause: ${safe(payload.cause)}.`;
+      }),
+      ...pivots.map((event) => {
+        const payload = event.payload || {};
+        return `Pivot: ${safe(payload.pivot)} Outcome: ${safe(payload.outcome)}.`;
+      })
+    ])
+  );
+  lines.push("");
+  lines.push("## Residual risks");
+  lines.push("");
+  lines.push(
+    list(
+      risks.map((event) => {
+        const payload = event.payload || {};
+        return `${safe(payload.risk)} Mitigation: ${safe(payload.mitigation)}.`;
+      })
+    )
+  );
+  lines.push("");
+  lines.push("## Trace integrity");
+  lines.push("");
+  lines.push(`- Raw events recorded: ${events.length}`);
+  lines.push(`- Redacted events: ${events.filter((event) => event.redaction?.redacted).length}`);
+  lines.push(`- Hash chained: ${events.every((event) => event.eventHash) ? "Yes" : "No"}`);
+  lines.push(`- Run completed event present: ${byType(events, "run.completed").length === 1 ? "Yes" : "No"}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Render raw trace events to Markdown and JSON summary files.
+ * @param {string} eventPath Raw JSONL event path.
+ * @param {string} markdownPath Markdown report path.
+ * @param {string} [summaryPath] Optional JSON summary path.
+ * @returns {Promise<{ eventCount: number, markdownPath: string, summaryPath?: string }>} Render metadata.
+ */
+export async function renderTrace(eventPath, markdownPath, summaryPath) {
+  const events = await readTraceEvents(eventPath);
+  const markdown = renderMarkdown(events);
+
+  await fs.mkdir(path.dirname(markdownPath), { recursive: true });
+  await fs.writeFile(markdownPath, markdown, "utf8");
+
+  if (summaryPath) {
+    await fs.mkdir(path.dirname(summaryPath), { recursive: true });
+    await fs.writeFile(summaryPath, `${JSON.stringify(buildTraceSummary(events), null, 2)}\n`, "utf8");
+  }
+
+  return {
+    eventCount: events.length,
+    markdownPath,
+    summaryPath
+  };
+}

--- a/scripts/agent-trace/trace-validator.mjs
+++ b/scripts/agent-trace/trace-validator.mjs
@@ -1,0 +1,134 @@
+/**
+ * @file trace-validator.mjs
+ * @module AgentTraceValidator
+ * @summary Validates trace completeness and trace integrity rules.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+
+function hashEvent(event) {
+  const copy = { ...event };
+  delete copy.eventHash;
+
+  return `sha256:${crypto.createHash("sha256").update(JSON.stringify(copy)).digest("hex")}`;
+}
+
+function has(events, eventType) {
+  return events.some((event) => event.eventType === eventType);
+}
+
+function count(events, eventType) {
+  return events.filter((event) => event.eventType === eventType).length;
+}
+
+/**
+ * Read a JSONL trace event file.
+ * @param {string} eventPath Raw event path.
+ * @returns {Promise<Array<Record<string, unknown>>>} Parsed events.
+ */
+export async function readEvents(eventPath) {
+  const text = await fs.readFile(eventPath, "utf8");
+
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+/**
+ * Validate an event stream.
+ * @param {Array<Record<string, unknown>>} events Parsed events.
+ * @returns {{ failures: string[], valid: boolean, warnings: string[] }} Validation result.
+ */
+export function validateEvents(events) {
+  const failures = [];
+  const warnings = [];
+
+  if (!events.length) {
+    failures.push("Trace contains no events.");
+    return { failures, valid: false, warnings };
+  }
+
+  if (count(events, "run.started") !== 1) {
+    failures.push("Trace must contain exactly one run.started event.");
+  }
+
+  if (count(events, "run.completed") !== 1) {
+    failures.push("Trace must contain exactly one run.completed event.");
+  }
+
+  if (!has(events, "prompt.received")) {
+    failures.push("Trace must contain a prompt.received event.");
+  }
+
+  if (has(events, "trigger.detected") && !has(events, "report.rendered")) {
+    failures.push("Trace detected [reasoning] but did not record report.rendered.");
+  }
+
+  if (!has(events, "bundle.applied")) {
+    warnings.push("Trace does not include bundle.applied evidence.");
+  }
+
+  if (!has(events, "decision.recorded")) {
+    warnings.push("Trace does not include decision.recorded evidence.");
+  }
+
+  const writes = events.filter((event) => event.eventType === "file.write.completed");
+
+  if (writes.length && !has(events, "file.write.planned")) {
+    failures.push("Trace includes file.write.completed without file.write.planned.");
+  }
+
+  if (writes.length && !has(events, "decision.recorded")) {
+    failures.push("Trace includes file writes without decision evidence.");
+  }
+
+  const failedCommands = events.filter(
+    (event) => event.eventType === "command.completed" && event.payload?.exitCode !== 0
+  );
+
+  if (failedCommands.length && !has(events, "issue.detected")) {
+    warnings.push("A command failed but no issue.detected event was recorded.");
+  }
+
+  if (failedCommands.length && !has(events, "pivot.recorded")) {
+    warnings.push("A command failed but no pivot.recorded event was recorded.");
+  }
+
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index];
+    const expectedPrevious = index === 0 ? null : events[index - 1].eventHash;
+
+    if (event.previousEventHash !== expectedPrevious) {
+      failures.push(`Event ${event.eventId} has an invalid previousEventHash.`);
+    }
+
+    if (event.eventHash !== hashEvent(event)) {
+      failures.push(`Event ${event.eventId} has an invalid eventHash.`);
+    }
+  }
+
+  const serialised = JSON.stringify(events);
+
+  if (/Bearer\s+[A-Za-z0-9._~+/=-]+/.test(serialised)) {
+    failures.push("Trace contains an unredacted bearer token pattern.");
+  }
+
+  return {
+    failures,
+    valid: failures.length === 0,
+    warnings
+  };
+}
+
+/**
+ * Validate a raw JSONL trace file.
+ * @param {string} eventPath Raw event path.
+ * @returns {Promise<{ failures: string[], valid: boolean, warnings: string[] }>} Validation result.
+ */
+export async function validateTrace(eventPath) {
+  const events = await readEvents(eventPath);
+
+  return validateEvents(events);
+}

--- a/scripts/agent-trace/trace-writer.mjs
+++ b/scripts/agent-trace/trace-writer.mjs
@@ -1,0 +1,170 @@
+/**
+ * @file trace-writer.mjs
+ * @module AgentTraceWriter
+ * @summary Writes append-only, hash-chained JSONL trace events for agent work.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { redactPayload } from "./trace-redactor.mjs";
+
+const DEFAULT_ACTOR = Object.freeze({
+  id: "researchops-agent",
+  kind: "agent",
+  model: "unknown"
+});
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function compactTimestamp(date = new Date()) {
+  const pad = (value) => String(value).padStart(2, "0");
+
+  return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}-${pad(
+    date.getUTCHours()
+  )}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`;
+}
+
+function slugify(value) {
+  return (
+    String(value || "agent-run")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 80) || "agent-run"
+  );
+}
+
+function randomId(prefix) {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function hashEvent(event) {
+  return `sha256:${crypto.createHash("sha256").update(JSON.stringify(event)).digest("hex")}`;
+}
+
+/**
+ * Append-only trace writer for agent audit events.
+ */
+export class AgentTraceWriter {
+  /**
+   * Create a trace writer.
+   * @param {object} [options] Writer options.
+   * @param {object} [options.actor] Actor metadata.
+   * @param {Date} [options.date] Date used for trace ID generation.
+   * @param {string} [options.rawDir] Raw event output directory.
+   * @param {string} [options.rootDir] Repository root directory.
+   * @param {string} [options.slug] Human-readable trace slug.
+   * @param {string} [options.traceId] Explicit trace ID.
+   */
+  constructor(options = {}) {
+    const date = options.date || new Date();
+    const slug = slugify(options.slug);
+
+    this.actor = options.actor || DEFAULT_ACTOR;
+    this.rootDir = options.rootDir || process.cwd();
+    this.rawDir = options.rawDir || path.join(this.rootDir, ".agent-traces", "raw");
+    this.traceId = options.traceId || `atrace-${compactTimestamp(date)}-${slug}`;
+    this.eventPath = path.join(this.rawDir, `${this.traceId}.jsonl`);
+    this.previousEventHash = null;
+
+    fs.mkdirSync(this.rawDir, { recursive: true });
+  }
+
+  /**
+   * Record a trace event.
+   * @param {string} eventType Event type.
+   * @param {Record<string, unknown>} [payload] Event payload.
+   * @param {object} [options] Event options.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  event(eventType, payload = {}, options = {}) {
+    const redacted = redactPayload(payload);
+    const event = {
+      actor: options.actor || this.actor,
+      eventId: options.eventId || randomId("evt"),
+      eventType,
+      hashes: options.hashes || {},
+      parentEventId: options.parentEventId,
+      payload: redacted.payload,
+      previousEventHash: this.previousEventHash,
+      redaction: redacted.redaction,
+      schemaVersion: "1.0.0",
+      severity: options.severity || "info",
+      timestamp: nowIso(),
+      traceId: this.traceId,
+      traceLayer: options.traceLayer || "operational"
+    };
+
+    event.eventHash = hashEvent(event);
+    fs.appendFileSync(this.eventPath, `${JSON.stringify(event)}\n`, "utf8");
+    this.previousEventHash = event.eventHash;
+
+    return event;
+  }
+
+  /**
+   * Record run start.
+   * @param {Record<string, unknown>} [payload] Run metadata.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  startRun(payload = {}) {
+    return this.event("run.started", payload);
+  }
+
+  /**
+   * Record run completion.
+   * @param {Record<string, unknown>} [payload] Completion metadata.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  completeRun(payload = {}) {
+    return this.event("run.completed", payload);
+  }
+
+  /**
+   * Record an auditable decision.
+   * @param {Record<string, unknown>} payload Decision payload.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  recordDecision(payload) {
+    return this.event("decision.recorded", payload);
+  }
+
+  /**
+   * Record an assumption.
+   * @param {Record<string, unknown>} payload Assumption payload.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  recordAssumption(payload) {
+    return this.event("assumption.recorded", payload);
+  }
+
+  /**
+   * Record an implementation issue.
+   * @param {Record<string, unknown>} payload Issue payload.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  recordIssue(payload) {
+    return this.event("issue.detected", payload, { severity: payload.severity || "warning" });
+  }
+
+  /**
+   * Record a pivot after an issue or constraint.
+   * @param {Record<string, unknown>} payload Pivot payload.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  recordPivot(payload) {
+    return this.event("pivot.recorded", payload, { severity: "notice" });
+  }
+
+  /**
+   * Record a residual risk.
+   * @param {Record<string, unknown>} payload Risk payload.
+   * @returns {Record<string, unknown>} Event written to disk.
+   */
+  recordRisk(payload) {
+    return this.event("risk.recorded", payload, { severity: payload.severity || "warning" });
+  }
+}

--- a/scripts/agent-trace/traced-command.mjs
+++ b/scripts/agent-trace/traced-command.mjs
@@ -1,0 +1,84 @@
+/**
+ * @file traced-command.mjs
+ * @module TracedCommand
+ * @summary Runs commands through a trace-emitting execution boundary.
+ */
+
+import { spawn } from "node:child_process";
+import { hashValue } from "./trace-redactor.mjs";
+
+function trimOutput(value, limit = 12000) {
+  if (!value) {
+    return "";
+  }
+
+  if (value.length <= limit) {
+    return value;
+  }
+
+  return `${value.slice(0, limit)}\n[TRACE_OUTPUT_TRUNCATED length=${value.length}]`;
+}
+
+/**
+ * Run a command and record start and completion events.
+ * @param {object} trace Trace writer.
+ * @param {string} command Command to run.
+ * @param {string[]} [args] Command arguments.
+ * @param {object} [options] Execution options.
+ * @returns {Promise<{ exitCode: number | null, stderr: string, stdout: string }>} Command result.
+ */
+export function runCommand(trace, command, args = [], options = {}) {
+  const started = trace.event("command.started", {
+    argsHash: hashValue(args),
+    argsPreview: options.safeArgsPreview || [],
+    command,
+    cwd: options.cwd || process.cwd(),
+    purpose: options.purpose || "Unspecified command"
+  });
+
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      shell: options.shell || false
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      stderr += error.message;
+    });
+
+    child.on("close", (exitCode) => {
+      trace.event(
+        "command.completed",
+        {
+          command,
+          exitCode,
+          purpose: options.purpose || "Unspecified command",
+          stderr: trimOutput(stderr),
+          stdout: trimOutput(stdout)
+        },
+        {
+          parentEventId: started.eventId,
+          severity: exitCode === 0 ? "info" : "error"
+        }
+      );
+
+      resolve({
+        exitCode,
+        stderr,
+        stdout
+      });
+    });
+  });
+}

--- a/scripts/agent-trace/traced-fs.mjs
+++ b/scripts/agent-trace/traced-fs.mjs
@@ -1,0 +1,89 @@
+/**
+ * @file traced-fs.mjs
+ * @module TracedFilesystem
+ * @summary Provides trace-emitting filesystem boundaries for agent work.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function hashContent(content) {
+  return `sha256:${crypto.createHash("sha256").update(content).digest("hex")}`;
+}
+
+function relativePath(rootDir, filePath) {
+  return path.relative(rootDir, path.resolve(rootDir, filePath));
+}
+
+/**
+ * Filesystem wrapper that records file reads and writes.
+ */
+export class TracedFilesystem {
+  /**
+   * Create a traced filesystem wrapper.
+   * @param {object} trace Trace writer.
+   * @param {object} [options] Wrapper options.
+   * @param {string} [options.rootDir] Repository root directory.
+   */
+  constructor(trace, options = {}) {
+    this.rootDir = options.rootDir || process.cwd();
+    this.trace = trace;
+  }
+
+  /**
+   * Read a text file and record the access.
+   * @param {string} filePath Repository-relative file path.
+   * @param {string} purpose Reason the file is needed.
+   * @returns {Promise<string>} File contents.
+   */
+  async readTextFile(filePath, purpose) {
+    const absolutePath = path.resolve(this.rootDir, filePath);
+    const content = await fs.readFile(absolutePath, "utf8");
+    const relative = relativePath(this.rootDir, absolutePath);
+
+    this.trace.event("file.read", {
+      bytes: Buffer.byteLength(content, "utf8"),
+      contentHash: hashContent(content),
+      path: relative,
+      purpose
+    });
+
+    return content;
+  }
+
+  /**
+   * Write a text file and record the planned and completed operation.
+   * @param {string} filePath Repository-relative file path.
+   * @param {string} content File contents.
+   * @param {string} purpose Reason the file is written.
+   * @returns {Promise<{ contentHash: string, path: string }>} Write metadata.
+   */
+  async writeTextFile(filePath, content, purpose) {
+    const absolutePath = path.resolve(this.rootDir, filePath);
+    const relative = relativePath(this.rootDir, absolutePath);
+    const contentHash = hashContent(content);
+
+    this.trace.event("file.write.planned", {
+      bytes: Buffer.byteLength(content, "utf8"),
+      contentHash,
+      path: relative,
+      purpose
+    });
+
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, content, "utf8");
+
+    this.trace.event("file.write.completed", {
+      bytes: Buffer.byteLength(content, "utf8"),
+      contentHash,
+      path: relative,
+      purpose
+    });
+
+    return {
+      contentHash,
+      path: relative
+    };
+  }
+}

--- a/scripts/agent-trace/validate-traces.mjs
+++ b/scripts/agent-trace/validate-traces.mjs
@@ -1,0 +1,56 @@
+/**
+ * @file validate-traces.mjs
+ * @module ValidateTraces
+ * @summary Validates raw agent trace files when present.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { validateTrace } from "./trace-validator.mjs";
+
+async function findJsonlFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await findJsonlFiles(fullPath)));
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const rootDir = process.cwd();
+const traceDir = path.join(rootDir, ".agent-traces", "raw");
+const files = await findJsonlFiles(traceDir);
+let failed = false;
+
+for (const file of files) {
+  const result = await validateTrace(file);
+
+  if (!result.valid) {
+    failed = true;
+    console.error(`Trace invalid: ${file}`);
+
+    for (const failure of result.failures) {
+      console.error(`- ${failure}`);
+    }
+  }
+
+  for (const warning of result.warnings) {
+    console.warn(`Trace warning in ${file}: ${warning}`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log(`Validated ${files.length} trace file(s).`);

--- a/tests/agent-trace-control.test.js
+++ b/tests/agent-trace-control.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { BundleRecorder } from "../scripts/agent-trace/bundle-recorder.mjs";
+import { renderTrace } from "../scripts/agent-trace/trace-renderer.mjs";
+import { hashValue } from "../scripts/agent-trace/trace-redactor.mjs";
+import { validateTrace } from "../scripts/agent-trace/trace-validator.mjs";
+import { AgentTraceWriter } from "../scripts/agent-trace/trace-writer.mjs";
+import { TracedFilesystem } from "../scripts/agent-trace/traced-fs.mjs";
+
+async function readJsonl(filePath) {
+  const text = await fs.readFile(filePath, "utf8");
+
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test("agent trace records bundle application, file boundaries, redaction and report rendering", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-trace-"));
+  const sourcePath = path.join(rootDir, "AGENTS.md");
+
+  await fs.writeFile(sourcePath, "Authorization: Bearer secret-token\nuser@example.com\n", "utf8");
+
+  const trace = new AgentTraceWriter({
+    actor: {
+      id: "test-agent",
+      kind: "agent",
+      model: "test-model"
+    },
+    date: new Date("2026-05-06T21:17:00Z"),
+    rootDir,
+    slug: "agent-audit-control"
+  });
+  const tracedFs = new TracedFilesystem(trace, { rootDir });
+  const bundles = new BundleRecorder(trace);
+
+  trace.startRun({
+    branch: "feature/agent-audit-trace-control",
+    interpretedTask: "Build robust agent audit trace control.",
+    repository: "kevinrapley/ResearchOps",
+    title: "Agent audit trace control"
+  });
+  trace.event("prompt.received", {
+    promptHash: hashValue("[reasoning] build trace"),
+    safeExcerpt: "[reasoning] build trace"
+  });
+  trace.event("trigger.detected", {
+    token: "[reasoning]"
+  });
+  trace.event("context.lookup.completed", {
+    authorization: "Bearer secret-token",
+    ownerEmail: "user@example.com"
+  });
+  bundles.apply(
+    {
+      id: "github-diamond",
+      name: "GitHub Diamond",
+      version: "2.9.1"
+    },
+    {
+      appliedRules: ["discover before change", "do not fabricate validation evidence"]
+    }
+  );
+  trace.recordDecision({
+    decision: "Use append-only JSONL trace events.",
+    rationale: "Structured events are easier to validate than a self-reported summary."
+  });
+
+  const content = await tracedFs.readTextFile("AGENTS.md", "Check repository agent instructions.");
+  await tracedFs.writeTextFile("out/report.txt", content, "Exercise traced file write.");
+
+  const markdownPath = path.join(rootDir, "docs", "agent-audit", "reasoning", `${trace.traceId}.md`);
+  const summaryPath = path.join(rootDir, "docs", "agent-audit", "reasoning", `${trace.traceId}.json`);
+
+  await renderTrace(trace.eventPath, markdownPath, summaryPath);
+  trace.event("report.rendered", {
+    outputPath: path.relative(rootDir, markdownPath)
+  });
+  trace.completeRun({
+    status: "completed"
+  });
+
+  const validation = await validateTrace(trace.eventPath);
+  const events = await readJsonl(trace.eventPath);
+  const markdown = await fs.readFile(markdownPath, "utf8");
+  const serialisedEvents = JSON.stringify(events);
+
+  assert.equal(validation.valid, true, validation.failures.join("\n"));
+  assert.match(markdown, /Agent audit trace control/);
+  assert.match(markdown, /Bundle orchestration/);
+  assert.match(serialisedEvents, /\[REDACTED\]/);
+  assert.match(serialisedEvents, /\[REDACTED_EMAIL\]/);
+  assert.match(serialisedEvents, /"token":"\[reasoning\]"/);
+  assert.doesNotMatch(serialisedEvents, /secret-token/);
+  assert.doesNotMatch(serialisedEvents, /user@example.com/);
+  assert.equal(events[0].previousEventHash, null);
+  assert.equal(events[1].previousEventHash, events[0].eventHash);
+});


### PR DESCRIPTION
Closed in favour of #205, which replays the same agent audit trace implementation onto the current main branch.