### PR TITLE
Harden agent trace redaction and path boundaries

### DIFF
--- a/scripts/agent-trace/trace-redactor.mjs
+++ b/scripts/agent-trace/trace-redactor.mjs
@@ -8,6 +8,7 @@ import crypto from "node:crypto";
 
 const SECRET_PATTERNS = [
   /(Authorization:\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi,
+  /(\bBearer\s+)[A-Za-z0-9._~+/=-]+/gi,
   /(api[_-]?key["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]+/gi,
   /(token["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]+/gi,
   /(secret["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]+/gi,

--- a/scripts/agent-trace/traced-fs.mjs
+++ b/scripts/agent-trace/traced-fs.mjs
@@ -12,8 +12,23 @@ function hashContent(content) {
   return `sha256:${crypto.createHash("sha256").update(content).digest("hex")}`;
 }
 
-function relativePath(rootDir, filePath) {
-  return path.relative(rootDir, path.resolve(rootDir, filePath));
+function resolveInsideRoot(rootDir, filePath) {
+  if (path.isAbsolute(filePath)) {
+    throw new Error(`Traced filesystem path must be relative: ${filePath}`);
+  }
+
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedPath = path.resolve(resolvedRoot, filePath);
+  const relative = path.relative(resolvedRoot, resolvedPath);
+
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Traced filesystem path escapes root: ${filePath}`);
+  }
+
+  return {
+    absolutePath: resolvedPath,
+    relative
+  };
 }
 
 /**
@@ -27,7 +42,7 @@ export class TracedFilesystem {
    * @param {string} [options.rootDir] Repository root directory.
    */
   constructor(trace, options = {}) {
-    this.rootDir = options.rootDir || process.cwd();
+    this.rootDir = path.resolve(options.rootDir || process.cwd());
     this.trace = trace;
   }
 
@@ -38,9 +53,8 @@ export class TracedFilesystem {
    * @returns {Promise<string>} File contents.
    */
   async readTextFile(filePath, purpose) {
-    const absolutePath = path.resolve(this.rootDir, filePath);
+    const { absolutePath, relative } = resolveInsideRoot(this.rootDir, filePath);
     const content = await fs.readFile(absolutePath, "utf8");
-    const relative = relativePath(this.rootDir, absolutePath);
 
     this.trace.event("file.read", {
       bytes: Buffer.byteLength(content, "utf8"),
@@ -60,8 +74,7 @@ export class TracedFilesystem {
    * @returns {Promise<{ contentHash: string, path: string }>} Write metadata.
    */
   async writeTextFile(filePath, content, purpose) {
-    const absolutePath = path.resolve(this.rootDir, filePath);
-    const relative = relativePath(this.rootDir, absolutePath);
+    const { absolutePath, relative } = resolveInsideRoot(this.rootDir, filePath);
     const contentHash = hashContent(content);
 
     this.trace.event("file.write.planned", {

--- a/scripts/agent-trace/traced-fs.mjs
+++ b/scripts/agent-trace/traced-fs.mjs
@@ -12,22 +12,107 @@ function hashContent(content) {
   return `sha256:${crypto.createHash("sha256").update(content).digest("hex")}`;
 }
 
-function resolveInsideRoot(rootDir, filePath) {
+function missing(error) {
+  return error?.code === "ENOENT";
+}
+
+function inside(rootPath, targetPath) {
+  const relative = path.relative(rootPath, targetPath);
+
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function lexicalPath(rootDir, filePath) {
   if (path.isAbsolute(filePath)) {
     throw new Error(`Traced filesystem path must be relative: ${filePath}`);
   }
 
-  const resolvedRoot = path.resolve(rootDir);
-  const resolvedPath = path.resolve(resolvedRoot, filePath);
-  const relative = path.relative(resolvedRoot, resolvedPath);
+  const rootPath = path.resolve(rootDir);
+  const targetPath = path.resolve(rootPath, filePath);
+  const relative = path.relative(rootPath, targetPath);
 
   if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
     throw new Error(`Traced filesystem path escapes root: ${filePath}`);
   }
 
+  return { relative, rootPath, targetPath };
+}
+
+async function optionalRealpath(filePath) {
+  try {
+    return await fs.realpath(filePath);
+  } catch (error) {
+    if (missing(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+async function nearestExisting(rootDir, targetPath) {
+  const rootPath = path.resolve(rootDir);
+  let currentPath = targetPath;
+
+  while (currentPath !== rootPath) {
+    try {
+      await fs.lstat(currentPath);
+      return currentPath;
+    } catch (error) {
+      if (!missing(error)) {
+        throw error;
+      }
+
+      currentPath = path.dirname(currentPath);
+    }
+  }
+
+  return rootPath;
+}
+
+async function realRootAndTarget(rootDir, targetPath, filePath) {
+  const realRoot = await fs.realpath(rootDir);
+  const realTarget = await fs.realpath(targetPath);
+
+  if (!inside(realRoot, realTarget)) {
+    throw new Error(`Traced filesystem path escapes root: ${filePath}`);
+  }
+
+  return { realRoot, realTarget };
+}
+
+async function readablePath(rootDir, filePath) {
+  const lexical = lexicalPath(rootDir, filePath);
+  const { realTarget } = await realRootAndTarget(rootDir, lexical.targetPath, filePath);
+
   return {
-    absolutePath: resolvedPath,
-    relative
+    absolutePath: realTarget,
+    relative: lexical.relative
+  };
+}
+
+async function writablePath(rootDir, filePath) {
+  const lexical = lexicalPath(rootDir, filePath);
+  const parentPath = path.dirname(lexical.targetPath);
+  const nearestPath = await nearestExisting(rootDir, parentPath);
+  const { realRoot } = await realRootAndTarget(rootDir, nearestPath, filePath);
+  const existingTarget = await optionalRealpath(lexical.targetPath);
+
+  if (existingTarget && !inside(realRoot, existingTarget)) {
+    throw new Error(`Traced filesystem path escapes root: ${filePath}`);
+  }
+
+  await fs.mkdir(parentPath, { recursive: true });
+
+  const realParent = await fs.realpath(parentPath);
+
+  if (!inside(realRoot, realParent)) {
+    throw new Error(`Traced filesystem path escapes root: ${filePath}`);
+  }
+
+  return {
+    absolutePath: existingTarget || path.join(realParent, path.basename(lexical.targetPath)),
+    relative: lexical.relative
   };
 }
 
@@ -53,7 +138,7 @@ export class TracedFilesystem {
    * @returns {Promise<string>} File contents.
    */
   async readTextFile(filePath, purpose) {
-    const { absolutePath, relative } = resolveInsideRoot(this.rootDir, filePath);
+    const { absolutePath, relative } = await readablePath(this.rootDir, filePath);
     const content = await fs.readFile(absolutePath, "utf8");
 
     this.trace.event("file.read", {
@@ -74,7 +159,7 @@ export class TracedFilesystem {
    * @returns {Promise<{ contentHash: string, path: string }>} Write metadata.
    */
   async writeTextFile(filePath, content, purpose) {
-    const { absolutePath, relative } = resolveInsideRoot(this.rootDir, filePath);
+    const { absolutePath, relative } = await writablePath(this.rootDir, filePath);
     const contentHash = hashContent(content);
 
     this.trace.event("file.write.planned", {
@@ -84,7 +169,6 @@ export class TracedFilesystem {
       purpose
     });
 
-    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
     await fs.writeFile(absolutePath, content, "utf8");
 
     this.trace.event("file.write.completed", {

--- a/tests/agent-trace-control-regression.test.js
+++ b/tests/agent-trace-control-regression.test.js
@@ -62,6 +62,13 @@ test("agent trace control records auditable evidence", async () => {
 		authorization: "Bearer secret-token",
 		ownerEmail: "user@example.com",
 	});
+	trace.event("command.completed", {
+		command: "test-command",
+		exitCode: 0,
+		purpose: "Exercise bare bearer redaction.",
+		stderr: "Bearer stderr-secret-token",
+		stdout: "Bearer stdout-secret-token",
+	});
 	bundles.apply(
 		{
 			id: "github-diamond",
@@ -91,6 +98,23 @@ test("agent trace control records auditable evidence", async () => {
 		"Exercise traced file write.",
 	);
 
+	await assert.rejects(
+		tracedFs.writeTextFile(
+			"../outside.txt",
+			"escape",
+			"Reject path traversal.",
+		),
+		/escapes root/,
+	);
+	await assert.rejects(
+		tracedFs.writeTextFile(
+			path.join(rootDir, "absolute.txt"),
+			"escape",
+			"Reject absolute path.",
+		),
+		/must be relative/,
+	);
+
 	const reportDir = path.join(rootDir, "docs", "agent-audit", "reasoning");
 	const markdownPath = path.join(reportDir, `${trace.traceId}.md`);
 	const summaryPath = path.join(reportDir, `${trace.traceId}.json`);
@@ -115,6 +139,8 @@ test("agent trace control records auditable evidence", async () => {
 	assert.match(serialisedEvents, /\[REDACTED_EMAIL\]/);
 	assert.match(serialisedEvents, /"token":"\[reasoning\]"/);
 	assert.doesNotMatch(serialisedEvents, /secret-token/);
+	assert.doesNotMatch(serialisedEvents, /stderr-secret-token/);
+	assert.doesNotMatch(serialisedEvents, /stdout-secret-token/);
 	assert.doesNotMatch(serialisedEvents, /user@example.com/);
 	assert.equal(events[0].previousEventHash, null);
 	assert.equal(events[1].previousEventHash, events[0].eventHash);

--- a/tests/agent-trace-control-regression.test.js
+++ b/tests/agent-trace-control-regression.test.js
@@ -115,6 +115,20 @@ test("agent trace control records auditable evidence", async () => {
 		/must be relative/,
 	);
 
+	const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-trace-outside-"));
+	const externalFile = path.join(externalDir, "outside.txt");
+
+	await fs.writeFile(externalFile, "outside", "utf8");
+	await fs.symlink(externalDir, path.join(rootDir, "link"), "dir");
+	await assert.rejects(
+		tracedFs.readTextFile("link/outside.txt", "Reject symlink read."),
+		/escapes root/,
+	);
+	await assert.rejects(
+		tracedFs.writeTextFile("link/pwn.txt", "escape", "Reject symlink write."),
+		/escapes root/,
+	);
+
 	const reportDir = path.join(rootDir, "docs", "agent-audit", "reasoning");
 	const markdownPath = path.join(reportDir, `${trace.traceId}.md`);
 	const summaryPath = path.join(reportDir, `${trace.traceId}.json`);


### PR DESCRIPTION
## Summary

Follow-up hardening for the agent audit trace work merged in #205.

This PR addresses the review comments left on the merged/original trace work and the follow-up PR:

- redacts generic bare `Bearer ...` credentials before trace events are persisted
- rejects traced filesystem paths that are absolute or escape `rootDir` before filesystem operations touch disk
- resolves symlinks for existing path components before allowing traced reads or writes
- writes through the resolved parent path for new files so `root/link -> external-dir` cannot redirect writes outside the trace root
- extends the existing regression test to cover bare bearer output, lexical path escape rejection and symlink escape rejection

## Review comments addressed

1. `scripts/agent-trace/trace-redactor.mjs`
   - Adds a generic `\bBearer\s+...` pattern so command stdout/stderr values such as `Bearer secret-token` are redacted even without an `Authorization:` prefix.

2. `scripts/agent-trace/traced-fs.mjs`
   - Rejects absolute paths.
   - Rejects `../` traversal and any resolved path outside `rootDir`.
   - Resolves the trace root and target path with `fs.realpath()` for reads.
   - For writes, checks the nearest existing ancestor, creates missing parent directories, re-checks the real parent path, and writes via the resolved parent rather than a possibly symlinked lexical path.
   - Applies the guard to both reads and writes.

## Testing

Updated `tests/agent-trace-control-regression.test.js` to assert:

- bare bearer strings in command output are redacted
- original bearer and email fixtures are redacted
- `../outside.txt` is rejected
- absolute paths are rejected
- symlinked reads outside root are rejected
- symlinked writes outside root are rejected
- trace validation still passes

## Notes

This branch is based on current `main` and only changes the three files needed for the review hardening.
