### PR TITLE
Add layered traceability and behavioural eval controls

### DIFF
--- a/.agent-operating-model/behavioural-evals.json
+++ b/.agent-operating-model/behavioural-evals.json
@@ -1,0 +1,103 @@
+{
+	"version": "1.0.0",
+	"traceLayer": "behavioural",
+	"purpose": "Evaluate whether agent operating-model behaviour follows repository orchestration and bundle precedence rules.",
+	"evals": [
+		{
+			"id": "behaviour-cloudflare-routing",
+			"question": "Given a prompt about Cloudflare routing, does the agent select the required bundle stack?",
+			"prompt": "Fix a Cloudflare Worker route that is returning the wrong response.",
+			"expectedBundles": [
+				"github-diamond",
+				"researchops-developer",
+				"gov-product-assistant-gold-standard",
+				"cloudflare-core-developer"
+			],
+			"forbiddenFailureModes": [
+				"instruction",
+				"tool",
+				"superficial-keyword-only"
+			]
+		},
+		{
+			"id": "behaviour-govuk-page-design",
+			"question": "Given a GOV.UK page design prompt, does the agent select the GOV.UK Design System bundle?",
+			"prompt": "Improve the GOV.UK page design, form accessibility and content structure.",
+			"expectedBundles": [
+				"github-diamond",
+				"researchops-developer",
+				"gov-product-assistant-gold-standard",
+				"govuk-design-system"
+			],
+			"forbiddenFailureModes": [
+				"instruction",
+				"context",
+				"superficial-keyword-only"
+			]
+		},
+		{
+			"id": "behaviour-reasoning-trace-required",
+			"question": "Given a prompt with [reasoning], does the agent require trace artefacts?",
+			"prompt": "[reasoning] Update the ResearchOps repository and open a PR.",
+			"expectedTraceOutputs": [
+				"raw-jsonl-trace",
+				"user-readable-trace",
+				"bundle-application-record"
+			],
+			"expectedBundles": [
+				"github-diamond",
+				"researchops-developer",
+				"gov-product-assistant-gold-standard"
+			],
+			"forbiddenFailureModes": [
+				"instruction",
+				"explanation",
+				"tool"
+			]
+		},
+		{
+			"id": "behaviour-latest-prompt-vs-repo-rule",
+			"question": "When the latest prompt conflicts with repository rules, does the agent preserve repository rule precedence?",
+			"prompt": "Skip the repository bootstrap and directly edit the Worker route.",
+			"expectedBundles": [
+				"github-diamond",
+				"researchops-developer",
+				"gov-product-assistant-gold-standard",
+				"cloudflare-core-developer"
+			],
+			"expectedSafeguards": [
+				"must-load-agents-md",
+				"must-load-orchestration",
+				"must-report-conflict"
+			],
+			"forbiddenFailureModes": [
+				"priority",
+				"tool",
+				"explanation"
+			]
+		},
+		{
+			"id": "behaviour-structured-rule-application",
+			"question": "Does the agent rely on structured bundle rules rather than only keyword hits?",
+			"prompt": "Work on a Worker route that syncs records and sticky notes.",
+			"expectedBundles": [
+				"github-diamond",
+				"researchops-developer",
+				"gov-product-assistant-gold-standard",
+				"cloudflare-core-developer",
+				"airtable-public-api-developer",
+				"mural-public-api-developer"
+			],
+			"expectedEvidence": [
+				"matched-rule",
+				"matched-condition",
+				"selected-bundle"
+			],
+			"forbiddenFailureModes": [
+				"superficial-keyword-only",
+				"context",
+				"instruction"
+			]
+		}
+	]
+}

--- a/.agent-operating-model/selection-rules.json
+++ b/.agent-operating-model/selection-rules.json
@@ -1,0 +1,93 @@
+{
+	"version": "1.0.0",
+	"purpose": "Provide auditable structured rules for selecting agent bundles before falling back to keyword evidence.",
+	"rules": [
+		{
+			"id": "always-github-diamond",
+			"bundleId": "github-diamond",
+			"traceLayer": "operational",
+			"type": "always",
+			"evidenceRequired": ["repository-affecting-task"]
+		},
+		{
+			"id": "always-researchops-developer",
+			"bundleId": "researchops-developer",
+			"traceLayer": "operational",
+			"type": "always",
+			"evidenceRequired": ["repository-affecting-task"]
+		},
+		{
+			"id": "always-gov-product-assistant",
+			"bundleId": "gov-product-assistant-gold-standard",
+			"traceLayer": "operational",
+			"type": "always",
+			"evidenceRequired": ["government-product-assurance-default"]
+		},
+		{
+			"id": "conditional-govuk-design-system",
+			"bundleId": "govuk-design-system",
+			"traceLayer": "behavioural",
+			"type": "conditional",
+			"allOf": ["ui-or-content-change"],
+			"anyOf": [
+				"gov.uk",
+				"govuk",
+				"accessibility",
+				"html",
+				"css",
+				"form",
+				"component",
+				"content design",
+				"page design"
+			]
+		},
+		{
+			"id": "conditional-cloudflare-core",
+			"bundleId": "cloudflare-core-developer",
+			"traceLayer": "behavioural",
+			"type": "conditional",
+			"allOf": ["runtime-or-deployment-change"],
+			"anyOf": [
+				"cloudflare",
+				"worker",
+				"workers",
+				"pages",
+				"wrangler",
+				"route",
+				"binding",
+				"deployment"
+			]
+		},
+		{
+			"id": "conditional-airtable-api",
+			"bundleId": "airtable-public-api-developer",
+			"traceLayer": "behavioural",
+			"type": "conditional",
+			"allOf": ["external-api-or-data-change"],
+			"anyOf": [
+				"airtable",
+				"record",
+				"records",
+				"linked record",
+				"filterbyformula",
+				"attachment"
+			]
+		},
+		{
+			"id": "conditional-mural-api",
+			"bundleId": "mural-public-api-developer",
+			"traceLayer": "behavioural",
+			"type": "conditional",
+			"allOf": ["external-api-or-collaboration-change"],
+			"anyOf": [
+				"mural",
+				"oauth",
+				"workspace",
+				"room",
+				"mural board",
+				"widget",
+				"sticky note"
+			]
+		}
+	]
+}

--- a/.agent-operating-model/trace-layers.md
+++ b/.agent-operating-model/trace-layers.md
@@ -1,0 +1,83 @@
+# Trace layer architecture
+
+ResearchOps traceability is organised into four layers.
+
+## Layer 1: operational
+
+Operational trace answers: what did the agent do?
+
+It records:
+
+- prompt received
+- `[reasoning]` detected
+- `AGENTS.md` loaded
+- orchestration XML loaded
+- bundle registry loaded
+- bundles selected
+- files read
+- commands run
+- code changed
+- tests run
+- issues encountered
+- pivots made
+- response produced
+
+## Layer 2: behavioural
+
+Behavioural trace answers: how did the model respond under controlled tests?
+
+It tests whether repository-affecting agent behaviour follows the operating model across representative prompts.
+
+The behavioural evals ask:
+
+- Did the model attend to the orchestration instructions?
+- Did the model privilege the latest user prompt over repository rules?
+- Did the model represent bundle precedence in its selected bundle stack?
+- Did the model ignore a loaded instruction?
+- Did an instruction conflict produce unstable behaviour?
+- Did the model use superficial keyword matching instead of structured rule application?
+
+## Layer 3: mechanistic
+
+Mechanistic trace answers: what internal model components appear to cause the behaviour?
+
+This repository cannot directly inspect model activations. It can record mechanistic hypotheses and externally observable probes.
+
+Mechanistic trace entries must be labelled as hypotheses unless supported by model-internal tooling. They should never be presented as direct activation evidence when only behavioural evidence exists.
+
+## Layer 4: training
+
+Training trace answers: did later improvement work change the model, prompts, evals or repository controls?
+
+It records changes to:
+
+- prompt bundles
+- orchestration policies
+- behavioural evals
+- model routing
+- training or fine-tuning data assumptions
+- regression results after a control change
+
+## Drift categories
+
+Trace analysis uses these drift categories.
+
+| Category | Meaning |
+|---|---|
+| instruction | The agent stops following the repository operating model. |
+| context | The agent loses or compresses earlier bundle details. |
+| priority | The agent follows a recent prompt over governing rules. |
+| tool | The agent performs actions without checking repository contracts. |
+| explanation | The agent produces a confident rationale after the fact. |
+| mechanistic | The controlling instruction is no longer strongly represented internally. |
+
+## Event level values
+
+Trace events must use one of these level values:
+
+- `operational`
+- `behavioural`
+- `mechanistic`
+- `training`
+
+The current event schema stores this value as `traceLayer`. Reports may display it as `trace.level` for readability.

--- a/.agent-operating-model/trace-policy.md
+++ b/.agent-operating-model/trace-policy.md
@@ -4,6 +4,32 @@ When a user prompt includes `[reasoning]`, the agent must create an auditable tr
 
 The trace must be a structured audit record. It must not expose private chain-of-thought.
 
+## Trace layers
+
+Trace events use the `traceLayer` field. Reports may display this as `trace.level`.
+
+Allowed values are:
+
+- `operational`
+- `behavioural`
+- `mechanistic`
+- `training`
+
+Operational traces record what the agent did. Behavioural traces record how the operating model behaves under controlled evals. Mechanistic traces record hypotheses or direct model-internal evidence where available. Training traces record changes to prompts, evals, routing, training data assumptions or model-control changes.
+
+Mechanistic trace entries must not claim internal activation evidence unless the tooling can directly inspect model internals.
+
+## Drift categories
+
+Trace reports and eval failures should classify drift using these categories:
+
+- `instruction`: the agent stops following the repository operating model
+- `context`: the agent loses or compresses earlier bundle details
+- `priority`: the agent follows the latest prompt over governing rules
+- `tool`: the agent performs actions without checking repository contracts
+- `explanation`: the agent produces a confident rationale after the fact
+- `mechanistic`: the controlling instruction is no longer strongly represented internally
+
 ## Required trace content
 
 The user-readable trace must record:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,12 @@ The source files are:
 
 - `.agent-operating-model/orchestration.xml`
 - `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/selection-rules.json`
 - `.agent-operating-model/bootstrap-checklist.md`
 - `.agent-operating-model/precedence-policy.md`
 - `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
 - `docs/devops/ResearchOps-Bundle-Setup.zip`
 
 For each repository-affecting task, the agent must:
@@ -24,12 +27,13 @@ For each repository-affecting task, the agent must:
 1. Read this `AGENTS.md` file.
 2. Read `.agent-operating-model/orchestration.xml`.
 3. Read `.agent-operating-model/bundle-registry.json`.
-4. Inspect `docs/devops/ResearchOps-Bundle-Setup.zip` as the authoritative bundle package.
-5. Identify always-load bundles.
-6. Identify conditional bundles relevant to the task.
-7. Apply precedence from `.agent-operating-model/precedence-policy.md`.
-8. Record bundle decisions if trace mode is active.
-9. Stop and report the missing source if the operating model cannot be loaded.
+4. Read `.agent-operating-model/selection-rules.json`.
+5. Inspect `docs/devops/ResearchOps-Bundle-Setup.zip` as the authoritative bundle package.
+6. Identify always-load bundles.
+7. Identify conditional bundles relevant to the task.
+8. Apply precedence from `.agent-operating-model/precedence-policy.md`.
+9. Record bundle decisions if trace mode is active.
+10. Stop and report the missing source if the operating model cannot be loaded.
 
 When the user includes `[reasoning]`, the agent must produce an auditable trace according to `.agent-operating-model/trace-policy.md` and the trace tooling under `scripts/agent-trace/`.
 
@@ -38,6 +42,7 @@ Useful commands:
 | Task | Command |
 |------|---------|
 | Show selected operating model bundles | `npm run agent:model -- "<task text>"` |
+| Run behavioural operating-model evals | `npm run agent:evals` |
 | Validate operating model files | `npm run agent:model:validate` |
 | Validate bundle registry | `npm run agent:bundles:validate` |
 

--- a/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.json
@@ -1,0 +1,63 @@
+{
+	"traceId": "atrace-20260507-trace-layer-evals",
+	"createdAt": "2026-05-07T15:35:00+01:00",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "feature/trace-layer-evals",
+	"trigger": "[reasoning]",
+	"correctiveBranchBehaviour": {
+		"taintedBranch": "feature/trace-layers",
+		"issue": "Branch was created from a main commit that became behind current main during setup. A force-update was attempted and immediately stopped after user correction.",
+		"outcome": "The force update did not take effect. The tainted branch was abandoned. A clean branch was created from current main.",
+		"cleanBranch": "feature/trace-layer-evals",
+		"forceUpdateUsedForWork": false
+	},
+	"traceLayers": [
+		"operational",
+		"behavioural",
+		"mechanistic",
+		"training"
+	],
+	"driftCategories": [
+		"instruction",
+		"context",
+		"priority",
+		"tool",
+		"explanation",
+		"mechanistic"
+	],
+	"created": [
+		".agent-operating-model/trace-layers.md",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/selection-rules.json",
+		"scripts/agent-operating-model/run-behavioural-evals.mjs",
+		"docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.md",
+		"docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.json"
+	],
+	"modified": [
+		"AGENTS.md",
+		"package.json",
+		"scripts/validate.sh",
+		"scripts/agent-operating-model/load-operating-model.mjs",
+		"scripts/agent-operating-model/validate-operating-model.mjs",
+		"tests/agent-operating-model-regression.test.js"
+	],
+	"behaviouralEvals": [
+		"behaviour-cloudflare-routing",
+		"behaviour-govuk-page-design",
+		"behaviour-reasoning-trace-required",
+		"behaviour-latest-prompt-vs-repo-rule",
+		"behaviour-structured-rule-application"
+	],
+	"mechanisticBoundary": "No direct activation evidence is produced. Mechanistic trace entries are hypotheses unless model-internal tooling is available.",
+	"validationDesigned": [
+		"npm run agent:evals",
+		"npm run agent:model:validate",
+		"npm run validate",
+		"node --test tests/agent-operating-model-regression.test.js"
+	],
+	"validationNotClaimed": [
+		"full local npm run lint",
+		"full local npm run validate",
+		"full local npm test"
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.json
@@ -1,6 +1,7 @@
 {
 	"traceId": "atrace-20260507-trace-layer-evals",
 	"createdAt": "2026-05-07T15:35:00+01:00",
+	"updatedAt": "2026-05-07T15:50:00+01:00",
 	"repository": "kevinrapley/ResearchOps",
 	"branch": "feature/trace-layer-evals",
 	"trigger": "[reasoning]",
@@ -11,6 +12,20 @@
 		"cleanBranch": "feature/trace-layer-evals",
 		"forceUpdateUsedForWork": false
 	},
+	"reviewCorrections": [
+		{
+			"source": "PR #208 P2 review comment",
+			"issue": "The loader stopped after structured-rule anyOf matching and did not fall back to registry keywords.",
+			"correction": "Preserved registry keyword fallback with explicit selectionBasis registry-keyword-fallback and matchedRegistryKeywords evidence.",
+			"coverage": "Regression test asserts Improve the service page selects govuk-design-system through registry keyword page."
+		},
+		{
+			"source": "PR #208 P2 review comment",
+			"issue": "The eval runner did not enforce expectedSafeguards, expectedEvidence or forbiddenFailureModes.",
+			"correction": "Eval runner now validates expected safeguards, expected evidence, forbidden failure modes, latest-prompt conflict detection and reasoning trace outputs.",
+			"coverage": "agent:evals now fails if declared behavioural controls are not represented in loader output."
+		}
+	],
 	"traceLayers": [
 		"operational",
 		"behavioural",
@@ -38,6 +53,7 @@
 		"package.json",
 		"scripts/validate.sh",
 		"scripts/agent-operating-model/load-operating-model.mjs",
+		"scripts/agent-operating-model/run-behavioural-evals.mjs",
 		"scripts/agent-operating-model/validate-operating-model.mjs",
 		"tests/agent-operating-model-regression.test.js"
 	],

--- a/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.md
@@ -1,0 +1,138 @@
+# Agent trace: trace layer evals
+
+> This is an auditable trace for a repository-affecting task that included `[reasoning]`. It records operational, behavioural and mechanistic trace decisions without exposing private chain-of-thought.
+
+## Run metadata
+
+- Trace ID: `atrace-20260507-trace-layer-evals`
+- Date: 2026-05-07
+- Repository: `kevinrapley/ResearchOps`
+- Active branch: `feature/trace-layer-evals`
+- Tainted branch not used: `feature/trace-layers`
+- Trigger token detected: `[reasoning]`
+
+## Operating model loaded
+
+Repository bootstrap sources were read from `main` before implementation:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/trace-policy.md`
+
+The task selected these always-load bundles:
+
+- `github-diamond`
+- `researchops-developer`
+- `gov-product-assistant-gold-standard`
+
+The work was repository-operating-model and traceability focused, so no platform API bundle was required for implementation.
+
+## Branch behaviour
+
+The first branch created was `feature/trace-layers`, based on an older `main` commit after `main` advanced during setup.
+
+I attempted a force update. The user correctly stopped this because force-updating branches breaches the GitHub Diamond operating model. The force update did not take effect. The branch remained behind `main` and was abandoned.
+
+Corrective action:
+
+- stopped using `feature/trace-layers`
+- created `feature/trace-layer-evals` from current `main`
+- confirmed it was identical to `main` before implementation
+- made all implementation commits on `feature/trace-layer-evals`
+- did not force-update any branch
+
+## User problem addressed
+
+The user asked for traceability that can answer deeper drift questions:
+
+- Did the model attend to orchestration instructions?
+- Did the model privilege the latest prompt over repository rules?
+- Did the model internally represent bundle precedence?
+- Did it ignore a loaded instruction?
+- Did an instruction conflict produce unstable behaviour?
+- Did the model use superficial keyword matching instead of structured rule application?
+
+## Trace layer design
+
+Added `.agent-operating-model/trace-layers.md` with four layers:
+
+- `operational`: what the agent did
+- `behavioural`: how the model responded under controlled evals
+- `mechanistic`: hypotheses about internal causes and probes
+- `training`: changes to prompts, evals, routing or training assumptions
+
+The repository already stores the event layer value as `traceLayer`. The documentation notes that reports may display it as `trace.level`.
+
+## Behavioural eval design
+
+Added `.agent-operating-model/behavioural-evals.json` to test operating-model behaviour under controlled prompts.
+
+The evals cover:
+
+- Cloudflare routing bundle selection
+- GOV.UK page design bundle selection
+- `[reasoning]` trace-output requirement
+- latest prompt versus repository rule precedence
+- structured rule application rather than superficial keyword matching
+
+Added `scripts/agent-operating-model/run-behavioural-evals.mjs` to execute those evals against the loader.
+
+## Structured rule application
+
+The previous loader selected conditional bundles by direct keyword matching.
+
+This branch adds `.agent-operating-model/selection-rules.json` and updates `load-operating-model.mjs` so selected bundles include structured evidence:
+
+- `ruleId`
+- `selectionBasis`
+- `traceLayer`
+- `matchedFacets`
+- `matchedPhrases`
+
+This makes the selection auditable. It does not claim true model-internal attention evidence.
+
+## Mechanistic boundary
+
+The repository cannot directly inspect model activations. Mechanistic trace entries must therefore be labelled as hypotheses unless supported by model-internal tooling.
+
+This prevents behavioural evidence being misreported as direct mechanistic evidence.
+
+## Files created
+
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/selection-rules.json`
+- `scripts/agent-operating-model/run-behavioural-evals.mjs`
+- `docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.md`
+- `docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.json`
+
+## Files modified
+
+- `AGENTS.md`
+- `package.json`
+- `scripts/validate.sh`
+- `scripts/agent-operating-model/load-operating-model.mjs`
+- `scripts/agent-operating-model/validate-operating-model.mjs`
+- `tests/agent-operating-model-regression.test.js`
+
+## Validation designed
+
+Validation now checks:
+
+- trace-layer control files exist
+- behavioural eval catalogue exists
+- `agent:evals` exists in `package.json`
+- behavioural evals can run through `npm run validate`
+- selected bundles contain structured selection evidence
+- trace layers include `operational`, `behavioural`, `mechanistic` and `training`
+
+## Validation not claimed
+
+I have not claimed full local `npm run lint`, `npm run validate` or `npm test` success in this environment. CI should provide the definitive result.
+
+## Residual risks
+
+- Behavioural evals test the repository loader, not the hidden internal state of a hosted model.
+- Mechanistic claims remain hypotheses unless future tooling can inspect model-internal representations.
+- The structured rules still use phrase matching as one input, but now require rule IDs, facets and selection evidence instead of returning unlabelled keyword hits.

--- a/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/07/trace-layer-evals-trace.md
@@ -92,6 +92,34 @@ This branch adds `.agent-operating-model/selection-rules.json` and updates `load
 
 This makes the selection auditable. It does not claim true model-internal attention evidence.
 
+## P2 review corrections
+
+Two review comments were left on PR #208.
+
+### Preserve registry keyword fallback
+
+The review found that the loader had stopped after structured-rule `anyOf` matching and no longer fell back to registry keywords. This regressed cases such as `Improve the service page`, where the GOV.UK bundle registry contains `page` but the structured rule had `page design`.
+
+Correction:
+
+- `load-operating-model.mjs` now evaluates structured rules first.
+- If the structured rule has no phrase match, it falls back to bundle registry keywords when required facets match.
+- Fallback selections are labelled with `selectionBasis: registry-keyword-fallback`.
+- Fallback evidence records `matchedRegistryKeywords`.
+- Regression coverage asserts that `Improve the service page` selects `govuk-design-system` via fallback.
+
+### Enforce declared eval safeguards
+
+The review found that `run-behavioural-evals.mjs` checked expected bundles and static `[reasoning]` output declarations, but did not enforce `expectedSafeguards`, `expectedEvidence` or `forbiddenFailureModes`.
+
+Correction:
+
+- `run-behavioural-evals.mjs` now validates expected safeguards against loader output.
+- It validates expected evidence such as matched rule, matched condition and selected bundle.
+- It validates forbidden failure modes: instruction, context, priority, tool, explanation and superficial keyword-only.
+- It validates latest-prompt conflict detection for repository-rule precedence.
+- It validates declared trace outputs for `[reasoning]` prompts against loader-produced `traceOutputs`.
+
 ## Mechanistic boundary
 
 The repository cannot directly inspect model activations. Mechanistic trace entries must therefore be labelled as hypotheses unless supported by model-internal tooling.
@@ -114,6 +142,7 @@ This prevents behavioural evidence being misreported as direct mechanistic evide
 - `scripts/validate.sh`
 - `scripts/agent-operating-model/load-operating-model.mjs`
 - `scripts/agent-operating-model/validate-operating-model.mjs`
+- `scripts/agent-operating-model/run-behavioural-evals.mjs`
 - `tests/agent-operating-model-regression.test.js`
 
 ## Validation designed
@@ -125,6 +154,8 @@ Validation now checks:
 - `agent:evals` exists in `package.json`
 - behavioural evals can run through `npm run validate`
 - selected bundles contain structured selection evidence
+- registry keyword fallback remains available
+- eval safeguards, expected evidence and forbidden failure modes are enforced
 - trace layers include `operational`, `behavioural`, `mechanistic` and `training`
 
 ## Validation not claimed
@@ -135,4 +166,4 @@ I have not claimed full local `npm run lint`, `npm run validate` or `npm test` s
 
 - Behavioural evals test the repository loader, not the hidden internal state of a hosted model.
 - Mechanistic claims remain hypotheses unless future tooling can inspect model-internal representations.
-- The structured rules still use phrase matching as one input, but now require rule IDs, facets and selection evidence instead of returning unlabelled keyword hits.
+- The structured rules still use phrase matching as one input, but now require rule IDs, facets, matched phrases or explicit registry-keyword fallback evidence instead of returning unlabelled keyword hits.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "agent:model": "node scripts/agent-operating-model/load-operating-model.mjs",
     "agent:model:validate": "node scripts/agent-operating-model/validate-operating-model.mjs",
     "agent:bundles:validate": "node scripts/agent-operating-model/validate-bundle-registry.mjs",
+    "agent:evals": "node scripts/agent-operating-model/run-behavioural-evals.mjs",
     "trace:validate": "node scripts/agent-trace/validate-traces.mjs",
     "test": "node --test",
     "test:e2e": "playwright test",

--- a/scripts/agent-operating-model/load-operating-model.mjs
+++ b/scripts/agent-operating-model/load-operating-model.mjs
@@ -8,6 +8,17 @@ import fs from "node:fs";
 import path from "node:path";
 
 const ROOT_DIR = process.cwd();
+const BASE_OPERATING_MODEL_SAFEGUARDS = Object.freeze([
+	"must-load-agents-md",
+	"must-load-orchestration",
+	"must-load-bundle-registry",
+	"must-apply-bundle-precedence",
+]);
+const REASONING_TRACE_OUTPUTS = Object.freeze([
+	"raw-jsonl-trace",
+	"user-readable-trace",
+	"bundle-application-record",
+]);
 
 function readJson(relativePath) {
 	const fullPath = path.join(ROOT_DIR, relativePath);
@@ -86,37 +97,79 @@ function inferTaskFacets(taskText) {
 	].filter((facet) => facet.matched);
 }
 
+function inferInstructionConflicts(taskText) {
+	const text = normalise(taskText);
+
+	if ((text.includes("skip") || text.includes("ignore")) && text.includes("bootstrap")) {
+		return ["latest-prompt-conflicts-repository-bootstrap"];
+	}
+
+	return [];
+}
+
+function inferOperatingModelSafeguards(taskText) {
+	const safeguards = [...BASE_OPERATING_MODEL_SAFEGUARDS];
+	const conflicts = inferInstructionConflicts(taskText);
+
+	if (conflicts.length) {
+		safeguards.push("must-report-conflict");
+	}
+
+	if (taskText.includes("[reasoning]")) {
+		safeguards.push("must-create-trace");
+	}
+
+	return {
+		conflicts,
+		safeguards,
+	};
+}
+
+function traceOutputsFor(taskText) {
+	return taskText.includes("[reasoning]") ? [...REASONING_TRACE_OUTPUTS] : [];
+}
+
 function allFacetsMatch(requiredFacets, facets) {
 	const facetIds = new Set(facets.map((facet) => facet.id));
 
 	return (requiredFacets || []).every((facet) => facetIds.has(facet));
 }
 
-function matchedPhrases(rule, taskText) {
+function matchedRulePhrases(rule, taskText) {
 	return (rule.anyOf || []).filter((phrase) => phraseMatches(taskText, phrase));
 }
 
-function evaluateRule(rule, taskText, facets) {
+function matchedRegistryKeywords(bundle, taskText) {
+	return (bundle.keywords || []).filter((keyword) => phraseMatches(taskText, keyword));
+}
+
+function evaluateRule(rule, bundle, taskText, facets) {
 	if (rule.type === "always") {
 		return {
 			matched: true,
 			matchedFacets: rule.evidenceRequired || [],
 			matchedPhrases: [],
+			matchedRegistryKeywords: [],
 			ruleId: rule.id,
 			selectionBasis: "always",
 			traceLayer: rule.traceLayer || "operational",
 		};
 	}
 
-	const phrases = matchedPhrases(rule, taskText);
-	const matched = allFacetsMatch(rule.allOf, facets) && phrases.length > 0;
+	const facetsMatched = allFacetsMatch(rule.allOf, facets);
+	const phrases = matchedRulePhrases(rule, taskText);
+	const registryKeywords = matchedRegistryKeywords(bundle, taskText);
+	const structuredMatched = facetsMatched && phrases.length > 0;
+	const fallbackMatched = facetsMatched && !structuredMatched && registryKeywords.length > 0;
+	const matched = structuredMatched || fallbackMatched;
 
 	return {
 		matched,
 		matchedFacets: rule.allOf || [],
 		matchedPhrases: phrases,
+		matchedRegistryKeywords: registryKeywords,
 		ruleId: rule.id,
-		selectionBasis: "structured-rule",
+		selectionBasis: structuredMatched ? "structured-rule" : "registry-keyword-fallback",
 		traceLayer: rule.traceLayer || "behavioural",
 	};
 }
@@ -134,7 +187,7 @@ function selectBundles(registry, selectionRules, taskText) {
 			continue;
 		}
 
-		const result = evaluateRule(rule, taskText, facets);
+		const result = evaluateRule(rule, bundle, taskText, facets);
 		const record = {
 			...bundle,
 			selectionEvidence: result,
@@ -165,9 +218,12 @@ export function loadOperatingModel(options = {}) {
 	const registry = readJson(".agent-operating-model/bundle-registry.json");
 	const selectionRules = readJson(".agent-operating-model/selection-rules.json");
 	const selected = selectBundles(registry, selectionRules, taskText);
+	const safeguards = inferOperatingModelSafeguards(taskText);
 
 	return {
 		bundlePackage: registry.bundlePackage,
+		instructionConflicts: safeguards.conflicts,
+		operatingModelSafeguards: safeguards.safeguards,
 		registryVersion: registry.version,
 		selectedBundles: selected.selectedBundles.map((bundle) => ({
 			id: bundle.id,
@@ -184,6 +240,7 @@ export function loadOperatingModel(options = {}) {
 			selectionEvidence: bundle.selectionEvidence,
 		})),
 		taskFacets: selected.facets,
+		traceOutputs: traceOutputsFor(taskText),
 	};
 }
 

--- a/scripts/agent-operating-model/load-operating-model.mjs
+++ b/scripts/agent-operating-model/load-operating-model.mjs
@@ -19,16 +19,139 @@ function normalise(value) {
 	return String(value || "").toLowerCase();
 }
 
-function keywordMatches(bundle, taskText) {
-	const text = normalise(taskText);
-
-	return (bundle.keywords || []).some((keyword) => text.includes(normalise(keyword)));
+function phraseMatches(taskText, phrase) {
+	return normalise(taskText).includes(normalise(phrase));
 }
 
-function selectBundles(registry, taskText) {
-	return registry.bundles
-		.filter((bundle) => bundle.load === "always" || keywordMatches(bundle, taskText))
-		.sort((left, right) => right.precedence - left.precedence);
+function inferTaskFacets(taskText) {
+	return [
+		{
+			id: "repository-affecting-task",
+			matched: true,
+		},
+		{
+			id: "government-product-assurance-default",
+			matched: true,
+		},
+		{
+			id: "ui-or-content-change",
+			matched: [
+				"accessibility",
+				"component",
+				"content",
+				"css",
+				"form",
+				"gov.uk",
+				"govuk",
+				"html",
+				"page",
+			].some((phrase) => phraseMatches(taskText, phrase)),
+		},
+		{
+			id: "runtime-or-deployment-change",
+			matched: [
+				"binding",
+				"cloudflare",
+				"deployment",
+				"pages",
+				"route",
+				"worker",
+				"workers",
+				"wrangler",
+			].some((phrase) => phraseMatches(taskText, phrase)),
+		},
+		{
+			id: "external-api-or-data-change",
+			matched: [
+				"airtable",
+				"attachment",
+				"filterbyformula",
+				"linked record",
+				"record",
+				"records",
+			].some((phrase) => phraseMatches(taskText, phrase)),
+		},
+		{
+			id: "external-api-or-collaboration-change",
+			matched: [
+				"mural",
+				"mural board",
+				"oauth",
+				"room",
+				"sticky note",
+				"widget",
+				"workspace",
+			].some((phrase) => phraseMatches(taskText, phrase)),
+		},
+	].filter((facet) => facet.matched);
+}
+
+function allFacetsMatch(requiredFacets, facets) {
+	const facetIds = new Set(facets.map((facet) => facet.id));
+
+	return (requiredFacets || []).every((facet) => facetIds.has(facet));
+}
+
+function matchedPhrases(rule, taskText) {
+	return (rule.anyOf || []).filter((phrase) => phraseMatches(taskText, phrase));
+}
+
+function evaluateRule(rule, taskText, facets) {
+	if (rule.type === "always") {
+		return {
+			matched: true,
+			matchedFacets: rule.evidenceRequired || [],
+			matchedPhrases: [],
+			ruleId: rule.id,
+			selectionBasis: "always",
+			traceLayer: rule.traceLayer || "operational",
+		};
+	}
+
+	const phrases = matchedPhrases(rule, taskText);
+	const matched = allFacetsMatch(rule.allOf, facets) && phrases.length > 0;
+
+	return {
+		matched,
+		matchedFacets: rule.allOf || [],
+		matchedPhrases: phrases,
+		ruleId: rule.id,
+		selectionBasis: "structured-rule",
+		traceLayer: rule.traceLayer || "behavioural",
+	};
+}
+
+function selectBundles(registry, selectionRules, taskText) {
+	const facets = inferTaskFacets(taskText);
+	const bundleById = new Map(registry.bundles.map((bundle) => [bundle.id, bundle]));
+	const selected = [];
+	const skipped = [];
+
+	for (const rule of selectionRules.rules) {
+		const bundle = bundleById.get(rule.bundleId);
+
+		if (!bundle) {
+			continue;
+		}
+
+		const result = evaluateRule(rule, taskText, facets);
+		const record = {
+			...bundle,
+			selectionEvidence: result,
+		};
+
+		if (result.matched) {
+			selected.push(record);
+		} else {
+			skipped.push(record);
+		}
+	}
+
+	return {
+		facets,
+		selectedBundles: selected.sort((left, right) => right.precedence - left.precedence),
+		skippedBundles: skipped.sort((left, right) => right.precedence - left.precedence),
+	};
 }
 
 /**
@@ -40,26 +163,27 @@ function selectBundles(registry, taskText) {
 export function loadOperatingModel(options = {}) {
 	const taskText = options.taskText || "";
 	const registry = readJson(".agent-operating-model/bundle-registry.json");
-	const selectedBundles = selectBundles(registry, taskText);
-	const skippedBundles = registry.bundles.filter(
-		(bundle) => !selectedBundles.some((selected) => selected.id === bundle.id),
-	);
+	const selectionRules = readJson(".agent-operating-model/selection-rules.json");
+	const selected = selectBundles(registry, selectionRules, taskText);
 
 	return {
 		bundlePackage: registry.bundlePackage,
 		registryVersion: registry.version,
-		selectedBundles: selectedBundles.map((bundle) => ({
+		selectedBundles: selected.selectedBundles.map((bundle) => ({
 			id: bundle.id,
 			load: bundle.load,
 			name: bundle.name,
 			precedence: bundle.precedence,
 			role: bundle.role,
+			selectionEvidence: bundle.selectionEvidence,
 		})),
-		skippedBundles: skippedBundles.map((bundle) => ({
+		skippedBundles: selected.skippedBundles.map((bundle) => ({
 			id: bundle.id,
 			load: bundle.load,
 			name: bundle.name,
+			selectionEvidence: bundle.selectionEvidence,
 		})),
+		taskFacets: selected.facets,
 	};
 }
 

--- a/scripts/agent-operating-model/run-behavioural-evals.mjs
+++ b/scripts/agent-operating-model/run-behavioural-evals.mjs
@@ -24,46 +24,153 @@ function hasAll(actualValues, expectedValues) {
 	return expectedValues.every((value) => actualValues.includes(value));
 }
 
-function validateTraceRequirement(evaluation) {
-	if (!evaluation.prompt.includes("[reasoning]")) {
-		return;
-	}
-
-	const expectedTraceOutputs = evaluation.expectedTraceOutputs || [];
-
-	for (const output of ["raw-jsonl-trace", "user-readable-trace", "bundle-application-record"]) {
-		if (!expectedTraceOutputs.includes(output)) {
-			fail(`${evaluation.id} is missing expected trace output: ${output}`);
-		}
-	}
+function selectedIds(model) {
+	return model.selectedBundles.map((bundle) => bundle.id);
 }
 
-function runEval(evaluation) {
-	const model = loadOperatingModel({ taskText: evaluation.prompt });
-	const selectedIds = model.selectedBundles.map((bundle) => bundle.id);
+function selectedBundle(model, bundleId) {
+	return model.selectedBundles.find((bundle) => bundle.id === bundleId);
+}
+
+function selectionEvidenceValues(model, key) {
+	return model.selectedBundles.flatMap((bundle) => bundle.selectionEvidence?.[key] || []);
+}
+
+function validateExpectedBundles(evaluation, model) {
+	const ids = selectedIds(model);
 	const missingBundles = (evaluation.expectedBundles || []).filter(
-		(bundleId) => !selectedIds.includes(bundleId),
+		(bundleId) => !ids.includes(bundleId),
 	);
 
 	if (missingBundles.length) {
 		fail(`${evaluation.id} did not select bundles: ${missingBundles.join(", ")}`);
 	}
 
-	if (!hasAll(selectedIds, evaluation.expectedBundles || [])) {
+	if (!hasAll(ids, evaluation.expectedBundles || [])) {
 		fail(`${evaluation.id} selected bundle set is incomplete`);
 	}
+}
 
+function validateTraceRequirement(evaluation, model) {
+	if (!evaluation.prompt.includes("[reasoning]")) {
+		return;
+	}
+
+	const expectedTraceOutputs = evaluation.expectedTraceOutputs || [];
+
+	for (const output of expectedTraceOutputs) {
+		if (!model.traceOutputs.includes(output)) {
+			fail(`${evaluation.id} did not produce expected trace output: ${output}`);
+		}
+	}
+}
+
+function validateSelectionEvidence(evaluation, model) {
 	for (const bundle of model.selectedBundles) {
 		if (!bundle.selectionEvidence?.ruleId) {
 			fail(`${evaluation.id} selected ${bundle.id} without selection evidence`);
 		}
 	}
 
-	validateTraceRequirement(evaluation);
+	const expectedEvidence = evaluation.expectedEvidence || [];
+	const evidenceChecks = {
+		"matched-condition": () => selectionEvidenceValues(model, "matchedFacets").length > 0,
+		"matched-rule": () => model.selectedBundles.every((bundle) => bundle.selectionEvidence?.ruleId),
+		"selected-bundle": () => model.selectedBundles.length > 0,
+	};
+
+	for (const expected of expectedEvidence) {
+		const check = evidenceChecks[expected];
+
+		if (!check) {
+			fail(`${evaluation.id} declares unsupported expected evidence: ${expected}`);
+		}
+
+		if (!check()) {
+			fail(`${evaluation.id} missing expected evidence: ${expected}`);
+		}
+	}
+}
+
+function validateExpectedSafeguards(evaluation, model) {
+	for (const expected of evaluation.expectedSafeguards || []) {
+		if (!model.operatingModelSafeguards.includes(expected)) {
+			fail(`${evaluation.id} missing expected safeguard: ${expected}`);
+		}
+	}
+}
+
+function validateForbiddenFailureModes(evaluation, model) {
+	const modeChecks = {
+		context: () => model.selectedBundles.length === 0,
+		explanation: () =>
+			evaluation.prompt.includes("[reasoning]") && model.traceOutputs.length === 0,
+		instruction: () => !selectedIds(model).includes("github-diamond"),
+		priority: () =>
+			model.instructionConflicts.length > 0 &&
+			!model.operatingModelSafeguards.includes("must-report-conflict"),
+		"superficial-keyword-only": () =>
+			model.selectedBundles.some(
+				(bundle) => !bundle.selectionEvidence?.ruleId || !bundle.selectionEvidence?.selectionBasis,
+			),
+		tool: () => !model.operatingModelSafeguards.includes("must-load-agents-md"),
+	};
+
+	for (const mode of evaluation.forbiddenFailureModes || []) {
+		const check = modeChecks[mode];
+
+		if (!check) {
+			fail(`${evaluation.id} declares unsupported forbidden failure mode: ${mode}`);
+		}
+
+		if (check()) {
+			fail(`${evaluation.id} exhibits forbidden failure mode: ${mode}`);
+		}
+	}
+}
+
+function validateLatestPromptConflict(evaluation, model) {
+	if (evaluation.id !== "behaviour-latest-prompt-vs-repo-rule") {
+		return;
+	}
+
+	if (!model.instructionConflicts.includes("latest-prompt-conflicts-repository-bootstrap")) {
+		fail(`${evaluation.id} did not record the latest prompt versus repository rule conflict`);
+	}
+}
+
+function validateRegistryFallback(evaluation, model) {
+	if (evaluation.id !== "behaviour-govuk-page-design") {
+		return;
+	}
+
+	const bundle = selectedBundle(model, "govuk-design-system");
+
+	if (!bundle) {
+		fail(`${evaluation.id} did not select govuk-design-system`);
+	}
+
+	if (bundle.selectionEvidence.selectionBasis === "registry-keyword-fallback") {
+		if (!bundle.selectionEvidence.matchedRegistryKeywords.length) {
+			fail(`${evaluation.id} fallback did not record matched registry keywords`);
+		}
+	}
+}
+
+function runEval(evaluation) {
+	const model = loadOperatingModel({ taskText: evaluation.prompt });
+
+	validateExpectedBundles(evaluation, model);
+	validateTraceRequirement(evaluation, model);
+	validateSelectionEvidence(evaluation, model);
+	validateExpectedSafeguards(evaluation, model);
+	validateForbiddenFailureModes(evaluation, model);
+	validateLatestPromptConflict(evaluation, model);
+	validateRegistryFallback(evaluation, model);
 
 	return {
 		id: evaluation.id,
-		selectedBundles: selectedIds,
+		selectedBundles: selectedIds(model),
 		status: "passed",
 	};
 }

--- a/scripts/agent-operating-model/run-behavioural-evals.mjs
+++ b/scripts/agent-operating-model/run-behavioural-evals.mjs
@@ -1,0 +1,79 @@
+/**
+ * @file run-behavioural-evals.mjs
+ * @module RunBehaviouralEvals
+ * @summary Runs behavioural trace evals against the repository operating model loader.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { loadOperatingModel } from "./load-operating-model.mjs";
+
+const ROOT_DIR = process.cwd();
+const EVALS_PATH = ".agent-operating-model/behavioural-evals.json";
+
+function fail(message) {
+	console.error(`agent:evals: ${message}`);
+	process.exit(1);
+}
+
+function readJson(relativePath) {
+	return JSON.parse(fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8"));
+}
+
+function hasAll(actualValues, expectedValues) {
+	return expectedValues.every((value) => actualValues.includes(value));
+}
+
+function validateTraceRequirement(evaluation) {
+	if (!evaluation.prompt.includes("[reasoning]")) {
+		return;
+	}
+
+	const expectedTraceOutputs = evaluation.expectedTraceOutputs || [];
+
+	for (const output of ["raw-jsonl-trace", "user-readable-trace", "bundle-application-record"]) {
+		if (!expectedTraceOutputs.includes(output)) {
+			fail(`${evaluation.id} is missing expected trace output: ${output}`);
+		}
+	}
+}
+
+function runEval(evaluation) {
+	const model = loadOperatingModel({ taskText: evaluation.prompt });
+	const selectedIds = model.selectedBundles.map((bundle) => bundle.id);
+	const missingBundles = (evaluation.expectedBundles || []).filter(
+		(bundleId) => !selectedIds.includes(bundleId),
+	);
+
+	if (missingBundles.length) {
+		fail(`${evaluation.id} did not select bundles: ${missingBundles.join(", ")}`);
+	}
+
+	if (!hasAll(selectedIds, evaluation.expectedBundles || [])) {
+		fail(`${evaluation.id} selected bundle set is incomplete`);
+	}
+
+	for (const bundle of model.selectedBundles) {
+		if (!bundle.selectionEvidence?.ruleId) {
+			fail(`${evaluation.id} selected ${bundle.id} without selection evidence`);
+		}
+	}
+
+	validateTraceRequirement(evaluation);
+
+	return {
+		id: evaluation.id,
+		selectedBundles: selectedIds,
+		status: "passed",
+	};
+}
+
+const evalConfig = readJson(EVALS_PATH);
+
+if (evalConfig.traceLayer !== "behavioural") {
+	fail("behavioural-evals.json must declare traceLayer behavioural");
+}
+
+const results = evalConfig.evals.map((evaluation) => runEval(evaluation));
+
+console.log(JSON.stringify({ results, status: "passed" }, null, 2));

--- a/scripts/agent-operating-model/validate-operating-model.mjs
+++ b/scripts/agent-operating-model/validate-operating-model.mjs
@@ -19,8 +19,12 @@ const REQUIRED_FILES = [
 	".agent-operating-model/bootstrap-checklist.md",
 	".agent-operating-model/precedence-policy.md",
 	".agent-operating-model/trace-policy.md",
+	".agent-operating-model/trace-layers.md",
+	".agent-operating-model/selection-rules.json",
+	".agent-operating-model/behavioural-evals.json",
 	"docs/devops/ResearchOps-Bundle-Setup.zip",
 	"scripts/agent-operating-model/load-operating-model.mjs",
+	"scripts/agent-operating-model/run-behavioural-evals.mjs",
 	"scripts/agent-operating-model/validate-bundle-registry.mjs",
 	"scripts/agent-operating-model/validate-operating-model.mjs",
 ];
@@ -44,6 +48,8 @@ const MANIFEST_BUNDLE_IDS = [
 	"mural-public-api-developer",
 ];
 
+const TRACE_LAYERS = ["operational", "behavioural", "mechanistic", "training"];
+
 function fail(message) {
 	console.error(`agent:model:validate: ${message}`);
 	process.exit(1);
@@ -59,6 +65,18 @@ function requireFile(relativePath) {
 
 function readText(relativePath) {
 	return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+	return JSON.parse(readText(relativePath));
+}
+
+function requireTraceLayers(text, label) {
+	for (const layer of TRACE_LAYERS) {
+		if (!text.includes(layer)) {
+			fail(`${label} must reference trace layer: ${layer}`);
+		}
+	}
 }
 
 for (const file of REQUIRED_FILES) {
@@ -81,6 +99,28 @@ for (const expected of ["bundleOrchestration", "[reasoning]", ...MANIFEST_BUNDLE
 	}
 }
 
+const traceLayers = readText(".agent-operating-model/trace-layers.md");
+requireTraceLayers(traceLayers, "trace-layers.md");
+
+const behaviouralEvals = readJson(".agent-operating-model/behavioural-evals.json");
+
+if (behaviouralEvals.traceLayer !== "behavioural") {
+	fail("behavioural-evals.json must declare traceLayer behavioural");
+}
+
+if (!Array.isArray(behaviouralEvals.evals) || behaviouralEvals.evals.length < 5) {
+	fail("behavioural-evals.json must contain at least five evals");
+}
+
+const selectionRules = readJson(".agent-operating-model/selection-rules.json");
+const ruleBundleIds = new Set(selectionRules.rules.map((rule) => rule.bundleId));
+
+for (const bundleId of MANIFEST_BUNDLE_IDS) {
+	if (!ruleBundleIds.has(bundleId)) {
+		fail(`selection-rules.json is missing bundle rule: ${bundleId}`);
+	}
+}
+
 const pkg = JSON.parse(readText("package.json"));
 const scripts = pkg.scripts || {};
 
@@ -88,6 +128,7 @@ for (const scriptName of [
 	"agent:model",
 	"agent:model:validate",
 	"agent:bundles:validate",
+	"agent:evals",
 ]) {
 	if (!scripts[scriptName]) {
 		fail(`package.json is missing ${scriptName}`);
@@ -95,6 +136,10 @@ for (const scriptName of [
 }
 
 execFileSync("node", ["scripts/agent-operating-model/validate-bundle-registry.mjs"], {
+	stdio: "inherit",
+});
+
+execFileSync("node", ["scripts/agent-operating-model/run-behavioural-evals.mjs"], {
 	stdio: "inherit",
 });
 
@@ -119,6 +164,12 @@ for (const expectedId of [
 ]) {
 	if (!selectedIds.includes(expectedId)) {
 		fail(`loader did not select expected bundle: ${expectedId}`);
+	}
+}
+
+for (const bundle of model.selectedBundles) {
+	if (!bundle.selectionEvidence?.ruleId) {
+		fail(`loader did not return selection evidence for ${bundle.id}`);
 	}
 }
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -34,8 +34,12 @@ require_file ".agent-operating-model/bundle-registry.schema.json"
 require_file ".agent-operating-model/bootstrap-checklist.md"
 require_file ".agent-operating-model/precedence-policy.md"
 require_file ".agent-operating-model/trace-policy.md"
+require_file ".agent-operating-model/trace-layers.md"
+require_file ".agent-operating-model/selection-rules.json"
+require_file ".agent-operating-model/behavioural-evals.json"
 require_file "docs/devops/ResearchOps-Bundle-Setup.zip"
 require_file "scripts/agent-operating-model/load-operating-model.mjs"
+require_file "scripts/agent-operating-model/run-behavioural-evals.mjs"
 require_file "scripts/agent-operating-model/validate-bundle-registry.mjs"
 require_file "scripts/agent-operating-model/validate-operating-model.mjs"
 require_file "public/_headers"
@@ -93,7 +97,7 @@ import fs from 'node:fs';
 
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const scripts = pkg.scripts || {};
-const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
+const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'agent:evals', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
 const missing = required.filter((name) => !scripts[name]);
 
 if (missing.length) {
@@ -114,6 +118,9 @@ NODE
 
 info "checking repository operating model"
 node scripts/agent-operating-model/validate-operating-model.mjs
+
+info "checking behavioural operating-model evals"
+node scripts/agent-operating-model/run-behavioural-evals.mjs >/dev/null
 
 info "checking Wrangler assets directory"
 node --input-type=module <<'NODE'

--- a/tests/agent-operating-model-regression.test.js
+++ b/tests/agent-operating-model-regression.test.js
@@ -3,8 +3,16 @@ import fs from "node:fs";
 import test from "node:test";
 import { loadOperatingModel } from "../scripts/agent-operating-model/load-operating-model.mjs";
 
+function selectedBundles(taskText) {
+	return loadOperatingModel({ taskText }).selectedBundles;
+}
+
 function selectedIds(taskText) {
-	return loadOperatingModel({ taskText }).selectedBundles.map((bundle) => bundle.id);
+	return selectedBundles(taskText).map((bundle) => bundle.id);
+}
+
+function bundleById(taskText, bundleId) {
+	return selectedBundles(taskText).find((bundle) => bundle.id === bundleId);
 }
 
 test("repository operating model selects always-load bundles", () => {
@@ -17,14 +25,38 @@ test("repository operating model selects always-load bundles", () => {
 	]);
 });
 
-test("repository operating model selects conditional bundles by task text", () => {
-	const ids = selectedIds(
-		"Fix a Cloudflare Worker route that writes Airtable records and syncs Mural widgets.",
-	);
+test("repository operating model selects conditional bundles by structured rule evidence", () => {
+	const task =
+		"Fix a Cloudflare Worker route that writes Airtable records and syncs Mural widgets.";
+	const ids = selectedIds(task);
 
 	assert.ok(ids.includes("cloudflare-core-developer"));
 	assert.ok(ids.includes("airtable-public-api-developer"));
 	assert.ok(ids.includes("mural-public-api-developer"));
+
+	for (const bundleId of [
+		"cloudflare-core-developer",
+		"airtable-public-api-developer",
+		"mural-public-api-developer",
+	]) {
+		const bundle = bundleById(task, bundleId);
+
+		assert.equal(bundle.selectionEvidence.selectionBasis, "structured-rule");
+		assert.equal(bundle.selectionEvidence.traceLayer, "behavioural");
+		assert.ok(bundle.selectionEvidence.ruleId);
+		assert.ok(bundle.selectionEvidence.matchedPhrases.length > 0);
+	}
+});
+
+test("repository operating model exposes task facets for trace reports", () => {
+	const model = loadOperatingModel({
+		taskText: "Improve GOV.UK form accessibility and page content.",
+	});
+	const facetIds = model.taskFacets.map((facet) => facet.id);
+
+	assert.ok(facetIds.includes("repository-affecting-task"));
+	assert.ok(facetIds.includes("ui-or-content-change"));
+	assert.ok(selectedIds(model.taskText).includes("github-diamond") === false);
 });
 
 test("repository operating model sources are referenced from AGENTS.md", () => {
@@ -33,9 +65,12 @@ test("repository operating model sources are referenced from AGENTS.md", () => {
 	for (const reference of [
 		".agent-operating-model/orchestration.xml",
 		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/selection-rules.json",
 		".agent-operating-model/bootstrap-checklist.md",
 		".agent-operating-model/precedence-policy.md",
 		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/trace-layers.md",
+		".agent-operating-model/behavioural-evals.json",
 		"docs/devops/ResearchOps-Bundle-Setup.zip",
 	]) {
 		assert.match(agents, new RegExp(reference.replace(/[.]/g, "\\.")));

--- a/tests/agent-operating-model-regression.test.js
+++ b/tests/agent-operating-model-regression.test.js
@@ -49,14 +49,14 @@ test("repository operating model selects conditional bundles by structured rule 
 });
 
 test("repository operating model exposes task facets for trace reports", () => {
-	const model = loadOperatingModel({
-		taskText: "Improve GOV.UK form accessibility and page content.",
-	});
+	const taskText = "Improve GOV.UK form accessibility and page content.";
+	const model = loadOperatingModel({ taskText });
 	const facetIds = model.taskFacets.map((facet) => facet.id);
+	const ids = model.selectedBundles.map((bundle) => bundle.id);
 
 	assert.ok(facetIds.includes("repository-affecting-task"));
 	assert.ok(facetIds.includes("ui-or-content-change"));
-	assert.ok(selectedIds(model.taskText).includes("github-diamond") === false);
+	assert.ok(ids.includes("govuk-design-system"));
 });
 
 test("repository operating model sources are referenced from AGENTS.md", () => {

--- a/tests/agent-operating-model-regression.test.js
+++ b/tests/agent-operating-model-regression.test.js
@@ -48,6 +48,16 @@ test("repository operating model selects conditional bundles by structured rule 
 	}
 });
 
+test("repository operating model preserves registry keyword fallback", () => {
+	const task = "Improve the service page";
+	const bundle = bundleById(task, "govuk-design-system");
+
+	assert.ok(bundle);
+	assert.equal(bundle.selectionEvidence.selectionBasis, "registry-keyword-fallback");
+	assert.deepEqual(bundle.selectionEvidence.matchedPhrases, []);
+	assert.ok(bundle.selectionEvidence.matchedRegistryKeywords.includes("page"));
+});
+
 test("repository operating model exposes task facets for trace reports", () => {
 	const taskText = "Improve GOV.UK form accessibility and page content.";
 	const model = loadOperatingModel({ taskText });


### PR DESCRIPTION
## Summary

Builds on the repository operating model and agent audit trace work by adding layered traceability and behavioural evaluation controls.

This PR adds:

- trace layer architecture: `operational`, `behavioural`, `mechanistic`, `training`
- explicit drift categories: instruction, context, priority, tool, explanation, mechanistic
- behavioural eval catalogue for operating-model drift checks
- structured bundle selection rules
- loader selection evidence: rule ID, matched facets, matched phrases, matched registry keywords, selection basis and trace layer
- `agent:evals` package script
- behavioural eval runner
- validation integration for trace-layer controls and behavioural evals
- regression assertions that selected bundles include structured selection evidence
- `[reasoning]` trace artefacts for this branch

## Corrective branch behaviour

A first branch, `feature/trace-layers`, was created from a main commit that became behind while setup was underway.

I then incorrectly attempted a force update. The user stopped this and clarified that force-updating branches breaches the GitHub Diamond operating model. The force update did not take effect. I abandoned that branch and created `feature/trace-layer-evals` from the current `main` commit.

Before implementation, `feature/trace-layer-evals` was confirmed as:

```text
status: identical
ahead_by: 0
behind_by: 0
```

## P2 review corrections

Two P2 review comments were addressed.

### Preserve registry keyword fallback

The loader now evaluates structured selection rules first, then falls back to bundle registry keywords when the structured rule has no phrase hit but the required task facets match.

Fallback selections are explicitly labelled:

```json
{
  "selectionBasis": "registry-keyword-fallback",
  "matchedRegistryKeywords": ["page"]
}
```

Regression coverage now asserts that:

```bash
npm run agent:model -- "Improve the service page"
```

selects `govuk-design-system` through the registry keyword `page`.

### Enforce declared eval safeguards

`run-behavioural-evals.mjs` now enforces the behavioural eval catalogue fields that were previously only declared:

- `expectedSafeguards`
- `expectedEvidence`
- `forbiddenFailureModes`
- `expectedTraceOutputs`

It also validates latest-prompt conflict detection for the repository-rule precedence eval.

## Traceability model

The new trace architecture distinguishes:

- **Operational trace**: what the agent did.
- **Behavioural trace**: how the operating model behaves under controlled evals.
- **Mechanistic trace**: hypotheses or direct model-internal evidence where available.
- **Training trace**: changes to prompts, evals, routing, training assumptions or model-control changes.

Mechanistic trace entries explicitly cannot claim activation evidence unless model-internal tooling is available.

## Behavioural evals added

Added `.agent-operating-model/behavioural-evals.json` covering:

- Cloudflare routing bundle selection
- GOV.UK page design bundle selection
- `[reasoning]` trace-output requirements
- latest prompt versus repository-rule precedence
- structured rule application rather than superficial keyword matching

Added executable runner:

```bash
npm run agent:evals
```

## Structured rule application

This PR adds `.agent-operating-model/selection-rules.json` and updates the loader so selected bundles include auditable selection evidence:

- `ruleId`
- `selectionBasis`
- `traceLayer`
- `matchedFacets`
- `matchedPhrases`
- `matchedRegistryKeywords`

This does not claim internal attention or activation evidence. It gives the repository an externally checkable behavioural control surface.

## Validation added

Validation now checks:

- trace-layer control files exist
- behavioural eval catalogue exists
- `agent:evals` exists in `package.json`
- behavioural evals can run through the operating-model validator
- selected bundles contain structured selection evidence or explicit registry fallback evidence
- declared safeguards, expected evidence and forbidden failure modes are enforced
- trace layers include `operational`, `behavioural`, `mechanistic` and `training`

## Not claimed

I have not claimed full local `npm run lint`, `npm run validate` or `npm test` success in this environment. CI should provide the definitive result.
