### PR TITLE
Create implementation authority from ResearchOps design critique

### DIFF
--- a/docs/product/researchops-design-critique-backlog-2026-05-07.md
+++ b/docs/product/researchops-design-critique-backlog-2026-05-07.md
@@ -1,0 +1,377 @@
+# ResearchOps design critique backlog
+
+Date: 2026-05-07  
+Source critique: `docs/design-critiques/researchops-platform-design-critique-2026-05-07.md`  
+Authority: `docs/product/researchops-design-critique-implementation-authority-2026-05-07.md`
+
+## Backlog status
+
+This backlog converts the design critique into product-planning items.
+
+The items are ready for triage, refinement and implementation sequencing. They are not code changes.
+
+## P1 backlog
+
+### ROPS-DC-P1-001: Require evidence linkage for insights and recommendations
+
+Priority: P1  
+Area: Evidence integrity  
+Problem: Recommendations may be weakly linked to underlying evidence.  
+Product change: Make the evidence-to-insight-to-recommendation chain visible and enforceable.
+
+Acceptance criteria:
+
+- Given a user creates an insight, when they save it, then the insight must show linked evidence or be marked incomplete.
+- Given a user creates a recommendation, when they save it, then the recommendation must show at least one linked insight or evidence item.
+- Given a recommendation has no evidence linkage, when it appears in a list or report, then it must display an incomplete evidence state.
+- Given a user reviews a recommendation, when they inspect its evidence chain, then they can navigate back to the source study, session or note.
+- Given evidence is deleted or withdrawn, when linked outputs are viewed, then affected insights and recommendations must show a broken-link or review-required state.
+
+Delivery commitment: Deliver as foundational traceability control before broad recommendation workflows are promoted.
+
+### ROPS-DC-P1-002: Introduce lifecycle states for core research objects
+
+Priority: P1  
+Area: Workflow state  
+Problem: Research objects need clearer lifecycle control.  
+Product change: Define and display states for studies, sessions, analysis and recommendations.
+
+Acceptance criteria:
+
+- Given a study exists, when it is viewed, then its current lifecycle state must be visible.
+- Given a session exists, when it is viewed, then its state must distinguish scheduled, rescheduled, cancelled and completed.
+- Given analysis is underway, when evidence outputs are viewed, then raw, coded, synthesised and reviewed states must be distinguishable.
+- Given a recommendation exists, when it is viewed, then draft, reviewed, accepted or rejected state must be visible.
+- Given a state changes, when the object is viewed later, then the change must be reflected in the audit trail.
+
+Delivery commitment: Deliver lifecycle state definitions before implementing advanced dashboards.
+
+### ROPS-DC-P1-003: Make pseudonymised participant views the default
+
+Priority: P1  
+Area: Consent and PII  
+Problem: Identifiable participant data should not be exposed by default.  
+Product change: Use pseudonymised display defaults and explicit reveal controls.
+
+Acceptance criteria:
+
+- Given a participant is shown in a research workflow, when the page loads, then pseudonymised details must be shown by default.
+- Given a user needs identifiable details, when they reveal them, then the interface must explain why the data is sensitive.
+- Given identifiable details are revealed, when audit logging is enabled, then the reveal event must be recorded.
+- Given a participant has consent restrictions, when their record is viewed, then the restrictions must be visible before session activity.
+- Given a user lacks permission, when they try to view identifiable data, then access must be blocked.
+
+Delivery commitment: Deliver before expanding participant or session management.
+
+### ROPS-DC-P1-004: Add accessibility acceptance criteria to core workflows
+
+Priority: P1  
+Area: Accessibility  
+Problem: Complex workflows may exclude keyboard, screen reader or cognitive access users.  
+Product change: Add accessibility acceptance criteria for each core workflow.
+
+Acceptance criteria:
+
+- Given a new user-facing workflow is planned, when acceptance criteria are written, then keyboard, screen reader, focus order and error-message criteria must be included.
+- Given a page uses status, colour or icons, when reviewed, then the state must also be conveyed textually.
+- Given a modal, drawer or dynamic panel opens, when keyboard users interact with it, then focus must be managed predictably.
+- Given a complex table is used, when reviewed, then headings, captions and row context must be meaningful.
+- Given a release is prepared, when accessibility checks fail, then the release must identify the failure and mitigation.
+
+Delivery commitment: Apply to all P1 user-facing implementation work.
+
+### ROPS-DC-P1-005: Define governance roles and decision ownership
+
+Priority: P1  
+Area: Governance  
+Problem: Decision ownership and approvals are not explicit enough.  
+Product change: Define roles for research authorship, review, approval and decision ownership.
+
+Acceptance criteria:
+
+- Given a study is approved, when it is viewed, then the approver and approval date must be visible.
+- Given a recommendation is accepted, when it is viewed, then the decision owner must be visible.
+- Given a user edits a governed object, when the change is saved, then authorship must be recorded.
+- Given a reviewer checks a finding, when they approve or reject it, then the status and reviewer must be recorded.
+- Given a governance status is missing, when the object is listed, then it must show a governance incomplete state.
+
+Delivery commitment: Deliver role definitions before implementing approval workflows.
+
+### ROPS-DC-P1-006: Label trace evidence by trace layer
+
+Priority: P1  
+Area: AI traceability  
+Problem: AI trace reports must avoid overstating model-internal evidence.  
+Product change: Ensure trace reports label evidence as operational, behavioural, mechanistic or training.
+
+Acceptance criteria:
+
+- Given an agent trace is generated, when the trace is viewed, then each trace event must show a trace layer.
+- Given a mechanistic claim is included, when the trace is reviewed, then it must be labelled as hypothesis unless model-internal tooling supports it.
+- Given operational evidence is shown, when the user inspects it, then the source file, command or tool action must be clear.
+- Given behavioural eval evidence is shown, when the user inspects it, then the eval name and outcome must be visible.
+- Given a trace omits required layer labels, when validation runs, then the trace should fail validation.
+
+Delivery commitment: Maintain trace layer labelling as a core AI governance control.
+
+### ROPS-DC-P1-007: Embed safeguarding prompts and escalation routes
+
+Priority: P1  
+Area: Safeguarding  
+Problem: Research workflows need visible risk escalation paths.  
+Product change: Add safeguarding prompts and escalation guidance to high-risk research workflows.
+
+Acceptance criteria:
+
+- Given a study may involve vulnerable users, when the study is planned, then safeguarding prompts must be visible.
+- Given a safeguarding risk is identified, when the user records it, then an escalation route must be shown.
+- Given a session has a safeguarding flag, when the session is viewed, then the flag must be visible to authorised users.
+- Given safeguarding guidance is required, when the user opens it, then it must explain immediate next steps in plain English.
+- Given a safeguarding concern is marked resolved, when reviewed, then the resolution evidence must be visible.
+
+Delivery commitment: Deliver risk prompts before expanding high-risk study workflows.
+
+### ROPS-DC-P1-008: Add task-based start page and study setup task list
+
+Priority: P1  
+Area: Service clarity  
+Problem: Users need clearer guidance about what to do first and next.  
+Product change: Add a task-based entry point and study setup task list.
+
+Acceptance criteria:
+
+- Given a user opens the service, when they arrive, then they can understand what the service does and what they need before starting.
+- Given a study is being set up, when the user views the setup page, then required and optional tasks must be distinguishable.
+- Given a setup task is complete, when the user returns, then completion state must be visible.
+- Given a required setup task is incomplete, when the user tries to progress, then the service must explain what is missing.
+- Given a user is new, when they start, then plain-language guidance must explain the research lifecycle.
+
+Delivery commitment: Deliver before expecting wider team adoption.
+
+## P2 backlog
+
+### ROPS-DC-P2-009: Add object headers with parent, state and next action
+
+Priority: P2  
+Area: Navigation  
+Product change: Add consistent object headers for core pages.
+
+Acceptance criteria:
+
+- Given a user views a project, study, session, insight or recommendation, then the page must show the object name, parent object, state and next action.
+- Given a user follows a deep link, then the object header must orient them within the hierarchy.
+- Given an object is blocked, then the header must show the blocker.
+
+Delivery commitment: Implement after lifecycle states are defined.
+
+### ROPS-DC-P2-010: Add recruitment, session and incentive dashboards
+
+Priority: P2  
+Area: ResearchOps  
+Product change: Add operational dashboards for recruitment and session management.
+
+Acceptance criteria:
+
+- Users can see scheduled, completed, cancelled and missing sessions.
+- Users can see participant consent and incentive status.
+- Users can filter operational dashboards by project and study.
+
+Delivery commitment: Implement after core lifecycle and participant state controls.
+
+### ROPS-DC-P2-011: Rename actions around user tasks
+
+Priority: P2  
+Area: Content design  
+Product change: Replace internal module labels with task-based language.
+
+Acceptance criteria:
+
+- Labels use verbs and user tasks where possible.
+- Navigation labels are tested with representative users.
+- Renamed items preserve existing routes or redirects where needed.
+
+Delivery commitment: Implement alongside navigation review.
+
+### ROPS-DC-P2-012: Support lightweight capture before structured tagging
+
+Priority: P2  
+Area: Interaction design  
+Product change: Make live session note capture lightweight, with structure added later.
+
+Acceptance criteria:
+
+- During a session, users can quickly capture notes without mandatory coding.
+- After a session, users can add structure, tags and evidence links.
+- The interface distinguishes live capture from later analysis.
+
+Delivery commitment: Implement after session lifecycle states are clarified.
+
+### ROPS-DC-P2-013: Add progressive disclosure to trace summaries
+
+Priority: P2  
+Area: Trace UX  
+Product change: Present trace summaries first, with expandable detail.
+
+Acceptance criteria:
+
+- Trace summaries show outcome, loaded bundles, skipped bundles and validation state.
+- Detailed evidence is available through accessible disclosure controls.
+- Keyboard and screen reader users can navigate the trace structure.
+
+Delivery commitment: Implement after trace layer labelling remains stable.
+
+### ROPS-DC-P2-014: Standardise GOV.UK task, summary, table and filter patterns
+
+Priority: P2  
+Area: GOV.UK patterns  
+Product change: Standardise high-use interface patterns.
+
+Acceptance criteria:
+
+- Study setup uses a GOV.UK-style task list where appropriate.
+- Object summaries use summary-list patterns where appropriate.
+- Tables include captions, headings and accessible filters.
+
+Delivery commitment: Implement iteratively across core workflows.
+
+### ROPS-DC-P2-015: Explain integration boundaries
+
+Priority: P2  
+Area: Service boundaries  
+Product change: Explain what happens in ResearchOps, Airtable, Mural and GitHub.
+
+Acceptance criteria:
+
+- Users can understand which system stores which data.
+- Integration status is visible where relevant.
+- Error states explain whether a problem is local or external.
+
+Delivery commitment: Implement before expanding integration-heavy workflows.
+
+### ROPS-DC-P2-016: Add evidence maturity labels
+
+Priority: P2  
+Area: Evidence maturity  
+Product change: Show whether evidence is raw, coded, synthesised, validated or accepted.
+
+Acceptance criteria:
+
+- Evidence outputs display maturity labels.
+- Users can distinguish draft insights from reviewed findings.
+- Reports preserve maturity labels.
+
+Delivery commitment: Implement after evidence linkage controls.
+
+## P3 backlog
+
+### ROPS-DC-P3-017: Define product success metrics
+
+Priority: P3  
+Area: Metrics  
+Product change: Define measures for traceability and research quality.
+
+Acceptance criteria:
+
+- Metrics include evidence linkage, insight review and recommendation adoption.
+- Metrics distinguish activity from quality.
+- Metrics are documented before instrumentation is added.
+
+Delivery commitment: Define after P1 foundations are scoped.
+
+### ROPS-DC-P3-018: Create accessible export templates
+
+Priority: P3  
+Area: Reporting  
+Product change: Create accessible templates for reports and exports.
+
+Acceptance criteria:
+
+- Exported artefacts use semantic headings.
+- Tables include headings and captions.
+- Reports preserve evidence links where possible.
+
+Delivery commitment: Implement after core reporting needs are confirmed.
+
+### ROPS-DC-P3-019: Add role-sensitive views
+
+Priority: P3  
+Area: Multi-actor views  
+Product change: Tailor views for researchers, product owners and reviewers.
+
+Acceptance criteria:
+
+- Researchers can see operational research tasks.
+- Product owners can see recommendations and decisions.
+- Reviewers can see risk, evidence and governance state.
+
+Delivery commitment: Implement after role definitions are agreed.
+
+### ROPS-DC-P3-020: Add onboarding prompts and example studies
+
+Priority: P3  
+Area: Training  
+Product change: Add guided onboarding for new users.
+
+Acceptance criteria:
+
+- New users can access example study flows.
+- Onboarding explains the research lifecycle.
+- Guidance can be dismissed and revisited.
+
+Delivery commitment: Implement after the core task flow stabilises.
+
+### ROPS-DC-P3-021: Improve evidence search and filtering
+
+Priority: P3  
+Area: Search  
+Product change: Improve search by study, evidence type, participant type, theme and decision.
+
+Acceptance criteria:
+
+- Users can filter evidence by study and evidence type.
+- Users can find recommendations from linked themes or decisions.
+- Search results show evidence maturity and linkage status.
+
+Delivery commitment: Implement after evidence metadata is stable.
+
+### ROPS-DC-P3-022: Summarise audit logs into readable histories
+
+Priority: P3  
+Area: Audit trail  
+Product change: Convert raw audit logs into readable change histories.
+
+Acceptance criteria:
+
+- Users can see who changed what and when.
+- Technical log detail is available separately where needed.
+- Readable histories preserve audit integrity.
+
+Delivery commitment: Implement after governance state controls.
+
+### ROPS-DC-P3-023: Add GOV.UK and WCAG release-readiness checks
+
+Priority: P3  
+Area: Standards  
+Product change: Make GOV.UK and accessibility checks visible in release readiness.
+
+Acceptance criteria:
+
+- Release readiness includes GOV.UK pattern checks.
+- Release readiness includes WCAG-related validation evidence.
+- Exceptions require documented rationale.
+
+Delivery commitment: Implement after accessibility criteria are standardised.
+
+### ROPS-DC-P3-024: Capture feedback after studies and synthesis
+
+Priority: P3  
+Area: Feedback loops  
+Product change: Add feedback capture after study and synthesis cycles.
+
+Acceptance criteria:
+
+- Users can record what worked and what did not after a study.
+- Feedback can be linked to workflow improvement themes.
+- Feedback is visible to product and ResearchOps maintainers.
+
+Delivery commitment: Implement after the study lifecycle is stable.

--- a/docs/product/researchops-design-critique-implementation-authority-2026-05-07.md
+++ b/docs/product/researchops-design-critique-implementation-authority-2026-05-07.md
@@ -1,0 +1,139 @@
+# ResearchOps design critique implementation authority
+
+Date: 2026-05-07  
+Source critique: `docs/design-critiques/researchops-platform-design-critique-2026-05-07.md`  
+Authority status: created by user request and subject to PR review before becoming the repository record  
+Scope: product planning, backlog definition and delivery commitments  
+Out of scope: direct code, UI, configuration or data model changes in this PR
+
+## Authority statement
+
+This document converts the merged ResearchOps platform design critique into implementation authority for product planning artefacts.
+
+The design critique itself was explicitly non-actionable. This document supersedes that non-action boundary only because a later user instruction explicitly requested implementation authority, backlog items, acceptance criteria, delivery commitments and product changes.
+
+This authority allows the repository to contain planning artefacts derived from the critique. It does not automatically authorise immediate production code changes. Each implementation change still requires its own branch, PR, review and validation.
+
+## Source evidence
+
+The source critique identified P1, P2 and P3 issues across:
+
+- evidence integrity
+- workflow state
+- consent and PII
+- accessibility
+- governance
+- AI traceability
+- safeguarding
+- service clarity
+- navigation
+- ResearchOps operations
+- content design
+- interaction design
+- trace UX
+- GOV.UK patterns
+- service boundaries
+- evidence maturity
+- metrics
+- reporting
+- multi-actor views
+- training
+- search
+- audit trail
+- standards
+- feedback loops
+
+## Product change authority
+
+The following product change themes are authorised for backlog planning:
+
+1. strengthen evidence traceability from raw evidence to accepted recommendations
+2. introduce clearer lifecycle states across studies, sessions, analysis and recommendations
+3. improve consent, pseudonymisation and PII exposure controls
+4. make complex ResearchOps workflows accessible by default
+5. define governance roles, approvals and decision ownership
+6. improve AI and agent trace readability without overstating model internals
+7. embed safeguarding prompts and escalation paths
+8. clarify the service start, task flow and next-step guidance
+9. improve navigation, object hierarchy and orientation
+10. improve ResearchOps operational dashboards
+11. use clearer task-based language
+12. make live note capture lighter
+13. improve trace UX with progressive disclosure
+14. standardise GOV.UK task, summary, table and filter patterns
+15. explain integration boundaries across ResearchOps, Airtable, Mural and GitHub
+16. show evidence maturity states
+17. define success metrics
+18. improve accessible exports
+19. add role-sensitive views
+20. improve onboarding
+21. improve evidence search and filtering
+22. summarise audit logs into readable histories
+23. expose GOV.UK and WCAG release-readiness checks
+24. capture feedback after study and synthesis cycles
+
+## Governance rules for implementation
+
+All work authorised by this document must follow these rules.
+
+1. P1 items take precedence over P2 and P3 unless a dependency requires earlier enabling work.
+2. Each implementation item must have acceptance criteria before code changes begin.
+3. Each implementation PR must include validation evidence.
+4. Accessibility acceptance criteria must be included for every user-facing change.
+5. Any work touching consent, PII, safeguarding or vulnerable users must include explicit risk review.
+6. AI traceability work must distinguish operational, behavioural, mechanistic and training evidence.
+7. Mechanistic claims must not be made unless supported by model-internal tooling.
+8. No integration-specific implementation may begin without loading the relevant API bundle.
+9. No delivery date is guaranteed by this document.
+10. Delivery commitments are commitments to manage and validate the work, not fixed-date promises.
+
+## Prioritisation model
+
+Priority is assigned as follows.
+
+P1 means high-value, high-risk or foundational. These items address evidence integrity, safety, accessibility, governance or service clarity.
+
+P2 means important enabling work. These items improve adoption, consistency and operational usability.
+
+P3 means useful improvement. These items improve maturity, reporting and long-term service quality.
+
+## Delivery commitment summary
+
+The delivery commitment is to maintain a governed implementation backlog derived from the critique.
+
+The first delivery tranche should focus on P1 items that reduce risk or create foundation controls:
+
+- evidence linkage
+- lifecycle states
+- consent and PII defaults
+- accessibility acceptance criteria
+- governance roles
+- trace evidence labelling
+- safeguarding escalation
+- service start and setup guidance
+
+Later tranches may address P2 and P3 items after P1 foundations are in place or deliberately deferred.
+
+## Non-implementation boundary for this PR
+
+This PR creates planning authority and backlog artefacts only.
+
+It does not:
+
+- change application code
+- change frontend UI
+- change data schema
+- change Cloudflare configuration
+- change Airtable or Mural integration behaviour
+- create GitHub issues
+- guarantee delivery dates
+
+## Review requirement
+
+Before implementation begins, reviewers should confirm:
+
+- the authority statement is acceptable
+- the backlog items accurately reflect the critique
+- the acceptance criteria are testable
+- delivery commitments are realistic and not date-bound
+- P1 items correctly represent risk and foundational value

--- a/docs/product/researchops-design-critique-product-change-register-2026-05-07.md
+++ b/docs/product/researchops-design-critique-product-change-register-2026-05-07.md
@@ -1,0 +1,396 @@
+# ResearchOps design critique product change register
+
+Date: 2026-05-07  
+Source critique: `docs/design-critiques/researchops-platform-design-critique-2026-05-07.md`  
+Authority: `docs/product/researchops-design-critique-implementation-authority-2026-05-07.md`  
+Backlog: `docs/product/researchops-design-critique-backlog-2026-05-07.md`
+
+## Purpose
+
+This register records the product changes authorised for planning from the ResearchOps design critique.
+
+It does not implement the changes. It provides a controlled bridge between the critique and future implementation PRs.
+
+## Delivery commitment model
+
+The delivery commitments in this register are commitments to manage the work through governed delivery.
+
+They are not fixed-date promises.
+
+Each product change must have:
+
+- a backlog item
+- acceptance criteria
+- implementation branch
+- validation evidence
+- PR review
+- accessibility consideration if user-facing
+- risk review if touching consent, PII, safeguarding or vulnerable users
+
+## Product changes
+
+### PC-001: Evidence linkage control
+
+Related backlog item: `ROPS-DC-P1-001`  
+Priority: P1  
+Change type: product control  
+Delivery commitment: establish evidence linkage as a foundational control before expanding recommendation workflows.
+
+Product change:
+
+ResearchOps should make evidence linkage visible and enforceable across insights and recommendations.
+
+Expected outcome:
+
+Teams can inspect the source evidence behind recommendations and identify incomplete evidence chains.
+
+### PC-002: Research object lifecycle model
+
+Related backlog item: `ROPS-DC-P1-002`  
+Priority: P1  
+Change type: workflow model  
+Delivery commitment: define lifecycle states before advanced dashboards or reporting depend on them.
+
+Product change:
+
+ResearchOps should show lifecycle states for studies, sessions, analysis outputs and recommendations.
+
+Expected outcome:
+
+Users can understand what is draft, active, complete, reviewed, blocked or accepted.
+
+### PC-003: Pseudonymised participant defaults
+
+Related backlog item: `ROPS-DC-P1-003`  
+Priority: P1  
+Change type: privacy and safety control  
+Delivery commitment: implement safer participant display defaults before broadening participant workflows.
+
+Product change:
+
+ResearchOps should show pseudonymised participant information by default and make identifiable information a deliberate reveal.
+
+Expected outcome:
+
+Participant privacy risk is reduced and sensitive data exposure becomes more intentional.
+
+### PC-004: Accessibility acceptance criteria standard
+
+Related backlog item: `ROPS-DC-P1-004`  
+Priority: P1  
+Change type: delivery standard  
+Delivery commitment: require accessibility criteria for all P1 user-facing changes.
+
+Product change:
+
+ResearchOps should include accessibility acceptance criteria for core workflows and release readiness.
+
+Expected outcome:
+
+Accessibility is treated as a design and delivery requirement, not a late QA activity.
+
+### PC-005: Governance roles and decision ownership
+
+Related backlog item: `ROPS-DC-P1-005`  
+Priority: P1  
+Change type: governance model  
+Delivery commitment: define roles before implementing approval workflows.
+
+Product change:
+
+ResearchOps should identify authors, reviewers, approvers and decision owners for governed objects.
+
+Expected outcome:
+
+Research decisions and recommendations become auditable and accountable.
+
+### PC-006: Trace evidence layer labelling
+
+Related backlog item: `ROPS-DC-P1-006`  
+Priority: P1  
+Change type: AI governance control  
+Delivery commitment: maintain trace layer labelling across agent trace work.
+
+Product change:
+
+ResearchOps should label trace evidence as operational, behavioural, mechanistic or training.
+
+Expected outcome:
+
+Trace reports become more trustworthy and less likely to overstate model-internal evidence.
+
+### PC-007: Safeguarding prompts and escalation routes
+
+Related backlog item: `ROPS-DC-P1-007`  
+Priority: P1  
+Change type: safeguarding control  
+Delivery commitment: deliver risk prompts before expanding high-risk study workflows.
+
+Product change:
+
+ResearchOps should include safeguarding prompts and escalation routes in high-risk research workflows.
+
+Expected outcome:
+
+Researchers are guided toward proportionate escalation when risk appears.
+
+### PC-008: Task-based service start and setup flow
+
+Related backlog item: `ROPS-DC-P1-008`  
+Priority: P1  
+Change type: service clarity improvement  
+Delivery commitment: deliver before expecting wider adoption by non-expert users.
+
+Product change:
+
+ResearchOps should provide a task-based start page and study setup task list.
+
+Expected outcome:
+
+Users understand what the service does, what they need and what to do next.
+
+### PC-009: Object headers and orientation controls
+
+Related backlog item: `ROPS-DC-P2-009`  
+Priority: P2  
+Change type: navigation improvement  
+Delivery commitment: implement after lifecycle states are defined.
+
+Product change:
+
+Core object pages should show parent object, state and next action.
+
+Expected outcome:
+
+Users can maintain orientation across complex project, study and evidence hierarchies.
+
+### PC-010: ResearchOps operational dashboards
+
+Related backlog item: `ROPS-DC-P2-010`  
+Priority: P2  
+Change type: operations visibility  
+Delivery commitment: implement after participant and session state controls.
+
+Product change:
+
+ResearchOps should provide dashboards for recruitment, sessions and incentives.
+
+Expected outcome:
+
+Research teams can monitor operational risks and missing activity.
+
+### PC-011: Task-based language revision
+
+Related backlog item: `ROPS-DC-P2-011`  
+Priority: P2  
+Change type: content design improvement  
+Delivery commitment: implement alongside navigation review.
+
+Product change:
+
+Interface labels should use user tasks rather than internal module terminology where possible.
+
+Expected outcome:
+
+The service becomes easier to understand for new or occasional users.
+
+### PC-012: Lightweight live capture workflow
+
+Related backlog item: `ROPS-DC-P2-012`  
+Priority: P2  
+Change type: interaction improvement  
+Delivery commitment: implement after session lifecycle states are clarified.
+
+Product change:
+
+Session note capture should support lightweight live capture with structure added later.
+
+Expected outcome:
+
+Researchers can capture useful notes without being overloaded during sessions.
+
+### PC-013: Trace progressive disclosure
+
+Related backlog item: `ROPS-DC-P2-013`  
+Priority: P2  
+Change type: trace UX improvement  
+Delivery commitment: implement after trace layer labelling remains stable.
+
+Product change:
+
+Trace reports should show summaries first and expose details through accessible disclosure.
+
+Expected outcome:
+
+Trace information becomes usable by product stakeholders and specialists.
+
+### PC-014: GOV.UK pattern standardisation
+
+Related backlog item: `ROPS-DC-P2-014`  
+Priority: P2  
+Change type: design-system alignment  
+Delivery commitment: implement iteratively across core workflows.
+
+Product change:
+
+ResearchOps should standardise GOV.UK task list, summary list, table and filter patterns where appropriate.
+
+Expected outcome:
+
+Interfaces become more consistent, accessible and easier to maintain.
+
+### PC-015: Integration boundary explanations
+
+Related backlog item: `ROPS-DC-P2-015`  
+Priority: P2  
+Change type: service boundary clarification  
+Delivery commitment: implement before expanding integration-heavy workflows.
+
+Product change:
+
+ResearchOps should explain which data and actions belong in ResearchOps, Airtable, Mural and GitHub.
+
+Expected outcome:
+
+Users better understand system behaviour and external dependency failures.
+
+### PC-016: Evidence maturity labels
+
+Related backlog item: `ROPS-DC-P2-016`  
+Priority: P2  
+Change type: evidence quality signal  
+Delivery commitment: implement after evidence linkage controls.
+
+Product change:
+
+ResearchOps should label evidence as raw, coded, synthesised, validated or accepted.
+
+Expected outcome:
+
+Teams can distinguish early evidence from reviewed or accepted findings.
+
+### PC-017: Product success metrics
+
+Related backlog item: `ROPS-DC-P3-017`  
+Priority: P3  
+Change type: measurement framework  
+Delivery commitment: define after P1 foundations are scoped.
+
+Product change:
+
+ResearchOps should define measures for traceability, research quality and decision adoption.
+
+Expected outcome:
+
+Product success is assessed through quality and outcome measures, not activity alone.
+
+### PC-018: Accessible export templates
+
+Related backlog item: `ROPS-DC-P3-018`  
+Priority: P3  
+Change type: reporting improvement  
+Delivery commitment: implement after reporting needs are confirmed.
+
+Product change:
+
+ResearchOps should provide accessible templates for reports and exports.
+
+Expected outcome:
+
+Research artefacts remain accessible when exported outside the platform.
+
+### PC-019: Role-sensitive views
+
+Related backlog item: `ROPS-DC-P3-019`  
+Priority: P3  
+Change type: multi-actor service view  
+Delivery commitment: implement after role definitions are agreed.
+
+Product change:
+
+ResearchOps should support different views for researchers, product owners and governance reviewers.
+
+Expected outcome:
+
+Different actors can work from the same evidence system without unnecessary detail overload.
+
+### PC-020: Onboarding prompts and example studies
+
+Related backlog item: `ROPS-DC-P3-020`  
+Priority: P3  
+Change type: adoption support  
+Delivery commitment: implement after the core task flow stabilises.
+
+Product change:
+
+ResearchOps should provide onboarding prompts and example study flows.
+
+Expected outcome:
+
+New researchers can understand the intended workflow without one-to-one training.
+
+### PC-021: Evidence search and filtering
+
+Related backlog item: `ROPS-DC-P3-021`  
+Priority: P3  
+Change type: findability improvement  
+Delivery commitment: implement after evidence metadata is stable.
+
+Product change:
+
+ResearchOps should improve search and filtering by study, evidence type, participant type, theme and decision.
+
+Expected outcome:
+
+Users can retrieve evidence and recommendations more efficiently.
+
+### PC-022: Readable audit histories
+
+Related backlog item: `ROPS-DC-P3-022`  
+Priority: P3  
+Change type: audit readability improvement  
+Delivery commitment: implement after governance state controls.
+
+Product change:
+
+ResearchOps should summarise audit logs into readable change histories.
+
+Expected outcome:
+
+Users can understand changes without reading raw technical logs.
+
+### PC-023: GOV.UK and WCAG release readiness checks
+
+Related backlog item: `ROPS-DC-P3-023`  
+Priority: P3  
+Change type: standards assurance  
+Delivery commitment: implement after accessibility criteria are standardised.
+
+Product change:
+
+ResearchOps should expose GOV.UK and WCAG checks in release readiness.
+
+Expected outcome:
+
+Standards compliance becomes visible before release.
+
+### PC-024: Post-study feedback loops
+
+Related backlog item: `ROPS-DC-P3-024`  
+Priority: P3  
+Change type: continuous improvement  
+Delivery commitment: implement after the study lifecycle is stable.
+
+Product change:
+
+ResearchOps should capture feedback after study and synthesis cycles.
+
+Expected outcome:
+
+The service learns from research team experience and improves over time.
+
+## Implementation boundary
+
+No product change listed here is implemented by this PR.
+
+Future implementation PRs must reference the relevant product change ID and backlog item ID.


### PR DESCRIPTION
## Summary

Creates implementation-planning artefacts from the merged ResearchOps platform design critique.

This PR converts the critique from a documentation-only record into governed product-planning authority, based on the latest explicit user instruction.

It adds:

- implementation authority
- backlog items
- acceptance criteria
- delivery commitments
- product change register

## Source critique

```text
docs/design-critiques/researchops-platform-design-critique-2026-05-07.md
```

## Files added

```text
docs/product/researchops-design-critique-implementation-authority-2026-05-07.md
docs/product/researchops-design-critique-backlog-2026-05-07.md
docs/product/researchops-design-critique-product-change-register-2026-05-07.md
```

## Authority boundary

The original critique explicitly said it did not create implementation authority, backlog items, acceptance criteria, delivery commitments or product changes.

This PR changes that only because a later explicit user instruction requested those artefacts.

The authority created here allows planning and future implementation PRs. It does not directly implement application changes.

## Backlog structure

The backlog preserves the critique priority ordering:

- P1: foundational risk and service clarity controls
- P2: important enabling and adoption improvements
- P3: useful maturity and continuous improvement items

Each backlog item includes:

- ID
- priority
- area
- problem or product change
- acceptance criteria
- delivery commitment

## Product changes

The product change register creates PC-001 to PC-024, mapped to ROPS-DC backlog items.

Each product change includes:

- related backlog item
- priority
- change type
- delivery commitment
- expected outcome

## Scope boundary

This PR does not:

- change application code
- change UI
- change tests
- change configuration
- change data schema
- create GitHub issues
- guarantee fixed delivery dates

Future implementation PRs must reference the relevant product change ID and backlog item ID.

## Branch hygiene

An initial branch was created from the PR #210 merge commit but was abandoned after `main` advanced by two commits before implementation.

The working branch `feature/design-critique-authority-current-main` was created from current `main` and confirmed clean before changes:

```text
status: identical
ahead_by: 0
behind_by: 0
```

Before PR creation it was confirmed as:

```text
status: ahead
ahead_by: 3
behind_by: 0
```

No force update was used.

## Validation

Documentation-only planning change. Review should focus on:

- whether the authority statement is acceptable
- whether backlog items accurately reflect the critique
- whether acceptance criteria are testable
- whether delivery commitments are realistic and not date-bound
- whether product change IDs are suitable for future implementation PRs

Not claimed: full local `npm run lint`, `npm run validate` or `npm test` success. CI should provide the definitive signal.
