### PR TITLE
Build authentication role-selection foundation

### DIFF
--- a/.github/workflows/apply-d1-auth-foundation.yml
+++ b/.github/workflows/apply-d1-auth-foundation.yml
@@ -1,0 +1,96 @@
+name: Apply D1 Authentication Foundation
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_database_name:
+        description: "Type researchops-d1 to confirm the target D1 database"
+        required: true
+        type: string
+      confirm_operation:
+        description: "Type APPLY_AUTH_FOUNDATION to apply the auth foundation migration"
+        required: true
+        type: string
+      run_post_apply_checks:
+        description: "Run post-apply D1 table and seed checks"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.34.0"
+  D1_DATABASE_NAME: "researchops-d1"
+  WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
+  AUTH_FOUNDATION_MIGRATION: "infra/cloudflare/migrations/0001_auth_foundation.sql"
+
+jobs:
+  apply:
+    name: Apply authentication foundation to remote D1
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Confirm requested target
+        run: |
+          if [ "${{ inputs.confirm_database_name }}" != "${D1_DATABASE_NAME}" ]; then
+            echo "confirm_database_name must be ${D1_DATABASE_NAME}"
+            exit 1
+          fi
+
+          if [ "${{ inputs.confirm_operation }}" != "APPLY_AUTH_FOUNDATION" ]; then
+            echo "confirm_operation must be APPLY_AUTH_FOUNDATION"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Confirm migration file exists
+        run: test -f "${AUTH_FOUNDATION_MIGRATION}"
+
+      - name: Apply authentication foundation migration to remote D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${AUTH_FOUNDATION_MIGRATION}"
+
+      - name: Check authentication tables exist
+        if: ${{ inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'auth_%' ORDER BY name;"
+
+      - name: Check seeded permissions, roles and route declarations
+        if: ${{ inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT 'permissions' AS record_type, COUNT(*) AS total FROM auth_permissions UNION ALL SELECT 'roles', COUNT(*) FROM auth_roles UNION ALL SELECT 'role_permissions', COUNT(*) FROM auth_role_permissions UNION ALL SELECT 'route_permissions', COUNT(*) FROM auth_route_permissions;"

--- a/.github/workflows/format-branch.yml
+++ b/.github/workflows/format-branch.yml
@@ -1,0 +1,54 @@
+name: Format branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to format
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: format-branch-${{ inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  format:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Run Prettier format
+        run: npm run format
+
+      - name: Commit formatting changes
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "No formatting changes required."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add .
+          git commit -m "Apply Prettier formatting"
+          git push origin HEAD:${{ inputs.branch }}

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -29,5 +29,25 @@ jobs:
       - name: Install dependencies without lifecycle scripts
         run: npm ci --ignore-scripts
 
-      - name: Check formatting
-        run: ./node_modules/.bin/prettier -c .
+      - name: Check formatting and capture patch
+        shell: bash
+        run: |
+          set +e
+          ./node_modules/.bin/prettier -c .
+          status=$?
+          set -e
+
+          if [ "$status" -ne 0 ]; then
+            ./node_modules/.bin/prettier --write .
+            git diff -- . > prettier-fix.patch
+            cat prettier-fix.patch
+            exit "$status"
+          fi
+
+      - name: Upload Prettier patch
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prettier-fix.patch
+          path: prettier-fix.patch
+          if-no-files-found: ignore

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md
@@ -1,0 +1,51 @@
+# Agent trace checkpoint 010: route-permission wiring plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the next implementation step before code changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Next implementation step
+
+Wire the route-permission helper into the first real authenticated endpoints:
+
+- `GET /api/me`
+- `GET /api/me/permissions`
+
+## Rationale
+
+The D1 migration seeds route declarations for both routes. The Worker already routes both endpoints through the Cloudflare Access identity resolver. The route-permission helper exists but is not yet used by product code.
+
+The next small slice is to make these identity endpoints check their D1 route declaration before returning account, team, role or permission data.
+
+## Intended changes
+
+Expected code changes:
+
+- update `infra/cloudflare/src/core/auth/access.js`
+- import `assertRoutePermission` and `routePermissionErrorResponse`
+- call `assertRoutePermission(request, env, context)` after authentication context has resolved
+- return route-permission errors through `routePermissionErrorResponse`
+
+Expected test changes:
+
+- update `tests/auth-foundation-route-state.test.js`
+- assert that the Access resolver imports the route-permission helper
+- assert that it calls `assertRoutePermission`
+
+## Boundary
+
+This step does not wire route-permission checks into all existing product routes.
+
+This step does not create users or role assignments.
+
+This step does not apply the D1 migration to the live database.
+
+## Cloudflare bundle implication
+
+Workers remain the server-side policy enforcement point. D1 remains the relational control plane. Cloudflare Agents are not used to decide access.
+
+## Live D1 status
+
+The remote `researchops-d1` database has not yet been changed by this workstream. The manual D1 workflow exists, but it has not been run in this chat.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md
@@ -1,0 +1,59 @@
+# Agent trace checkpoint 011: route-permission wiring complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the implementation result after the route-permission wiring change. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Files changed in this checkpoint
+
+- `infra/cloudflare/src/core/auth/access.js`
+- `tests/auth-foundation-route-state.test.js`
+
+## Implementation completed
+
+The identity endpoints now call the route-permission helper after the authenticated context has resolved:
+
+- `GET /api/me`
+- `GET /api/me/permissions`
+
+The implementation imports:
+
+- `assertRoutePermission`
+- `routePermissionErrorResponse`
+
+The implementation calls:
+
+- `await assertRoutePermission(request, env, context)`
+
+## Design decision covered
+
+This implements the principle that authenticated identity is not enough on its own. Even identity-facing product endpoints should pass through declared route-permission policy.
+
+The seeded D1 route declarations for `/api/me` and `/api/me/permissions` currently require authentication and no extra permission code. This keeps sign-in state readable while still proving route declarations are enforced.
+
+## Tests updated
+
+`tests/auth-foundation-route-state.test.js` now asserts that:
+
+- `access.js` imports or references the route-permission helper
+- `access.js` calls `assertRoutePermission(request, env, context)`
+- no mock identity mode exists
+- identity routes fail closed without `Cf-Access-Jwt-Assertion`
+
+## Boundary
+
+This does not yet wire route-permission checks into all product routes.
+
+This does not apply the D1 migration to the live database.
+
+This does not create user-facing role management UI.
+
+## Next planned task
+
+Document Cloudflare Access environment variables and the D1 application workflow so the implementation has an explicit operational route to live D1 table creation and seed validation.
+
+Planned documentation file:
+
+- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md
@@ -1,0 +1,57 @@
+# Agent trace checkpoint 012: Cloudflare operations documentation plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the next documentation step before repository changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Next implementation support task
+
+Create the Cloudflare operations document for the authentication role-selection foundation.
+
+Planned file:
+
+- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
+
+## Purpose
+
+The implementation now has:
+
+- a D1 auth foundation migration
+- a Cloudflare Access identity resolver
+- a route-permission helper
+- a manual workflow for applying the D1 migration to the remote `researchops-d1` database
+
+The operational documentation must make clear how these pieces are configured and applied safely.
+
+## Planned coverage
+
+The document should cover:
+
+- required Cloudflare Access configuration values
+- required Worker variables or secrets
+- D1 migration workflow inputs and expected checks
+- how live D1 creation is confirmed
+- what must not be claimed before workflow or API evidence exists
+- how route permission enforcement depends on seeded D1 route declarations
+- safe rollout order
+- rollback and retry notes
+
+## Cloudflare source check
+
+Official Cloudflare documentation checked before this task:
+
+- Cloudflare Access JWT validation documentation
+- Cloudflare D1 Wrangler command documentation
+- Cloudflare D1 getting started documentation for `--remote --file` execution
+
+## Boundary
+
+This task creates operational documentation only.
+
+It does not apply the migration to the live D1 database.
+
+It does not change Worker runtime behaviour.
+
+It does not add Cloudflare Agents to the access-control decision path.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md
@@ -1,0 +1,61 @@
+# Agent trace checkpoint 013: Cloudflare operations documentation complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the result of the Cloudflare operations documentation step. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Files changed in this checkpoint
+
+- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
+
+## Implementation support completed
+
+The Cloudflare operations note now documents the operational route for taking the authentication role-selection foundation from repository code into Cloudflare runtime.
+
+## Coverage added
+
+The document records:
+
+- Cloudflare Access runtime values required by the Worker identity resolver
+- `Cf-Access-Jwt-Assertion` as the JWT-bearing request header
+- the D1 `RESEARCHOPS_D1` binding
+- the expected `researchops-d1` database target
+- GitHub secrets required by Wrangler
+- the manual D1 workflow inputs
+- the D1 migration file path
+- expected D1 control-plane tables
+- expected seed counts
+- post-apply verification queries
+- rollout order
+- failure and retry notes
+- the evidence requirement before claiming live D1 table creation
+
+## Design decision covered
+
+This checkpoint supports the user's clarification that the build must create real D1 tables and seed them where necessary. The repository now contains a real migration and a controlled manual path for applying that migration to the remote D1 database.
+
+## Live D1 status
+
+The live `researchops-d1` database has not been changed by this documentation step.
+
+The operational note explicitly states that live table creation and seeding are confirmed only after successful workflow, Wrangler, or Cloudflare API evidence.
+
+## Boundary
+
+This checkpoint does not run the manual D1 workflow.
+
+This checkpoint does not execute Cloudflare APIs.
+
+This checkpoint does not change Worker runtime behaviour.
+
+## Next planned task
+
+Run or prepare validation for the branch:
+
+- repository tests for the newly added auth foundation files
+- workflow syntax sanity check where possible
+- branch comparison and PR readiness review
+
+If direct Cloudflare execution is available, the next real-environment step is to apply the D1 migration and capture the evidence in the trace.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md
@@ -1,0 +1,42 @@
+# Agent trace checkpoint 014: validation wiring plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the next implementation step before code changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Next task
+
+Wire the authentication foundation tests into the repository validation contract.
+
+## Rationale
+
+The branch has added two authentication-specific test files:
+
+- `tests/auth-foundation-route-state.test.js`
+- `tests/auth-route-permissions.test.js`
+
+The Worker deployment workflow runs `npm run validate`, which delegates to `scripts/validate.sh`. The validation script currently does not require or execute these new tests.
+
+To make the authentication slice part of the normal CI quality gate, `scripts/validate.sh` should be updated to require and run both test files.
+
+## Intended change
+
+Update `scripts/validate.sh` to:
+
+- require `tests/auth-foundation-route-state.test.js`
+- require `tests/auth-route-permissions.test.js`
+- run both tests during validation
+
+## Boundary
+
+This does not run tests in this assistant environment.
+
+This does not apply the D1 migration to the live database.
+
+This does not change Worker runtime behaviour.
+
+## Expected result
+
+Future `npm run validate` executions should include the authentication foundation tests automatically.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md
@@ -1,0 +1,49 @@
+# Agent trace checkpoint 015: validation wiring complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the result of wiring the authentication tests into the repository validation contract. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Files changed in this checkpoint
+
+- `scripts/validate.sh`
+
+## Implementation support completed
+
+The repository validation contract now requires and executes the authentication foundation tests.
+
+## Required files added to validation
+
+The validation script now requires:
+
+- `tests/auth-foundation-route-state.test.js`
+- `tests/auth-route-permissions.test.js`
+
+## Test execution added to validation
+
+The validation script now runs:
+
+```bash
+node tests/auth-foundation-route-state.test.js
+node tests/auth-route-permissions.test.js
+```
+
+## Design decision covered
+
+This makes the authentication foundation part of the standard CI quality gate. Future Worker deployments already run `npm run validate`, so these auth tests are now included in deployment validation.
+
+## Boundary
+
+This checkpoint updates the validation contract only.
+
+It does not run the validation script in this assistant environment.
+
+It does not apply the D1 migration to the live database.
+
+It does not change Worker runtime behaviour beyond prior code changes.
+
+## Next planned task
+
+Update the main implementation trace with this checkpoint, then run a branch comparison and prepare PR readiness evidence.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md
@@ -1,0 +1,41 @@
+# Agent trace checkpoint 016: trace index and JSON plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the trace maintenance correction requested by the user before repository changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## User correction
+
+The user noted that the markdown trace has been maintained, but the companion JSON trace has not been maintained.
+
+The user also noted that checkpoint markdown files are useful for this large job, but they must be linked from the main trace and their captured events must be represented in the single companion JSON trace file.
+
+## Next task
+
+Create and maintain:
+
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
+
+Update:
+
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
+
+## Intended changes
+
+The main markdown trace should include a linked checkpoint index.
+
+The JSON trace should include structured entries for the implementation checkpoints and checkpoint markdown files already created.
+
+The JSON trace should remain a single consolidated JSON file. Individual checkpoint JSON files should not be created.
+
+## Boundary
+
+This is a trace governance correction.
+
+It does not change Worker runtime behaviour.
+
+It does not apply the D1 migration to the live database.
+
+It does not run validation.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md
@@ -1,0 +1,64 @@
+# Agent trace checkpoint 017: PR readiness plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the branch comparison and planned PR step before a pull request is opened. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Branch comparison
+
+Comparison against `main` shows:
+
+- branch status: ahead
+- commits ahead: 29
+- commits behind: 0
+- base commit: `8305adeed3b7e4047f132bc8c50347ce47e6205f`
+
+## Changed implementation files
+
+- `.github/workflows/apply-d1-auth-foundation.yml`
+- `infra/cloudflare/migrations/0001_auth_foundation.sql`
+- `infra/cloudflare/src/core/auth/access.js`
+- `infra/cloudflare/src/core/auth/route-permissions.js`
+- `infra/cloudflare/src/worker.js`
+- `scripts/validate.sh`
+- `tests/auth-foundation-route-state.test.js`
+- `tests/auth-route-permissions.test.js`
+
+## Changed documentation and trace files
+
+- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
+- checkpoint markdown files 010 to 017
+
+## Planned next step
+
+Open a pull request from:
+
+`feature/auth-foundation-real-d1-current-main`
+
+into:
+
+`main`
+
+## PR intent
+
+The PR should make the authentication role-selection foundation reviewable and allow repository CI to run the validation contract.
+
+## PR boundary
+
+The PR must state that:
+
+- live D1 migration has not been applied by this branch alone
+- the manual D1 workflow exists but has not been run in this chat
+- Cloudflare Access values still need environment configuration before runtime use
+- route-permission helper is wired only into identity routes so far
+- no role-management UI is included in this slice
+
+## Validation status
+
+No local validation result is claimed before PR creation.
+
+The branch now wires the auth tests into `npm run validate`, but the validation script has not been executed in this environment.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md
@@ -1,0 +1,42 @@
+# Agent trace checkpoint 018: route-permission test lint fix plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the CI lint failure and planned fix before code changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions failed during:
+
+```bash
+npm run lint
+```
+
+Prettier reported formatting issues in:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## Failure boundary
+
+The reported failure is formatting only.
+
+No runtime, unit test, validation, D1 migration or Cloudflare execution success is claimed.
+
+## Planned fix
+
+Update `tests/auth-route-permissions.test.js` to match Prettier formatting.
+
+Expected changes include:
+
+- long `assertRoutePermission` calls split across lines where Prettier requires it
+- no behavioural change to test assertions
+
+## Validation plan
+
+This checkpoint does not run validation.
+
+The next CI run should re-run `npm run lint`. If further failures appear, they should be handled in a new checkpoint.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md
@@ -1,0 +1,45 @@
+# Agent trace checkpoint 019: route-permission test lint fix complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the result of the lint-format correction after the reported CI failure. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions failed during:
+
+```bash
+npm run lint
+```
+
+Prettier reported formatting issues in:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## File changed
+
+- `tests/auth-route-permissions.test.js`
+
+## Fix applied
+
+The long `assertRoutePermission` call in `assertDiagnosticsCanIncludeMissingPermissionCodes` was reformatted to match the multiline call style used elsewhere in the repository test files.
+
+No test behaviour was changed.
+
+## Validation status
+
+This checkpoint does not claim local validation success.
+
+The next CI run should confirm whether `npm run lint` now passes or whether another formatting issue remains.
+
+## Boundary
+
+This fix does not change Worker runtime behaviour.
+
+This fix does not apply the D1 migration to the live database.
+
+This fix does not change route-permission semantics.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md
@@ -1,0 +1,43 @@
+# Agent trace checkpoint 020: route-permission test lint fix rerun plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the repeated CI formatting failure and the second planned formatting correction before code changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions again failed during:
+
+```bash
+./node_modules/.bin/prettier -c .
+```
+
+Prettier again reported formatting issues in:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## Diagnosis
+
+The first formatting fix corrected one long call site but left another call site in a shape that Prettier still rewrites.
+
+The remaining offender is the `assertRoutePermission` call in `assertMissingRouteFailsClosed`.
+
+## Planned fix
+
+Rewrite `tests/auth-route-permissions.test.js` using the exact Prettier output shape for the file.
+
+Expected behavioural impact:
+
+- none
+
+## Boundary
+
+This fix does not change Worker runtime behaviour.
+
+This fix does not apply the D1 migration to the live database.
+
+This fix does not change route-permission semantics.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md
@@ -1,0 +1,60 @@
+# Agent trace checkpoint 021: route-permission test lint fix rerun complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the second formatting correction after the repeated CI Prettier failure. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions again failed during:
+
+```bash
+./node_modules/.bin/prettier -c .
+```
+
+Prettier again reported formatting issues in:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## File changed
+
+- `tests/auth-route-permissions.test.js`
+
+## Fix applied
+
+The file was rewritten to match Prettier output for the remaining long `assertRoutePermission` call in `assertMissingRouteFailsClosed`.
+
+The relevant call is now multiline in the same shape produced by local Prettier execution.
+
+## Local formatting check used before commit
+
+A temporary copy of the file content was formatted using:
+
+```bash
+npx --yes prettier --write /tmp/auth-route-permissions.test.js
+npx --yes prettier -c /tmp/auth-route-permissions.test.js
+```
+
+The temporary local check reported:
+
+```text
+All matched files use Prettier code style!
+```
+
+## Validation status
+
+This checkpoint does not claim full repository lint or validation success.
+
+The next CI run must confirm whether the repository-level Prettier check now passes.
+
+## Boundary
+
+This fix does not change Worker runtime behaviour.
+
+This fix does not apply the D1 migration to the live database.
+
+This fix does not change route-permission semantics.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md
@@ -1,0 +1,51 @@
+# Agent trace checkpoint 022: escaped JSON lint fix plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the repeated Prettier failure and the next formatting correction before code changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions again failed during:
+
+```bash
+npm run lint
+```
+
+Prettier again reported formatting issues in:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## Diagnosis
+
+The remaining formatting issue is the escaped double quotes inside single-quoted JSON strings, for example:
+
+```js
+'[\"audit.view\"]'
+```
+
+Prettier rewrites these as unescaped JSON strings inside single quotes:
+
+```js
+'["audit.view"]'
+```
+
+## Planned fix
+
+Update `tests/auth-route-permissions.test.js` to remove unnecessary escaping from JSON string literals used in D1 route-permission test fixtures.
+
+Expected behavioural impact:
+
+- none
+
+## Boundary
+
+This fix does not change Worker runtime behaviour.
+
+This fix does not apply the D1 migration to the live database.
+
+This fix does not change route-permission semantics.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md
@@ -1,0 +1,71 @@
+# Agent trace checkpoint 023: JSON fixture lint fix plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the third repeated Prettier failure and the planned resilient fix before code changes are made. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions again failed during:
+
+```bash
+npm run lint
+```
+
+Prettier again reported formatting issues in:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## Diagnosis
+
+Repeated small formatting edits have not resolved the CI signal. The test file still uses inline JSON string fixtures for `required_permissions_json`.
+
+The resilient correction is to remove the fragile inline JSON literal pattern entirely and generate those fixture values using `JSON.stringify`.
+
+## Planned fix
+
+Update `tests/auth-route-permissions.test.js` to add a small helper:
+
+```js
+function requiredPermissions(...codes) {
+  return JSON.stringify(codes);
+}
+```
+
+Then replace inline JSON string fixtures with calls such as:
+
+```js
+required_permissions_json: requiredPermissions("audit.view"),
+```
+
+## Local check before repository update
+
+A temporary copy of the planned file content was checked with:
+
+```bash
+npx --yes prettier@3.6.2 -c /tmp/auth-route-permissions-v2.test.js
+```
+
+The check reported:
+
+```text
+All matched files use Prettier code style!
+```
+
+## Expected behavioural impact
+
+None.
+
+The helper returns the same JSON string shape consumed by `parsePermissions` in `route-permissions.js`.
+
+## Boundary
+
+This fix does not change Worker runtime behaviour.
+
+This fix does not apply the D1 migration to the live database.
+
+This fix does not change route-permission semantics.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md
@@ -1,0 +1,81 @@
+# Agent trace checkpoint 024: JSON fixture lint fix complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the resilient fixture-formatting correction after repeated CI Prettier failures. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions repeatedly failed during:
+
+```bash
+npm run lint
+```
+
+Prettier repeatedly reported formatting issues in:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## File changed
+
+- `tests/auth-route-permissions.test.js`
+
+## Fix applied
+
+The fragile inline JSON string fixtures were replaced with a helper:
+
+```js
+function requiredPermissions(...codes) {
+  return JSON.stringify(codes);
+}
+```
+
+Fixtures now use calls such as:
+
+```js
+required_permissions_json: requiredPermissions("audit.view"),
+```
+
+## Reason for this correction
+
+The repeated Prettier failures were isolated to `tests/auth-route-permissions.test.js`. The previous formatting-only attempts still left the file in a state that CI rewrote.
+
+Using `JSON.stringify` removes the escaped JSON literal formatting ambiguity while preserving the same string value passed into the D1-style fixture.
+
+## Local formatting check used before commit
+
+A temporary copy of the planned file content was checked with:
+
+```bash
+npx --yes prettier@3.6.2 -c /tmp/auth-route-permissions-v2.test.js
+```
+
+The check reported:
+
+```text
+All matched files use Prettier code style!
+```
+
+## Expected behavioural impact
+
+None.
+
+The helper returns the same JSON string shape consumed by `parsePermissions` in `route-permissions.js`.
+
+## Validation status
+
+This checkpoint does not claim full repository lint or validation success.
+
+The next CI run must confirm whether the repository-level Prettier check now passes.
+
+## Boundary
+
+This fix does not change Worker runtime behaviour.
+
+This fix does not apply the D1 migration to the live database.
+
+This fix does not change route-permission semantics.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md
@@ -1,0 +1,149 @@
+# Agent trace checkpoint 025: Prettier tooling findings
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the repeated Prettier failure, the available tooling boundary, and the prevention notes that should become repository rules after CI confirms the final fix. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions repeatedly reported:
+
+```bash
+npm run lint
+```
+
+with Prettier failing on:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+The latest user-provided log was from 2026-05-08T19:28:57Z and still reported the same file.
+
+## Repository lint command
+
+`package.json` defines:
+
+```json
+{
+  "lint": "prettier -c . && eslint .",
+  "format": "prettier -w .",
+  "format:check": "prettier -c ."
+}
+```
+
+The repository dev dependency is:
+
+```json
+{
+  "prettier": "^3.6.2"
+}
+```
+
+## Prettier config check
+
+Repository search did not find a dedicated Prettier config such as `.prettierrc`, `prettier.config.*`, or equivalent formatting override.
+
+This means the effective formatting contract is Prettier 3 defaults unless a hidden or unsynchronised config appears outside the searched repository surface.
+
+## Tooling boundary
+
+The GitHub connector can create and edit repository files but does not execute shell commands in the repository checkout.
+
+A direct repository clone in the execution container was attempted but failed because the container could not resolve `github.com`.
+
+Therefore a true repository-level command such as:
+
+```bash
+npm run format
+```
+
+or:
+
+```bash
+./node_modules/.bin/prettier --write .
+```
+
+could not be executed against the live branch checkout from this assistant environment.
+
+## File-level Prettier check used
+
+A temporary local copy of the planned `tests/auth-route-permissions.test.js` content was checked with Prettier 3.6.2:
+
+```bash
+npx --yes prettier@3.6.2 -c /tmp/auth-route-permissions-v2.test.js
+```
+
+That temporary file-level check reported:
+
+```text
+All matched files use Prettier code style!
+```
+
+## Current resilient fix candidate
+
+The latest code change removed fragile inline JSON strings from route-permission test fixtures and replaced them with a helper:
+
+```js
+function requiredPermissions(...codes) {
+  return JSON.stringify(codes);
+}
+```
+
+Before:
+
+```js
+required_permissions_json: '["audit.view"]',
+```
+
+After:
+
+```js
+required_permissions_json: requiredPermissions("audit.view"),
+```
+
+## Why this should prevent recurrence
+
+The previous pattern embedded JSON inside a JavaScript string literal. That created avoidable formatting ambiguity around escaping and quote normalisation.
+
+The helper makes the fixture data structural. It leaves quote rendering to JavaScript and removes the need to hand-format escaped JSON.
+
+## Draft rule to add after CI confirms the fix
+
+For JavaScript tests, do not hand-write escaped JSON fixtures where the target code expects a JSON string.
+
+Use a helper such as:
+
+```js
+function fixtureJson(value) {
+  return JSON.stringify(value);
+}
+```
+
+or for route permissions specifically:
+
+```js
+function requiredPermissions(...codes) {
+  return JSON.stringify(codes);
+}
+```
+
+Then run one of these before committing:
+
+```bash
+npm run format
+```
+
+or, for a targeted file:
+
+```bash
+npx prettier --write tests/auth-route-permissions.test.js
+```
+
+## Status
+
+The latest fix is committed, but repository-level CI has not yet confirmed it.
+
+This checkpoint should become the basis for a repository instruction update only after CI confirms the final fix.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md
@@ -1,0 +1,76 @@
+# Agent trace checkpoint 026: Prettier root cause plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the confirmed root cause of the repeated Prettier failure before applying the exact formatting output. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Reported failure
+
+GitHub Actions repeatedly failed during:
+
+```bash
+prettier -c .
+```
+
+The repeatedly reported file was:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+## Root cause now identified
+
+The repository has an `.editorconfig` file with:
+
+```ini
+[*]
+indent_style = tab
+indent_size = 2
+```
+
+Prettier reads `.editorconfig` by default. That means JavaScript files in this repository are formatted with tabs, not two spaces.
+
+The earlier local checks were wrong because they checked a temporary standalone file outside the repository context. Without the repository `.editorconfig`, Prettier used its default space indentation and reported a false local pass.
+
+## Correct reproduction
+
+The failure reproduces when the repository `.editorconfig` is present beside the file:
+
+```bash
+npx --yes prettier@3.6.2 -c tests/auth-route-permissions.test.js
+```
+
+The same file then passes after applying:
+
+```bash
+npx --yes prettier@3.6.2 --write tests/auth-route-permissions.test.js
+```
+
+## Exact planned fix
+
+Replace `tests/auth-route-permissions.test.js` with the output produced by Prettier 3.6.2 while `.editorconfig` is present.
+
+The concrete change is tab indentation throughout the JavaScript file.
+
+## Copilot workflow suggestion assessment
+
+The suggestion to add `npx prettier --write .` before lint in the validation workflow should not be used as the primary fix.
+
+Reason:
+
+- validation workflows should detect formatting drift rather than silently mutate it
+- a `--write` step in CI changes the runner workspace but does not automatically commit the correction back to the PR
+- it can mask formatting problems in later steps and still leave the branch unformatted
+
+The better rule is:
+
+- run `npm run format` or `npx prettier --write <file>` before committing
+- keep CI as `prettier -c .` so it enforces the repository contract
+
+## Prevention rule to write after CI confirms the fix
+
+When formatting JavaScript in this repository, run Prettier from the repository root so it can read `.editorconfig`.
+
+Do not rely on temporary file-level checks outside the repository tree because they will miss `indent_style = tab`.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md
@@ -1,0 +1,103 @@
+# Agent trace checkpoint 027: Prettier root cause fix complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the exact formatting fix after the root cause was identified. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## File changed
+
+- `tests/auth-route-permissions.test.js`
+
+## Root cause
+
+The repeated Prettier failures were caused by repository-level `.editorconfig` settings that were not present in earlier temporary file-only checks.
+
+The repository `.editorconfig` sets:
+
+```ini
+[*]
+indent_style = tab
+indent_size = 2
+```
+
+Prettier reads `.editorconfig` by default. The file had been formatted with spaces. CI checked the file inside the repository and therefore expected tabs.
+
+## Exact fix applied
+
+`tests/auth-route-permissions.test.js` was replaced with the output shape produced by Prettier 3.6.2 when `.editorconfig` is present.
+
+The concrete fix is tab indentation across the JavaScript file.
+
+Example before:
+
+```js
+import {
+  assertRoutePermission,
+  resolveRoutePermissionDeclaration,
+  routePermissionErrorResponse,
+} from "../infra/cloudflare/src/core/auth/route-permissions.js";
+```
+
+Example after:
+
+```js
+import {
+	assertRoutePermission,
+	resolveRoutePermissionDeclaration,
+	routePermissionErrorResponse,
+} from "../infra/cloudflare/src/core/auth/route-permissions.js";
+```
+
+Nested object example after:
+
+```js
+return {
+	prepare() {
+		return {
+			bind(method, pathname) {
+				return {
+					async first() {
+						if (!declaration) return null;
+					},
+				};
+			},
+		};
+	},
+};
+```
+
+## Behavioural impact
+
+None.
+
+The change is formatting only. It does not change route-permission test assertions or Worker runtime behaviour.
+
+## Validation status
+
+The formatting has been aligned to the repository `.editorconfig` contract.
+
+Repository-level CI still needs to confirm that `prettier -c .` passes.
+
+## Future rule candidate
+
+When formatting JavaScript in this repository, run Prettier from the repository root so it reads `.editorconfig`.
+
+Do not rely on temporary standalone file checks outside the repository tree.
+
+Use:
+
+```bash
+npm run format
+```
+
+or targeted:
+
+```bash
+npx prettier --write tests/auth-route-permissions.test.js
+```
+
+from the repository root.
+
+Do not add `prettier --write .` into CI before lint as a normal validation step. CI should detect formatting drift, not silently rewrite it without committing the result.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-028-format-automation-plan.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-028-format-automation-plan.md
@@ -1,0 +1,81 @@
+# Agent trace checkpoint 028: format automation plan
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the automation plan for preventing repeated Prettier failures. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Trigger
+
+The user asked what needs to be automated so the Prettier failure does not keep recurring.
+
+## Current facts
+
+The repository already has:
+
+```json
+{
+  "format": "prettier -w .",
+  "format:check": "prettier -c .",
+  "lint": "prettier -c . && eslint ."
+}
+```
+
+The repository also has `.editorconfig` with:
+
+```ini
+[*]
+indent_style = tab
+indent_size = 2
+```
+
+The existing `Format pull request` workflow checks formatting but only reports the file name. It does not show the exact diff that `prettier --write` would produce.
+
+## Automation decision
+
+Do not add `prettier --write .` as a normal pre-lint step in validating CI.
+
+Reason:
+
+- validating CI should detect formatting drift
+- `--write` in a read-only CI job mutates the runner workspace but does not commit the correction
+- it can hide the evidence needed to fix the source branch
+
+## Planned repository changes
+
+Add an explicit Prettier config:
+
+- `prettier.config.mjs`
+
+This will make the repository formatting contract visible instead of relying only on `.editorconfig`.
+
+Update the formatting workflow:
+
+- `.github/workflows/format-pr.yml`
+
+The workflow should still fail on unformatted code, but on failure it should:
+
+1. run Prettier with `--write` in the runner
+2. show the resulting `git diff`
+3. fail with the exact patch visible in logs
+
+Add a manual branch formatter workflow:
+
+- `.github/workflows/format-branch.yml`
+
+This workflow should only run on `workflow_dispatch`. It should:
+
+1. require an explicit branch input
+2. check out that branch
+3. run `npm ci --ignore-scripts`
+4. run `npm run format`
+5. commit and push the formatting diff only if there are changes
+
+## Expected result
+
+The normal CI path remains strict.
+
+The manual rescue path can apply the exact Prettier output to a branch without guessing.
+
+Future failures will provide an exact diff, not just a filename.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-029-format-automation-complete.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-029-format-automation-complete.md
@@ -1,0 +1,85 @@
+# Agent trace checkpoint 029: format automation complete
+
+> This checkpoint belongs to `[reasoning]` trace `atrace-20260508-authentication-role-selection-real-implementation`. It records the implementation of the Prettier automation path. It does not expose private chain-of-thought.
+
+## Branch
+
+`feature/auth-foundation-real-d1-current-main`
+
+## Trigger
+
+The user asked for the path forward to implement automation so the repeated Prettier failure does not keep recurring.
+
+## Files changed
+
+- `prettier.config.mjs`
+- `.github/workflows/format-pr.yml`
+- `.github/workflows/format-branch.yml`
+
+## Implementation completed
+
+### Explicit Prettier contract
+
+A new `prettier.config.mjs` file now makes the repository formatting contract visible:
+
+```js
+export default {
+	useTabs: true,
+	tabWidth: 2,
+	endOfLine: "lf",
+};
+```
+
+This aligns with the existing `.editorconfig` tab rule and prevents agents or contributors from missing the repository indentation contract.
+
+### Diagnostic PR formatting workflow
+
+`.github/workflows/format-pr.yml` now keeps the strict formatting check, but when Prettier fails it runs:
+
+```bash
+./node_modules/.bin/prettier --write .
+git diff -- . > prettier-fix.patch
+cat prettier-fix.patch
+```
+
+The workflow then uploads `prettier-fix.patch` as an artifact.
+
+This means future failures provide the exact patch rather than only naming the failing file.
+
+### Manual formatting workflow
+
+A new manual workflow exists:
+
+```text
+.github/workflows/format-branch.yml
+```
+
+It runs on `workflow_dispatch` only and requires a branch input.
+
+It:
+
+1. checks out the named branch
+2. installs dependencies using `npm ci --ignore-scripts`
+3. runs `npm run format`
+4. commits and pushes formatting changes only if there is a diff
+
+## Design decision
+
+The normal CI check remains strict. It does not silently format before lint.
+
+The new workflow separates detection from repair:
+
+- `format-pr.yml` detects formatting drift and shows the exact patch
+- `format-branch.yml` is the controlled repair path that can commit Prettier output to the branch
+
+## Boundary
+
+This checkpoint does not claim that CI has passed.
+
+This checkpoint does not apply the D1 migration to the live database.
+
+This checkpoint does not change Worker runtime behaviour.
+
+## Next step
+
+Wait for PR CI to rerun. If Prettier still fails, use the generated `prettier-fix.patch` or run the manual `Format branch` workflow against `feature/auth-foundation-real-d1-current-main`.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -12,36 +12,19 @@
     "url": "https://github.com/kevinrapley/ResearchOps/pull/215",
     "state": "open"
   },
-  "companion_markdown_trace": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md",
   "status": {
     "repository_migration_created": true,
     "manual_d1_apply_workflow_created": true,
     "live_d1_migration_applied": false,
-    "validation_executed_in_this_environment": false,
     "pull_request_opened": true,
-    "pr_readiness_checked": true,
     "latest_known_ci_failure": "Repeated Prettier formatting warning in tests/auth-route-permissions.test.js",
     "latest_known_ci_failure_fix_committed": true,
     "latest_known_ci_failure_fix_validated_by_ci": false,
-    "temporary_prettier_check_used_for_latest_fix": true,
-    "repository_level_prettier_write_executed_in_assistant_environment": false
+    "root_cause_identified": true,
+    "root_cause": "Prettier reads repository .editorconfig by default. The repository requires tab indentation via indent_style = tab, while earlier temporary file checks were outside the repository tree and used Prettier space defaults.",
+    "repository_level_prettier_write_executed_in_assistant_environment": false,
+    "prettier_write_simulated_with_repository_editorconfig": true
   },
-  "selected_bundles": [
-    "github-diamond",
-    "researchops-developer",
-    "gov-product-assistant-gold-standard",
-    "govuk-design-system",
-    "cloudflare-core-developer",
-    "cloudflare-developer-platform-bundle",
-    "cloudflare-agents-workbench",
-    "airtable-public-api-developer"
-  ],
-  "skipped_bundles": [
-    {
-      "bundle": "mural-public-api-developer",
-      "reason": "No Mural OAuth, workspace, room, board, widget or sticky-note implementation is in scope for this authentication slice."
-    }
-  ],
   "changed_files": {
     "implementation": [
       ".github/workflows/apply-d1-auth-foundation.yml",
@@ -74,7 +57,9 @@
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md"
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md"
     ]
   },
   "prettier_investigation": {
@@ -85,175 +70,161 @@
       "format_check": "prettier -c ."
     },
     "prettier_version_from_package_json": "^3.6.2",
-    "dedicated_prettier_config_found_by_repository_search": false,
-    "attempted_repository_clone_for_exact_prettier_write": {
-      "attempted": true,
-      "result": "failed",
-      "reason": "container could not resolve github.com"
+    "repository_editorconfig": {
+      "path": ".editorconfig",
+      "indent_style": "tab",
+      "indent_size": "2",
+      "effect": "Prettier reads .editorconfig by default, so JavaScript files are expected to use tab indentation in this repository."
     },
-    "file_level_temp_check": {
-      "command": "npx --yes prettier@3.6.2 -c /tmp/auth-route-permissions-v2.test.js",
-      "result": "All matched files use Prettier code style!"
+    "failed_local_method": {
+      "description": "Temporary file-level checks outside the repository tree passed incorrectly because the repository .editorconfig was absent.",
+      "lesson": "Run Prettier from the repository root or with a matching .editorconfig."
     },
-    "latest_fix_pattern": {
-      "before": "required_permissions_json: '[\"audit.view\"]',",
-      "after": "required_permissions_json: requiredPermissions(\"audit.view\"),",
-      "helper": "function requiredPermissions(...codes) { return JSON.stringify(codes); }",
-      "reason": "Avoid hand-written escaped JSON string fixtures so Prettier has no quote/escape ambiguity to normalise."
+    "correct_reproduction": {
+      "steps": [
+        "Place .editorconfig beside the test file in a temporary repository tree.",
+        "Run npx --yes prettier@3.6.2 -c tests/auth-route-permissions.test.js.",
+        "The check fails when the file uses spaces.",
+        "Run npx --yes prettier@3.6.2 --write tests/auth-route-permissions.test.js.",
+        "The written output uses tabs and then passes Prettier."
+      ]
+    },
+    "exact_fix": {
+      "file": "tests/auth-route-permissions.test.js",
+      "change": "Replace space indentation with repository Prettier output using tab indentation.",
+      "before_example": "import {\n  assertRoutePermission,\n  resolveRoutePermissionDeclaration,\n  routePermissionErrorResponse,\n} from \"../infra/cloudflare/src/core/auth/route-permissions.js\";",
+      "after_example": "import {\n\tassertRoutePermission,\n\tresolveRoutePermissionDeclaration,\n\troutePermissionErrorResponse,\n} from \"../infra/cloudflare/src/core/auth/route-permissions.js\";",
+      "behavioural_impact": "none"
+    },
+    "copilot_workflow_suggestion_assessment": {
+      "suggestion": "Add npx prettier --write . before lint in CI.",
+      "decision": "Do not use as the primary validation fix.",
+      "reason": "CI should detect formatting drift rather than silently mutating the runner workspace. A --write step does not commit the result back to the branch."
     }
   },
   "checkpoints": [
     {
       "id": "001",
       "title": "D1 auth foundation migration",
-      "kind": "implementation",
       "status": "complete_in_repository_not_applied_to_live_d1",
-      "files_changed": ["infra/cloudflare/migrations/0001_auth_foundation.sql"],
-      "summary": "Created the real D1 control-plane migration for users, identities, teams, memberships, permissions, roles, role-permission mappings, role assignments, permission exceptions, auth events, audit events and route permissions. It also seeds permissions, roles, role-permission mappings and route declarations.",
-      "live_environment_status": "not_applied"
+      "files_changed": ["infra/cloudflare/migrations/0001_auth_foundation.sql"]
     },
     {
       "id": "002",
       "title": "Cloudflare Access identity resolver",
-      "kind": "implementation",
       "status": "complete_in_repository",
-      "files_changed": ["infra/cloudflare/src/core/auth/access.js"],
-      "summary": "Added a real Cloudflare Access identity resolver that reads Cf-Access-Jwt-Assertion, validates Access JWT structure, signature, expiry and audience, maps the provider identity to a ResearchOps D1 user, and returns active team, roles and permissions."
+      "files_changed": ["infra/cloudflare/src/core/auth/access.js"]
     },
     {
       "id": "003",
       "title": "Worker route wiring",
-      "kind": "implementation",
       "status": "complete_in_repository",
-      "files_changed": ["infra/cloudflare/src/worker.js"],
-      "summary": "Wired GET /api/me and GET /api/me/permissions through the Cloudflare Access identity resolver and allowed X-ResearchOps-Team-Id as a request header."
+      "files_changed": ["infra/cloudflare/src/worker.js"]
     },
     {
       "id": "004",
       "title": "Authentication foundation route-state tests",
-      "kind": "test",
       "status": "created_not_executed_here",
-      "files_changed": ["tests/auth-foundation-route-state.test.js"],
-      "summary": "Added tests for identity route fail-closed behaviour, Worker route wiring, absence of mock identity mode, route-permission wiring and D1 migration structure."
+      "files_changed": ["tests/auth-foundation-route-state.test.js"]
     },
     {
       "id": "006",
       "title": "Route-permission helper created",
-      "kind": "implementation",
       "status": "complete_in_repository",
-      "files_changed": ["infra/cloudflare/src/core/auth/route-permissions.js"],
-      "summary": "Added a helper that reads route declarations from auth_route_permissions, fails closed where no declaration exists, checks required permissions and avoids exposing missing permission codes unless diagnostics are explicitly requested."
+      "files_changed": ["infra/cloudflare/src/core/auth/route-permissions.js"]
     },
     {
       "id": "007",
       "title": "Route-permission helper tests",
-      "kind": "test",
       "status": "created_not_executed_here",
-      "files_changed": ["tests/auth-route-permissions.test.js"],
-      "summary": "Added tests for declared route resolution, missing-route fail-closed behaviour, ordinary denied response redaction, diagnostic missing permission codes and matching-permission allow behaviour."
+      "files_changed": ["tests/auth-route-permissions.test.js"]
     },
     {
       "id": "009",
       "title": "Controlled D1 migration workflow created",
-      "kind": "implementation",
       "status": "complete_in_repository_not_run",
-      "files_changed": [".github/workflows/apply-d1-auth-foundation.yml"],
-      "summary": "Added a manual GitHub Actions workflow that requires explicit confirmation inputs and uses Wrangler d1 execute --remote to apply the auth foundation migration, with optional post-apply table and seed checks.",
-      "live_environment_status": "workflow_created_not_run"
+      "files_changed": [".github/workflows/apply-d1-auth-foundation.yml"]
     },
     {
       "id": "011",
       "title": "Route-permission wiring complete",
-      "kind": "trace_checkpoint",
       "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md",
-      "files_changed": ["infra/cloudflare/src/core/auth/access.js", "tests/auth-foundation-route-state.test.js"],
-      "summary": "Recorded that identity routes now call assertRoutePermission(request, env, context) after Cloudflare Access identity resolution and that tests assert this wiring."
+      "files_changed": ["infra/cloudflare/src/core/auth/access.js", "tests/auth-foundation-route-state.test.js"]
     },
     {
       "id": "013",
       "title": "Cloudflare operations documentation complete",
-      "kind": "trace_checkpoint",
       "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md",
-      "files_changed": ["docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md"],
-      "summary": "Recorded creation of the Cloudflare operations note covering Access runtime values, RESEARCHOPS_D1, researchops-d1, GitHub secrets, D1 workflow inputs, expected tables, seed counts, verification queries, rollout order and evidence requirements."
+      "files_changed": ["docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md"]
     },
     {
       "id": "015",
       "title": "Validation wiring complete",
-      "kind": "trace_checkpoint",
       "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
-      "files_changed": ["scripts/validate.sh"],
-      "summary": "Recorded that scripts/validate.sh now requires and runs tests/auth-foundation-route-state.test.js and tests/auth-route-permissions.test.js."
+      "files_changed": ["scripts/validate.sh"]
     },
     {
       "id": "018",
       "title": "Route-permission test lint fix plan",
-      "kind": "trace_checkpoint",
       "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
-      "summary": "Recorded the CI lint failure from npm run lint. Prettier reported tests/auth-route-permissions.test.js. The planned fix was formatting-only with no behavioural test change."
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md"
     },
     {
       "id": "019",
       "title": "Route-permission test lint fix complete",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
-      "files_changed": ["tests/auth-route-permissions.test.js"],
-      "summary": "Recorded that the long assertRoutePermission call in tests/auth-route-permissions.test.js was reformatted for Prettier. CI later showed another Prettier formatting change remained."
+      "status": "superseded_by_027",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md"
     },
     {
       "id": "020",
       "title": "Route-permission test lint fix rerun plan",
-      "kind": "trace_checkpoint",
       "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md",
-      "summary": "Recorded the repeated CI Prettier failure in tests/auth-route-permissions.test.js and identified the remaining long assertRoutePermission call in assertMissingRouteFailsClosed."
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md"
     },
     {
       "id": "021",
       "title": "Route-permission test lint fix rerun complete",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md",
-      "files_changed": ["tests/auth-route-permissions.test.js"],
-      "summary": "Recorded that tests/auth-route-permissions.test.js was rewritten to match local Prettier output. A temporary local Prettier check on that file content reported that all matched files use Prettier code style. Repository-level CI later still reported the same file."
+      "status": "superseded_by_027",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md"
     },
     {
       "id": "022",
       "title": "Escaped JSON lint fix plan",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md",
-      "summary": "Recorded the repeated Prettier failure and identified escaped inline JSON string fixtures as the remaining fragile pattern."
+      "status": "superseded_by_026",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md"
     },
     {
       "id": "023",
       "title": "JSON fixture lint fix plan",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md",
-      "summary": "Planned the resilient correction of replacing inline JSON string fixtures with JSON.stringify through a helper."
+      "status": "superseded_by_026",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md"
     },
     {
       "id": "024",
       "title": "JSON fixture lint fix complete",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md",
-      "files_changed": ["tests/auth-route-permissions.test.js"],
-      "summary": "Added requiredPermissions(...codes) and replaced inline JSON string fixtures with requiredPermissions calls. This preserves parser input while removing escaped JSON literal formatting ambiguity."
+      "status": "partially_retained_fixture_improvement_but_not_root_format_fix",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md"
     },
     {
       "id": "025",
       "title": "Prettier tooling findings",
-      "kind": "trace_checkpoint",
+      "status": "superseded_by_026_and_027",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md"
+    },
+    {
+      "id": "026",
+      "title": "Prettier root cause plan",
       "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md",
-      "summary": "Recorded the repository lint scripts, Prettier version, absence of a discovered Prettier config, failed repository clone attempt, file-level Prettier check, latest helper-based fix pattern and draft prevention rule for future instructions."
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md",
+      "summary": "Identified .editorconfig tab indentation as the true root cause and rejected CI auto-formatting as the primary validation fix."
+    },
+    {
+      "id": "027",
+      "title": "Prettier root cause fix complete",
+      "status": "committed_pending_ci_confirmation",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md",
+      "files_changed": ["tests/auth-route-permissions.test.js"],
+      "summary": "Applied the repository Prettier output with tab indentation to tests/auth-route-permissions.test.js. No behavioural test change."
     }
   ],
   "real_d1_requirement": {
@@ -261,12 +232,7 @@
     "manual_workflow": ".github/workflows/apply-d1-auth-foundation.yml",
     "database_name": "researchops-d1",
     "worker_binding": "RESEARCHOPS_D1",
-    "status": "repository_path_created_live_execution_not_claimed",
-    "evidence_required_before_claiming_live_tables": [
-      "successful GitHub Actions run for Apply D1 Authentication Foundation",
-      "successful direct Wrangler execution against --remote",
-      "successful Cloudflare API evidence showing auth tables and seed records exist"
-    ]
+    "status": "repository_path_created_live_execution_not_claimed"
   },
   "validation_status": {
     "new_tests_created": ["tests/auth-foundation-route-state.test.js", "tests/auth-route-permissions.test.js"],
@@ -275,35 +241,26 @@
     "test_success_claimed": false,
     "latest_lint_failure_fixed_in_repository": true,
     "latest_lint_failure_confirmed_fixed_by_ci": false,
-    "latest_file_level_prettier_check_on_temp_copy_passed": true
+    "latest_root_cause_fixed_by_tab_indentation": true
   },
   "prevention_rule_candidate_after_ci_confirmation": {
-    "rule": "Do not hand-write escaped JSON fixtures in JavaScript tests where the target code expects a JSON string. Use JSON.stringify through a named helper, then run npm run format or npx prettier --write <file> before committing.",
-    "example_helper": "function requiredPermissions(...codes) { return JSON.stringify(codes); }",
-    "example_usage": "required_permissions_json: requiredPermissions(\"audit.view\"),"
+    "rule": "Run Prettier from the repository root so it reads .editorconfig. Do not rely on temporary standalone file checks outside the repository tree. JavaScript files inherit indent_style = tab from .editorconfig unless a file-specific override is added.",
+    "commands": [
+      "npm run format",
+      "npx prettier --write tests/auth-route-permissions.test.js",
+      "npm run format:check"
+    ],
+    "do_not": "Do not add prettier --write . as a normal pre-lint step in CI. CI should detect formatting drift; developers or automation should commit formatted output before lint runs."
   },
   "process_deviations": [
     {
-      "summary": "The Access identity resolver commit exceeded the preferred 300-line atomic diff size from AGENTS.md.",
-      "correction": "Future changes should be split into smaller files and commits, with trace checkpoints before or alongside each change."
-    },
-    {
-      "summary": "Repeated formatting fixes were attempted without repository-level Prettier --write execution against a branch checkout.",
-      "correction": "For future formatting failures, prefer running npm run format or npx prettier --write <file> in a real repository checkout before committing; if tool access cannot do that, record the boundary and avoid claiming repository-level formatting success."
+      "summary": "Repeated formatting fixes were attempted without repository-root Prettier context.",
+      "correction": "For future formatting failures, run Prettier from a real repository root or reproduce .editorconfig beside the target file before committing."
     }
   ],
   "residual_risks": [
-    "Cloudflare Access JWT validation depends on environment configuration for certificates and audience.",
+    "The latest lint fix still needs repository-level CI confirmation.",
     "The D1 migration has not yet been run in the live environment.",
-    "The route wiring has not yet been validated by executed tests.",
-    "Route-permission helper is only wired into identity routes so far.",
-    "The latest lint fix still needs repository-level CI confirmation."
-  ],
-  "next_candidates": [
-    "Wait for PR CI to rerun and inspect any new failure.",
-    "If Prettier still fails, obtain exact Prettier write diff from CI or run npm run format in a repository checkout and commit the resulting file.",
-    "After CI confirms the fix, create permanent repository guidance based on checkpoint 025.",
-    "Apply the D1 migration through the manual workflow after review or explicit release decision.",
-    "Wire route-permission checks into the next protected product endpoint in a narrow slice."
+    "Route-permission helper is only wired into identity routes so far."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -7,41 +7,23 @@
   "active_branch": "feature/auth-foundation-real-d1-current-main",
   "base_branch": "main",
   "base_commit_at_branch_creation": "8305adeed3b7e4047f132bc8c50347ce47e6205f",
+  "pull_request": {
+    "number": 215,
+    "url": "https://github.com/kevinrapley/ResearchOps/pull/215",
+    "state": "open"
+  },
   "companion_markdown_trace": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md",
   "status": {
     "repository_migration_created": true,
     "manual_d1_apply_workflow_created": true,
     "live_d1_migration_applied": false,
     "validation_executed_in_this_environment": false,
-    "pull_request_opened": false,
-    "pr_readiness_checked": true
+    "pull_request_opened": true,
+    "pr_readiness_checked": true,
+    "latest_known_ci_failure": "Prettier formatting warning in tests/auth-route-permissions.test.js",
+    "latest_known_ci_failure_fix_committed": true,
+    "latest_known_ci_failure_fix_validated_by_ci": false
   },
-  "user_direction": [
-    {
-      "sequence": 1,
-      "summary": "Build the authentication role-selection capability systematically from the captured documentation."
-    },
-    {
-      "sequence": 2,
-      "summary": "Do not implement this as a mock identity build. Build the real authentication foundation."
-    },
-    {
-      "sequence": 3,
-      "summary": "Continuously maintain reasoning trace files during the build instead of reconstructing them at the end."
-    },
-    {
-      "sequence": 4,
-      "summary": "The build must include real D1 table creation and seeding where necessary, with evidence before claiming live D1 changes."
-    },
-    {
-      "sequence": 5,
-      "summary": "Cloudflare APIs and Cloudflare Developer Platform bundles are in scope, but live Cloudflare execution must be evidenced before being claimed."
-    },
-    {
-      "sequence": 6,
-      "summary": "Maintain a companion JSON trace and link checkpoint markdown files from the main markdown trace. Keep checkpoint JSON consolidated in this single JSON file."
-    }
-  ],
   "selected_bundles": [
     "github-diamond",
     "researchops-developer",
@@ -82,15 +64,17 @@
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md"
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md"
     ]
   },
   "branch_comparison": {
     "base": "main",
     "head": "feature/auth-foundation-real-d1-current-main",
     "status": "ahead",
-    "ahead_by": 29,
-    "behind_by": 0,
+    "ahead_by_after_lint_fix": 34,
+    "behind_by_after_lint_fix": 0,
     "base_commit": "8305adeed3b7e4047f132bc8c50347ce47e6205f"
   },
   "checkpoints": [
@@ -100,14 +84,7 @@
       "kind": "implementation",
       "status": "complete_in_repository_not_applied_to_live_d1",
       "files_changed": ["infra/cloudflare/migrations/0001_auth_foundation.sql"],
-      "summary": "Created the real D1 control-plane migration for users, identities, teams, memberships, permissions, roles, role-permission mappings, role assignments, permission exceptions, auth events, audit events and route permissions.",
-      "decision_coverage": [
-        "D1 is the canonical control plane.",
-        "scope_type and scope_id exist from the first schema.",
-        "Team is the first enforceable scope while project and study scopes are structurally supported.",
-        "Sensitive and reserved permissions are represented explicitly.",
-        "General audit and safeguarding audit are separate permissions."
-      ],
+      "summary": "Created the real D1 control-plane migration for users, identities, teams, memberships, permissions, roles, role-permission mappings, role assignments, permission exceptions, auth events, audit events and route permissions. It also seeds permissions, roles, role-permission mappings and route declarations.",
       "live_environment_status": "not_applied"
     },
     {
@@ -117,12 +94,7 @@
       "status": "complete_in_repository",
       "files_changed": ["infra/cloudflare/src/core/auth/access.js"],
       "summary": "Added a real Cloudflare Access identity resolver that reads Cf-Access-Jwt-Assertion, validates Access JWT structure, signature, expiry and audience, maps the provider identity to a ResearchOps D1 user, and returns active team, roles and permissions.",
-      "non_goals": [
-        "No mock identity behaviour.",
-        "No password authentication.",
-        "No role-management UI.",
-        "No Airtable schema change."
-      ]
+      "non_goals": ["No mock identity behaviour", "No password authentication", "No role-management UI", "No Airtable schema change"]
     },
     {
       "id": "003",
@@ -185,8 +157,7 @@
       "kind": "trace_checkpoint",
       "status": "complete",
       "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md",
-      "summary": "Recorded the plan to wire assertRoutePermission into GET /api/me and GET /api/me/permissions before code changes were made.",
-      "planned_files": ["infra/cloudflare/src/core/auth/access.js", "tests/auth-foundation-route-state.test.js"]
+      "summary": "Recorded the plan to wire assertRoutePermission into GET /api/me and GET /api/me/permissions before code changes were made."
     },
     {
       "id": "011",
@@ -237,10 +208,7 @@
       "kind": "trace_checkpoint",
       "status": "complete",
       "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
-      "files_changed": [
-        "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json",
-        "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md"
-      ],
+      "files_changed": ["docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json", "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md"],
       "summary": "Recorded the user correction that the companion JSON trace must be maintained and checkpoint markdown files must be linked from the main trace. This JSON file consolidates checkpoint traces rather than creating individual checkpoint JSON files."
     },
     {
@@ -249,12 +217,24 @@
       "kind": "trace_checkpoint",
       "status": "complete",
       "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
-      "summary": "Recorded branch comparison before opening a pull request. The branch is ahead of main by 29 commits and behind by 0. The planned PR must state that live D1 has not been migrated and that validation has not been executed in this environment.",
-      "branch_comparison": {
-        "ahead_by": 29,
-        "behind_by": 0,
-        "base_commit": "8305adeed3b7e4047f132bc8c50347ce47e6205f"
-      }
+      "summary": "Recorded branch comparison before opening a pull request. The branch was ahead of main by 29 commits and behind by 0 before PR creation."
+    },
+    {
+      "id": "018",
+      "title": "Route-permission test lint fix plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
+      "summary": "Recorded the CI lint failure from npm run lint. Prettier reported tests/auth-route-permissions.test.js. The planned fix was formatting-only with no behavioural test change."
+    },
+    {
+      "id": "019",
+      "title": "Route-permission test lint fix complete",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
+      "files_changed": ["tests/auth-route-permissions.test.js"],
+      "summary": "Recorded that the long assertRoutePermission call in tests/auth-route-permissions.test.js was reformatted for Prettier. No test behaviour was changed. CI has not yet confirmed the fix."
     }
   ],
   "real_d1_requirement": {
@@ -270,13 +250,12 @@
     ]
   },
   "validation_status": {
-    "new_tests_created": [
-      "tests/auth-foundation-route-state.test.js",
-      "tests/auth-route-permissions.test.js"
-    ],
+    "new_tests_created": ["tests/auth-foundation-route-state.test.js", "tests/auth-route-permissions.test.js"],
     "new_tests_wired_into_validate": true,
     "validate_script_executed_here": false,
-    "test_success_claimed": false
+    "test_success_claimed": false,
+    "latest_lint_failure_fixed_in_repository": true,
+    "latest_lint_failure_confirmed_fixed_by_ci": false
   },
   "process_deviations": [
     {
@@ -289,11 +268,10 @@
     "The D1 migration has not yet been run in the live environment.",
     "The route wiring has not yet been validated by executed tests.",
     "Route-permission helper is only wired into identity routes so far.",
-    "No pull request has been opened for this branch yet."
+    "The latest lint fix still needs CI confirmation."
   ],
   "next_candidates": [
-    "Update the main markdown trace with checkpoint 017.",
-    "Open a PR for review and CI execution.",
+    "Wait for PR CI to rerun and inspect any new failure.",
     "Apply the D1 migration through the manual workflow after review or explicit release decision.",
     "Wire route-permission checks into the next protected product endpoint in a narrow slice.",
     "Continue role-management UI and role-assignment API in separate slices."

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -1,0 +1,278 @@
+{
+  "trace_id": "atrace-20260508-authentication-role-selection-real-implementation",
+  "trace_layer": "operational",
+  "trigger_token_detected": "[reasoning]",
+  "date": "2026-05-08",
+  "repository": "kevinrapley/ResearchOps",
+  "active_branch": "feature/auth-foundation-real-d1-current-main",
+  "base_branch": "main",
+  "base_commit_at_branch_creation": "8305adeed3b7e4047f132bc8c50347ce47e6205f",
+  "companion_markdown_trace": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md",
+  "status": {
+    "repository_migration_created": true,
+    "manual_d1_apply_workflow_created": true,
+    "live_d1_migration_applied": false,
+    "validation_executed_in_this_environment": false,
+    "pull_request_opened": false
+  },
+  "user_direction": [
+    {
+      "sequence": 1,
+      "summary": "Build the authentication role-selection capability systematically from the captured documentation."
+    },
+    {
+      "sequence": 2,
+      "summary": "Do not implement this as a mock identity build. Build the real authentication foundation."
+    },
+    {
+      "sequence": 3,
+      "summary": "Continuously maintain reasoning trace files during the build instead of reconstructing them at the end."
+    },
+    {
+      "sequence": 4,
+      "summary": "The build must include real D1 table creation and seeding where necessary, with evidence before claiming live D1 changes."
+    },
+    {
+      "sequence": 5,
+      "summary": "Cloudflare APIs and Cloudflare Developer Platform bundles are in scope, but live Cloudflare execution must be evidenced before being claimed."
+    },
+    {
+      "sequence": 6,
+      "summary": "Maintain a companion JSON trace and link checkpoint markdown files from the main markdown trace. Keep checkpoint JSON consolidated in this single JSON file."
+    }
+  ],
+  "selected_bundles": [
+    "github-diamond",
+    "researchops-developer",
+    "gov-product-assistant-gold-standard",
+    "govuk-design-system",
+    "cloudflare-core-developer",
+    "cloudflare-developer-platform-bundle",
+    "cloudflare-agents-workbench",
+    "airtable-public-api-developer"
+  ],
+  "skipped_bundles": [
+    {
+      "bundle": "mural-public-api-developer",
+      "reason": "No Mural OAuth, workspace, room, board, widget or sticky-note implementation is in scope for this authentication slice."
+    }
+  ],
+  "changed_files": {
+    "implementation": [
+      ".github/workflows/apply-d1-auth-foundation.yml",
+      "infra/cloudflare/migrations/0001_auth_foundation.sql",
+      "infra/cloudflare/src/core/auth/access.js",
+      "infra/cloudflare/src/core/auth/route-permissions.js",
+      "infra/cloudflare/src/worker.js",
+      "scripts/validate.sh",
+      "tests/auth-foundation-route-state.test.js",
+      "tests/auth-route-permissions.test.js"
+    ],
+    "product_documentation": [
+      "docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md"
+    ],
+    "trace_files": [
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md"
+    ]
+  },
+  "checkpoints": [
+    {
+      "id": "001",
+      "title": "D1 auth foundation migration",
+      "kind": "implementation",
+      "status": "complete_in_repository_not_applied_to_live_d1",
+      "files_changed": ["infra/cloudflare/migrations/0001_auth_foundation.sql"],
+      "summary": "Created the real D1 control-plane migration for users, identities, teams, memberships, permissions, roles, role-permission mappings, role assignments, permission exceptions, auth events, audit events and route permissions.",
+      "decision_coverage": [
+        "D1 is the canonical control plane.",
+        "scope_type and scope_id exist from the first schema.",
+        "Team is the first enforceable scope while project and study scopes are structurally supported.",
+        "Sensitive and reserved permissions are represented explicitly.",
+        "General audit and safeguarding audit are separate permissions."
+      ],
+      "live_environment_status": "not_applied"
+    },
+    {
+      "id": "002",
+      "title": "Cloudflare Access identity resolver",
+      "kind": "implementation",
+      "status": "complete_in_repository",
+      "files_changed": ["infra/cloudflare/src/core/auth/access.js"],
+      "summary": "Added a real Cloudflare Access identity resolver that reads Cf-Access-Jwt-Assertion, validates Access JWT structure, signature, expiry and audience, maps the provider identity to a ResearchOps D1 user, and returns active team, roles and permissions.",
+      "non_goals": [
+        "No mock identity behaviour.",
+        "No password authentication.",
+        "No role-management UI.",
+        "No Airtable schema change."
+      ]
+    },
+    {
+      "id": "003",
+      "title": "Worker route wiring",
+      "kind": "implementation",
+      "status": "complete_in_repository",
+      "files_changed": ["infra/cloudflare/src/worker.js"],
+      "summary": "Wired GET /api/me and GET /api/me/permissions through the Cloudflare Access identity resolver and allowed X-ResearchOps-Team-Id as a request header."
+    },
+    {
+      "id": "004",
+      "title": "Authentication foundation route-state tests",
+      "kind": "test",
+      "status": "created_not_executed_here",
+      "files_changed": ["tests/auth-foundation-route-state.test.js"],
+      "summary": "Added tests for identity route fail-closed behaviour, Worker route wiring, absence of mock identity mode, route-permission wiring and D1 migration structure."
+    },
+    {
+      "id": "005",
+      "title": "Route-permission helper plan",
+      "kind": "trace_plan",
+      "status": "captured_in_main_trace",
+      "summary": "Recorded the plan to add a D1-backed route-permission helper before creating the helper."
+    },
+    {
+      "id": "006",
+      "title": "Route-permission helper created",
+      "kind": "implementation",
+      "status": "complete_in_repository",
+      "files_changed": ["infra/cloudflare/src/core/auth/route-permissions.js"],
+      "summary": "Added a helper that reads route declarations from auth_route_permissions, fails closed where no declaration exists, checks required permissions and avoids exposing missing permission codes unless diagnostics are explicitly requested."
+    },
+    {
+      "id": "007",
+      "title": "Route-permission helper tests",
+      "kind": "test",
+      "status": "created_not_executed_here",
+      "files_changed": ["tests/auth-route-permissions.test.js"],
+      "summary": "Added tests for declared route resolution, missing-route fail-closed behaviour, ordinary denied response redaction, diagnostic missing permission codes and matching-permission allow behaviour."
+    },
+    {
+      "id": "008",
+      "title": "Controlled D1 migration path plan",
+      "kind": "trace_plan",
+      "status": "captured_in_main_trace",
+      "summary": "Recorded the plan to create a manual workflow_dispatch path for applying the D1 auth foundation migration to the remote researchops-d1 database."
+    },
+    {
+      "id": "009",
+      "title": "Controlled D1 migration workflow created",
+      "kind": "implementation",
+      "status": "complete_in_repository_not_run",
+      "files_changed": [".github/workflows/apply-d1-auth-foundation.yml"],
+      "summary": "Added a manual GitHub Actions workflow that requires explicit confirmation inputs and uses Wrangler d1 execute --remote to apply the auth foundation migration, with optional post-apply table and seed checks.",
+      "live_environment_status": "workflow_created_not_run"
+    },
+    {
+      "id": "010",
+      "title": "Route-permission wiring plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md",
+      "summary": "Recorded the plan to wire assertRoutePermission into GET /api/me and GET /api/me/permissions before code changes were made.",
+      "planned_files": ["infra/cloudflare/src/core/auth/access.js", "tests/auth-foundation-route-state.test.js"]
+    },
+    {
+      "id": "011",
+      "title": "Route-permission wiring complete",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md",
+      "files_changed": ["infra/cloudflare/src/core/auth/access.js", "tests/auth-foundation-route-state.test.js"],
+      "summary": "Recorded that identity routes now call assertRoutePermission(request, env, context) after Cloudflare Access identity resolution and that tests assert this wiring."
+    },
+    {
+      "id": "012",
+      "title": "Cloudflare operations documentation plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md",
+      "summary": "Recorded the plan to create operational documentation for Cloudflare Access, D1 binding, workflow inputs, live evidence and rollout controls before writing the documentation."
+    },
+    {
+      "id": "013",
+      "title": "Cloudflare operations documentation complete",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md",
+      "files_changed": ["docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md"],
+      "summary": "Recorded creation of the Cloudflare operations note covering Access runtime values, RESEARCHOPS_D1, researchops-d1, GitHub secrets, D1 workflow inputs, expected tables, seed counts, verification queries, rollout order and evidence requirements."
+    },
+    {
+      "id": "014",
+      "title": "Validation wiring plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
+      "summary": "Recorded the plan to wire authentication tests into scripts/validate.sh before changing the validation contract."
+    },
+    {
+      "id": "015",
+      "title": "Validation wiring complete",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
+      "files_changed": ["scripts/validate.sh"],
+      "summary": "Recorded that scripts/validate.sh now requires and runs tests/auth-foundation-route-state.test.js and tests/auth-route-permissions.test.js."
+    },
+    {
+      "id": "016",
+      "title": "Trace index and JSON plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
+      "files_changed": [
+        "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json",
+        "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md"
+      ],
+      "summary": "Recorded the user correction that the companion JSON trace must be maintained and checkpoint markdown files must be linked from the main trace. This JSON file consolidates checkpoint traces rather than creating individual checkpoint JSON files."
+    }
+  ],
+  "real_d1_requirement": {
+    "migration_file": "infra/cloudflare/migrations/0001_auth_foundation.sql",
+    "manual_workflow": ".github/workflows/apply-d1-auth-foundation.yml",
+    "database_name": "researchops-d1",
+    "worker_binding": "RESEARCHOPS_D1",
+    "status": "repository_path_created_live_execution_not_claimed",
+    "evidence_required_before_claiming_live_tables": [
+      "successful GitHub Actions run for Apply D1 Authentication Foundation",
+      "successful direct Wrangler execution against --remote",
+      "successful Cloudflare API evidence showing auth tables and seed records exist"
+    ]
+  },
+  "validation_status": {
+    "new_tests_created": [
+      "tests/auth-foundation-route-state.test.js",
+      "tests/auth-route-permissions.test.js"
+    ],
+    "new_tests_wired_into_validate": true,
+    "validate_script_executed_here": false,
+    "test_success_claimed": false
+  },
+  "process_deviations": [
+    {
+      "summary": "The Access identity resolver commit exceeded the preferred 300-line atomic diff size from AGENTS.md.",
+      "correction": "Future changes should be split into smaller files and commits, with trace checkpoints before or alongside each change."
+    }
+  ],
+  "residual_risks": [
+    "Cloudflare Access JWT validation depends on environment configuration for certificates and audience.",
+    "The D1 migration has not yet been run in the live environment.",
+    "The route wiring has not yet been validated by executed tests.",
+    "Route-permission helper is only wired into identity routes so far.",
+    "No pull request has been opened for this branch yet."
+  ],
+  "next_candidates": [
+    "Update the main markdown trace with a linked checkpoint index.",
+    "Run or trigger validation through PR CI.",
+    "Open a PR for review and CI execution.",
+    "Apply the D1 migration through the manual workflow after review or explicit release decision.",
+    "Wire route-permission checks into the next protected product endpoint in a narrow slice."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -23,7 +23,8 @@
     "latest_known_ci_failure": "Repeated Prettier formatting warning in tests/auth-route-permissions.test.js",
     "latest_known_ci_failure_fix_committed": true,
     "latest_known_ci_failure_fix_validated_by_ci": false,
-    "temporary_prettier_check_used_for_latest_fix": true
+    "temporary_prettier_check_used_for_latest_fix": true,
+    "repository_level_prettier_write_executed_in_assistant_environment": false
   },
   "selected_bundles": [
     "github-diamond",
@@ -69,8 +70,37 @@
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md"
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md"
     ]
+  },
+  "prettier_investigation": {
+    "reported_file": "tests/auth-route-permissions.test.js",
+    "repository_scripts": {
+      "lint": "prettier -c . && eslint .",
+      "format": "prettier -w .",
+      "format_check": "prettier -c ."
+    },
+    "prettier_version_from_package_json": "^3.6.2",
+    "dedicated_prettier_config_found_by_repository_search": false,
+    "attempted_repository_clone_for_exact_prettier_write": {
+      "attempted": true,
+      "result": "failed",
+      "reason": "container could not resolve github.com"
+    },
+    "file_level_temp_check": {
+      "command": "npx --yes prettier@3.6.2 -c /tmp/auth-route-permissions-v2.test.js",
+      "result": "All matched files use Prettier code style!"
+    },
+    "latest_fix_pattern": {
+      "before": "required_permissions_json: '[\"audit.view\"]',",
+      "after": "required_permissions_json: requiredPermissions(\"audit.view\"),",
+      "helper": "function requiredPermissions(...codes) { return JSON.stringify(codes); }",
+      "reason": "Avoid hand-written escaped JSON string fixtures so Prettier has no quote/escape ambiguity to normalise."
+    }
   },
   "checkpoints": [
     {
@@ -190,7 +220,40 @@
       "status": "complete",
       "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md",
       "files_changed": ["tests/auth-route-permissions.test.js"],
-      "summary": "Recorded that tests/auth-route-permissions.test.js was rewritten to match local Prettier output. A temporary local Prettier check on that file content reported that all matched files use Prettier code style. Repository-level CI confirmation is still pending."
+      "summary": "Recorded that tests/auth-route-permissions.test.js was rewritten to match local Prettier output. A temporary local Prettier check on that file content reported that all matched files use Prettier code style. Repository-level CI later still reported the same file."
+    },
+    {
+      "id": "022",
+      "title": "Escaped JSON lint fix plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md",
+      "summary": "Recorded the repeated Prettier failure and identified escaped inline JSON string fixtures as the remaining fragile pattern."
+    },
+    {
+      "id": "023",
+      "title": "JSON fixture lint fix plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md",
+      "summary": "Planned the resilient correction of replacing inline JSON string fixtures with JSON.stringify through a helper."
+    },
+    {
+      "id": "024",
+      "title": "JSON fixture lint fix complete",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md",
+      "files_changed": ["tests/auth-route-permissions.test.js"],
+      "summary": "Added requiredPermissions(...codes) and replaced inline JSON string fixtures with requiredPermissions calls. This preserves parser input while removing escaped JSON literal formatting ambiguity."
+    },
+    {
+      "id": "025",
+      "title": "Prettier tooling findings",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md",
+      "summary": "Recorded the repository lint scripts, Prettier version, absence of a discovered Prettier config, failed repository clone attempt, file-level Prettier check, latest helper-based fix pattern and draft prevention rule for future instructions."
     }
   ],
   "real_d1_requirement": {
@@ -214,10 +277,19 @@
     "latest_lint_failure_confirmed_fixed_by_ci": false,
     "latest_file_level_prettier_check_on_temp_copy_passed": true
   },
+  "prevention_rule_candidate_after_ci_confirmation": {
+    "rule": "Do not hand-write escaped JSON fixtures in JavaScript tests where the target code expects a JSON string. Use JSON.stringify through a named helper, then run npm run format or npx prettier --write <file> before committing.",
+    "example_helper": "function requiredPermissions(...codes) { return JSON.stringify(codes); }",
+    "example_usage": "required_permissions_json: requiredPermissions(\"audit.view\"),"
+  },
   "process_deviations": [
     {
       "summary": "The Access identity resolver commit exceeded the preferred 300-line atomic diff size from AGENTS.md.",
       "correction": "Future changes should be split into smaller files and commits, with trace checkpoints before or alongside each change."
+    },
+    {
+      "summary": "Repeated formatting fixes were attempted without repository-level Prettier --write execution against a branch checkout.",
+      "correction": "For future formatting failures, prefer running npm run format or npx prettier --write <file> in a real repository checkout before committing; if tool access cannot do that, record the boundary and avoid claiming repository-level formatting success."
     }
   ],
   "residual_risks": [
@@ -225,12 +297,13 @@
     "The D1 migration has not yet been run in the live environment.",
     "The route wiring has not yet been validated by executed tests.",
     "Route-permission helper is only wired into identity routes so far.",
-    "The latest lint fix still needs CI confirmation."
+    "The latest lint fix still needs repository-level CI confirmation."
   ],
   "next_candidates": [
     "Wait for PR CI to rerun and inspect any new failure.",
+    "If Prettier still fails, obtain exact Prettier write diff from CI or run npm run format in a repository checkout and commit the resulting file.",
+    "After CI confirms the fix, create permanent repository guidance based on checkpoint 025.",
     "Apply the D1 migration through the manual workflow after review or explicit release decision.",
-    "Wire route-permission checks into the next protected product endpoint in a narrow slice.",
-    "Continue role-management UI and role-assignment API in separate slices."
+    "Wire route-permission checks into the next protected product endpoint in a narrow slice."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -1,266 +1,132 @@
 {
-  "trace_id": "atrace-20260508-authentication-role-selection-real-implementation",
-  "trace_layer": "operational",
-  "trigger_token_detected": "[reasoning]",
-  "date": "2026-05-08",
-  "repository": "kevinrapley/ResearchOps",
-  "active_branch": "feature/auth-foundation-real-d1-current-main",
-  "base_branch": "main",
-  "base_commit_at_branch_creation": "8305adeed3b7e4047f132bc8c50347ce47e6205f",
-  "pull_request": {
-    "number": 215,
-    "url": "https://github.com/kevinrapley/ResearchOps/pull/215",
-    "state": "open"
-  },
-  "status": {
-    "repository_migration_created": true,
-    "manual_d1_apply_workflow_created": true,
-    "live_d1_migration_applied": false,
-    "pull_request_opened": true,
-    "latest_known_ci_failure": "Repeated Prettier formatting warning in tests/auth-route-permissions.test.js",
-    "latest_known_ci_failure_fix_committed": true,
-    "latest_known_ci_failure_fix_validated_by_ci": false,
-    "root_cause_identified": true,
-    "root_cause": "Prettier reads repository .editorconfig by default. The repository requires tab indentation via indent_style = tab, while earlier temporary file checks were outside the repository tree and used Prettier space defaults.",
-    "repository_level_prettier_write_executed_in_assistant_environment": false,
-    "prettier_write_simulated_with_repository_editorconfig": true
-  },
-  "changed_files": {
-    "implementation": [
-      ".github/workflows/apply-d1-auth-foundation.yml",
-      "infra/cloudflare/migrations/0001_auth_foundation.sql",
-      "infra/cloudflare/src/core/auth/access.js",
-      "infra/cloudflare/src/core/auth/route-permissions.js",
-      "infra/cloudflare/src/worker.js",
-      "scripts/validate.sh",
-      "tests/auth-foundation-route-state.test.js",
-      "tests/auth-route-permissions.test.js"
-    ],
-    "product_documentation": [
-      "docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md"
-    ],
-    "trace_files": [
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md"
-    ]
-  },
-  "prettier_investigation": {
-    "reported_file": "tests/auth-route-permissions.test.js",
-    "repository_scripts": {
-      "lint": "prettier -c . && eslint .",
-      "format": "prettier -w .",
-      "format_check": "prettier -c ."
-    },
-    "prettier_version_from_package_json": "^3.6.2",
-    "repository_editorconfig": {
-      "path": ".editorconfig",
-      "indent_style": "tab",
-      "indent_size": "2",
-      "effect": "Prettier reads .editorconfig by default, so JavaScript files are expected to use tab indentation in this repository."
-    },
-    "failed_local_method": {
-      "description": "Temporary file-level checks outside the repository tree passed incorrectly because the repository .editorconfig was absent.",
-      "lesson": "Run Prettier from the repository root or with a matching .editorconfig."
-    },
-    "correct_reproduction": {
-      "steps": [
-        "Place .editorconfig beside the test file in a temporary repository tree.",
-        "Run npx --yes prettier@3.6.2 -c tests/auth-route-permissions.test.js.",
-        "The check fails when the file uses spaces.",
-        "Run npx --yes prettier@3.6.2 --write tests/auth-route-permissions.test.js.",
-        "The written output uses tabs and then passes Prettier."
-      ]
-    },
-    "exact_fix": {
-      "file": "tests/auth-route-permissions.test.js",
-      "change": "Replace space indentation with repository Prettier output using tab indentation.",
-      "before_example": "import {\n  assertRoutePermission,\n  resolveRoutePermissionDeclaration,\n  routePermissionErrorResponse,\n} from \"../infra/cloudflare/src/core/auth/route-permissions.js\";",
-      "after_example": "import {\n\tassertRoutePermission,\n\tresolveRoutePermissionDeclaration,\n\troutePermissionErrorResponse,\n} from \"../infra/cloudflare/src/core/auth/route-permissions.js\";",
-      "behavioural_impact": "none"
-    },
-    "copilot_workflow_suggestion_assessment": {
-      "suggestion": "Add npx prettier --write . before lint in CI.",
-      "decision": "Do not use as the primary validation fix.",
-      "reason": "CI should detect formatting drift rather than silently mutating the runner workspace. A --write step does not commit the result back to the branch."
-    }
-  },
-  "checkpoints": [
-    {
-      "id": "001",
-      "title": "D1 auth foundation migration",
-      "status": "complete_in_repository_not_applied_to_live_d1",
-      "files_changed": ["infra/cloudflare/migrations/0001_auth_foundation.sql"]
-    },
-    {
-      "id": "002",
-      "title": "Cloudflare Access identity resolver",
-      "status": "complete_in_repository",
-      "files_changed": ["infra/cloudflare/src/core/auth/access.js"]
-    },
-    {
-      "id": "003",
-      "title": "Worker route wiring",
-      "status": "complete_in_repository",
-      "files_changed": ["infra/cloudflare/src/worker.js"]
-    },
-    {
-      "id": "004",
-      "title": "Authentication foundation route-state tests",
-      "status": "created_not_executed_here",
-      "files_changed": ["tests/auth-foundation-route-state.test.js"]
-    },
-    {
-      "id": "006",
-      "title": "Route-permission helper created",
-      "status": "complete_in_repository",
-      "files_changed": ["infra/cloudflare/src/core/auth/route-permissions.js"]
-    },
-    {
-      "id": "007",
-      "title": "Route-permission helper tests",
-      "status": "created_not_executed_here",
-      "files_changed": ["tests/auth-route-permissions.test.js"]
-    },
-    {
-      "id": "009",
-      "title": "Controlled D1 migration workflow created",
-      "status": "complete_in_repository_not_run",
-      "files_changed": [".github/workflows/apply-d1-auth-foundation.yml"]
-    },
-    {
-      "id": "011",
-      "title": "Route-permission wiring complete",
-      "status": "complete",
-      "files_changed": ["infra/cloudflare/src/core/auth/access.js", "tests/auth-foundation-route-state.test.js"]
-    },
-    {
-      "id": "013",
-      "title": "Cloudflare operations documentation complete",
-      "status": "complete",
-      "files_changed": ["docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md"]
-    },
-    {
-      "id": "015",
-      "title": "Validation wiring complete",
-      "status": "complete",
-      "files_changed": ["scripts/validate.sh"]
-    },
-    {
-      "id": "018",
-      "title": "Route-permission test lint fix plan",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md"
-    },
-    {
-      "id": "019",
-      "title": "Route-permission test lint fix complete",
-      "status": "superseded_by_027",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md"
-    },
-    {
-      "id": "020",
-      "title": "Route-permission test lint fix rerun plan",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md"
-    },
-    {
-      "id": "021",
-      "title": "Route-permission test lint fix rerun complete",
-      "status": "superseded_by_027",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md"
-    },
-    {
-      "id": "022",
-      "title": "Escaped JSON lint fix plan",
-      "status": "superseded_by_026",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md"
-    },
-    {
-      "id": "023",
-      "title": "JSON fixture lint fix plan",
-      "status": "superseded_by_026",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md"
-    },
-    {
-      "id": "024",
-      "title": "JSON fixture lint fix complete",
-      "status": "partially_retained_fixture_improvement_but_not_root_format_fix",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md"
-    },
-    {
-      "id": "025",
-      "title": "Prettier tooling findings",
-      "status": "superseded_by_026_and_027",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md"
-    },
-    {
-      "id": "026",
-      "title": "Prettier root cause plan",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md",
-      "summary": "Identified .editorconfig tab indentation as the true root cause and rejected CI auto-formatting as the primary validation fix."
-    },
-    {
-      "id": "027",
-      "title": "Prettier root cause fix complete",
-      "status": "committed_pending_ci_confirmation",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md",
-      "files_changed": ["tests/auth-route-permissions.test.js"],
-      "summary": "Applied the repository Prettier output with tab indentation to tests/auth-route-permissions.test.js. No behavioural test change."
-    }
-  ],
-  "real_d1_requirement": {
-    "migration_file": "infra/cloudflare/migrations/0001_auth_foundation.sql",
-    "manual_workflow": ".github/workflows/apply-d1-auth-foundation.yml",
-    "database_name": "researchops-d1",
-    "worker_binding": "RESEARCHOPS_D1",
-    "status": "repository_path_created_live_execution_not_claimed"
-  },
-  "validation_status": {
-    "new_tests_created": ["tests/auth-foundation-route-state.test.js", "tests/auth-route-permissions.test.js"],
-    "new_tests_wired_into_validate": true,
-    "validate_script_executed_here": false,
-    "test_success_claimed": false,
-    "latest_lint_failure_fixed_in_repository": true,
-    "latest_lint_failure_confirmed_fixed_by_ci": false,
-    "latest_root_cause_fixed_by_tab_indentation": true
-  },
-  "prevention_rule_candidate_after_ci_confirmation": {
-    "rule": "Run Prettier from the repository root so it reads .editorconfig. Do not rely on temporary standalone file checks outside the repository tree. JavaScript files inherit indent_style = tab from .editorconfig unless a file-specific override is added.",
-    "commands": [
-      "npm run format",
-      "npx prettier --write tests/auth-route-permissions.test.js",
-      "npm run format:check"
-    ],
-    "do_not": "Do not add prettier --write . as a normal pre-lint step in CI. CI should detect formatting drift; developers or automation should commit formatted output before lint runs."
-  },
-  "process_deviations": [
-    {
-      "summary": "Repeated formatting fixes were attempted without repository-root Prettier context.",
-      "correction": "For future formatting failures, run Prettier from a real repository root or reproduce .editorconfig beside the target file before committing."
-    }
-  ],
-  "residual_risks": [
-    "The latest lint fix still needs repository-level CI confirmation.",
-    "The D1 migration has not yet been run in the live environment.",
-    "Route-permission helper is only wired into identity routes so far."
-  ]
+	"trace_id": "atrace-20260508-authentication-role-selection-real-implementation",
+	"trace_layer": "operational",
+	"trigger_token_detected": "[reasoning]",
+	"date": "2026-05-08",
+	"repository": "kevinrapley/ResearchOps",
+	"active_branch": "feature/auth-foundation-real-d1-current-main",
+	"pull_request": {
+		"number": 215,
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/215",
+		"state": "open"
+	},
+	"status": {
+		"repository_migration_created": true,
+		"manual_d1_apply_workflow_created": true,
+		"live_d1_migration_applied": false,
+		"pull_request_opened": true,
+		"prettier_root_cause_identified": true,
+		"prettier_root_cause": "Prettier reads repository .editorconfig by default. The repository requires tab indentation via indent_style = tab, while earlier temporary file checks were outside the repository tree and used Prettier space defaults.",
+		"format_automation_implemented": true,
+		"latest_format_automation_ci_confirmed": false
+	},
+	"changed_files": {
+		"implementation": [
+			".github/workflows/apply-d1-auth-foundation.yml",
+			".github/workflows/format-branch.yml",
+			".github/workflows/format-pr.yml",
+			"infra/cloudflare/migrations/0001_auth_foundation.sql",
+			"infra/cloudflare/src/core/auth/access.js",
+			"infra/cloudflare/src/core/auth/route-permissions.js",
+			"infra/cloudflare/src/worker.js",
+			"prettier.config.mjs",
+			"scripts/validate.sh",
+			"tests/auth-foundation-route-state.test.js",
+			"tests/auth-route-permissions.test.js"
+		],
+		"product_documentation": [
+			"docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md"
+		],
+		"trace_files": [
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-028-format-automation-plan.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-029-format-automation-complete.md"
+		]
+	},
+	"prettier_automation": {
+		"explicit_config": {
+			"file": "prettier.config.mjs",
+			"content": "export default { useTabs: true, tabWidth: 2, endOfLine: \"lf\" };",
+			"purpose": "Make the formatting contract visible rather than relying only on .editorconfig."
+		},
+		"strict_check_workflow": {
+			"file": ".github/workflows/format-pr.yml",
+			"behaviour": "Run Prettier check. If it fails, run Prettier write in the runner, print the resulting git diff, upload prettier-fix.patch, then fail the workflow.",
+			"reason": "Future failures show the exact patch rather than only the filename."
+		},
+		"manual_repair_workflow": {
+			"file": ".github/workflows/format-branch.yml",
+			"trigger": "workflow_dispatch",
+			"behaviour": "Check out a named branch, run npm run format, commit and push formatting changes only when there is a diff.",
+			"reason": "Provides a controlled rescue path that commits exact Prettier output to the branch."
+		},
+		"ci_decision": {
+			"normal_lint_stays_strict": true,
+			"do_not_silently_run_prettier_write_before_lint": true,
+			"reason": "CI should detect formatting drift. Repair automation must commit exact output to the branch."
+		}
+	},
+	"checkpoints": [
+		{
+			"id": "026",
+			"title": "Prettier root cause plan",
+			"status": "complete",
+			"summary": "Identified .editorconfig tab indentation as the true root cause and rejected CI auto-formatting as the primary validation fix."
+		},
+		{
+			"id": "027",
+			"title": "Prettier root cause fix complete",
+			"status": "committed_pending_ci_confirmation",
+			"files_changed": ["tests/auth-route-permissions.test.js"],
+			"summary": "Applied repository Prettier output with tab indentation to tests/auth-route-permissions.test.js."
+		},
+		{
+			"id": "028",
+			"title": "Format automation plan",
+			"status": "complete",
+			"summary": "Planned explicit Prettier config, diagnostic PR formatting workflow, and manual branch formatting workflow."
+		},
+		{
+			"id": "029",
+			"title": "Format automation complete",
+			"status": "committed_pending_ci_confirmation",
+			"files_changed": [
+				"prettier.config.mjs",
+				".github/workflows/format-pr.yml",
+				".github/workflows/format-branch.yml"
+			],
+			"summary": "Implemented the automation path: explicit Prettier tab config, exact patch output on PR formatting failure, and manual format-and-commit workflow."
+		}
+	],
+	"real_d1_requirement": {
+		"migration_file": "infra/cloudflare/migrations/0001_auth_foundation.sql",
+		"manual_workflow": ".github/workflows/apply-d1-auth-foundation.yml",
+		"database_name": "researchops-d1",
+		"worker_binding": "RESEARCHOPS_D1",
+		"status": "repository_path_created_live_execution_not_claimed"
+	},
+	"residual_risks": [
+		"The latest format automation still needs repository-level CI confirmation.",
+		"The D1 migration has not yet been run in the live environment.",
+		"Route-permission helper is only wired into identity routes so far."
+	]
 }

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -20,9 +20,10 @@
     "validation_executed_in_this_environment": false,
     "pull_request_opened": true,
     "pr_readiness_checked": true,
-    "latest_known_ci_failure": "Prettier formatting warning in tests/auth-route-permissions.test.js",
+    "latest_known_ci_failure": "Repeated Prettier formatting warning in tests/auth-route-permissions.test.js",
     "latest_known_ci_failure_fix_committed": true,
-    "latest_known_ci_failure_fix_validated_by_ci": false
+    "latest_known_ci_failure_fix_validated_by_ci": false,
+    "temporary_prettier_check_used_for_latest_fix": true
   },
   "selected_bundles": [
     "github-diamond",
@@ -66,16 +67,10 @@
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md"
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md"
     ]
-  },
-  "branch_comparison": {
-    "base": "main",
-    "head": "feature/auth-foundation-real-d1-current-main",
-    "status": "ahead",
-    "ahead_by_after_lint_fix": 34,
-    "behind_by_after_lint_fix": 0,
-    "base_commit": "8305adeed3b7e4047f132bc8c50347ce47e6205f"
   },
   "checkpoints": [
     {
@@ -93,8 +88,7 @@
       "kind": "implementation",
       "status": "complete_in_repository",
       "files_changed": ["infra/cloudflare/src/core/auth/access.js"],
-      "summary": "Added a real Cloudflare Access identity resolver that reads Cf-Access-Jwt-Assertion, validates Access JWT structure, signature, expiry and audience, maps the provider identity to a ResearchOps D1 user, and returns active team, roles and permissions.",
-      "non_goals": ["No mock identity behaviour", "No password authentication", "No role-management UI", "No Airtable schema change"]
+      "summary": "Added a real Cloudflare Access identity resolver that reads Cf-Access-Jwt-Assertion, validates Access JWT structure, signature, expiry and audience, maps the provider identity to a ResearchOps D1 user, and returns active team, roles and permissions."
     },
     {
       "id": "003",
@@ -113,13 +107,6 @@
       "summary": "Added tests for identity route fail-closed behaviour, Worker route wiring, absence of mock identity mode, route-permission wiring and D1 migration structure."
     },
     {
-      "id": "005",
-      "title": "Route-permission helper plan",
-      "kind": "trace_plan",
-      "status": "captured_in_main_trace",
-      "summary": "Recorded the plan to add a D1-backed route-permission helper before creating the helper."
-    },
-    {
       "id": "006",
       "title": "Route-permission helper created",
       "kind": "implementation",
@@ -136,13 +123,6 @@
       "summary": "Added tests for declared route resolution, missing-route fail-closed behaviour, ordinary denied response redaction, diagnostic missing permission codes and matching-permission allow behaviour."
     },
     {
-      "id": "008",
-      "title": "Controlled D1 migration path plan",
-      "kind": "trace_plan",
-      "status": "captured_in_main_trace",
-      "summary": "Recorded the plan to create a manual workflow_dispatch path for applying the D1 auth foundation migration to the remote researchops-d1 database."
-    },
-    {
       "id": "009",
       "title": "Controlled D1 migration workflow created",
       "kind": "implementation",
@@ -150,14 +130,6 @@
       "files_changed": [".github/workflows/apply-d1-auth-foundation.yml"],
       "summary": "Added a manual GitHub Actions workflow that requires explicit confirmation inputs and uses Wrangler d1 execute --remote to apply the auth foundation migration, with optional post-apply table and seed checks.",
       "live_environment_status": "workflow_created_not_run"
-    },
-    {
-      "id": "010",
-      "title": "Route-permission wiring plan",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md",
-      "summary": "Recorded the plan to wire assertRoutePermission into GET /api/me and GET /api/me/permissions before code changes were made."
     },
     {
       "id": "011",
@@ -169,14 +141,6 @@
       "summary": "Recorded that identity routes now call assertRoutePermission(request, env, context) after Cloudflare Access identity resolution and that tests assert this wiring."
     },
     {
-      "id": "012",
-      "title": "Cloudflare operations documentation plan",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md",
-      "summary": "Recorded the plan to create operational documentation for Cloudflare Access, D1 binding, workflow inputs, live evidence and rollout controls before writing the documentation."
-    },
-    {
       "id": "013",
       "title": "Cloudflare operations documentation complete",
       "kind": "trace_checkpoint",
@@ -186,14 +150,6 @@
       "summary": "Recorded creation of the Cloudflare operations note covering Access runtime values, RESEARCHOPS_D1, researchops-d1, GitHub secrets, D1 workflow inputs, expected tables, seed counts, verification queries, rollout order and evidence requirements."
     },
     {
-      "id": "014",
-      "title": "Validation wiring plan",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
-      "summary": "Recorded the plan to wire authentication tests into scripts/validate.sh before changing the validation contract."
-    },
-    {
       "id": "015",
       "title": "Validation wiring complete",
       "kind": "trace_checkpoint",
@@ -201,23 +157,6 @@
       "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
       "files_changed": ["scripts/validate.sh"],
       "summary": "Recorded that scripts/validate.sh now requires and runs tests/auth-foundation-route-state.test.js and tests/auth-route-permissions.test.js."
-    },
-    {
-      "id": "016",
-      "title": "Trace index and JSON plan",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
-      "files_changed": ["docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json", "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md"],
-      "summary": "Recorded the user correction that the companion JSON trace must be maintained and checkpoint markdown files must be linked from the main trace. This JSON file consolidates checkpoint traces rather than creating individual checkpoint JSON files."
-    },
-    {
-      "id": "017",
-      "title": "PR readiness plan",
-      "kind": "trace_checkpoint",
-      "status": "complete",
-      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
-      "summary": "Recorded branch comparison before opening a pull request. The branch was ahead of main by 29 commits and behind by 0 before PR creation."
     },
     {
       "id": "018",
@@ -234,7 +173,24 @@
       "status": "complete",
       "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
       "files_changed": ["tests/auth-route-permissions.test.js"],
-      "summary": "Recorded that the long assertRoutePermission call in tests/auth-route-permissions.test.js was reformatted for Prettier. No test behaviour was changed. CI has not yet confirmed the fix."
+      "summary": "Recorded that the long assertRoutePermission call in tests/auth-route-permissions.test.js was reformatted for Prettier. CI later showed another Prettier formatting change remained."
+    },
+    {
+      "id": "020",
+      "title": "Route-permission test lint fix rerun plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md",
+      "summary": "Recorded the repeated CI Prettier failure in tests/auth-route-permissions.test.js and identified the remaining long assertRoutePermission call in assertMissingRouteFailsClosed."
+    },
+    {
+      "id": "021",
+      "title": "Route-permission test lint fix rerun complete",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md",
+      "files_changed": ["tests/auth-route-permissions.test.js"],
+      "summary": "Recorded that tests/auth-route-permissions.test.js was rewritten to match local Prettier output. A temporary local Prettier check on that file content reported that all matched files use Prettier code style. Repository-level CI confirmation is still pending."
     }
   ],
   "real_d1_requirement": {
@@ -255,7 +211,8 @@
     "validate_script_executed_here": false,
     "test_success_claimed": false,
     "latest_lint_failure_fixed_in_repository": true,
-    "latest_lint_failure_confirmed_fixed_by_ci": false
+    "latest_lint_failure_confirmed_fixed_by_ci": false,
+    "latest_file_level_prettier_check_on_temp_copy_passed": true
   },
   "process_deviations": [
     {

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -13,7 +13,8 @@
     "manual_d1_apply_workflow_created": true,
     "live_d1_migration_applied": false,
     "validation_executed_in_this_environment": false,
-    "pull_request_opened": false
+    "pull_request_opened": false,
+    "pr_readiness_checked": true
   },
   "user_direction": [
     {
@@ -80,8 +81,17 @@
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
       "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
-      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md"
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
+      "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md"
     ]
+  },
+  "branch_comparison": {
+    "base": "main",
+    "head": "feature/auth-foundation-real-d1-current-main",
+    "status": "ahead",
+    "ahead_by": 29,
+    "behind_by": 0,
+    "base_commit": "8305adeed3b7e4047f132bc8c50347ce47e6205f"
   },
   "checkpoints": [
     {
@@ -232,6 +242,19 @@
         "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md"
       ],
       "summary": "Recorded the user correction that the companion JSON trace must be maintained and checkpoint markdown files must be linked from the main trace. This JSON file consolidates checkpoint traces rather than creating individual checkpoint JSON files."
+    },
+    {
+      "id": "017",
+      "title": "PR readiness plan",
+      "kind": "trace_checkpoint",
+      "status": "complete",
+      "checkpoint_file": "docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
+      "summary": "Recorded branch comparison before opening a pull request. The branch is ahead of main by 29 commits and behind by 0. The planned PR must state that live D1 has not been migrated and that validation has not been executed in this environment.",
+      "branch_comparison": {
+        "ahead_by": 29,
+        "behind_by": 0,
+        "base_commit": "8305adeed3b7e4047f132bc8c50347ce47e6205f"
+      }
     }
   ],
   "real_d1_requirement": {
@@ -269,10 +292,10 @@
     "No pull request has been opened for this branch yet."
   ],
   "next_candidates": [
-    "Update the main markdown trace with a linked checkpoint index.",
-    "Run or trigger validation through PR CI.",
+    "Update the main markdown trace with checkpoint 017.",
     "Open a PR for review and CI execution.",
     "Apply the D1 migration through the manual workflow after review or explicit release decision.",
-    "Wire route-permission checks into the next protected product endpoint in a narrow slice."
+    "Wire route-permission checks into the next protected product endpoint in a narrow slice.",
+    "Continue role-management UI and role-assignment API in separate slices."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -84,13 +84,13 @@ Skip rationale:
 
 ## Files changed so far on this branch
 
-Current branch comparison against `main` shows three changed files:
+Current implementation files created or modified:
 
 - `infra/cloudflare/migrations/0001_auth_foundation.sql`
 - `infra/cloudflare/src/core/auth/access.js`
 - `infra/cloudflare/src/worker.js`
-
-No test file has been created yet. A check for `tests/auth-foundation-route-state.test.js` returned not found.
+- `tests/auth-foundation-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 
 ## Implementation checkpoint 1: D1 auth foundation migration
 
@@ -158,15 +158,38 @@ Purpose:
 - Route `GET /api/me` and `GET /api/me/permissions` through the real Cloudflare Access identity resolver.
 - Add `X-ResearchOps-Team-Id` to allowed request headers so an authenticated user can select an active team context.
 
+## Implementation checkpoint 4: Auth foundation route tests
+
+File created:
+
+- `tests/auth-foundation-route-state.test.js`
+
+Purpose:
+
+- Confirm the identity routes fail closed without `Cf-Access-Jwt-Assertion`.
+- Confirm Worker route wiring sends `/api/me` and `/api/me/permissions` through `core/auth/access.js`.
+- Confirm no mock identity mode exists in `core/auth/access.js`.
+- Confirm the D1 migration contains the required control-plane tables, scoped role fields and reserved permissions.
+
+Test coverage currently asserted:
+
+- `GET /api/me` returns `401` without an Access JWT.
+- `GET /api/me/permissions` returns `401` without an Access JWT.
+- Worker source imports and routes to `handleMeRoute`.
+- Auth resolver source contains no `RESEARCHOPS_AUTH_MODE`, `MOCK` or `mock` identity branch.
+- Migration contains required auth control-plane tables.
+- Migration contains `scope_type`, `scope_id`, `safeguarding.audit.view`, `audit.export` and `participant.pii.export`.
+
 ## Trace governance correction
 
 The user raised a valid governance concern that trace records were not being continuously updated as implementation proceeded.
 
 Correction now applied:
 
-- this trace checkpoint has been created on the active implementation branch
+- this trace checkpoint exists on the active implementation branch
+- the test file was created only after the first trace checkpoint was recorded
+- this trace was updated immediately after the test file was created
 - future implementation steps must update this trace before or alongside code changes
-- test file creation has been paused until this trace checkpoint exists
 - future responses should report both implementation progress and trace updates
 
 ## Process issue recorded
@@ -184,23 +207,23 @@ Correction for future steps:
 - update this trace as each implementation step completes
 - do not batch large design and code changes without a trace checkpoint
 
-## Pending next step
-
-The user asked to keep the planned test file in memory before creation:
-
-- `tests/auth-foundation-route-state.test.js`
-
-The intended test file should verify:
-
-- `/api/me` fails closed without `Cf-Access-Jwt-Assertion`
-- `/api/me/permissions` fails closed without `Cf-Access-Jwt-Assertion`
-- Worker routes identity endpoints through the Access resolver
-- no mock identity mode exists in the auth resolver
-- the D1 migration contains the required control-plane tables and scoped role fields
-
 ## Validation not yet claimed
 
 No local lint, format, typecheck, test or build result is claimed at this checkpoint.
+
+The new test file has been created but not yet executed in this environment.
+
+## Pending next steps
+
+The next implementation slice should be small and trace-updated before or alongside changes.
+
+Candidate next steps:
+
+- run or reason-check the new test route file if tool access allows
+- add route-permission middleware as a small separate module
+- add route-permission tests for fail-closed behaviour
+- document environment variables required for Cloudflare Access JWT validation
+- consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit
 
 ## Residual risks
 

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -27,42 +27,10 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 - Live D1 migration has not been applied.
 - Repository migration and manual D1 workflow exist.
 - Authentication tests are wired into `npm run validate`.
-- CI reported a Prettier formatting failure in `tests/auth-route-permissions.test.js`.
-- A formatting-only fix has been committed.
-- CI has not yet confirmed that the formatting fix passes.
-
-## User task summary
-
-The user asked to begin systematically building authentication role selection into the application using all captured documentation.
-
-The user corrected the course by stating that this must not be a mock implementation. The work was restarted from current `main` on `feature/auth-foundation-real-d1-current-main`.
-
-The user required continuous `[reasoning]` trace updates during the build and clarified that the work must systematically build the real authentication role-selection capability, including D1 table creation and seeding where necessary.
-
-The user clarified that Cloudflare APIs are in scope and provided Cloudflare Developer Platform and Cloudflare Agents Workbench bundles.
-
-The user then clarified that this main markdown trace must link to checkpoint markdown files and that the companion JSON trace must be maintained as one consolidated JSON record.
-
-## Operating-model sources loaded
-
-Repository operating-model sources loaded during this workstream:
-
-- `AGENTS.md`
-- `.agent-operating-model/orchestration.xml`
-- `.agent-operating-model/bundle-registry.json`
-- `.agent-operating-model/task-signal-catalog.json`
-- `.agent-operating-model/selection-rules.json`
-- `.agent-operating-model/bootstrap-checklist.md`
-- `.agent-operating-model/precedence-policy.md`
-- `.agent-operating-model/trace-policy.md`
-- `.agent-operating-model/trace-layers.md`
-- `.agent-operating-model/behavioural-evals.json`
-- `docs/devops/ResearchOps-Bundle-Setup.zip`
-
-Uploaded Cloudflare bundle files inspected:
-
-- `/mnt/data/cloudflare-developer-platform-bundle.zip`
-- `/mnt/data/cloudflare-agents-workbench.zip`
+- CI reported repeated Prettier formatting failures in `tests/auth-route-permissions.test.js`.
+- A second formatting-only fix has been committed.
+- A temporary local Prettier check on the file content reported: `All matched files use Prettier code style!`
+- Repository-level CI has not yet confirmed the fix.
 
 ## Checkpoint index
 
@@ -78,6 +46,8 @@ Uploaded Cloudflare bundle files inspected:
 | 017 | [`authentication-role-selection-checkpoint-017-pr-readiness-plan.md`](authentication-role-selection-checkpoint-017-pr-readiness-plan.md) | Complete |
 | 018 | [`authentication-role-selection-checkpoint-018-lint-fix-plan.md`](authentication-role-selection-checkpoint-018-lint-fix-plan.md) | Complete |
 | 019 | [`authentication-role-selection-checkpoint-019-lint-fix-complete.md`](authentication-role-selection-checkpoint-019-lint-fix-complete.md) | Complete |
+| 020 | [`authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md`](authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md) | Complete |
+| 021 | [`authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md`](authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md) | Complete |
 
 ## Files changed so far on this branch
 
@@ -100,7 +70,7 @@ Agent trace files:
 
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- checkpoint markdown files 010 to 019
+- checkpoint markdown files 010 to 021
 
 ## Implementation checkpoints
 
@@ -306,6 +276,37 @@ File changed:
 Purpose:
 
 - Reformat a long `assertRoutePermission` call to satisfy Prettier.
+- CI later showed another Prettier formatting change remained.
+
+### Checkpoint 20: route-permission test lint fix rerun plan
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md`](authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md)
+
+Reported failure:
+
+- `./node_modules/.bin/prettier -c .` again reported `tests/auth-route-permissions.test.js`.
+
+Purpose:
+
+- Record the repeated Prettier failure.
+- Identify the remaining long `assertRoutePermission` call in `assertMissingRouteFailsClosed`.
+
+### Checkpoint 21: route-permission test lint fix rerun complete
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md`](authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md)
+
+File changed:
+
+- `tests/auth-route-permissions.test.js`
+
+Purpose:
+
+- Rewrite `tests/auth-route-permissions.test.js` to match local Prettier output.
+- Record that a temporary file-level Prettier check reported `All matched files use Prettier code style!`.
 - No test behaviour was changed.
 
 ## Real D1 implementation requirement
@@ -323,8 +324,10 @@ Required next implementation controls:
 ## Validation status
 
 - Initial CI lint failed on Prettier formatting in `tests/auth-route-permissions.test.js`.
-- A formatting-only fix has been committed.
-- CI has not yet confirmed that the fix passes.
+- CI repeated the Prettier formatting failure for the same file.
+- A second formatting-only fix has been committed.
+- A temporary file-level Prettier check on the file content passed.
+- CI has not yet confirmed that the repository-level check passes.
 - No live D1 migration has been run.
 
 ## Process issue recorded
@@ -357,4 +360,4 @@ Candidate next steps:
 - Cloudflare Access JWT validation depends on environment configuration for Access certificates and audience.
 - The D1 migration has not yet been run in the live environment.
 - Route-permission helper is only wired into identity routes so far.
-- The latest lint fix still needs CI confirmation.
+- The latest lint fix still needs repository-level CI confirmation.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -180,6 +180,26 @@ Test coverage currently asserted:
 - Migration contains required auth control-plane tables.
 - Migration contains `scope_type`, `scope_id`, `safeguarding.audit.view`, `audit.export` and `participant.pii.export`.
 
+## Implementation checkpoint 5: route-permission middleware plan
+
+Next planned file:
+
+- `infra/cloudflare/src/core/auth/route-permissions.js`
+
+Purpose:
+
+- Add a small real authorisation helper that reads declared route permissions from D1.
+- Fail closed when a protected route has no declaration.
+- Deny access where the authenticated context lacks a required permission.
+- Avoid exposing missing permission codes to ordinary users.
+
+Boundary for this step:
+
+- Do not wire the helper into every existing product route yet.
+- Do not create mock users or mock roles.
+- Do not change Airtable behaviour yet.
+- Keep the slice small and testable.
+
 ## Trace governance correction
 
 The user raised a valid governance concern that trace records were not being continuously updated as implementation proceeded.
@@ -189,6 +209,7 @@ Correction now applied:
 - this trace checkpoint exists on the active implementation branch
 - the test file was created only after the first trace checkpoint was recorded
 - this trace was updated immediately after the test file was created
+- the route-permission middleware plan has been recorded before creating that file
 - future implementation steps must update this trace before or alongside code changes
 - future responses should report both implementation progress and trace updates
 
@@ -219,8 +240,7 @@ The next implementation slice should be small and trace-updated before or alongs
 
 Candidate next steps:
 
-- run or reason-check the new test route file if tool access allows
-- add route-permission middleware as a small separate module
+- create `infra/cloudflare/src/core/auth/route-permissions.js`
 - add route-permission tests for fail-closed behaviour
 - document environment variables required for Cloudflare Access JWT validation
 - consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -23,6 +23,8 @@ The user then raised a trace governance concern: trace records must be continuou
 
 The user then clarified that the work must not become trace-only or document-only. It must systematically build the real authentication role-selection capability, including D1 table creation and seeding where necessary.
 
+The user then clarified that Cloudflare APIs are in scope for this build and provided Cloudflare Developer Platform and Cloudflare Agents Workbench bundles.
+
 ## Operating-model sources loaded before repository-affecting work
 
 The repository operating model had already been loaded during this workstream from the following files:
@@ -39,6 +41,31 @@ The repository operating model had already been loaded during this workstream fr
 - `.agent-operating-model/behavioural-evals.json`
 - `docs/devops/ResearchOps-Bundle-Setup.zip`
 
+## Additional Cloudflare bundle sources loaded
+
+Uploaded bundle files inspected during this implementation:
+
+- `/mnt/data/cloudflare-developer-platform-bundle.zip`
+- `/mnt/data/cloudflare-agents-workbench.zip`
+
+Relevant bundle materials inspected:
+
+- `cloudflare-developer-platform-bundle/prompt.body.xml`
+- `cloudflare-developer-platform-bundle/domains/state-and-data-domain.xml`
+- `cloudflare-developer-platform-bundle/references/cloudflare-product-surface-reference.xml`
+- `cloudflare-developer-platform-bundle/workflows/implementation-phasing-workflow.xml`
+- `cloudflare-agents-workbench/prompt.body.xml`
+- `cloudflare-agents-workbench/policies/non-invented-api-policy.xml`
+- `cloudflare-agents-workbench/policies/freshness-and-citation-policy.xml`
+
+Cloudflare bundle implications for this slice:
+
+- D1 is the selected relational control-plane store for native Cloudflare-hosted application data.
+- Workers remain the server-side policy enforcement point.
+- The implementation should use the smallest viable Cloudflare product set before adding extra platform services.
+- Cloudflare Agents are not part of this slice because access-control decisions must stay deterministic and auditable.
+- Cloudflare API or Wrangler execution may be used to apply real D1 changes, but live D1 changes must not be claimed without execution evidence.
+
 ## Selected bundles
 
 Selected bundles:
@@ -48,6 +75,8 @@ Selected bundles:
 - `gov-product-assistant-gold-standard`
 - `govuk-design-system`
 - `cloudflare-core-developer`
+- `cloudflare-developer-platform-bundle`
+- `cloudflare-agents-workbench`
 - `airtable-public-api-developer`
 
 Selection rationale:
@@ -57,6 +86,8 @@ Selection rationale:
 - `gov-product-assistant-gold-standard` applies because the task affects governance, personal data, safeguarding and assurance.
 - `govuk-design-system` applies because account, role and permission UI are in scope for the wider implementation.
 - `cloudflare-core-developer` applies because Worker, D1 and Cloudflare Access are in scope.
+- `cloudflare-developer-platform-bundle` applies because this slice uses Workers and D1 as Cloudflare platform services.
+- `cloudflare-agents-workbench` applies as a boundary bundle: it confirms agents are not the decision-maker for role assignment or access control in this slice.
 - `airtable-public-api-developer` applies because the implementation must protect Airtable behind Worker authorisation.
 
 ## Skipped bundles
@@ -75,7 +106,8 @@ Skip rationale:
 - ResearchOps Developer governs the platform architecture and service boundary.
 - Gold Standard Gov Product Assistant governs personal data, safeguarding, governance and service assurance risk.
 - GOV.UK Design System governs UI and accessibility when UI changes begin.
-- Cloudflare Core Developer governs Worker, D1, Access JWT and binding behaviour.
+- Cloudflare Core Developer and Cloudflare Developer Platform govern Worker, D1, Access JWT and binding behaviour.
+- Cloudflare Agents Workbench governs agent boundaries and prevents invented agent/API claims.
 - Airtable Public API governs the boundary that Airtable remains a data layer and not an authorisation engine.
 
 ## Branch hygiene
@@ -88,6 +120,7 @@ Skip rationale:
 
 Current implementation files created or modified:
 
+- `.github/workflows/apply-d1-auth-foundation.yml`
 - `infra/cloudflare/migrations/0001_auth_foundation.sql`
 - `infra/cloudflare/src/core/auth/access.js`
 - `infra/cloudflare/src/core/auth/route-permissions.js`
@@ -248,7 +281,7 @@ Test coverage currently asserted:
 
 ## Implementation checkpoint 8: controlled D1 migration path plan
 
-Next planned file:
+Planned file before creation:
 
 - `.github/workflows/apply-d1-auth-foundation.yml`
 
@@ -266,23 +299,41 @@ Boundary for this step:
 - It must not claim the migration has run.
 - It must record that real D1 table creation is only confirmed after a successful workflow run.
 
+## Implementation checkpoint 9: controlled D1 migration workflow created
+
+File created:
+
+- `.github/workflows/apply-d1-auth-foundation.yml`
+
+Purpose:
+
+- Provide a manual GitHub Actions path for applying `infra/cloudflare/migrations/0001_auth_foundation.sql` to the remote `researchops-d1` D1 database.
+- Require explicit confirmation inputs: `researchops-d1` and `APPLY_AUTH_FOUNDATION`.
+- Use Wrangler `d1 execute` with `--remote` against `infra/cloudflare/wrangler.toml`.
+- Run optional post-apply checks for `auth_%` tables and seed record counts.
+
+Current boundary:
+
+- The workflow has been added but not run.
+- The live D1 database has not been changed by this assistant turn.
+- Real table creation and seeding are only confirmed after a successful workflow run or direct Cloudflare API evidence.
+
 ## Real D1 implementation requirement
 
 The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
 
-The build must include a safe path to apply the migration to the real `researchops-d1` database that is bound as `RESEARCHOPS_D1` in `infra/cloudflare/wrangler.toml`.
+The build now includes a safe manual path to apply the migration to the real `researchops-d1` database that is bound as `RESEARCHOPS_D1` in `infra/cloudflare/wrangler.toml`.
 
 Required next implementation controls:
 
-- Add or confirm a controlled Wrangler command path for applying `infra/cloudflare/migrations/0001_auth_foundation.sql` to the remote D1 database.
-- Prefer a manual `workflow_dispatch` or explicitly documented maintainer command rather than an automatic push-time migration.
-- Ensure the seed records in the migration create permissions, roles, role-permission mappings and route permission declarations.
-- Do not claim live D1 tables have been created until Wrangler migration output or other direct Cloudflare evidence confirms it.
+- Run the manual workflow or use an equivalent direct Cloudflare API/Wrangler path before claiming real D1 tables exist.
+- Preserve the seed records in the migration for permissions, roles, role-permission mappings and route permission declarations.
+- Capture the workflow result or API output in this trace once the migration has actually run.
 
 Tool boundary:
 
-- The current available tool access is GitHub repository access.
-- Direct Cloudflare execution has not been performed through this assistant turn.
+- The current available repository tool access has created the workflow and migration.
+- Direct Cloudflare execution has not been performed in this step.
 - Therefore live D1 creation cannot be claimed yet.
 
 ## Trace governance correction
@@ -298,7 +349,8 @@ Correction now applied:
 - the trace was updated after route-permission helper creation
 - the route-permission test creation was recorded immediately after the file was created
 - the real D1 application requirement has now been recorded explicitly
-- the controlled D1 migration path plan has been recorded before creating that workflow
+- the controlled D1 migration path plan was recorded before creating that workflow
+- the trace was updated after creating the controlled D1 migration workflow
 - future implementation steps must update this trace before or alongside code changes
 - future responses should report both implementation progress and trace updates
 
@@ -321,7 +373,7 @@ Correction for future steps:
 
 No local lint, format, typecheck, test or build result is claimed at this checkpoint.
 
-The test files have been created but not yet executed in this environment.
+The test files and D1 workflow have been created but not executed in this environment.
 
 ## Pending next steps
 
@@ -329,14 +381,15 @@ The next implementation slice should be small and trace-updated before or alongs
 
 Candidate next steps:
 
-- create `.github/workflows/apply-d1-auth-foundation.yml`
-- document environment variables required for Cloudflare Access JWT validation
+- document required Cloudflare Access environment variables and D1 workflow execution steps
+- wire route-permission checks into the first protected endpoint in a narrow slice
 - consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit
+- run repository tests or open a PR for CI execution
 
 ## Residual risks
 
 - Cloudflare Access JWT validation depends on environment configuration for Access certificates and audience.
-- The D1 migration has not yet been run in an environment.
+- The D1 migration has not yet been run in the live environment.
 - The route wiring has not yet been validated by test execution.
-- The implementation is not yet protected by a route-permission middleware for wider product routes.
+- The route-permission helper is not yet wired into existing product routes.
 - No PR has been opened for this branch yet.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -246,6 +246,26 @@ Test coverage currently asserted:
 - diagnostic permission-denied responses can include `missingPermissions`
 - matching permission `audit.view` allows `/api/audit/team-events`
 
+## Implementation checkpoint 8: controlled D1 migration path plan
+
+Next planned file:
+
+- `.github/workflows/apply-d1-auth-foundation.yml`
+
+Purpose:
+
+- Provide a manual `workflow_dispatch` path for applying the authentication foundation migration to the real remote D1 database.
+- Require an explicit confirmation input before executing the migration.
+- Use the existing Cloudflare secret pattern: `CF_API_TOKEN` and `CF_ACCOUNT_ID`.
+- Use Wrangler against `infra/cloudflare/wrangler.toml` and `infra/cloudflare/migrations/0001_auth_foundation.sql`.
+
+Boundary for this step:
+
+- The workflow is manual only.
+- It must not run automatically on push.
+- It must not claim the migration has run.
+- It must record that real D1 table creation is only confirmed after a successful workflow run.
+
 ## Real D1 implementation requirement
 
 The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
@@ -278,6 +298,7 @@ Correction now applied:
 - the trace was updated after route-permission helper creation
 - the route-permission test creation was recorded immediately after the file was created
 - the real D1 application requirement has now been recorded explicitly
+- the controlled D1 migration path plan has been recorded before creating that workflow
 - future implementation steps must update this trace before or alongside code changes
 - future responses should report both implementation progress and trace updates
 
@@ -308,7 +329,7 @@ The next implementation slice should be small and trace-updated before or alongs
 
 Candidate next steps:
 
-- add a controlled remote D1 migration application path
+- create `.github/workflows/apply-d1-auth-foundation.yml`
 - document environment variables required for Cloudflare Access JWT validation
 - consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit
 

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -2,6 +2,13 @@
 
 > This is an auditable trace for repository-affecting work triggered by `[reasoning]`. It records what happened, what changed, what remains unverified, and what must happen next. It does not expose private chain-of-thought.
 
+## Trace files
+
+- Main markdown trace: `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
+- Consolidated JSON trace: [`authentication-role-selection-real-implementation-trace.json`](authentication-role-selection-real-implementation-trace.json)
+
+The checkpoint markdown files are used to keep this large build readable. Their captured events are also represented in the single consolidated JSON trace. Individual checkpoint JSON files are intentionally not created.
+
 ## Run metadata
 
 - Trace ID: `atrace-20260508-authentication-role-selection-real-implementation`
@@ -21,7 +28,9 @@ The user corrected the course by stating that this must not be a mock implementa
 
 The user required continuous `[reasoning]` trace updates during the build and clarified that the work must systematically build the real authentication role-selection capability, including D1 table creation and seeding where necessary.
 
-The user also clarified that Cloudflare APIs are in scope and provided Cloudflare Developer Platform and Cloudflare Agents Workbench bundles.
+The user clarified that Cloudflare APIs are in scope and provided Cloudflare Developer Platform and Cloudflare Agents Workbench bundles.
+
+The user then clarified that this main markdown trace must link to checkpoint markdown files and that the companion JSON trace must be maintained as one consolidated JSON record.
 
 ## Operating-model sources loaded
 
@@ -91,6 +100,18 @@ Skip rationale:
 - Fresh branch `feature/auth-foundation-real-d1-current-main` was created from current `main` commit `8305adeed3b7e4047f132bc8c50347ce47e6205f`.
 - No force update was used.
 
+## Checkpoint index
+
+| Checkpoint | File | Status |
+|---:|---|---|
+| 010 | [`authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`](authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md) | Complete |
+| 011 | [`authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md`](authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md) | Complete |
+| 012 | [`authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`](authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md) | Complete |
+| 013 | [`authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md`](authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md) | Complete |
+| 014 | [`authentication-role-selection-checkpoint-014-validation-wiring-plan.md`](authentication-role-selection-checkpoint-014-validation-wiring-plan.md) | Complete |
+| 015 | [`authentication-role-selection-checkpoint-015-validation-wiring-complete.md`](authentication-role-selection-checkpoint-015-validation-wiring-complete.md) | Complete |
+| 016 | [`authentication-role-selection-checkpoint-016-trace-index-json-plan.md`](authentication-role-selection-checkpoint-016-trace-index-json-plan.md) | Complete |
+
 ## Files changed so far on this branch
 
 Implementation files:
@@ -111,14 +132,18 @@ Product and operational documentation:
 Agent trace files:
 
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md`
 
-## Implementation checkpoint 1: D1 auth foundation migration
+## Implementation checkpoints
+
+### Checkpoint 1: D1 auth foundation migration
 
 File created:
 
@@ -159,7 +184,7 @@ Decision coverage:
 - Reserved export permissions are represented without implementing export.
 - General audit and safeguarding audit are separate permissions.
 
-## Implementation checkpoint 2: Cloudflare Access identity resolver
+### Checkpoint 2: Cloudflare Access identity resolver
 
 File created:
 
@@ -180,7 +205,7 @@ Non-goals:
 - It does not implement role-management UI.
 - It does not change Airtable schema.
 
-## Implementation checkpoint 3: Worker route wiring
+### Checkpoint 3: Worker route wiring
 
 File modified:
 
@@ -191,7 +216,7 @@ Purpose:
 - Route `GET /api/me` and `GET /api/me/permissions` through the real Cloudflare Access identity resolver.
 - Add `X-ResearchOps-Team-Id` to allowed request headers so an authenticated user can select an active team context.
 
-## Implementation checkpoint 4: auth foundation route tests
+### Checkpoint 4: auth foundation route tests
 
 File created:
 
@@ -204,7 +229,7 @@ Purpose:
 - Confirm no mock identity mode exists in `core/auth/access.js`.
 - Confirm the D1 migration contains required control-plane tables, scoped role fields and reserved permissions.
 
-## Implementation checkpoint 5: route-permission middleware plan
+### Checkpoint 5: route-permission middleware plan
 
 Planned file before creation:
 
@@ -217,7 +242,7 @@ Purpose:
 - Deny access where the authenticated context lacks a required permission.
 - Avoid exposing missing permission codes to ordinary users.
 
-## Implementation checkpoint 6: route-permission helper created
+### Checkpoint 6: route-permission helper created
 
 File created:
 
@@ -236,7 +261,7 @@ Current boundary:
 - The helper is now used by the identity routes.
 - The helper is not yet wired into all existing product routes.
 
-## Implementation checkpoint 7: route-permission helper tests
+### Checkpoint 7: route-permission helper tests
 
 File created:
 
@@ -250,7 +275,7 @@ Purpose:
 - Confirm diagnostics can include missing permission codes only when explicitly requested.
 - Confirm a matching permission allows the route.
 
-## Implementation checkpoint 8: controlled D1 migration path plan
+### Checkpoint 8: controlled D1 migration path plan
 
 Planned file before creation:
 
@@ -262,7 +287,7 @@ Purpose:
 - Require explicit confirmation input before executing the migration.
 - Use Wrangler against `infra/cloudflare/wrangler.toml` and `infra/cloudflare/migrations/0001_auth_foundation.sql`.
 
-## Implementation checkpoint 9: controlled D1 migration workflow created
+### Checkpoint 9: controlled D1 migration workflow created
 
 File created:
 
@@ -281,17 +306,21 @@ Current boundary:
 - The live D1 database has not been changed by this assistant turn.
 - Real table creation and seeding are only confirmed after a successful workflow run or direct Cloudflare API evidence.
 
-## Implementation checkpoint 10: route-permission wiring plan
+### Checkpoint 10: route-permission wiring plan
 
 Trace file created:
 
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`
+- [`authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`](authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md)
 
 Purpose:
 
 - Record the plan before wiring route-permission checks into the first real identity endpoints.
 
-## Implementation checkpoint 11: route-permission wiring complete
+### Checkpoint 11: route-permission wiring complete
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md`](authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md)
 
 Files changed:
 
@@ -307,17 +336,21 @@ Decision coverage:
 
 - Authenticated identity is not enough on its own. Identity-facing product endpoints now pass through declared D1 route-permission policy.
 
-## Implementation checkpoint 12: Cloudflare operations documentation plan
+### Checkpoint 12: Cloudflare operations documentation plan
 
 Trace file created:
 
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`
+- [`authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`](authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md)
 
 Purpose:
 
 - Record the plan before creating operational documentation for Cloudflare Access, D1 and the migration workflow.
 
-## Implementation checkpoint 13: Cloudflare operations documentation complete
+### Checkpoint 13: Cloudflare operations documentation complete
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md`](authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md)
 
 File created:
 
@@ -332,17 +365,21 @@ Purpose:
 - Document expected D1 tables, seed counts and post-apply verification queries.
 - Document rollout order, retry notes and evidence required before claiming live D1 creation.
 
-## Implementation checkpoint 14: validation wiring plan
+### Checkpoint 14: validation wiring plan
 
 Trace file created:
 
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md`
+- [`authentication-role-selection-checkpoint-014-validation-wiring-plan.md`](authentication-role-selection-checkpoint-014-validation-wiring-plan.md)
 
 Purpose:
 
 - Record the plan before wiring authentication tests into the repository validation contract.
 
-## Implementation checkpoint 15: validation wiring complete
+### Checkpoint 15: validation wiring complete
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-015-validation-wiring-complete.md`](authentication-role-selection-checkpoint-015-validation-wiring-complete.md)
 
 File changed:
 
@@ -364,6 +401,23 @@ Decision coverage:
 
 - Authentication foundation checks are now part of the standard CI validation path used by Worker deployment.
 
+### Checkpoint 16: trace index and JSON plan
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-016-trace-index-json-plan.md`](authentication-role-selection-checkpoint-016-trace-index-json-plan.md)
+
+Files created or updated:
+
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
+
+Purpose:
+
+- Create and maintain the consolidated JSON trace.
+- Link checkpoint markdown files from the main markdown trace.
+- Record checkpoint events in one JSON trace rather than separate checkpoint JSON files.
+
 ## Real D1 implementation requirement
 
 The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
@@ -384,12 +438,11 @@ Tool boundary:
 
 ## Trace governance correction
 
-The user raised a valid governance concern that trace records were not being continuously updated as implementation proceeded.
-
 Correction applied:
 
 - trace checkpoints are now written before or immediately after each implementation step
-- main trace is updated after major groups of work
+- main trace links to checkpoint markdown files
+- consolidated JSON trace represents checkpoint events in one file
 - live D1 status is explicitly separated from repository migration status
 - future responses should report both implementation progress and trace updates
 
@@ -406,6 +459,7 @@ Correction for future steps:
 
 - split future changes into smaller files and smaller commits
 - update trace before or alongside code changes
+- update both markdown and JSON trace records where a checkpoint changes the implementation state
 - do not batch large design and code changes without a trace checkpoint
 
 ## Validation not yet claimed

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -111,6 +111,7 @@ Skip rationale:
 | 014 | [`authentication-role-selection-checkpoint-014-validation-wiring-plan.md`](authentication-role-selection-checkpoint-014-validation-wiring-plan.md) | Complete |
 | 015 | [`authentication-role-selection-checkpoint-015-validation-wiring-complete.md`](authentication-role-selection-checkpoint-015-validation-wiring-complete.md) | Complete |
 | 016 | [`authentication-role-selection-checkpoint-016-trace-index-json-plan.md`](authentication-role-selection-checkpoint-016-trace-index-json-plan.md) | Complete |
+| 017 | [`authentication-role-selection-checkpoint-017-pr-readiness-plan.md`](authentication-role-selection-checkpoint-017-pr-readiness-plan.md) | Complete |
 
 ## Files changed so far on this branch
 
@@ -140,6 +141,7 @@ Agent trace files:
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md`
 
 ## Implementation checkpoints
 
@@ -418,6 +420,24 @@ Purpose:
 - Link checkpoint markdown files from the main markdown trace.
 - Record checkpoint events in one JSON trace rather than separate checkpoint JSON files.
 
+### Checkpoint 17: PR readiness plan
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-017-pr-readiness-plan.md`](authentication-role-selection-checkpoint-017-pr-readiness-plan.md)
+
+Branch comparison:
+
+- status: ahead
+- ahead by: 29 commits
+- behind by: 0 commits
+- base commit: `8305adeed3b7e4047f132bc8c50347ce47e6205f`
+
+Purpose:
+
+- Record branch readiness before opening a pull request.
+- Ensure the PR states that live D1 has not been migrated and validation has not been executed in this environment.
+
 ## Real D1 implementation requirement
 
 The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
@@ -472,7 +492,6 @@ The test files and D1 workflow have been created but not executed in this enviro
 
 Candidate next steps:
 
-- run or trigger validation through PR CI
 - open a PR for review and CI execution
 - apply the D1 migration through the manual workflow after review or explicit release decision
 - wire route-permission checks into the next protected product endpoint in a narrow slice

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -28,10 +28,10 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 - Repository migration and manual D1 workflow exist.
 - Authentication tests are wired into `npm run validate`.
 - CI repeatedly reported Prettier formatting failures in `tests/auth-route-permissions.test.js`.
-- The latest fix removes fragile inline JSON string fixtures and uses `JSON.stringify` through a helper.
-- A temporary local Prettier 3.6.2 check on the planned file content passed.
+- Root cause is now identified: Prettier reads `.editorconfig`, and this repository sets `indent_style = tab`.
+- Earlier temporary file checks were wrong because they ran outside the repository tree and missed `.editorconfig`.
+- `tests/auth-route-permissions.test.js` has now been replaced with repository Prettier output using tabs.
 - Repository-level CI has not yet confirmed the latest fix.
-- The Prettier tooling investigation and future prevention-rule candidate have been recorded in checkpoint 025 and the consolidated JSON trace.
 
 ## Checkpoint index
 
@@ -46,13 +46,15 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 | 016 | [`authentication-role-selection-checkpoint-016-trace-index-json-plan.md`](authentication-role-selection-checkpoint-016-trace-index-json-plan.md) | Complete |
 | 017 | [`authentication-role-selection-checkpoint-017-pr-readiness-plan.md`](authentication-role-selection-checkpoint-017-pr-readiness-plan.md) | Complete |
 | 018 | [`authentication-role-selection-checkpoint-018-lint-fix-plan.md`](authentication-role-selection-checkpoint-018-lint-fix-plan.md) | Complete |
-| 019 | [`authentication-role-selection-checkpoint-019-lint-fix-complete.md`](authentication-role-selection-checkpoint-019-lint-fix-complete.md) | Complete |
+| 019 | [`authentication-role-selection-checkpoint-019-lint-fix-complete.md`](authentication-role-selection-checkpoint-019-lint-fix-complete.md) | Superseded by 027 |
 | 020 | [`authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md`](authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md) | Complete |
-| 021 | [`authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md`](authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md) | Complete |
-| 022 | [`authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md`](authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md) | Complete |
-| 023 | [`authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md`](authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md) | Complete |
-| 024 | [`authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md`](authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md) | Complete |
-| 025 | [`authentication-role-selection-checkpoint-025-prettier-tooling-findings.md`](authentication-role-selection-checkpoint-025-prettier-tooling-findings.md) | Complete |
+| 021 | [`authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md`](authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md) | Superseded by 027 |
+| 022 | [`authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md`](authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md) | Superseded by 026 |
+| 023 | [`authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md`](authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md) | Superseded by 026 |
+| 024 | [`authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md`](authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md) | Fixture improvement retained; root format fix superseded by 027 |
+| 025 | [`authentication-role-selection-checkpoint-025-prettier-tooling-findings.md`](authentication-role-selection-checkpoint-025-prettier-tooling-findings.md) | Superseded by 026 and 027 |
+| 026 | [`authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md`](authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md) | Complete |
+| 027 | [`authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md`](authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md) | Committed; pending CI confirmation |
 
 ## Files changed so far on this branch
 
@@ -75,7 +77,91 @@ Agent trace files:
 
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- checkpoint markdown files 010 to 025
+- checkpoint markdown files 010 to 027
+
+## Prettier failure record
+
+### Repeated symptom
+
+CI repeatedly failed during:
+
+```bash
+prettier -c .
+```
+
+The reported file was always:
+
+```text
+tests/auth-route-permissions.test.js
+```
+
+### Root cause
+
+Repository `.editorconfig` contains:
+
+```ini
+[*]
+indent_style = tab
+indent_size = 2
+```
+
+Prettier reads `.editorconfig` by default. Therefore JavaScript files in this repository must use tab indentation unless a more specific override is introduced.
+
+Temporary standalone file checks outside the repository tree missed this rule. Those checks incorrectly passed because Prettier fell back to its default space indentation.
+
+### Exact fix committed
+
+`tests/auth-route-permissions.test.js` was replaced with the Prettier 3.6.2 output produced when `.editorconfig` is present.
+
+The concrete fix is tab indentation.
+
+Before:
+
+```js
+import {
+  assertRoutePermission,
+  resolveRoutePermissionDeclaration,
+  routePermissionErrorResponse,
+} from "../infra/cloudflare/src/core/auth/route-permissions.js";
+```
+
+After:
+
+```js
+import {
+	assertRoutePermission,
+	resolveRoutePermissionDeclaration,
+	routePermissionErrorResponse,
+} from "../infra/cloudflare/src/core/auth/route-permissions.js";
+```
+
+The JSON fixture helper improvement from checkpoint 024 is retained:
+
+```js
+function requiredPermissions(...codes) {
+	return JSON.stringify(codes);
+}
+```
+
+### Workflow change decision
+
+The proposed workaround of adding `npx prettier --write .` before lint in CI should not be used as the primary fix.
+
+CI should detect formatting drift. It should not silently mutate the runner workspace without committing the change back to the branch.
+
+Correct practice is to run formatting before committing:
+
+```bash
+npm run format
+```
+
+or targeted:
+
+```bash
+npx prettier --write tests/auth-route-permissions.test.js
+```
+
+Both commands must be run from the repository root so `.editorconfig` is applied.
 
 ## Implementation checkpoints
 
@@ -254,25 +340,32 @@ Purpose:
 - Record branch readiness before opening PR #215.
 - State that live D1 had not been migrated and validation had not been executed in this environment.
 
-### Checkpoint 18: route-permission test lint fix plan
+### Checkpoints 18 to 25: Prettier false starts and tooling findings
+
+These checkpoints record the repeated Prettier investigation and the earlier incorrect hypotheses.
+
+Key correction:
+
+- Inline JSON fixture cleanup was useful but not the formatting root cause.
+- The root cause was repository `.editorconfig` tab indentation.
+- Earlier temporary checks were invalid because they did not include `.editorconfig`.
+
+### Checkpoint 26: Prettier root cause plan
 
 Trace file created:
 
-- [`authentication-role-selection-checkpoint-018-lint-fix-plan.md`](authentication-role-selection-checkpoint-018-lint-fix-plan.md)
-
-Reported failure:
-
-- `npm run lint` failed because Prettier reported `tests/auth-route-permissions.test.js`.
+- [`authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md`](authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md)
 
 Purpose:
 
-- Record the formatting-only fix plan before changing the test file.
+- Record `.editorconfig` tab indentation as the true root cause.
+- Record that CI auto-formatting should not replace explicit committed formatting fixes.
 
-### Checkpoint 19: route-permission test lint fix complete
+### Checkpoint 27: Prettier root cause fix complete
 
 Trace file created:
 
-- [`authentication-role-selection-checkpoint-019-lint-fix-complete.md`](authentication-role-selection-checkpoint-019-lint-fix-complete.md)
+- [`authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md`](authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md)
 
 File changed:
 
@@ -280,113 +373,9 @@ File changed:
 
 Purpose:
 
-- Reformat a long `assertRoutePermission` call to satisfy Prettier.
-- CI later showed another Prettier formatting change remained.
-
-### Checkpoint 20: route-permission test lint fix rerun plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md`](authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md)
-
-Reported failure:
-
-- `./node_modules/.bin/prettier -c .` again reported `tests/auth-route-permissions.test.js`.
-
-Purpose:
-
-- Record the repeated Prettier failure.
-- Identify the remaining long `assertRoutePermission` call in `assertMissingRouteFailsClosed`.
-
-### Checkpoint 21: route-permission test lint fix rerun complete
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md`](authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md)
-
-File changed:
-
-- `tests/auth-route-permissions.test.js`
-
-Purpose:
-
-- Rewrite `tests/auth-route-permissions.test.js` to match local Prettier output.
-- Record that a temporary file-level Prettier check reported `All matched files use Prettier code style!`.
-- CI later still reported the same file.
-
-### Checkpoint 22: escaped JSON lint fix plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md`](authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md)
-
-Purpose:
-
-- Record the repeated Prettier failure and identify escaped inline JSON string fixtures as the remaining fragile pattern.
-
-### Checkpoint 23: JSON fixture lint fix plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md`](authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md)
-
-Purpose:
-
-- Plan the resilient correction of replacing inline JSON string fixtures with `JSON.stringify` through a helper.
-
-### Checkpoint 24: JSON fixture lint fix complete
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md`](authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md)
-
-File changed:
-
-- `tests/auth-route-permissions.test.js`
-
-Purpose:
-
-- Add `requiredPermissions(...codes)` helper.
-- Replace inline JSON string fixtures with `requiredPermissions("...")` calls.
-- Preserve the same JSON string value consumed by the route-permission parser.
-
-### Checkpoint 25: Prettier tooling findings
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-025-prettier-tooling-findings.md`](authentication-role-selection-checkpoint-025-prettier-tooling-findings.md)
-
-Purpose:
-
-- Record the repository lint scripts and Prettier version.
-- Record that repository search did not find a dedicated Prettier config.
-- Record that cloning the branch into the execution container failed because `github.com` could not be resolved.
-- Record that true repository-level `npm run format` or `prettier --write .` could not be executed from this assistant environment.
-- Record the latest helper-based fix pattern and a candidate repository rule once CI confirms the fix.
-
-Code pattern recorded:
-
-```js
-function requiredPermissions(...codes) {
-  return JSON.stringify(codes);
-}
-```
-
-Before:
-
-```js
-required_permissions_json: '["audit.view"]',
-```
-
-After:
-
-```js
-required_permissions_json: requiredPermissions("audit.view"),
-```
-
-Prevention-rule candidate after CI confirmation:
-
-> Do not hand-write escaped JSON fixtures in JavaScript tests where the target code expects a JSON string. Use `JSON.stringify` through a named helper, then run `npm run format` or `npx prettier --write <file>` before committing.
+- Apply repository Prettier output with tab indentation.
+- Preserve route-permission test behaviour.
+- Record future prevention guidance.
 
 ## Real D1 implementation requirement
 
@@ -404,9 +393,8 @@ Required next implementation controls:
 
 - Initial CI lint failed on Prettier formatting in `tests/auth-route-permissions.test.js`.
 - CI repeated the Prettier formatting failure for the same file.
-- The latest fix replaces inline JSON fixtures with a helper to remove formatting ambiguity.
-- A temporary Prettier 3.6.2 check on the planned file content passed.
-- True repository-level `prettier --write .` has not been executed from this assistant environment because a branch checkout was not available.
+- Root cause identified as `.editorconfig` tab indentation.
+- `tests/auth-route-permissions.test.js` has been rewritten with repository Prettier tab output.
 - CI has not yet confirmed that the repository-level check passes.
 - No live D1 migration has been run.
 
@@ -414,18 +402,17 @@ Required next implementation controls:
 
 `AGENTS.md` says commits should be incremental and atomic with a diff of no more than 300 lines.
 
-Current issue:
+Current issues:
 
 - the Access identity resolver commit had more than 300 added lines
-- this is recorded as a process deviation
-- repeated formatting fixes were attempted without a true repository-level `prettier --write` against the branch checkout
+- repeated formatting fixes were attempted without repository-root Prettier context
 
 Correction for future steps:
 
 - split future changes into smaller files and smaller commits
 - update trace before or alongside code changes
 - update both markdown and JSON trace records where a checkpoint changes the implementation state
-- for formatting failures, prefer `npm run format` or `npx prettier --write <file>` in a real repository checkout before committing
+- for formatting failures, run Prettier from the repository root so `.editorconfig` applies
 - do not claim repository-level formatting success until CI or a real repository checkout confirms it
 
 ## Pending next steps
@@ -433,8 +420,7 @@ Correction for future steps:
 Candidate next steps:
 
 - wait for PR CI to rerun and inspect any new failure
-- if Prettier still fails, obtain the exact Prettier `--write` diff from CI or from a real repository checkout and commit that output
-- after CI confirms the fix, create permanent repository guidance from checkpoint 025
+- after CI confirms the fix, create permanent repository guidance from checkpoints 026 and 027
 - apply the D1 migration through the manual workflow after review or explicit release decision
 - wire route-permission checks into the next protected product endpoint in a narrow slice
 

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -21,6 +21,8 @@ The user then corrected the course by stating that this must not be a mock imple
 
 The user then raised a trace governance concern: trace records must be continuously updated as the build progresses, rather than reconstructed at the end.
 
+The user then clarified that the work must not become trace-only or document-only. It must systematically build the real authentication role-selection capability, including D1 table creation and seeding where necessary.
+
 ## Operating-model sources loaded before repository-affecting work
 
 The repository operating model had already been loaded during this workstream from the following files:
@@ -222,6 +224,25 @@ Current boundary:
 - It does not change Airtable behaviour.
 - It still needs unit tests.
 
+## Real D1 implementation requirement
+
+The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
+
+The build must include a safe path to apply the migration to the real `researchops-d1` database that is bound as `RESEARCHOPS_D1` in `infra/cloudflare/wrangler.toml`.
+
+Required next implementation controls:
+
+- Add or confirm a controlled Wrangler command path for applying `infra/cloudflare/migrations/0001_auth_foundation.sql` to the remote D1 database.
+- Prefer a manual `workflow_dispatch` or explicitly documented maintainer command rather than an automatic push-time migration.
+- Ensure the seed records in the migration create permissions, roles, role-permission mappings and route permission declarations.
+- Do not claim live D1 tables have been created until Wrangler migration output or other direct Cloudflare evidence confirms it.
+
+Tool boundary:
+
+- The current available tool access is GitHub repository access.
+- Direct Cloudflare execution has not been performed through this assistant turn.
+- Therefore live D1 creation cannot be claimed yet.
+
 ## Trace governance correction
 
 The user raised a valid governance concern that trace records were not being continuously updated as implementation proceeded.
@@ -233,6 +254,7 @@ Correction now applied:
 - this trace was updated immediately after the test file was created
 - the route-permission middleware plan was recorded before creating that file
 - the trace was updated after route-permission helper creation
+- the real D1 application requirement has now been recorded explicitly
 - future implementation steps must update this trace before or alongside code changes
 - future responses should report both implementation progress and trace updates
 
@@ -263,7 +285,8 @@ The next implementation slice should be small and trace-updated before or alongs
 
 Candidate next steps:
 
-- add route-permission tests for fail-closed behaviour
+- create `tests/auth-route-permissions.test.js`
+- add a controlled remote D1 migration application path
 - document environment variables required for Cloudflare Access JWT validation
 - consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit
 

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -93,6 +93,7 @@ Current implementation files created or modified:
 - `infra/cloudflare/src/core/auth/route-permissions.js`
 - `infra/cloudflare/src/worker.js`
 - `tests/auth-foundation-route-state.test.js`
+- `tests/auth-route-permissions.test.js`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 
 ## Implementation checkpoint 1: D1 auth foundation migration
@@ -222,7 +223,28 @@ Current boundary:
 - The helper is not yet wired into existing product routes.
 - It does not create users or roles.
 - It does not change Airtable behaviour.
-- It still needs unit tests.
+
+## Implementation checkpoint 7: route-permission helper tests
+
+File created:
+
+- `tests/auth-route-permissions.test.js`
+
+Purpose:
+
+- Confirm declared route permissions can be resolved from a D1-style binding.
+- Confirm protected routes fail closed when no route declaration exists.
+- Confirm missing permissions are denied without exposing missing permission codes to ordinary users.
+- Confirm diagnostics can include missing permission codes only when explicitly requested.
+- Confirm a matching permission allows the route.
+
+Test coverage currently asserted:
+
+- route declarations resolve method, route pattern, required permissions and auth state
+- missing route declarations produce `route_permission_missing`
+- ordinary permission-denied responses do not contain `details`
+- diagnostic permission-denied responses can include `missingPermissions`
+- matching permission `audit.view` allows `/api/audit/team-events`
 
 ## Real D1 implementation requirement
 
@@ -254,6 +276,7 @@ Correction now applied:
 - this trace was updated immediately after the test file was created
 - the route-permission middleware plan was recorded before creating that file
 - the trace was updated after route-permission helper creation
+- the route-permission test creation was recorded immediately after the file was created
 - the real D1 application requirement has now been recorded explicitly
 - future implementation steps must update this trace before or alongside code changes
 - future responses should report both implementation progress and trace updates
@@ -277,7 +300,7 @@ Correction for future steps:
 
 No local lint, format, typecheck, test or build result is claimed at this checkpoint.
 
-The new test file has been created but not yet executed in this environment.
+The test files have been created but not yet executed in this environment.
 
 ## Pending next steps
 
@@ -285,7 +308,6 @@ The next implementation slice should be small and trace-updated before or alongs
 
 Candidate next steps:
 
-- create `tests/auth-route-permissions.test.js`
 - add a controlled remote D1 migration application path
 - document environment variables required for Cloudflare Access JWT validation
 - consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -27,10 +27,10 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 - Live D1 migration has not been applied.
 - Repository migration and manual D1 workflow exist.
 - Authentication tests are wired into `npm run validate`.
-- CI reported repeated Prettier formatting failures in `tests/auth-route-permissions.test.js`.
-- A second formatting-only fix has been committed.
-- A temporary local Prettier check on the file content reported: `All matched files use Prettier code style!`
-- Repository-level CI has not yet confirmed the fix.
+- CI repeatedly reported Prettier formatting failures in `tests/auth-route-permissions.test.js`.
+- The latest fix removes fragile inline JSON string fixtures and uses `JSON.stringify` through a helper.
+- A temporary local Prettier 3.6.2 check on the planned file content passed.
+- Repository-level CI has not yet confirmed the latest fix.
 
 ## Checkpoint index
 
@@ -48,6 +48,9 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 | 019 | [`authentication-role-selection-checkpoint-019-lint-fix-complete.md`](authentication-role-selection-checkpoint-019-lint-fix-complete.md) | Complete |
 | 020 | [`authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md`](authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md) | Complete |
 | 021 | [`authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md`](authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md) | Complete |
+| 022 | [`authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md`](authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md) | Complete |
+| 023 | [`authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md`](authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md) | Complete |
+| 024 | [`authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md`](authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md) | Complete |
 
 ## Files changed so far on this branch
 
@@ -70,7 +73,7 @@ Agent trace files:
 
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- checkpoint markdown files 010 to 021
+- checkpoint markdown files 010 to 024
 
 ## Implementation checkpoints
 
@@ -307,7 +310,43 @@ Purpose:
 
 - Rewrite `tests/auth-route-permissions.test.js` to match local Prettier output.
 - Record that a temporary file-level Prettier check reported `All matched files use Prettier code style!`.
-- No test behaviour was changed.
+- CI later still reported the same file.
+
+### Checkpoint 22: escaped JSON lint fix plan
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md`](authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md)
+
+Purpose:
+
+- Record the repeated Prettier failure and identify escaped inline JSON string fixtures as the remaining fragile pattern.
+
+### Checkpoint 23: JSON fixture lint fix plan
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md`](authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md)
+
+Purpose:
+
+- Plan the resilient correction of replacing inline JSON string fixtures with `JSON.stringify` through a helper.
+
+### Checkpoint 24: JSON fixture lint fix complete
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md`](authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md)
+
+File changed:
+
+- `tests/auth-route-permissions.test.js`
+
+Purpose:
+
+- Add `requiredPermissions(...codes)` helper.
+- Replace inline JSON string fixtures with `requiredPermissions("...")` calls.
+- Preserve the same JSON string value consumed by the route-permission parser.
 
 ## Real D1 implementation requirement
 
@@ -325,8 +364,8 @@ Required next implementation controls:
 
 - Initial CI lint failed on Prettier formatting in `tests/auth-route-permissions.test.js`.
 - CI repeated the Prettier formatting failure for the same file.
-- A second formatting-only fix has been committed.
-- A temporary file-level Prettier check on the file content passed.
+- The latest fix replaces inline JSON fixtures with a helper to remove formatting ambiguity.
+- A temporary Prettier 3.6.2 check on the planned file content passed.
 - CI has not yet confirmed that the repository-level check passes.
 - No live D1 migration has been run.
 

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -88,6 +88,7 @@ Current implementation files created or modified:
 
 - `infra/cloudflare/migrations/0001_auth_foundation.sql`
 - `infra/cloudflare/src/core/auth/access.js`
+- `infra/cloudflare/src/core/auth/route-permissions.js`
 - `infra/cloudflare/src/worker.js`
 - `tests/auth-foundation-route-state.test.js`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
@@ -182,7 +183,7 @@ Test coverage currently asserted:
 
 ## Implementation checkpoint 5: route-permission middleware plan
 
-Next planned file:
+Planned file before creation:
 
 - `infra/cloudflare/src/core/auth/route-permissions.js`
 
@@ -200,6 +201,27 @@ Boundary for this step:
 - Do not change Airtable behaviour yet.
 - Keep the slice small and testable.
 
+## Implementation checkpoint 6: route-permission helper created
+
+File created:
+
+- `infra/cloudflare/src/core/auth/route-permissions.js`
+
+Purpose:
+
+- Read route declarations from `auth_route_permissions` in D1.
+- Fail closed where no route permission declaration exists.
+- Check an authenticated context for required permissions.
+- Return ordinary permission-denied responses without exposing missing permission codes.
+- Allow diagnostics to include details only when explicitly requested by the caller.
+
+Current boundary:
+
+- The helper is not yet wired into existing product routes.
+- It does not create users or roles.
+- It does not change Airtable behaviour.
+- It still needs unit tests.
+
 ## Trace governance correction
 
 The user raised a valid governance concern that trace records were not being continuously updated as implementation proceeded.
@@ -209,7 +231,8 @@ Correction now applied:
 - this trace checkpoint exists on the active implementation branch
 - the test file was created only after the first trace checkpoint was recorded
 - this trace was updated immediately after the test file was created
-- the route-permission middleware plan has been recorded before creating that file
+- the route-permission middleware plan was recorded before creating that file
+- the trace was updated after route-permission helper creation
 - future implementation steps must update this trace before or alongside code changes
 - future responses should report both implementation progress and trace updates
 
@@ -240,7 +263,6 @@ The next implementation slice should be small and trace-updated before or alongs
 
 Candidate next steps:
 
-- create `infra/cloudflare/src/core/auth/route-permissions.js`
 - add route-permission tests for fail-closed behaviour
 - document environment variables required for Cloudflare Access JWT validation
 - consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -31,6 +31,7 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 - The latest fix removes fragile inline JSON string fixtures and uses `JSON.stringify` through a helper.
 - A temporary local Prettier 3.6.2 check on the planned file content passed.
 - Repository-level CI has not yet confirmed the latest fix.
+- The Prettier tooling investigation and future prevention-rule candidate have been recorded in checkpoint 025 and the consolidated JSON trace.
 
 ## Checkpoint index
 
@@ -51,6 +52,7 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 | 022 | [`authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md`](authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md) | Complete |
 | 023 | [`authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md`](authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md) | Complete |
 | 024 | [`authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md`](authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md) | Complete |
+| 025 | [`authentication-role-selection-checkpoint-025-prettier-tooling-findings.md`](authentication-role-selection-checkpoint-025-prettier-tooling-findings.md) | Complete |
 
 ## Files changed so far on this branch
 
@@ -73,7 +75,7 @@ Agent trace files:
 
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- checkpoint markdown files 010 to 024
+- checkpoint markdown files 010 to 025
 
 ## Implementation checkpoints
 
@@ -348,6 +350,44 @@ Purpose:
 - Replace inline JSON string fixtures with `requiredPermissions("...")` calls.
 - Preserve the same JSON string value consumed by the route-permission parser.
 
+### Checkpoint 25: Prettier tooling findings
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-025-prettier-tooling-findings.md`](authentication-role-selection-checkpoint-025-prettier-tooling-findings.md)
+
+Purpose:
+
+- Record the repository lint scripts and Prettier version.
+- Record that repository search did not find a dedicated Prettier config.
+- Record that cloning the branch into the execution container failed because `github.com` could not be resolved.
+- Record that true repository-level `npm run format` or `prettier --write .` could not be executed from this assistant environment.
+- Record the latest helper-based fix pattern and a candidate repository rule once CI confirms the fix.
+
+Code pattern recorded:
+
+```js
+function requiredPermissions(...codes) {
+  return JSON.stringify(codes);
+}
+```
+
+Before:
+
+```js
+required_permissions_json: '["audit.view"]',
+```
+
+After:
+
+```js
+required_permissions_json: requiredPermissions("audit.view"),
+```
+
+Prevention-rule candidate after CI confirmation:
+
+> Do not hand-write escaped JSON fixtures in JavaScript tests where the target code expects a JSON string. Use `JSON.stringify` through a named helper, then run `npm run format` or `npx prettier --write <file>` before committing.
+
 ## Real D1 implementation requirement
 
 The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
@@ -366,6 +406,7 @@ Required next implementation controls:
 - CI repeated the Prettier formatting failure for the same file.
 - The latest fix replaces inline JSON fixtures with a helper to remove formatting ambiguity.
 - A temporary Prettier 3.6.2 check on the planned file content passed.
+- True repository-level `prettier --write .` has not been executed from this assistant environment because a branch checkout was not available.
 - CI has not yet confirmed that the repository-level check passes.
 - No live D1 migration has been run.
 
@@ -377,22 +418,25 @@ Current issue:
 
 - the Access identity resolver commit had more than 300 added lines
 - this is recorded as a process deviation
+- repeated formatting fixes were attempted without a true repository-level `prettier --write` against the branch checkout
 
 Correction for future steps:
 
 - split future changes into smaller files and smaller commits
 - update trace before or alongside code changes
 - update both markdown and JSON trace records where a checkpoint changes the implementation state
-- do not batch large design and code changes without a trace checkpoint
+- for formatting failures, prefer `npm run format` or `npx prettier --write <file>` in a real repository checkout before committing
+- do not claim repository-level formatting success until CI or a real repository checkout confirms it
 
 ## Pending next steps
 
 Candidate next steps:
 
 - wait for PR CI to rerun and inspect any new failure
+- if Prettier still fails, obtain the exact Prettier `--write` diff from CI or from a real repository checkout and commit that output
+- after CI confirms the fix, create permanent repository guidance from checkpoint 025
 - apply the D1 migration through the manual workflow after review or explicit release decision
 - wire route-permission checks into the next protected product endpoint in a narrow slice
-- continue role-management UI and role-assignment API in separate slices
 
 ## Residual risks
 

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -1,0 +1,211 @@
+# Agent trace: authentication role-selection real implementation
+
+> This is an auditable trace for repository-affecting work triggered by `[reasoning]`. It records what happened, what was changed, what was paused, and what must be corrected before continuing. It does not expose private chain-of-thought.
+
+## Run metadata
+
+- Trace ID: `atrace-20260508-authentication-role-selection-real-implementation`
+- Date: 2026-05-08
+- Repository: `kevinrapley/ResearchOps`
+- Active branch: `feature/auth-foundation-real-d1-current-main`
+- Base branch: `main`
+- Base commit at branch creation: `8305adeed3b7e4047f132bc8c50347ce47e6205f`
+- Trigger token detected: `[reasoning]`
+- Trace layer: `operational`
+
+## User task summary
+
+The user asked to begin systematically building authentication role selection into the application using all captured documentation.
+
+The user then corrected the course by stating that this must not be a mock implementation. A prior branch had recorded the correction and the work was restarted from current `main` on `feature/auth-foundation-real-d1-current-main`.
+
+The user then raised a trace governance concern: trace records must be continuously updated as the build progresses, rather than reconstructed at the end.
+
+## Operating-model sources loaded before repository-affecting work
+
+The repository operating model had already been loaded during this workstream from the following files:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `docs/devops/ResearchOps-Bundle-Setup.zip`
+
+## Selected bundles
+
+Selected bundles:
+
+- `github-diamond`
+- `researchops-developer`
+- `gov-product-assistant-gold-standard`
+- `govuk-design-system`
+- `cloudflare-core-developer`
+- `airtable-public-api-developer`
+
+Selection rationale:
+
+- `github-diamond` applies because the task creates branch changes and will lead to a PR.
+- `researchops-developer` applies because the task changes the ResearchOps platform architecture.
+- `gov-product-assistant-gold-standard` applies because the task affects governance, personal data, safeguarding and assurance.
+- `govuk-design-system` applies because account, role and permission UI are in scope for the wider implementation.
+- `cloudflare-core-developer` applies because Worker, D1 and Cloudflare Access are in scope.
+- `airtable-public-api-developer` applies because the implementation must protect Airtable behind Worker authorisation.
+
+## Skipped bundles
+
+Skipped bundle:
+
+- `mural-public-api-developer`
+
+Skip rationale:
+
+- No Mural OAuth, workspace, room, board, widget or sticky-note implementation is in scope for this authentication slice.
+
+## Precedence decisions
+
+- GitHub Diamond governs branch hygiene, atomic changes, validation evidence and PR discipline.
+- ResearchOps Developer governs the platform architecture and service boundary.
+- Gold Standard Gov Product Assistant governs personal data, safeguarding, governance and service assurance risk.
+- GOV.UK Design System governs UI and accessibility when UI changes begin.
+- Cloudflare Core Developer governs Worker, D1, Access JWT and binding behaviour.
+- Airtable Public API governs the boundary that Airtable remains a data layer and not an authorisation engine.
+
+## Branch hygiene
+
+- The earlier branch `feature/auth-foundation-d1-rbac-current-main` diverged from `main` after new commits landed.
+- A fresh branch, `feature/auth-foundation-real-d1-current-main`, was created from current `main` commit `8305adeed3b7e4047f132bc8c50347ce47e6205f`.
+- No force update was used.
+
+## Files changed so far on this branch
+
+Current branch comparison against `main` shows three changed files:
+
+- `infra/cloudflare/migrations/0001_auth_foundation.sql`
+- `infra/cloudflare/src/core/auth/access.js`
+- `infra/cloudflare/src/worker.js`
+
+No test file has been created yet. A check for `tests/auth-foundation-route-state.test.js` returned not found.
+
+## Implementation checkpoint 1: D1 auth foundation migration
+
+File created:
+
+- `infra/cloudflare/migrations/0001_auth_foundation.sql`
+
+Purpose:
+
+- Create the D1 control-plane schema for real authentication and role selection.
+
+Schema coverage:
+
+- `auth_users`
+- `auth_identities`
+- `auth_teams`
+- `auth_team_memberships`
+- `auth_permissions`
+- `auth_roles`
+- `auth_role_permissions`
+- `auth_role_assignments`
+- `auth_permission_exceptions`
+- `auth_events`
+- `auth_audit_events`
+- `auth_route_permissions`
+
+Decision coverage:
+
+- D1 is the canonical control plane.
+- `scope_type` and `scope_id` are present from the first schema.
+- First enforceable scope can be team while project and study scope are supported structurally.
+- Sensitive permissions are represented separately.
+- Reserved export permissions are represented without implementing export.
+- General audit and safeguarding audit are separate permissions.
+
+## Implementation checkpoint 2: Cloudflare Access identity resolver
+
+File created:
+
+- `infra/cloudflare/src/core/auth/access.js`
+
+Purpose:
+
+- Resolve a real authenticated identity from the `Cf-Access-Jwt-Assertion` header.
+- Validate the Access JWT signature using Cloudflare Access certificates.
+- Validate token expiry and audience.
+- Map the validated provider identity to a D1 ResearchOps user.
+- Return active team, roles and permissions from D1.
+
+Non-goals:
+
+- It does not create mock identity behaviour.
+- It does not implement password authentication.
+- It does not implement role-management UI.
+- It does not change Airtable schema.
+
+## Implementation checkpoint 3: Worker route wiring
+
+File modified:
+
+- `infra/cloudflare/src/worker.js`
+
+Purpose:
+
+- Route `GET /api/me` and `GET /api/me/permissions` through the real Cloudflare Access identity resolver.
+- Add `X-ResearchOps-Team-Id` to allowed request headers so an authenticated user can select an active team context.
+
+## Trace governance correction
+
+The user raised a valid governance concern that trace records were not being continuously updated as implementation proceeded.
+
+Correction now applied:
+
+- this trace checkpoint has been created on the active implementation branch
+- future implementation steps must update this trace before or alongside code changes
+- test file creation has been paused until this trace checkpoint exists
+- future responses should report both implementation progress and trace updates
+
+## Process issue recorded
+
+`AGENTS.md` says commits should be incremental and atomic with a diff of no more than 300 lines.
+
+Current issue:
+
+- the Access identity resolver commit has more than 300 added lines
+- this should be treated as a process deviation
+
+Correction for future steps:
+
+- split future changes into smaller files and smaller commits
+- update this trace as each implementation step completes
+- do not batch large design and code changes without a trace checkpoint
+
+## Pending next step
+
+The user asked to keep the planned test file in memory before creation:
+
+- `tests/auth-foundation-route-state.test.js`
+
+The intended test file should verify:
+
+- `/api/me` fails closed without `Cf-Access-Jwt-Assertion`
+- `/api/me/permissions` fails closed without `Cf-Access-Jwt-Assertion`
+- Worker routes identity endpoints through the Access resolver
+- no mock identity mode exists in the auth resolver
+- the D1 migration contains the required control-plane tables and scoped role fields
+
+## Validation not yet claimed
+
+No local lint, format, typecheck, test or build result is claimed at this checkpoint.
+
+## Residual risks
+
+- Cloudflare Access JWT validation depends on environment configuration for Access certificates and audience.
+- The D1 migration has not yet been run in an environment.
+- The route wiring has not yet been validated by test execution.
+- The implementation is not yet protected by a route-permission middleware for wider product routes.
+- No PR has been opened for this branch yet.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -1,6 +1,6 @@
 # Agent trace: authentication role-selection real implementation
 
-> This is an auditable trace for repository-affecting work triggered by `[reasoning]`. It records what happened, what was changed, what was paused, and what must be corrected before continuing. It does not expose private chain-of-thought.
+> This is an auditable trace for repository-affecting work triggered by `[reasoning]`. It records what happened, what changed, what remains unverified, and what must happen next. It does not expose private chain-of-thought.
 
 ## Run metadata
 
@@ -17,17 +17,15 @@
 
 The user asked to begin systematically building authentication role selection into the application using all captured documentation.
 
-The user then corrected the course by stating that this must not be a mock implementation. A prior branch had recorded the correction and the work was restarted from current `main` on `feature/auth-foundation-real-d1-current-main`.
+The user corrected the course by stating that this must not be a mock implementation. The work was restarted from current `main` on `feature/auth-foundation-real-d1-current-main`.
 
-The user then raised a trace governance concern: trace records must be continuously updated as the build progresses, rather than reconstructed at the end.
+The user required continuous `[reasoning]` trace updates during the build and clarified that the work must systematically build the real authentication role-selection capability, including D1 table creation and seeding where necessary.
 
-The user then clarified that the work must not become trace-only or document-only. It must systematically build the real authentication role-selection capability, including D1 table creation and seeding where necessary.
+The user also clarified that Cloudflare APIs are in scope and provided Cloudflare Developer Platform and Cloudflare Agents Workbench bundles.
 
-The user then clarified that Cloudflare APIs are in scope for this build and provided Cloudflare Developer Platform and Cloudflare Agents Workbench bundles.
+## Operating-model sources loaded
 
-## Operating-model sources loaded before repository-affecting work
-
-The repository operating model had already been loaded during this workstream from the following files:
+Repository operating-model sources loaded during this workstream:
 
 - `AGENTS.md`
 - `.agent-operating-model/orchestration.xml`
@@ -41,14 +39,12 @@ The repository operating model had already been loaded during this workstream fr
 - `.agent-operating-model/behavioural-evals.json`
 - `docs/devops/ResearchOps-Bundle-Setup.zip`
 
-## Additional Cloudflare bundle sources loaded
-
-Uploaded bundle files inspected during this implementation:
+Uploaded Cloudflare bundle files inspected:
 
 - `/mnt/data/cloudflare-developer-platform-bundle.zip`
 - `/mnt/data/cloudflare-agents-workbench.zip`
 
-Relevant bundle materials inspected:
+Relevant Cloudflare bundle materials inspected:
 
 - `cloudflare-developer-platform-bundle/prompt.body.xml`
 - `cloudflare-developer-platform-bundle/domains/state-and-data-domain.xml`
@@ -57,14 +53,6 @@ Relevant bundle materials inspected:
 - `cloudflare-agents-workbench/prompt.body.xml`
 - `cloudflare-agents-workbench/policies/non-invented-api-policy.xml`
 - `cloudflare-agents-workbench/policies/freshness-and-citation-policy.xml`
-
-Cloudflare bundle implications for this slice:
-
-- D1 is the selected relational control-plane store for native Cloudflare-hosted application data.
-- Workers remain the server-side policy enforcement point.
-- The implementation should use the smallest viable Cloudflare product set before adding extra platform services.
-- Cloudflare Agents are not part of this slice because access-control decisions must stay deterministic and auditable.
-- Cloudflare API or Wrangler execution may be used to apply real D1 changes, but live D1 changes must not be claimed without execution evidence.
 
 ## Selected bundles
 
@@ -78,19 +66,6 @@ Selected bundles:
 - `cloudflare-developer-platform-bundle`
 - `cloudflare-agents-workbench`
 - `airtable-public-api-developer`
-
-Selection rationale:
-
-- `github-diamond` applies because the task creates branch changes and will lead to a PR.
-- `researchops-developer` applies because the task changes the ResearchOps platform architecture.
-- `gov-product-assistant-gold-standard` applies because the task affects governance, personal data, safeguarding and assurance.
-- `govuk-design-system` applies because account, role and permission UI are in scope for the wider implementation.
-- `cloudflare-core-developer` applies because Worker, D1 and Cloudflare Access are in scope.
-- `cloudflare-developer-platform-bundle` applies because this slice uses Workers and D1 as Cloudflare platform services.
-- `cloudflare-agents-workbench` applies as a boundary bundle: it confirms agents are not the decision-maker for role assignment or access control in this slice.
-- `airtable-public-api-developer` applies because the implementation must protect Airtable behind Worker authorisation.
-
-## Skipped bundles
 
 Skipped bundle:
 
@@ -112,22 +87,36 @@ Skip rationale:
 
 ## Branch hygiene
 
-- The earlier branch `feature/auth-foundation-d1-rbac-current-main` diverged from `main` after new commits landed.
-- A fresh branch, `feature/auth-foundation-real-d1-current-main`, was created from current `main` commit `8305adeed3b7e4047f132bc8c50347ce47e6205f`.
+- Earlier branch `feature/auth-foundation-d1-rbac-current-main` diverged from `main` after new commits landed.
+- Fresh branch `feature/auth-foundation-real-d1-current-main` was created from current `main` commit `8305adeed3b7e4047f132bc8c50347ce47e6205f`.
 - No force update was used.
 
 ## Files changed so far on this branch
 
-Current implementation files created or modified:
+Implementation files:
 
 - `.github/workflows/apply-d1-auth-foundation.yml`
 - `infra/cloudflare/migrations/0001_auth_foundation.sql`
 - `infra/cloudflare/src/core/auth/access.js`
 - `infra/cloudflare/src/core/auth/route-permissions.js`
 - `infra/cloudflare/src/worker.js`
+- `scripts/validate.sh`
 - `tests/auth-foundation-route-state.test.js`
 - `tests/auth-route-permissions.test.js`
+
+Product and operational documentation:
+
+- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
+
+Agent trace files:
+
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md`
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md`
 
 ## Implementation checkpoint 1: D1 auth foundation migration
 
@@ -154,11 +143,18 @@ Schema coverage:
 - `auth_audit_events`
 - `auth_route_permissions`
 
+Seed coverage:
+
+- permission records
+- role records
+- role-permission mappings
+- route permission declarations
+
 Decision coverage:
 
 - D1 is the canonical control plane.
 - `scope_type` and `scope_id` are present from the first schema.
-- First enforceable scope can be team while project and study scope are supported structurally.
+- Team is the first enforceable scope while project and study scope are supported structurally.
 - Sensitive permissions are represented separately.
 - Reserved export permissions are represented without implementing export.
 - General audit and safeguarding audit are separate permissions.
@@ -195,7 +191,7 @@ Purpose:
 - Route `GET /api/me` and `GET /api/me/permissions` through the real Cloudflare Access identity resolver.
 - Add `X-ResearchOps-Team-Id` to allowed request headers so an authenticated user can select an active team context.
 
-## Implementation checkpoint 4: Auth foundation route tests
+## Implementation checkpoint 4: auth foundation route tests
 
 File created:
 
@@ -203,19 +199,10 @@ File created:
 
 Purpose:
 
-- Confirm the identity routes fail closed without `Cf-Access-Jwt-Assertion`.
+- Confirm identity routes fail closed without `Cf-Access-Jwt-Assertion`.
 - Confirm Worker route wiring sends `/api/me` and `/api/me/permissions` through `core/auth/access.js`.
 - Confirm no mock identity mode exists in `core/auth/access.js`.
-- Confirm the D1 migration contains the required control-plane tables, scoped role fields and reserved permissions.
-
-Test coverage currently asserted:
-
-- `GET /api/me` returns `401` without an Access JWT.
-- `GET /api/me/permissions` returns `401` without an Access JWT.
-- Worker source imports and routes to `handleMeRoute`.
-- Auth resolver source contains no `RESEARCHOPS_AUTH_MODE`, `MOCK` or `mock` identity branch.
-- Migration contains required auth control-plane tables.
-- Migration contains `scope_type`, `scope_id`, `safeguarding.audit.view`, `audit.export` and `participant.pii.export`.
+- Confirm the D1 migration contains required control-plane tables, scoped role fields and reserved permissions.
 
 ## Implementation checkpoint 5: route-permission middleware plan
 
@@ -225,17 +212,10 @@ Planned file before creation:
 
 Purpose:
 
-- Add a small real authorisation helper that reads declared route permissions from D1.
+- Add a real authorisation helper that reads declared route permissions from D1.
 - Fail closed when a protected route has no declaration.
 - Deny access where the authenticated context lacks a required permission.
 - Avoid exposing missing permission codes to ordinary users.
-
-Boundary for this step:
-
-- Do not wire the helper into every existing product route yet.
-- Do not create mock users or mock roles.
-- Do not change Airtable behaviour yet.
-- Keep the slice small and testable.
 
 ## Implementation checkpoint 6: route-permission helper created
 
@@ -253,9 +233,8 @@ Purpose:
 
 Current boundary:
 
-- The helper is not yet wired into existing product routes.
-- It does not create users or roles.
-- It does not change Airtable behaviour.
+- The helper is now used by the identity routes.
+- The helper is not yet wired into all existing product routes.
 
 ## Implementation checkpoint 7: route-permission helper tests
 
@@ -271,14 +250,6 @@ Purpose:
 - Confirm diagnostics can include missing permission codes only when explicitly requested.
 - Confirm a matching permission allows the route.
 
-Test coverage currently asserted:
-
-- route declarations resolve method, route pattern, required permissions and auth state
-- missing route declarations produce `route_permission_missing`
-- ordinary permission-denied responses do not contain `details`
-- diagnostic permission-denied responses can include `missingPermissions`
-- matching permission `audit.view` allows `/api/audit/team-events`
-
 ## Implementation checkpoint 8: controlled D1 migration path plan
 
 Planned file before creation:
@@ -288,16 +259,8 @@ Planned file before creation:
 Purpose:
 
 - Provide a manual `workflow_dispatch` path for applying the authentication foundation migration to the real remote D1 database.
-- Require an explicit confirmation input before executing the migration.
-- Use the existing Cloudflare secret pattern: `CF_API_TOKEN` and `CF_ACCOUNT_ID`.
+- Require explicit confirmation input before executing the migration.
 - Use Wrangler against `infra/cloudflare/wrangler.toml` and `infra/cloudflare/migrations/0001_auth_foundation.sql`.
-
-Boundary for this step:
-
-- The workflow is manual only.
-- It must not run automatically on push.
-- It must not claim the migration has run.
-- It must record that real D1 table creation is only confirmed after a successful workflow run.
 
 ## Implementation checkpoint 9: controlled D1 migration workflow created
 
@@ -318,6 +281,89 @@ Current boundary:
 - The live D1 database has not been changed by this assistant turn.
 - Real table creation and seeding are only confirmed after a successful workflow run or direct Cloudflare API evidence.
 
+## Implementation checkpoint 10: route-permission wiring plan
+
+Trace file created:
+
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`
+
+Purpose:
+
+- Record the plan before wiring route-permission checks into the first real identity endpoints.
+
+## Implementation checkpoint 11: route-permission wiring complete
+
+Files changed:
+
+- `infra/cloudflare/src/core/auth/access.js`
+- `tests/auth-foundation-route-state.test.js`
+
+Purpose:
+
+- `GET /api/me` and `GET /api/me/permissions` now call `assertRoutePermission(request, env, context)` after Cloudflare Access identity resolution.
+- The route-state test now asserts route-permission wiring exists.
+
+Decision coverage:
+
+- Authenticated identity is not enough on its own. Identity-facing product endpoints now pass through declared D1 route-permission policy.
+
+## Implementation checkpoint 12: Cloudflare operations documentation plan
+
+Trace file created:
+
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`
+
+Purpose:
+
+- Record the plan before creating operational documentation for Cloudflare Access, D1 and the migration workflow.
+
+## Implementation checkpoint 13: Cloudflare operations documentation complete
+
+File created:
+
+- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
+
+Purpose:
+
+- Document Cloudflare Access runtime values.
+- Document the `RESEARCHOPS_D1` binding and `researchops-d1` target.
+- Document GitHub secrets for Wrangler execution.
+- Document manual D1 workflow inputs.
+- Document expected D1 tables, seed counts and post-apply verification queries.
+- Document rollout order, retry notes and evidence required before claiming live D1 creation.
+
+## Implementation checkpoint 14: validation wiring plan
+
+Trace file created:
+
+- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md`
+
+Purpose:
+
+- Record the plan before wiring authentication tests into the repository validation contract.
+
+## Implementation checkpoint 15: validation wiring complete
+
+File changed:
+
+- `scripts/validate.sh`
+
+Purpose:
+
+- Require both authentication foundation test files.
+- Run both authentication foundation test files during `npm run validate`.
+
+Validation contract additions:
+
+```bash
+node tests/auth-foundation-route-state.test.js
+node tests/auth-route-permissions.test.js
+```
+
+Decision coverage:
+
+- Authentication foundation checks are now part of the standard CI validation path used by Worker deployment.
+
 ## Real D1 implementation requirement
 
 The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
@@ -327,12 +373,12 @@ The build now includes a safe manual path to apply the migration to the real `re
 Required next implementation controls:
 
 - Run the manual workflow or use an equivalent direct Cloudflare API/Wrangler path before claiming real D1 tables exist.
-- Preserve the seed records in the migration for permissions, roles, role-permission mappings and route permission declarations.
-- Capture the workflow result or API output in this trace once the migration has actually run.
+- Preserve seed records in the migration for permissions, roles, role-permission mappings and route permission declarations.
+- Capture workflow result or API output in this trace once the migration has actually run.
 
 Tool boundary:
 
-- The current available repository tool access has created the workflow and migration.
+- Repository tool access has created the workflow and migration.
 - Direct Cloudflare execution has not been performed in this step.
 - Therefore live D1 creation cannot be claimed yet.
 
@@ -340,18 +386,11 @@ Tool boundary:
 
 The user raised a valid governance concern that trace records were not being continuously updated as implementation proceeded.
 
-Correction now applied:
+Correction applied:
 
-- this trace checkpoint exists on the active implementation branch
-- the test file was created only after the first trace checkpoint was recorded
-- this trace was updated immediately after the test file was created
-- the route-permission middleware plan was recorded before creating that file
-- the trace was updated after route-permission helper creation
-- the route-permission test creation was recorded immediately after the file was created
-- the real D1 application requirement has now been recorded explicitly
-- the controlled D1 migration path plan was recorded before creating that workflow
-- the trace was updated after creating the controlled D1 migration workflow
-- future implementation steps must update this trace before or alongside code changes
+- trace checkpoints are now written before or immediately after each implementation step
+- main trace is updated after major groups of work
+- live D1 status is explicitly separated from repository migration status
 - future responses should report both implementation progress and trace updates
 
 ## Process issue recorded
@@ -360,13 +399,13 @@ Correction now applied:
 
 Current issue:
 
-- the Access identity resolver commit has more than 300 added lines
-- this should be treated as a process deviation
+- the Access identity resolver commit had more than 300 added lines
+- this is recorded as a process deviation
 
 Correction for future steps:
 
 - split future changes into smaller files and smaller commits
-- update this trace as each implementation step completes
+- update trace before or alongside code changes
 - do not batch large design and code changes without a trace checkpoint
 
 ## Validation not yet claimed
@@ -377,19 +416,18 @@ The test files and D1 workflow have been created but not executed in this enviro
 
 ## Pending next steps
 
-The next implementation slice should be small and trace-updated before or alongside changes.
-
 Candidate next steps:
 
-- document required Cloudflare Access environment variables and D1 workflow execution steps
-- wire route-permission checks into the first protected endpoint in a narrow slice
-- consider splitting the Access resolver into smaller modules if PR review flags the earlier large commit
-- run repository tests or open a PR for CI execution
+- run or trigger validation through PR CI
+- open a PR for review and CI execution
+- apply the D1 migration through the manual workflow after review or explicit release decision
+- wire route-permission checks into the next protected product endpoint in a narrow slice
+- continue role-management UI and role-assignment API in separate slices
 
 ## Residual risks
 
 - Cloudflare Access JWT validation depends on environment configuration for Access certificates and audience.
 - The D1 migration has not yet been run in the live environment.
 - The route wiring has not yet been validated by test execution.
-- The route-permission helper is not yet wired into existing product routes.
+- Route-permission helper is only wired into identity routes so far.
 - No PR has been opened for this branch yet.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -15,10 +15,21 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 - Date: 2026-05-08
 - Repository: `kevinrapley/ResearchOps`
 - Active branch: `feature/auth-foundation-real-d1-current-main`
+- Pull request: `#215`
 - Base branch: `main`
 - Base commit at branch creation: `8305adeed3b7e4047f132bc8c50347ce47e6205f`
 - Trigger token detected: `[reasoning]`
 - Trace layer: `operational`
+
+## Current status
+
+- PR #215 is open.
+- Live D1 migration has not been applied.
+- Repository migration and manual D1 workflow exist.
+- Authentication tests are wired into `npm run validate`.
+- CI reported a Prettier formatting failure in `tests/auth-route-permissions.test.js`.
+- A formatting-only fix has been committed.
+- CI has not yet confirmed that the formatting fix passes.
 
 ## User task summary
 
@@ -53,53 +64,6 @@ Uploaded Cloudflare bundle files inspected:
 - `/mnt/data/cloudflare-developer-platform-bundle.zip`
 - `/mnt/data/cloudflare-agents-workbench.zip`
 
-Relevant Cloudflare bundle materials inspected:
-
-- `cloudflare-developer-platform-bundle/prompt.body.xml`
-- `cloudflare-developer-platform-bundle/domains/state-and-data-domain.xml`
-- `cloudflare-developer-platform-bundle/references/cloudflare-product-surface-reference.xml`
-- `cloudflare-developer-platform-bundle/workflows/implementation-phasing-workflow.xml`
-- `cloudflare-agents-workbench/prompt.body.xml`
-- `cloudflare-agents-workbench/policies/non-invented-api-policy.xml`
-- `cloudflare-agents-workbench/policies/freshness-and-citation-policy.xml`
-
-## Selected bundles
-
-Selected bundles:
-
-- `github-diamond`
-- `researchops-developer`
-- `gov-product-assistant-gold-standard`
-- `govuk-design-system`
-- `cloudflare-core-developer`
-- `cloudflare-developer-platform-bundle`
-- `cloudflare-agents-workbench`
-- `airtable-public-api-developer`
-
-Skipped bundle:
-
-- `mural-public-api-developer`
-
-Skip rationale:
-
-- No Mural OAuth, workspace, room, board, widget or sticky-note implementation is in scope for this authentication slice.
-
-## Precedence decisions
-
-- GitHub Diamond governs branch hygiene, atomic changes, validation evidence and PR discipline.
-- ResearchOps Developer governs the platform architecture and service boundary.
-- Gold Standard Gov Product Assistant governs personal data, safeguarding, governance and service assurance risk.
-- GOV.UK Design System governs UI and accessibility when UI changes begin.
-- Cloudflare Core Developer and Cloudflare Developer Platform govern Worker, D1, Access JWT and binding behaviour.
-- Cloudflare Agents Workbench governs agent boundaries and prevents invented agent/API claims.
-- Airtable Public API governs the boundary that Airtable remains a data layer and not an authorisation engine.
-
-## Branch hygiene
-
-- Earlier branch `feature/auth-foundation-d1-rbac-current-main` diverged from `main` after new commits landed.
-- Fresh branch `feature/auth-foundation-real-d1-current-main` was created from current `main` commit `8305adeed3b7e4047f132bc8c50347ce47e6205f`.
-- No force update was used.
-
 ## Checkpoint index
 
 | Checkpoint | File | Status |
@@ -112,6 +76,8 @@ Skip rationale:
 | 015 | [`authentication-role-selection-checkpoint-015-validation-wiring-complete.md`](authentication-role-selection-checkpoint-015-validation-wiring-complete.md) | Complete |
 | 016 | [`authentication-role-selection-checkpoint-016-trace-index-json-plan.md`](authentication-role-selection-checkpoint-016-trace-index-json-plan.md) | Complete |
 | 017 | [`authentication-role-selection-checkpoint-017-pr-readiness-plan.md`](authentication-role-selection-checkpoint-017-pr-readiness-plan.md) | Complete |
+| 018 | [`authentication-role-selection-checkpoint-018-lint-fix-plan.md`](authentication-role-selection-checkpoint-018-lint-fix-plan.md) | Complete |
+| 019 | [`authentication-role-selection-checkpoint-019-lint-fix-complete.md`](authentication-role-selection-checkpoint-019-lint-fix-complete.md) | Complete |
 
 ## Files changed so far on this branch
 
@@ -134,14 +100,7 @@ Agent trace files:
 
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md`
+- checkpoint markdown files 010 to 019
 
 ## Implementation checkpoints
 
@@ -154,37 +113,11 @@ File created:
 Purpose:
 
 - Create the D1 control-plane schema for real authentication and role selection.
+- Seed permissions, roles, role-permission mappings and route permission declarations.
 
-Schema coverage:
+Live status:
 
-- `auth_users`
-- `auth_identities`
-- `auth_teams`
-- `auth_team_memberships`
-- `auth_permissions`
-- `auth_roles`
-- `auth_role_permissions`
-- `auth_role_assignments`
-- `auth_permission_exceptions`
-- `auth_events`
-- `auth_audit_events`
-- `auth_route_permissions`
-
-Seed coverage:
-
-- permission records
-- role records
-- role-permission mappings
-- route permission declarations
-
-Decision coverage:
-
-- D1 is the canonical control plane.
-- `scope_type` and `scope_id` are present from the first schema.
-- Team is the first enforceable scope while project and study scope are supported structurally.
-- Sensitive permissions are represented separately.
-- Reserved export permissions are represented without implementing export.
-- General audit and safeguarding audit are separate permissions.
+- The migration has not been applied to the live `researchops-d1` database.
 
 ### Checkpoint 2: Cloudflare Access identity resolver
 
@@ -195,17 +128,16 @@ File created:
 Purpose:
 
 - Resolve a real authenticated identity from the `Cf-Access-Jwt-Assertion` header.
-- Validate the Access JWT signature using Cloudflare Access certificates.
-- Validate token expiry and audience.
-- Map the validated provider identity to a D1 ResearchOps user.
+- Validate Access JWT structure, signature, expiry and audience.
+- Map the provider identity to a D1 ResearchOps user.
 - Return active team, roles and permissions from D1.
 
 Non-goals:
 
-- It does not create mock identity behaviour.
-- It does not implement password authentication.
-- It does not implement role-management UI.
-- It does not change Airtable schema.
+- No mock identity behaviour.
+- No password authentication.
+- No role-management UI.
+- No Airtable schema change.
 
 ### Checkpoint 3: Worker route wiring
 
@@ -216,7 +148,7 @@ File modified:
 Purpose:
 
 - Route `GET /api/me` and `GET /api/me/permissions` through the real Cloudflare Access identity resolver.
-- Add `X-ResearchOps-Team-Id` to allowed request headers so an authenticated user can select an active team context.
+- Add `X-ResearchOps-Team-Id` to allowed request headers.
 
 ### Checkpoint 4: auth foundation route tests
 
@@ -228,21 +160,8 @@ Purpose:
 
 - Confirm identity routes fail closed without `Cf-Access-Jwt-Assertion`.
 - Confirm Worker route wiring sends `/api/me` and `/api/me/permissions` through `core/auth/access.js`.
-- Confirm no mock identity mode exists in `core/auth/access.js`.
-- Confirm the D1 migration contains required control-plane tables, scoped role fields and reserved permissions.
-
-### Checkpoint 5: route-permission middleware plan
-
-Planned file before creation:
-
-- `infra/cloudflare/src/core/auth/route-permissions.js`
-
-Purpose:
-
-- Add a real authorisation helper that reads declared route permissions from D1.
-- Fail closed when a protected route has no declaration.
-- Deny access where the authenticated context lacks a required permission.
-- Avoid exposing missing permission codes to ordinary users.
+- Confirm no mock identity mode exists.
+- Confirm route-permission wiring and D1 migration structure.
 
 ### Checkpoint 6: route-permission helper created
 
@@ -256,12 +175,11 @@ Purpose:
 - Fail closed where no route permission declaration exists.
 - Check an authenticated context for required permissions.
 - Return ordinary permission-denied responses without exposing missing permission codes.
-- Allow diagnostics to include details only when explicitly requested by the caller.
 
 Current boundary:
 
-- The helper is now used by the identity routes.
-- The helper is not yet wired into all existing product routes.
+- The helper is used by the identity routes.
+- The helper is not yet wired into all product routes.
 
 ### Checkpoint 7: route-permission helper tests
 
@@ -277,18 +195,6 @@ Purpose:
 - Confirm diagnostics can include missing permission codes only when explicitly requested.
 - Confirm a matching permission allows the route.
 
-### Checkpoint 8: controlled D1 migration path plan
-
-Planned file before creation:
-
-- `.github/workflows/apply-d1-auth-foundation.yml`
-
-Purpose:
-
-- Provide a manual `workflow_dispatch` path for applying the authentication foundation migration to the real remote D1 database.
-- Require explicit confirmation input before executing the migration.
-- Use Wrangler against `infra/cloudflare/wrangler.toml` and `infra/cloudflare/migrations/0001_auth_foundation.sql`.
-
 ### Checkpoint 9: controlled D1 migration workflow created
 
 File created:
@@ -297,32 +203,17 @@ File created:
 
 Purpose:
 
-- Provide a manual GitHub Actions path for applying `infra/cloudflare/migrations/0001_auth_foundation.sql` to the remote `researchops-d1` D1 database.
+- Provide a manual GitHub Actions path for applying `infra/cloudflare/migrations/0001_auth_foundation.sql` to remote `researchops-d1`.
 - Require explicit confirmation inputs: `researchops-d1` and `APPLY_AUTH_FOUNDATION`.
-- Use Wrangler `d1 execute` with `--remote` against `infra/cloudflare/wrangler.toml`.
-- Run optional post-apply checks for `auth_%` tables and seed record counts.
+- Use Wrangler `d1 execute` with `--remote`.
+- Run optional post-apply checks for tables and seed counts.
 
 Current boundary:
 
-- The workflow has been added but not run.
-- The live D1 database has not been changed by this assistant turn.
-- Real table creation and seeding are only confirmed after a successful workflow run or direct Cloudflare API evidence.
-
-### Checkpoint 10: route-permission wiring plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md`](authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md)
-
-Purpose:
-
-- Record the plan before wiring route-permission checks into the first real identity endpoints.
+- The workflow has not been run.
+- Live D1 has not been changed.
 
 ### Checkpoint 11: route-permission wiring complete
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md`](authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md)
 
 Files changed:
 
@@ -331,28 +222,9 @@ Files changed:
 
 Purpose:
 
-- `GET /api/me` and `GET /api/me/permissions` now call `assertRoutePermission(request, env, context)` after Cloudflare Access identity resolution.
-- The route-state test now asserts route-permission wiring exists.
-
-Decision coverage:
-
-- Authenticated identity is not enough on its own. Identity-facing product endpoints now pass through declared D1 route-permission policy.
-
-### Checkpoint 12: Cloudflare operations documentation plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md`](authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md)
-
-Purpose:
-
-- Record the plan before creating operational documentation for Cloudflare Access, D1 and the migration workflow.
+- `GET /api/me` and `GET /api/me/permissions` now call `assertRoutePermission(request, env, context)` after identity resolution.
 
 ### Checkpoint 13: Cloudflare operations documentation complete
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md`](authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md)
 
 File created:
 
@@ -361,27 +233,12 @@ File created:
 Purpose:
 
 - Document Cloudflare Access runtime values.
-- Document the `RESEARCHOPS_D1` binding and `researchops-d1` target.
-- Document GitHub secrets for Wrangler execution.
+- Document `RESEARCHOPS_D1` and `researchops-d1`.
 - Document manual D1 workflow inputs.
-- Document expected D1 tables, seed counts and post-apply verification queries.
-- Document rollout order, retry notes and evidence required before claiming live D1 creation.
-
-### Checkpoint 14: validation wiring plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-014-validation-wiring-plan.md`](authentication-role-selection-checkpoint-014-validation-wiring-plan.md)
-
-Purpose:
-
-- Record the plan before wiring authentication tests into the repository validation contract.
+- Document expected tables, seed counts and post-apply checks.
+- Document evidence required before claiming live D1 creation.
 
 ### Checkpoint 15: validation wiring complete
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-015-validation-wiring-complete.md`](authentication-role-selection-checkpoint-015-validation-wiring-complete.md)
 
 File changed:
 
@@ -389,8 +246,7 @@ File changed:
 
 Purpose:
 
-- Require both authentication foundation test files.
-- Run both authentication foundation test files during `npm run validate`.
+- Require and run both authentication foundation test files during `npm run validate`.
 
 Validation contract additions:
 
@@ -399,15 +255,7 @@ node tests/auth-foundation-route-state.test.js
 node tests/auth-route-permissions.test.js
 ```
 
-Decision coverage:
-
-- Authentication foundation checks are now part of the standard CI validation path used by Worker deployment.
-
 ### Checkpoint 16: trace index and JSON plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-016-trace-index-json-plan.md`](authentication-role-selection-checkpoint-016-trace-index-json-plan.md)
 
 Files created or updated:
 
@@ -418,7 +266,7 @@ Purpose:
 
 - Create and maintain the consolidated JSON trace.
 - Link checkpoint markdown files from the main markdown trace.
-- Record checkpoint events in one JSON trace rather than separate checkpoint JSON files.
+- Record checkpoint events in one JSON trace.
 
 ### Checkpoint 17: PR readiness plan
 
@@ -426,23 +274,45 @@ Trace file created:
 
 - [`authentication-role-selection-checkpoint-017-pr-readiness-plan.md`](authentication-role-selection-checkpoint-017-pr-readiness-plan.md)
 
-Branch comparison:
+Purpose:
 
-- status: ahead
-- ahead by: 29 commits
-- behind by: 0 commits
-- base commit: `8305adeed3b7e4047f132bc8c50347ce47e6205f`
+- Record branch readiness before opening PR #215.
+- State that live D1 had not been migrated and validation had not been executed in this environment.
+
+### Checkpoint 18: route-permission test lint fix plan
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-018-lint-fix-plan.md`](authentication-role-selection-checkpoint-018-lint-fix-plan.md)
+
+Reported failure:
+
+- `npm run lint` failed because Prettier reported `tests/auth-route-permissions.test.js`.
 
 Purpose:
 
-- Record branch readiness before opening a pull request.
-- Ensure the PR states that live D1 has not been migrated and validation has not been executed in this environment.
+- Record the formatting-only fix plan before changing the test file.
+
+### Checkpoint 19: route-permission test lint fix complete
+
+Trace file created:
+
+- [`authentication-role-selection-checkpoint-019-lint-fix-complete.md`](authentication-role-selection-checkpoint-019-lint-fix-complete.md)
+
+File changed:
+
+- `tests/auth-route-permissions.test.js`
+
+Purpose:
+
+- Reformat a long `assertRoutePermission` call to satisfy Prettier.
+- No test behaviour was changed.
 
 ## Real D1 implementation requirement
 
 The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
 
-The build now includes a safe manual path to apply the migration to the real `researchops-d1` database that is bound as `RESEARCHOPS_D1` in `infra/cloudflare/wrangler.toml`.
+The build includes a safe manual path to apply the migration to the real `researchops-d1` database bound as `RESEARCHOPS_D1` in `infra/cloudflare/wrangler.toml`.
 
 Required next implementation controls:
 
@@ -450,21 +320,12 @@ Required next implementation controls:
 - Preserve seed records in the migration for permissions, roles, role-permission mappings and route permission declarations.
 - Capture workflow result or API output in this trace once the migration has actually run.
 
-Tool boundary:
+## Validation status
 
-- Repository tool access has created the workflow and migration.
-- Direct Cloudflare execution has not been performed in this step.
-- Therefore live D1 creation cannot be claimed yet.
-
-## Trace governance correction
-
-Correction applied:
-
-- trace checkpoints are now written before or immediately after each implementation step
-- main trace links to checkpoint markdown files
-- consolidated JSON trace represents checkpoint events in one file
-- live D1 status is explicitly separated from repository migration status
-- future responses should report both implementation progress and trace updates
+- Initial CI lint failed on Prettier formatting in `tests/auth-route-permissions.test.js`.
+- A formatting-only fix has been committed.
+- CI has not yet confirmed that the fix passes.
+- No live D1 migration has been run.
 
 ## Process issue recorded
 
@@ -482,17 +343,11 @@ Correction for future steps:
 - update both markdown and JSON trace records where a checkpoint changes the implementation state
 - do not batch large design and code changes without a trace checkpoint
 
-## Validation not yet claimed
-
-No local lint, format, typecheck, test or build result is claimed at this checkpoint.
-
-The test files and D1 workflow have been created but not executed in this environment.
-
 ## Pending next steps
 
 Candidate next steps:
 
-- open a PR for review and CI execution
+- wait for PR CI to rerun and inspect any new failure
 - apply the D1 migration through the manual workflow after review or explicit release decision
 - wire route-permission checks into the next protected product endpoint in a narrow slice
 - continue role-management UI and role-assignment API in separate slices
@@ -501,6 +356,5 @@ Candidate next steps:
 
 - Cloudflare Access JWT validation depends on environment configuration for Access certificates and audience.
 - The D1 migration has not yet been run in the live environment.
-- The route wiring has not yet been validated by test execution.
 - Route-permission helper is only wired into identity routes so far.
-- No PR has been opened for this branch yet.
+- The latest lint fix still needs CI confirmation.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -28,10 +28,11 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 - Repository migration and manual D1 workflow exist.
 - Authentication tests are wired into `npm run validate`.
 - CI repeatedly reported Prettier formatting failures in `tests/auth-route-permissions.test.js`.
-- Root cause is now identified: Prettier reads `.editorconfig`, and this repository sets `indent_style = tab`.
+- Root cause is identified: Prettier reads `.editorconfig`, and this repository sets `indent_style = tab`.
 - Earlier temporary file checks were wrong because they ran outside the repository tree and missed `.editorconfig`.
-- `tests/auth-route-permissions.test.js` has now been replaced with repository Prettier output using tabs.
-- Repository-level CI has not yet confirmed the latest fix.
+- `tests/auth-route-permissions.test.js` has been replaced with repository Prettier output using tabs.
+- The repository now has explicit Prettier automation to prevent repeated guesswork.
+- Repository-level CI has not yet confirmed the latest automation and formatting changes.
 
 ## Checkpoint index
 
@@ -55,16 +56,21 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 | 025 | [`authentication-role-selection-checkpoint-025-prettier-tooling-findings.md`](authentication-role-selection-checkpoint-025-prettier-tooling-findings.md) | Superseded by 026 and 027 |
 | 026 | [`authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md`](authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md) | Complete |
 | 027 | [`authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md`](authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md) | Committed; pending CI confirmation |
+| 028 | [`authentication-role-selection-checkpoint-028-format-automation-plan.md`](authentication-role-selection-checkpoint-028-format-automation-plan.md) | Complete |
+| 029 | [`authentication-role-selection-checkpoint-029-format-automation-complete.md`](authentication-role-selection-checkpoint-029-format-automation-complete.md) | Committed; pending CI confirmation |
 
 ## Files changed so far on this branch
 
 Implementation files:
 
 - `.github/workflows/apply-d1-auth-foundation.yml`
+- `.github/workflows/format-branch.yml`
+- `.github/workflows/format-pr.yml`
 - `infra/cloudflare/migrations/0001_auth_foundation.sql`
 - `infra/cloudflare/src/core/auth/access.js`
 - `infra/cloudflare/src/core/auth/route-permissions.js`
 - `infra/cloudflare/src/worker.js`
+- `prettier.config.mjs`
 - `scripts/validate.sh`
 - `tests/auth-foundation-route-state.test.js`
 - `tests/auth-route-permissions.test.js`
@@ -77,9 +83,9 @@ Agent trace files:
 
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 - `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- checkpoint markdown files 010 to 027
+- checkpoint markdown files 010 to 029
 
-## Prettier failure record
+## Prettier failure and automation record
 
 ### Repeated symptom
 
@@ -109,7 +115,7 @@ Prettier reads `.editorconfig` by default. Therefore JavaScript files in this re
 
 Temporary standalone file checks outside the repository tree missed this rule. Those checks incorrectly passed because Prettier fell back to its default space indentation.
 
-### Exact fix committed
+### Exact file fix committed
 
 `tests/auth-route-permissions.test.js` was replaced with the Prettier 3.6.2 output produced when `.editorconfig` is present.
 
@@ -143,9 +149,33 @@ function requiredPermissions(...codes) {
 }
 ```
 
+### Automation implemented
+
+`prettier.config.mjs` makes the tab contract explicit:
+
+```js
+export default {
+	useTabs: true,
+	tabWidth: 2,
+	endOfLine: "lf",
+};
+```
+
+`.github/workflows/format-pr.yml` remains strict, but now captures the exact repair patch on failure:
+
+```bash
+./node_modules/.bin/prettier --write .
+git diff -- . > prettier-fix.patch
+cat prettier-fix.patch
+```
+
+The workflow uploads `prettier-fix.patch` as an artifact.
+
+`.github/workflows/format-branch.yml` is a manual `workflow_dispatch` repair path. It checks out a named branch, runs `npm run format`, and commits/pushes formatting changes only if there is a diff.
+
 ### Workflow change decision
 
-The proposed workaround of adding `npx prettier --write .` before lint in CI should not be used as the primary fix.
+The proposed workaround of adding `npx prettier --write .` before lint in normal CI should not be used as the primary validation fix.
 
 CI should detect formatting drift. It should not silently mutate the runner workspace without committing the change back to the branch.
 
@@ -161,11 +191,11 @@ or targeted:
 npx prettier --write tests/auth-route-permissions.test.js
 ```
 
-Both commands must be run from the repository root so `.editorconfig` is applied.
+Both commands must be run from the repository root so `.editorconfig` and `prettier.config.mjs` are applied.
 
-## Implementation checkpoints
+## Authentication implementation checkpoints
 
-### Checkpoint 1: D1 auth foundation migration
+### D1 auth foundation migration
 
 File created:
 
@@ -180,7 +210,7 @@ Live status:
 
 - The migration has not been applied to the live `researchops-d1` database.
 
-### Checkpoint 2: Cloudflare Access identity resolver
+### Cloudflare Access identity resolver
 
 File created:
 
@@ -200,7 +230,7 @@ Non-goals:
 - No role-management UI.
 - No Airtable schema change.
 
-### Checkpoint 3: Worker route wiring
+### Worker route wiring
 
 File modified:
 
@@ -211,7 +241,7 @@ Purpose:
 - Route `GET /api/me` and `GET /api/me/permissions` through the real Cloudflare Access identity resolver.
 - Add `X-ResearchOps-Team-Id` to allowed request headers.
 
-### Checkpoint 4: auth foundation route tests
+### Auth foundation route tests
 
 File created:
 
@@ -224,7 +254,7 @@ Purpose:
 - Confirm no mock identity mode exists.
 - Confirm route-permission wiring and D1 migration structure.
 
-### Checkpoint 6: route-permission helper created
+### Route-permission helper
 
 File created:
 
@@ -242,7 +272,7 @@ Current boundary:
 - The helper is used by the identity routes.
 - The helper is not yet wired into all product routes.
 
-### Checkpoint 7: route-permission helper tests
+### Route-permission helper tests
 
 File created:
 
@@ -256,7 +286,7 @@ Purpose:
 - Confirm diagnostics can include missing permission codes only when explicitly requested.
 - Confirm a matching permission allows the route.
 
-### Checkpoint 9: controlled D1 migration workflow created
+### Controlled D1 migration workflow
 
 File created:
 
@@ -273,109 +303,6 @@ Current boundary:
 
 - The workflow has not been run.
 - Live D1 has not been changed.
-
-### Checkpoint 11: route-permission wiring complete
-
-Files changed:
-
-- `infra/cloudflare/src/core/auth/access.js`
-- `tests/auth-foundation-route-state.test.js`
-
-Purpose:
-
-- `GET /api/me` and `GET /api/me/permissions` now call `assertRoutePermission(request, env, context)` after identity resolution.
-
-### Checkpoint 13: Cloudflare operations documentation complete
-
-File created:
-
-- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
-
-Purpose:
-
-- Document Cloudflare Access runtime values.
-- Document `RESEARCHOPS_D1` and `researchops-d1`.
-- Document manual D1 workflow inputs.
-- Document expected tables, seed counts and post-apply checks.
-- Document evidence required before claiming live D1 creation.
-
-### Checkpoint 15: validation wiring complete
-
-File changed:
-
-- `scripts/validate.sh`
-
-Purpose:
-
-- Require and run both authentication foundation test files during `npm run validate`.
-
-Validation contract additions:
-
-```bash
-node tests/auth-foundation-route-state.test.js
-node tests/auth-route-permissions.test.js
-```
-
-### Checkpoint 16: trace index and JSON plan
-
-Files created or updated:
-
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
-
-Purpose:
-
-- Create and maintain the consolidated JSON trace.
-- Link checkpoint markdown files from the main markdown trace.
-- Record checkpoint events in one JSON trace.
-
-### Checkpoint 17: PR readiness plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-017-pr-readiness-plan.md`](authentication-role-selection-checkpoint-017-pr-readiness-plan.md)
-
-Purpose:
-
-- Record branch readiness before opening PR #215.
-- State that live D1 had not been migrated and validation had not been executed in this environment.
-
-### Checkpoints 18 to 25: Prettier false starts and tooling findings
-
-These checkpoints record the repeated Prettier investigation and the earlier incorrect hypotheses.
-
-Key correction:
-
-- Inline JSON fixture cleanup was useful but not the formatting root cause.
-- The root cause was repository `.editorconfig` tab indentation.
-- Earlier temporary checks were invalid because they did not include `.editorconfig`.
-
-### Checkpoint 26: Prettier root cause plan
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md`](authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md)
-
-Purpose:
-
-- Record `.editorconfig` tab indentation as the true root cause.
-- Record that CI auto-formatting should not replace explicit committed formatting fixes.
-
-### Checkpoint 27: Prettier root cause fix complete
-
-Trace file created:
-
-- [`authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md`](authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md)
-
-File changed:
-
-- `tests/auth-route-permissions.test.js`
-
-Purpose:
-
-- Apply repository Prettier output with tab indentation.
-- Preserve route-permission test behaviour.
-- Record future prevention guidance.
 
 ## Real D1 implementation requirement
 
@@ -395,6 +322,7 @@ Required next implementation controls:
 - CI repeated the Prettier formatting failure for the same file.
 - Root cause identified as `.editorconfig` tab indentation.
 - `tests/auth-route-permissions.test.js` has been rewritten with repository Prettier tab output.
+- Formatting automation is now in place to expose or commit exact Prettier output.
 - CI has not yet confirmed that the repository-level check passes.
 - No live D1 migration has been run.
 
@@ -412,7 +340,7 @@ Correction for future steps:
 - split future changes into smaller files and smaller commits
 - update trace before or alongside code changes
 - update both markdown and JSON trace records where a checkpoint changes the implementation state
-- for formatting failures, run Prettier from the repository root so `.editorconfig` applies
+- for formatting failures, run Prettier from the repository root so `.editorconfig` and `prettier.config.mjs` apply
 - do not claim repository-level formatting success until CI or a real repository checkout confirms it
 
 ## Pending next steps
@@ -420,7 +348,8 @@ Correction for future steps:
 Candidate next steps:
 
 - wait for PR CI to rerun and inspect any new failure
-- after CI confirms the fix, create permanent repository guidance from checkpoints 026 and 027
+- if format still fails, use the new `prettier-fix.patch` artifact or run the manual `Format branch` workflow against `feature/auth-foundation-real-d1-current-main`
+- after CI confirms the format path, create permanent repository guidance from checkpoints 026 to 029
 - apply the D1 migration through the manual workflow after review or explicit release decision
 - wire route-permission checks into the next protected product endpoint in a narrow slice
 
@@ -429,4 +358,4 @@ Candidate next steps:
 - Cloudflare Access JWT validation depends on environment configuration for Access certificates and audience.
 - The D1 migration has not yet been run in the live environment.
 - Route-permission helper is only wired into identity routes so far.
-- The latest lint fix still needs repository-level CI confirmation.
+- The latest format automation still needs repository-level CI confirmation.

--- a/docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md
+++ b/docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md
@@ -1,0 +1,243 @@
+# Authentication role-selection Cloudflare operations
+
+**Date:** 2026-05-08  
+**Status:** operational implementation note  
+**Related decision record:** [`authentication-role-selection-decisions-2026-05-08.md`](authentication-role-selection-decisions-2026-05-08.md)  
+**Related migration:** [`../../../infra/cloudflare/migrations/0001_auth_foundation.sql`](../../../../infra/cloudflare/migrations/0001_auth_foundation.sql)  
+**Related workflow:** [`../../../../.github/workflows/apply-d1-auth-foundation.yml`](../../../../.github/workflows/apply-d1-auth-foundation.yml)
+
+## Purpose
+
+This note records the Cloudflare operational setup for the real authentication role-selection foundation.
+
+It covers the Worker, Cloudflare Access, D1, GitHub Actions and Wrangler path needed to turn the repository changes into live database tables and seed records.
+
+## Implementation boundary
+
+This work uses Cloudflare Access for identity, Workers for server-side enforcement and D1 for the ResearchOps access-control plane.
+
+D1 is the canonical store for ResearchOps users, identities, teams, roles, permissions, assignments, route declarations and audit state.
+
+Airtable remains the research data layer. It must not decide permissions.
+
+Cloudflare Agents are not used to grant access, reveal participant data or make role-selection decisions. They may later support admin guidance, but access-control decisions must remain deterministic and auditable.
+
+## Cloudflare Access runtime values
+
+The Worker identity resolver expects Cloudflare Access to place a JWT in the `Cf-Access-Jwt-Assertion` request header.
+
+The resolver validates:
+
+- the Access JWT is present
+- the token has three JWT segments
+- the signing algorithm is `RS256`
+- the token signature matches a trusted Cloudflare Access public key
+- the token is not expired
+- the token is not before its valid time
+- the token audience matches the configured Access application audience
+- the token includes a subject and email claim
+
+The implementation uses these environment values:
+
+| Value | Purpose |
+|---|---|
+| `CLOUDFLARE_ACCESS_AUD` | Preferred ResearchOps variable for the Access Application Audience tag. |
+| `CF_ACCESS_AUD` | Supported fallback name for the Access Application Audience tag. |
+| `CF_ACCESS_AUD_TAG` | Supported fallback name for the Access Application Audience tag. |
+| `CLOUDFLARE_ACCESS_CERTS_URL` | Explicit URL for the Cloudflare Access signing keys. |
+| `CF_ACCESS_CERTS_URL` | Supported fallback signing-key URL. |
+| `CLOUDFLARE_ACCESS_TEAM_DOMAIN` | Team domain used to build `https://<team-domain>/cdn-cgi/access/certs` when explicit cert URL is not provided. |
+
+Use either an explicit certs URL or a team domain. Do not configure both with conflicting values.
+
+## Required Worker binding
+
+The Worker must have this D1 binding available:
+
+| Binding | Database |
+|---|---|
+| `RESEARCHOPS_D1` | `researchops-d1` |
+
+The current `infra/cloudflare/wrangler.toml` already binds `RESEARCHOPS_D1` to `researchops-d1`.
+
+## Required GitHub secrets
+
+The manual D1 workflow uses the same Cloudflare secret pattern as the Worker deployment workflow.
+
+Required repository or environment secrets:
+
+| Secret | Purpose |
+|---|---|
+| `CF_API_TOKEN` | Allows Wrangler to execute against Cloudflare. |
+| `CF_ACCOUNT_ID` | Identifies the Cloudflare account. |
+
+The token must have enough permission to execute D1 commands against `researchops-d1`.
+
+## D1 migration file
+
+The migration file is:
+
+```text
+infra/cloudflare/migrations/0001_auth_foundation.sql
+```
+
+It creates these control-plane tables:
+
+- `auth_users`
+- `auth_identities`
+- `auth_teams`
+- `auth_team_memberships`
+- `auth_permissions`
+- `auth_roles`
+- `auth_role_permissions`
+- `auth_role_assignments`
+- `auth_permission_exceptions`
+- `auth_events`
+- `auth_audit_events`
+- `auth_route_permissions`
+
+It also seeds:
+
+- 17 permission records
+- 6 role records
+- 15 role-permission mapping records
+- 6 route-permission declaration records
+
+The migration uses `CREATE TABLE IF NOT EXISTS` and `INSERT OR IGNORE` so it can be retried safely where the previous execution partly completed or where records already exist.
+
+## Manual workflow for applying the migration
+
+The manual workflow is:
+
+```text
+.github/workflows/apply-d1-auth-foundation.yml
+```
+
+It must be run manually through GitHub Actions.
+
+Required workflow inputs:
+
+| Input | Required value |
+|---|---|
+| `confirm_database_name` | `researchops-d1` |
+| `confirm_operation` | `APPLY_AUTH_FOUNDATION` |
+| `run_post_apply_checks` | `true` unless there is a specific reason to skip checks |
+
+The workflow applies the SQL file using Wrangler:
+
+```bash
+npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+  --remote \
+  --config "${WRANGLER_CONFIG}" \
+  --file "${AUTH_FOUNDATION_MIGRATION}"
+```
+
+The `--remote` flag is required. Without it, Wrangler may operate against a local D1 database rather than the deployed database.
+
+## Post-apply checks
+
+The workflow checks that `auth_%` tables exist:
+
+```sql
+SELECT name
+FROM sqlite_master
+WHERE type = 'table'
+  AND name LIKE 'auth_%'
+ORDER BY name;
+```
+
+The workflow also checks seed counts:
+
+```sql
+SELECT 'permissions' AS record_type, COUNT(*) AS total FROM auth_permissions
+UNION ALL
+SELECT 'roles', COUNT(*) FROM auth_roles
+UNION ALL
+SELECT 'role_permissions', COUNT(*) FROM auth_role_permissions
+UNION ALL
+SELECT 'route_permissions', COUNT(*) FROM auth_route_permissions;
+```
+
+Expected minimum counts after this migration:
+
+| Record type | Expected count |
+|---|---:|
+| `permissions` | 17 |
+| `roles` | 6 |
+| `role_permissions` | 15 |
+| `route_permissions` | 6 |
+
+## Evidence required before claiming live D1 creation
+
+Do not claim that the live D1 tables exist until there is evidence from one of these routes:
+
+- successful GitHub Actions run for `Apply D1 Authentication Foundation`
+- successful direct Wrangler execution against `--remote`
+- successful Cloudflare API evidence showing the tables and seed records exist
+
+The agent audit trace must be updated with the evidence source.
+
+## First live verification checks
+
+After successful migration, verify the real database has the expected route declarations.
+
+```sql
+SELECT method, route_pattern, required_permissions_json, auth_required, implementation_status
+FROM auth_route_permissions
+ORDER BY method, route_pattern;
+```
+
+The first seeded route declarations are:
+
+| Method | Route | Required permissions |
+|---|---|---|
+| `GET` | `/api/me` | `[]` |
+| `GET` | `/api/me/permissions` | `[]` |
+| `POST` | `/api/auth/role-assignments` | `role.assign` |
+| `GET` | `/api/audit/account-activity` | `[]` |
+| `GET` | `/api/audit/team-events` | `audit.view` |
+| `GET` | `/api/safeguarding/audit` | `safeguarding.audit.view` |
+
+## Rollout order
+
+Use this sequence:
+
+1. Merge the authentication foundation PR after review.
+2. Run validation and deployment checks.
+3. Confirm Cloudflare Access values are configured.
+4. Run the manual D1 workflow with the required confirmations.
+5. Capture the workflow result in the agent audit trace.
+6. Verify table and seed counts.
+7. Deploy or redeploy the Worker.
+8. Test `/api/me` and `/api/me/permissions` through Cloudflare Access.
+9. Continue with role-management UI and wider route-permission wiring.
+
+## Failure and retry notes
+
+If the D1 execution fails, do not assume partial success.
+
+Check the workflow output and rerun the post-apply checks. The migration is designed to tolerate repeat execution because table creation and seed inserts are idempotent.
+
+If a seed count is lower than expected, stop and inspect the D1 output before continuing with Worker rollout.
+
+If the Access JWT fails validation, check:
+
+- the Access application audience value
+- the team domain or certs URL
+- whether the Worker receives `Cf-Access-Jwt-Assertion`
+- whether the Access application protects the Worker route
+- whether the Access signing keys have rotated
+
+## Current status
+
+The repository now contains the migration and the manual workflow.
+
+The live `researchops-d1` database has not been changed by this document.
+
+Live table creation and seeding are confirmed only after a successful workflow run or equivalent direct Cloudflare execution evidence.
+
+## Source check
+
+Cloudflare Access documentation says Access sends the application token in the `Cf-Access-Jwt-Assertion` request header and recommends validating that header rather than relying on the cookie.
+
+Cloudflare D1 Wrangler documentation says `d1 execute` can execute SQL from `--command` or `--file`, and the D1 getting-started guidance shows `--remote --file` for applying schema to a deployed D1 database.

--- a/infra/cloudflare/migrations/0001_auth_foundation.sql
+++ b/infra/cloudflare/migrations/0001_auth_foundation.sql
@@ -1,0 +1,204 @@
+-- Authentication and role-selection foundation
+-- Date: 2026-05-08
+-- Scope: D1 control-plane schema for real authentication, role assignment,
+-- permissions, scoped access and audit. This migration does not create a mock
+-- identity route or change Airtable schema.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS auth_users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  account_status TEXT NOT NULL DEFAULT 'active' CHECK (account_status IN ('pending', 'active', 'suspended', 'closed')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS auth_identities (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  provider_subject TEXT NOT NULL,
+  email TEXT NOT NULL,
+  email_verified INTEGER NOT NULL DEFAULT 0 CHECK (email_verified IN (0, 1)),
+  mfa_claim TEXT,
+  last_seen_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE (provider, provider_subject)
+);
+
+CREATE TABLE IF NOT EXISTS auth_teams (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  team_status TEXT NOT NULL DEFAULT 'active' CHECK (team_status IN ('active', 'suspended', 'closed')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS auth_team_memberships (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_users(id) ON DELETE CASCADE,
+  team_id TEXT NOT NULL REFERENCES auth_teams(id) ON DELETE CASCADE,
+  membership_status TEXT NOT NULL DEFAULT 'active' CHECK (membership_status IN ('pending', 'active', 'removed')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  removed_at TEXT,
+  UNIQUE (user_id, team_id)
+);
+
+CREATE TABLE IF NOT EXISTS auth_permissions (
+  code TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  description TEXT NOT NULL,
+  is_sensitive INTEGER NOT NULL DEFAULT 0 CHECK (is_sensitive IN (0, 1)),
+  is_reserved INTEGER NOT NULL DEFAULT 0 CHECK (is_reserved IN (0, 1))
+);
+
+CREATE TABLE IF NOT EXISTS auth_roles (
+  id TEXT PRIMARY KEY,
+  role_key TEXT NOT NULL UNIQUE,
+  label TEXT NOT NULL,
+  description TEXT NOT NULL,
+  is_sensitive INTEGER NOT NULL DEFAULT 0 CHECK (is_sensitive IN (0, 1)),
+  approval_required INTEGER NOT NULL DEFAULT 0 CHECK (approval_required IN (0, 1)),
+  default_expiry_days INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS auth_role_permissions (
+  role_id TEXT NOT NULL REFERENCES auth_roles(id) ON DELETE CASCADE,
+  permission_code TEXT NOT NULL REFERENCES auth_permissions(code) ON DELETE CASCADE,
+  PRIMARY KEY (role_id, permission_code)
+);
+
+CREATE TABLE IF NOT EXISTS auth_role_assignments (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_users(id) ON DELETE CASCADE,
+  role_id TEXT NOT NULL REFERENCES auth_roles(id) ON DELETE CASCADE,
+  scope_type TEXT NOT NULL CHECK (scope_type IN ('team', 'project', 'study')),
+  scope_id TEXT NOT NULL,
+  assignment_status TEXT NOT NULL DEFAULT 'active' CHECK (assignment_status IN ('pending', 'active', 'rejected', 'expired', 'revoked')),
+  requested_reason TEXT,
+  approved_by_user_id TEXT REFERENCES auth_users(id),
+  approved_at TEXT,
+  expires_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE (user_id, role_id, scope_type, scope_id)
+);
+
+CREATE TABLE IF NOT EXISTS auth_permission_exceptions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_users(id) ON DELETE CASCADE,
+  permission_code TEXT NOT NULL REFERENCES auth_permissions(code) ON DELETE CASCADE,
+  scope_type TEXT NOT NULL CHECK (scope_type IN ('team', 'project', 'study')),
+  scope_id TEXT NOT NULL,
+  exception_status TEXT NOT NULL DEFAULT 'active' CHECK (exception_status IN ('active', 'expired', 'revoked')),
+  reason TEXT NOT NULL,
+  granted_by_user_id TEXT REFERENCES auth_users(id),
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS auth_events (
+  id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  actor_user_id TEXT REFERENCES auth_users(id),
+  target_user_id TEXT REFERENCES auth_users(id),
+  team_id TEXT REFERENCES auth_teams(id),
+  provider TEXT,
+  route_path TEXT,
+  request_id TEXT,
+  ip_hash TEXT,
+  user_agent_family TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS auth_audit_events (
+  id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  actor_user_id TEXT REFERENCES auth_users(id),
+  team_id TEXT REFERENCES auth_teams(id),
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  permission_code TEXT REFERENCES auth_permissions(code),
+  route_path TEXT,
+  request_id TEXT,
+  field_group TEXT,
+  outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'denied', 'pending', 'redacted')),
+  is_safeguarding INTEGER NOT NULL DEFAULT 0 CHECK (is_safeguarding IN (0, 1)),
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  redacted_by_user_id TEXT REFERENCES auth_users(id),
+  redacted_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS auth_route_permissions (
+  id TEXT PRIMARY KEY,
+  method TEXT NOT NULL,
+  route_pattern TEXT NOT NULL,
+  required_permissions_json TEXT NOT NULL DEFAULT '[]',
+  auth_required INTEGER NOT NULL DEFAULT 1 CHECK (auth_required IN (0, 1)),
+  implementation_status TEXT NOT NULL DEFAULT 'declared' CHECK (implementation_status IN ('declared', 'implemented', 'deferred')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE (method, route_pattern)
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_identities_user ON auth_identities(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_memberships_user ON auth_team_memberships(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_assignments_user_scope ON auth_role_assignments(user_id, scope_type, scope_id);
+CREATE INDEX IF NOT EXISTS idx_auth_events_actor ON auth_events(actor_user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_auth_audit_actor ON auth_audit_events(actor_user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_auth_audit_target ON auth_audit_events(target_type, target_id, created_at);
+
+INSERT OR IGNORE INTO auth_permissions (code, label, description, is_sensitive, is_reserved) VALUES
+  ('participant.pii.view', 'View participant personal data state', 'Can access participant records beyond the public or anonymous service shell.', 1, 0),
+  ('participant.pii.reveal', 'Reveal participant personal data', 'Can intentionally reveal identifiable participant fields where context access permits it.', 1, 0),
+  ('participant.pii.export', 'Export participant personal data', 'Reserved permission for future identifiable participant exports.', 1, 1),
+  ('governed.create', 'Create governed research records', 'Can create governed evidence, findings or recommendations.', 0, 0),
+  ('governed.edit', 'Edit governed research records', 'Can edit governed research records with authorship and audit capture.', 0, 0),
+  ('governed.review', 'Review governed research records', 'Can review findings or governed records.', 1, 0),
+  ('governed.approve', 'Approve governed research records', 'Can approve studies, findings or governed records where approval is required.', 1, 0),
+  ('recommendation.own', 'Own accepted recommendations', 'Can be assigned as decision owner for accepted recommendations.', 1, 0),
+  ('safeguarding.view', 'View safeguarding detail', 'Can view restricted safeguarding detail.', 1, 0),
+  ('safeguarding.record', 'Record safeguarding observations', 'Can record safeguarding risks or observations.', 1, 0),
+  ('safeguarding.resolve', 'Resolve safeguarding concerns', 'Can resolve or close safeguarding concerns.', 1, 0),
+  ('safeguarding.audit.view', 'View safeguarding audit', 'Can view restricted safeguarding audit events.', 1, 0),
+  ('safeguarding.export', 'Export safeguarding records', 'Reserved permission for future safeguarding export controls.', 1, 1),
+  ('audit.view', 'View audit events', 'Can view general audit events.', 1, 0),
+  ('audit.export', 'Export audit events', 'Reserved permission for future audit export controls.', 1, 1),
+  ('team.manage', 'Manage team membership', 'Can manage team members and team settings.', 1, 0),
+  ('role.assign', 'Assign roles', 'Can assign or approve role access where policy permits.', 1, 0);
+
+INSERT OR IGNORE INTO auth_roles (id, role_key, label, description, is_sensitive, approval_required, default_expiry_days) VALUES
+  ('role_observer', 'observer', 'Observer', 'Can observe low-risk research context without participant personal data reveal.', 0, 0, NULL),
+  ('role_researcher', 'researcher', 'Researcher', 'Can create and edit governed research records.', 0, 0, NULL),
+  ('role_research_lead', 'research_lead', 'Research Lead', 'Can create, edit and review governed research records.', 1, 1, 180),
+  ('role_approver', 'approver', 'Approver', 'Can approve governed research records and own accepted recommendations.', 1, 1, 180),
+  ('role_safeguarding_lead', 'safeguarding_lead', 'Safeguarding Lead', 'Can view, record, resolve and audit safeguarding concerns.', 1, 1, 180),
+  ('role_team_admin', 'team_admin', 'Team Admin', 'Can manage team membership, roles and general audit oversight.', 1, 1, 180);
+
+INSERT OR IGNORE INTO auth_role_permissions (role_id, permission_code) VALUES
+  ('role_researcher', 'governed.create'),
+  ('role_researcher', 'governed.edit'),
+  ('role_research_lead', 'governed.create'),
+  ('role_research_lead', 'governed.edit'),
+  ('role_research_lead', 'governed.review'),
+  ('role_approver', 'governed.review'),
+  ('role_approver', 'governed.approve'),
+  ('role_approver', 'recommendation.own'),
+  ('role_safeguarding_lead', 'safeguarding.view'),
+  ('role_safeguarding_lead', 'safeguarding.record'),
+  ('role_safeguarding_lead', 'safeguarding.resolve'),
+  ('role_safeguarding_lead', 'safeguarding.audit.view'),
+  ('role_team_admin', 'team.manage'),
+  ('role_team_admin', 'role.assign'),
+  ('role_team_admin', 'audit.view');
+
+INSERT OR IGNORE INTO auth_route_permissions (id, method, route_pattern, required_permissions_json, auth_required, implementation_status) VALUES
+  ('route_api_me_get', 'GET', '/api/me', '[]', 1, 'implemented'),
+  ('route_api_me_permissions_get', 'GET', '/api/me/permissions', '[]', 1, 'implemented'),
+  ('route_api_role_assignments_post', 'POST', '/api/auth/role-assignments', '["role.assign"]', 1, 'deferred'),
+  ('route_api_account_activity_get', 'GET', '/api/audit/account-activity', '[]', 1, 'deferred'),
+  ('route_api_team_audit_get', 'GET', '/api/audit/team-events', '["audit.view"]', 1, 'deferred'),
+  ('route_api_safeguarding_audit_get', 'GET', '/api/safeguarding/audit', '["safeguarding.audit.view"]', 1, 'deferred');

--- a/infra/cloudflare/src/core/auth/access.js
+++ b/infra/cloudflare/src/core/auth/access.js
@@ -1,0 +1,309 @@
+const PROVIDER = "cloudflare_access";
+
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+  "cache-control": "no-store",
+  "x-content-type-options": "nosniff"
+};
+
+class AuthError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function decodeBase64Url(value) {
+  const padded = `${value}${"=".repeat((4 - (value.length % 4)) % 4)}`;
+  const binary = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function decodeJsonSegment(value) {
+  return JSON.parse(new TextDecoder().decode(decodeBase64Url(value)));
+}
+
+function getAccessJwt(request) {
+  const token = request.headers.get("Cf-Access-Jwt-Assertion");
+  if (!token) {
+    throw new AuthError(401, "authentication_required", "Sign in is required to use this part of ResearchOps.");
+  }
+  return token;
+}
+
+function getAudience(env) {
+  return env.CLOUDFLARE_ACCESS_AUD || env.CF_ACCESS_AUD || env.CF_ACCESS_AUD_TAG || "";
+}
+
+function getCertsUrl(env) {
+  if (env.CLOUDFLARE_ACCESS_CERTS_URL) return env.CLOUDFLARE_ACCESS_CERTS_URL;
+  if (env.CF_ACCESS_CERTS_URL) return env.CF_ACCESS_CERTS_URL;
+  if (env.CLOUDFLARE_ACCESS_TEAM_DOMAIN) {
+    return `https://${env.CLOUDFLARE_ACCESS_TEAM_DOMAIN}/cdn-cgi/access/certs`;
+  }
+  return "";
+}
+
+async function verifyJwtSignature(token, header, env) {
+  if (header.alg !== "RS256") {
+    throw new AuthError(401, "unsupported_access_token_algorithm", "The sign-in token uses an unsupported algorithm.");
+  }
+
+  const certsUrl = getCertsUrl(env);
+  if (!certsUrl) {
+    throw new AuthError(503, "access_configuration_missing", "Cloudflare Access certificate configuration is missing.");
+  }
+
+  const response = await fetch(certsUrl, { headers: { accept: "application/json" } });
+  if (!response.ok) {
+    throw new AuthError(503, "access_certs_unavailable", "Cloudflare Access certificates could not be loaded.");
+  }
+
+  const body = await response.json();
+  const key = (body.keys || []).find((candidate) => candidate.kid === header.kid);
+  if (!key) {
+    throw new AuthError(401, "access_key_not_found", "The sign-in token could not be matched to a trusted key.");
+  }
+
+  const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+  const cryptoKey = await crypto.subtle.importKey(
+    "jwk",
+    key,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+  const ok = await crypto.subtle.verify(
+    "RSASSA-PKCS1-v1_5",
+    cryptoKey,
+    decodeBase64Url(encodedSignature),
+    new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`)
+  );
+
+  if (!ok) {
+    throw new AuthError(401, "access_signature_invalid", "The sign-in token signature is invalid.");
+  }
+}
+
+async function validateAccessToken(request, env) {
+  const token = getAccessJwt(request);
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new AuthError(401, "access_token_malformed", "The sign-in token is malformed.");
+  }
+
+  const header = decodeJsonSegment(parts[0]);
+  const payload = decodeJsonSegment(parts[1]);
+  await verifyJwtSignature(token, header, env);
+
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp && payload.exp <= now) {
+    throw new AuthError(401, "access_token_expired", "The sign-in token has expired.");
+  }
+  if (payload.nbf && payload.nbf > now) {
+    throw new AuthError(401, "access_token_not_yet_valid", "The sign-in token is not yet valid.");
+  }
+
+  const expectedAud = getAudience(env);
+  if (!expectedAud) {
+    throw new AuthError(503, "access_audience_missing", "Cloudflare Access audience configuration is missing.");
+  }
+
+  const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud].filter(Boolean);
+  if (!audiences.includes(expectedAud)) {
+    throw new AuthError(401, "access_audience_invalid", "The sign-in token audience is invalid.");
+  }
+
+  if (!payload.sub || !payload.email) {
+    throw new AuthError(401, "access_identity_incomplete", "The sign-in token does not include the required identity claims.");
+  }
+
+  return payload;
+}
+
+function dbFor(env) {
+  const db = env.RESEARCHOPS_D1;
+  if (!db || typeof db.prepare !== "function") {
+    throw new AuthError(503, "d1_binding_missing", "The ResearchOps identity database is not available.");
+  }
+  return db;
+}
+
+function makeId(prefix) {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+async function findUserByIdentity(db, subject) {
+  return db
+    .prepare(`
+      SELECT u.id, u.email, u.display_name, u.account_status
+      FROM auth_identities i
+      INNER JOIN auth_users u ON u.id = i.user_id
+      WHERE i.provider = ? AND i.provider_subject = ?
+      LIMIT 1
+    `)
+    .bind(PROVIDER, subject)
+    .first();
+}
+
+async function ensureUserForAccessPayload(db, payload) {
+  const existing = await findUserByIdentity(db, payload.sub);
+  if (existing) return existing;
+
+  const userId = makeId("usr");
+  const identityId = makeId("idn");
+  const displayName = payload.name || payload.email;
+
+  await db.prepare("INSERT INTO auth_users (id, email, display_name, account_status) VALUES (?, ?, ?, 'pending')")
+    .bind(userId, payload.email, displayName)
+    .run();
+  await db.prepare(`
+    INSERT INTO auth_identities (id, user_id, provider, provider_subject, email, email_verified, mfa_claim, last_seen_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  `)
+    .bind(identityId, userId, PROVIDER, payload.sub, payload.email, payload.email_verified ? 1 : 0, payload.amr || null)
+    .run();
+
+  return findUserByIdentity(db, payload.sub);
+}
+
+async function updateLastSeen(db, subject) {
+  await db.prepare(`
+    UPDATE auth_identities
+    SET last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+    WHERE provider = ? AND provider_subject = ?
+  `)
+    .bind(PROVIDER, subject)
+    .run();
+}
+
+async function listTeams(db, userId) {
+  const result = await db.prepare(`
+    SELECT t.id, t.name
+    FROM auth_team_memberships m
+    INNER JOIN auth_teams t ON t.id = m.team_id
+    WHERE m.user_id = ? AND m.membership_status = 'active' AND t.team_status = 'active'
+    ORDER BY t.name ASC
+  `)
+    .bind(userId)
+    .all();
+  return result.results || [];
+}
+
+function selectActiveTeam(request, teams) {
+  const requestedTeamId = request.headers.get("X-ResearchOps-Team-Id");
+  return teams.find((team) => team.id === requestedTeamId) || teams[0] || null;
+}
+
+async function listRoles(db, userId, teamId) {
+  if (!teamId) return [];
+  const result = await db.prepare(`
+    SELECT r.role_key, r.label, r.description, r.is_sensitive, ra.scope_type, ra.scope_id, ra.expires_at
+    FROM auth_role_assignments ra
+    INNER JOIN auth_roles r ON r.id = ra.role_id
+    WHERE ra.user_id = ?
+      AND ra.scope_type = 'team'
+      AND ra.scope_id = ?
+      AND ra.assignment_status = 'active'
+      AND (ra.expires_at IS NULL OR ra.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    ORDER BY r.label ASC
+  `)
+    .bind(userId, teamId)
+    .all();
+  return result.results || [];
+}
+
+async function listPermissions(db, userId, teamId) {
+  if (!teamId) return [];
+  const result = await db.prepare(`
+    SELECT DISTINCT p.code, p.label, p.description, p.is_sensitive, p.is_reserved
+    FROM auth_role_assignments ra
+    INNER JOIN auth_role_permissions rp ON rp.role_id = ra.role_id
+    INNER JOIN auth_permissions p ON p.code = rp.permission_code
+    WHERE ra.user_id = ?
+      AND ra.scope_type = 'team'
+      AND ra.scope_id = ?
+      AND ra.assignment_status = 'active'
+      AND (ra.expires_at IS NULL OR ra.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    UNION
+    SELECT DISTINCT p.code, p.label, p.description, p.is_sensitive, p.is_reserved
+    FROM auth_permission_exceptions e
+    INNER JOIN auth_permissions p ON p.code = e.permission_code
+    WHERE e.user_id = ?
+      AND e.scope_type = 'team'
+      AND e.scope_id = ?
+      AND e.exception_status = 'active'
+      AND e.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+    ORDER BY code ASC
+  `)
+    .bind(userId, teamId, userId, teamId)
+    .all();
+  return result.results || [];
+}
+
+export async function resolveAuthenticatedContext(request, env) {
+  const accessPayload = await validateAccessToken(request, env);
+  const db = dbFor(env);
+  const user = await ensureUserForAccessPayload(db, accessPayload);
+  await updateLastSeen(db, accessPayload.sub);
+
+  const teams = await listTeams(db, user.id);
+  const activeTeam = selectActiveTeam(request, teams);
+  const roles = await listRoles(db, user.id, activeTeam?.id);
+  const permissions = await listPermissions(db, user.id, activeTeam?.id);
+
+  return {
+    authenticated: true,
+    provider: PROVIDER,
+    user: {
+      id: user.id,
+      email: user.email,
+      displayName: user.display_name,
+      accountStatus: user.account_status
+    },
+    activeTeam,
+    teams,
+    roles: roles.map((role) => ({
+      key: role.role_key,
+      label: role.label,
+      description: role.description,
+      sensitive: role.is_sensitive === 1,
+      scopeType: role.scope_type,
+      scopeId: role.scope_id,
+      expiresAt: role.expires_at
+    })),
+    permissions: permissions.map((permission) => ({
+      code: permission.code,
+      label: permission.label,
+      description: permission.description,
+      sensitive: permission.is_sensitive === 1,
+      reserved: permission.is_reserved === 1
+    }))
+  };
+}
+
+export async function handleMeRoute(request, env, apiPath) {
+  try {
+    const context = await resolveAuthenticatedContext(request, env);
+    if (apiPath === "/api/me/permissions") {
+      return jsonResponse({
+        ok: true,
+        authenticated: true,
+        user: context.user,
+        activeTeam: context.activeTeam,
+        permissions: context.permissions
+      });
+    }
+    return jsonResponse({ ok: true, ...context });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return jsonResponse({ ok: false, error: error.code, message: error.message }, error.status);
+    }
+    return jsonResponse({ ok: false, error: "authentication_error", message: "Authentication could not be completed." }, 500);
+  }
+}

--- a/infra/cloudflare/src/core/auth/access.js
+++ b/infra/cloudflare/src/core/auth/access.js
@@ -1,3 +1,8 @@
+import {
+  assertRoutePermission,
+  routePermissionErrorResponse
+} from "./route-permissions.js";
+
 const PROVIDER = "cloudflare_access";
 
 const JSON_HEADERS = {
@@ -290,6 +295,8 @@ export async function resolveAuthenticatedContext(request, env) {
 export async function handleMeRoute(request, env, apiPath) {
   try {
     const context = await resolveAuthenticatedContext(request, env);
+    await assertRoutePermission(request, env, context);
+
     if (apiPath === "/api/me/permissions") {
       return jsonResponse({
         ok: true,
@@ -304,6 +311,11 @@ export async function handleMeRoute(request, env, apiPath) {
     if (error instanceof AuthError) {
       return jsonResponse({ ok: false, error: error.code, message: error.message }, error.status);
     }
-    return jsonResponse({ ok: false, error: "authentication_error", message: "Authentication could not be completed." }, 500);
+
+    try {
+      return routePermissionErrorResponse(error);
+    } catch {
+      return jsonResponse({ ok: false, error: "authentication_error", message: "Authentication could not be completed." }, 500);
+    }
   }
 }

--- a/infra/cloudflare/src/core/auth/route-permissions.js
+++ b/infra/cloudflare/src/core/auth/route-permissions.js
@@ -1,0 +1,142 @@
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+  "cache-control": "no-store",
+  "x-content-type-options": "nosniff"
+};
+
+class RoutePermissionError extends Error {
+  constructor(status, code, message, details = {}) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function dbFor(env = {}) {
+  const db = env.RESEARCHOPS_D1;
+  if (!db || typeof db.prepare !== "function") {
+    throw new RoutePermissionError(
+      503,
+      "route_permission_store_unavailable",
+      "Route permissions cannot be checked right now."
+    );
+  }
+  return db;
+}
+
+function normalisePath(pathname) {
+  let path = pathname || "/";
+  path = path.replace(/\/{2,}/g, "/");
+  if (path.startsWith("/api/") && path.endsWith("/") && path !== "/api/") {
+    path = path.slice(0, -1);
+  }
+  return path;
+}
+
+function parsePermissions(value) {
+  try {
+    const parsed = JSON.parse(value || "[]");
+    return Array.isArray(parsed)
+      ? parsed.filter((permission) => typeof permission === "string" && permission.trim())
+      : [];
+  } catch {
+    throw new RoutePermissionError(
+      500,
+      "route_permission_invalid",
+      "Route permission configuration is invalid."
+    );
+  }
+}
+
+async function readDeclaration(db, method, pathname) {
+  return db
+    .prepare(`
+      SELECT method, route_pattern, required_permissions_json, auth_required, implementation_status
+      FROM auth_route_permissions
+      WHERE method = ? AND route_pattern = ?
+      LIMIT 1
+    `)
+    .bind(method, pathname)
+    .first();
+}
+
+function permissionCodesFor(context = {}) {
+  return new Set(
+    (context.permissions || [])
+      .map((permission) => permission.code)
+      .filter(Boolean)
+  );
+}
+
+function missingPermissions(requiredPermissions, context) {
+  const heldPermissions = permissionCodesFor(context);
+  return requiredPermissions.filter((permission) => !heldPermissions.has(permission));
+}
+
+export async function resolveRoutePermissionDeclaration(request, env = {}) {
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+  const pathname = normalisePath(url.pathname);
+  const declaration = await readDeclaration(dbFor(env), method, pathname);
+
+  if (!declaration) {
+    throw new RoutePermissionError(
+      403,
+      "route_permission_missing",
+      "This route is not available because no permission rule has been declared.",
+      { method, pathname }
+    );
+  }
+
+  return {
+    method: declaration.method,
+    routePattern: declaration.route_pattern,
+    requiredPermissions: parsePermissions(declaration.required_permissions_json),
+    authRequired: declaration.auth_required === 1,
+    implementationStatus: declaration.implementation_status
+  };
+}
+
+export async function assertRoutePermission(request, env, context) {
+  const declaration = await resolveRoutePermissionDeclaration(request, env);
+
+  if (declaration.authRequired && !context?.authenticated) {
+    throw new RoutePermissionError(
+      401,
+      "authentication_required",
+      "Sign in is required to use this part of ResearchOps."
+    );
+  }
+
+  const missing = missingPermissions(declaration.requiredPermissions, context);
+  if (missing.length) {
+    throw new RoutePermissionError(
+      403,
+      "permission_denied",
+      "You do not have permission to use this part of ResearchOps.",
+      { missingPermissions: missing }
+    );
+  }
+
+  return declaration;
+}
+
+export function routePermissionErrorResponse(error, options = {}) {
+  if (!(error instanceof RoutePermissionError)) throw error;
+
+  const body = {
+    ok: false,
+    error: error.code,
+    message: error.message
+  };
+
+  if (options.includeDiagnostics) {
+    body.details = error.details;
+  }
+
+  return new Response(JSON.stringify(body), {
+    status: error.status,
+    headers: JSON_HEADERS
+  });
+}

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -1,3 +1,4 @@
+import { handleMeRoute } from "./core/auth/access.js";
 import { handleRequest } from "./core/router.js";
 import { ResearchOpsService } from "./service/index.js";
 
@@ -30,7 +31,7 @@ function buildCorsHeaders(env, request) {
 		"Access-Control-Allow-Origin": resolveAllowedOrigin(env, request),
 		"Vary": "Origin",
 		"Access-Control-Allow-Methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
-		"Access-Control-Allow-Headers": "Authorization, Content-Type",
+		"Access-Control-Allow-Headers": "Authorization, Content-Type, X-ResearchOps-Team-Id",
 		"Access-Control-Allow-Credentials": "true"
 	};
 }
@@ -163,7 +164,8 @@ export default {
 
 		try {
 			let result;
-			if (method === "GET" && apiPath === "/api/projects") result = await handleProjects(request, env);
+			if (method === "GET" && (apiPath === "/api/me" || apiPath === "/api/me/permissions")) result = await handleMeRoute(request, env, apiPath);
+			else if (method === "GET" && apiPath === "/api/projects") result = await handleProjects(request, env);
 			else if (apiPath.startsWith("/api/projects/")) result = await handleProjectRecord(request, env, apiPath);
 			else if (apiPath === "/api/synthesis" || apiPath.startsWith("/api/synthesis/")) result = await handleSynthesis(request, env, apiPath);
 			else if (apiPath === "/api/consent-forms" || apiPath.startsWith("/api/consent-forms/")) result = await handleConsentForms(request, env, apiPath);

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,5 @@
+export default {
+	useTabs: true,
+	tabWidth: 2,
+	endOfLine: "lf",
+};

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -90,6 +90,8 @@ require_file "tests/start-page-route-state.test.js"
 require_file "tests/participants-page-route-state.test.js"
 require_file "tests/consent-forms-route-state.test.js"
 require_file "tests/participant-consent-route-state.test.js"
+require_file "tests/auth-foundation-route-state.test.js"
+require_file "tests/auth-route-permissions.test.js"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -220,6 +222,12 @@ node tests/govuk-page-chrome-navigation-route-state.test.js
 
 info "checking GOV.UK breadcrumb and back-link route-state contract"
 node tests/govuk-breadcrumb-back-link-route-state.test.js
+
+info "checking authentication foundation route-state contract"
+node tests/auth-foundation-route-state.test.js
+
+info "checking authentication route-permission contract"
+node tests/auth-route-permissions.test.js
 
 info "checking Projects API route contract"
 node tests/projects-route-contract.test.js

--- a/tests/auth-foundation-route-state.test.js
+++ b/tests/auth-foundation-route-state.test.js
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import worker from "../infra/cloudflare/src/worker.js";
+
+const env = {
+  ALLOWED_ORIGINS: "https://researchops.pages.dev",
+};
+
+async function readJson(response) {
+  return response.json();
+}
+
+async function assertMeRouteFailsClosedWithoutAccessToken() {
+  const response = await worker.fetch(
+    new Request("https://worker.test/api/me"),
+    env,
+    {},
+  );
+
+  assert.equal(response.status, 401);
+
+  const payload = await readJson(response);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error, "authentication_required");
+}
+
+async function assertPermissionsRouteFailsClosedWithoutAccessToken() {
+  const response = await worker.fetch(
+    new Request("https://worker.test/api/me/permissions"),
+    env,
+    {},
+  );
+
+  assert.equal(response.status, 401);
+
+  const payload = await readJson(response);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error, "authentication_required");
+}
+
+function assertWorkerRoutesAuthThroughAccessResolver() {
+  const workerSource = fs.readFileSync("infra/cloudflare/src/worker.js", "utf8");
+
+  assert.match(
+    workerSource,
+    /import \{ handleMeRoute \} from "\.\/core\/auth\/access\.js";/,
+  );
+  assert.match(workerSource, /apiPath === "\/api\/me"/);
+  assert.match(workerSource, /apiPath === "\/api\/me\/permissions"/);
+}
+
+function assertNoMockIdentityModeExists() {
+  const authSource = fs.readFileSync(
+    "infra/cloudflare/src/core/auth/access.js",
+    "utf8",
+  );
+
+  assert.equal(authSource.includes("RESEARCHOPS_AUTH_MODE"), false);
+  assert.equal(authSource.includes("MOCK"), false);
+  assert.equal(authSource.includes("mock"), false);
+}
+
+function assertMigrationContainsRequiredControlPlaneTables() {
+  const migration = fs.readFileSync(
+    "infra/cloudflare/migrations/0001_auth_foundation.sql",
+    "utf8",
+  );
+
+  for (const tableName of [
+    "auth_users",
+    "auth_identities",
+    "auth_teams",
+    "auth_team_memberships",
+    "auth_permissions",
+    "auth_roles",
+    "auth_role_permissions",
+    "auth_role_assignments",
+    "auth_permission_exceptions",
+    "auth_events",
+    "auth_audit_events",
+    "auth_route_permissions",
+  ]) {
+    assert.match(migration, new RegExp(`CREATE TABLE IF NOT EXISTS ${tableName}`));
+  }
+
+  assert.match(
+    migration,
+    /scope_type TEXT NOT NULL CHECK \(scope_type IN \('team', 'project', 'study'\)\)/,
+  );
+  assert.match(migration, /scope_id TEXT NOT NULL/);
+  assert.match(migration, /safeguarding\.audit\.view/);
+  assert.match(migration, /audit\.export/);
+  assert.match(migration, /participant\.pii\.export/);
+}
+
+await assertMeRouteFailsClosedWithoutAccessToken();
+await assertPermissionsRouteFailsClosedWithoutAccessToken();
+assertWorkerRoutesAuthThroughAccessResolver();
+assertNoMockIdentityModeExists();
+assertMigrationContainsRequiredControlPlaneTables();

--- a/tests/auth-foundation-route-state.test.js
+++ b/tests/auth-foundation-route-state.test.js
@@ -49,6 +49,17 @@ function assertWorkerRoutesAuthThroughAccessResolver() {
   assert.match(workerSource, /apiPath === "\/api\/me\/permissions"/);
 }
 
+function assertIdentityRoutesUseRoutePermissions() {
+  const authSource = fs.readFileSync(
+    "infra/cloudflare/src/core/auth/access.js",
+    "utf8",
+  );
+
+  assert.match(authSource, /assertRoutePermission/);
+  assert.match(authSource, /routePermissionErrorResponse/);
+  assert.match(authSource, /await assertRoutePermission\(request, env, context\)/);
+}
+
 function assertNoMockIdentityModeExists() {
   const authSource = fs.readFileSync(
     "infra/cloudflare/src/core/auth/access.js",
@@ -96,5 +107,6 @@ function assertMigrationContainsRequiredControlPlaneTables() {
 await assertMeRouteFailsClosedWithoutAccessToken();
 await assertPermissionsRouteFailsClosedWithoutAccessToken();
 assertWorkerRoutesAuthThroughAccessResolver();
+assertIdentityRoutesUseRoutePermissions();
 assertNoMockIdentityModeExists();
 assertMigrationContainsRequiredControlPlaneTables();

--- a/tests/auth-route-permissions.test.js
+++ b/tests/auth-route-permissions.test.js
@@ -108,10 +108,14 @@ async function assertDiagnosticsCanIncludeMissingPermissionCodes() {
   };
 
   try {
-    await assertRoutePermission(requestFor("/api/auth/role-assignments", "POST"), env, {
-      authenticated: true,
-      permissions: [],
-    });
+    await assertRoutePermission(
+      requestFor("/api/auth/role-assignments", "POST"),
+      env,
+      {
+        authenticated: true,
+        permissions: [],
+      },
+    );
     assert.fail("Expected role assignment permission to be denied");
   } catch (error) {
     const response = routePermissionErrorResponse(error, {

--- a/tests/auth-route-permissions.test.js
+++ b/tests/auth-route-permissions.test.js
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import {
+  assertRoutePermission,
+  resolveRoutePermissionDeclaration,
+  routePermissionErrorResponse,
+} from "../infra/cloudflare/src/core/auth/route-permissions.js";
+
+function createD1(declaration) {
+  return {
+    prepare() {
+      return {
+        bind(method, pathname) {
+          return {
+            async first() {
+              if (!declaration) return null;
+
+              return {
+                method,
+                route_pattern: pathname,
+                required_permissions_json:
+                  declaration.required_permissions_json ?? "[]",
+                auth_required: declaration.auth_required ?? 1,
+                implementation_status:
+                  declaration.implementation_status ?? "implemented",
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function requestFor(path, method = "GET") {
+  return new Request(`https://worker.test${path}`, { method });
+}
+
+async function assertDeclaredRouteIsResolved() {
+  const env = {
+    RESEARCHOPS_D1: createD1({
+      required_permissions_json: '["audit.view"]',
+      auth_required: 1,
+    }),
+  };
+
+  const declaration = await resolveRoutePermissionDeclaration(
+    requestFor("/api/audit/team-events"),
+    env,
+  );
+
+  assert.equal(declaration.method, "GET");
+  assert.equal(declaration.routePattern, "/api/audit/team-events");
+  assert.deepEqual(declaration.requiredPermissions, ["audit.view"]);
+  assert.equal(declaration.authRequired, true);
+}
+
+async function assertMissingRouteFailsClosed() {
+  const env = { RESEARCHOPS_D1: createD1(null) };
+
+  try {
+    await assertRoutePermission(requestFor("/api/unknown-protected-route"), env, {
+      authenticated: true,
+      permissions: [{ code: "audit.view" }],
+    });
+    assert.fail("Expected missing route permission declaration to fail closed");
+  } catch (error) {
+    const response = routePermissionErrorResponse(error);
+    assert.equal(response.status, 403);
+
+    const body = await response.json();
+    assert.equal(body.ok, false);
+    assert.equal(body.error, "route_permission_missing");
+    assert.equal(Object.hasOwn(body, "details"), false);
+  }
+}
+
+async function assertMissingPermissionIsDeniedWithoutDetails() {
+  const env = {
+    RESEARCHOPS_D1: createD1({
+      required_permissions_json: '["safeguarding.audit.view"]',
+      auth_required: 1,
+    }),
+  };
+
+  try {
+    await assertRoutePermission(requestFor("/api/safeguarding/audit"), env, {
+      authenticated: true,
+      permissions: [{ code: "audit.view" }],
+    });
+    assert.fail("Expected missing safeguarding permission to be denied");
+  } catch (error) {
+    const response = routePermissionErrorResponse(error);
+    assert.equal(response.status, 403);
+
+    const body = await response.json();
+    assert.equal(body.ok, false);
+    assert.equal(body.error, "permission_denied");
+    assert.equal(Object.hasOwn(body, "details"), false);
+  }
+}
+
+async function assertDiagnosticsCanIncludeMissingPermissionCodes() {
+  const env = {
+    RESEARCHOPS_D1: createD1({
+      required_permissions_json: '["role.assign"]',
+      auth_required: 1,
+    }),
+  };
+
+  try {
+    await assertRoutePermission(requestFor("/api/auth/role-assignments", "POST"), env, {
+      authenticated: true,
+      permissions: [],
+    });
+    assert.fail("Expected role assignment permission to be denied");
+  } catch (error) {
+    const response = routePermissionErrorResponse(error, {
+      includeDiagnostics: true,
+    });
+    assert.equal(response.status, 403);
+
+    const body = await response.json();
+    assert.deepEqual(body.details.missingPermissions, ["role.assign"]);
+  }
+}
+
+async function assertMatchingPermissionAllowsRoute() {
+  const env = {
+    RESEARCHOPS_D1: createD1({
+      required_permissions_json: '["audit.view"]',
+      auth_required: 1,
+    }),
+  };
+
+  const declaration = await assertRoutePermission(
+    requestFor("/api/audit/team-events"),
+    env,
+    {
+      authenticated: true,
+      permissions: [{ code: "audit.view" }],
+    },
+  );
+
+  assert.equal(declaration.routePattern, "/api/audit/team-events");
+  assert.deepEqual(declaration.requiredPermissions, ["audit.view"]);
+}
+
+await assertDeclaredRouteIsResolved();
+await assertMissingRouteFailsClosed();
+await assertMissingPermissionIsDeniedWithoutDetails();
+await assertDiagnosticsCanIncludeMissingPermissionCodes();
+await assertMatchingPermissionAllowsRoute();

--- a/tests/auth-route-permissions.test.js
+++ b/tests/auth-route-permissions.test.js
@@ -5,6 +5,10 @@ import {
   routePermissionErrorResponse,
 } from "../infra/cloudflare/src/core/auth/route-permissions.js";
 
+function requiredPermissions(...codes) {
+  return JSON.stringify(codes);
+}
+
 function createD1(declaration) {
   return {
     prepare() {
@@ -38,7 +42,7 @@ function requestFor(path, method = "GET") {
 async function assertDeclaredRouteIsResolved() {
   const env = {
     RESEARCHOPS_D1: createD1({
-      required_permissions_json: '["audit.view"]',
+      required_permissions_json: requiredPermissions("audit.view"),
       auth_required: 1,
     }),
   };
@@ -81,7 +85,7 @@ async function assertMissingRouteFailsClosed() {
 async function assertMissingPermissionIsDeniedWithoutDetails() {
   const env = {
     RESEARCHOPS_D1: createD1({
-      required_permissions_json: '["safeguarding.audit.view"]',
+      required_permissions_json: requiredPermissions("safeguarding.audit.view"),
       auth_required: 1,
     }),
   };
@@ -106,7 +110,7 @@ async function assertMissingPermissionIsDeniedWithoutDetails() {
 async function assertDiagnosticsCanIncludeMissingPermissionCodes() {
   const env = {
     RESEARCHOPS_D1: createD1({
-      required_permissions_json: '["role.assign"]',
+      required_permissions_json: requiredPermissions("role.assign"),
       auth_required: 1,
     }),
   };
@@ -135,7 +139,7 @@ async function assertDiagnosticsCanIncludeMissingPermissionCodes() {
 async function assertMatchingPermissionAllowsRoute() {
   const env = {
     RESEARCHOPS_D1: createD1({
-      required_permissions_json: '["audit.view"]',
+      required_permissions_json: requiredPermissions("audit.view"),
       auth_required: 1,
     }),
   };

--- a/tests/auth-route-permissions.test.js
+++ b/tests/auth-route-permissions.test.js
@@ -1,160 +1,160 @@
 import assert from "node:assert/strict";
 import {
-  assertRoutePermission,
-  resolveRoutePermissionDeclaration,
-  routePermissionErrorResponse,
+	assertRoutePermission,
+	resolveRoutePermissionDeclaration,
+	routePermissionErrorResponse,
 } from "../infra/cloudflare/src/core/auth/route-permissions.js";
 
 function requiredPermissions(...codes) {
-  return JSON.stringify(codes);
+	return JSON.stringify(codes);
 }
 
 function createD1(declaration) {
-  return {
-    prepare() {
-      return {
-        bind(method, pathname) {
-          return {
-            async first() {
-              if (!declaration) return null;
+	return {
+		prepare() {
+			return {
+				bind(method, pathname) {
+					return {
+						async first() {
+							if (!declaration) return null;
 
-              return {
-                method,
-                route_pattern: pathname,
-                required_permissions_json:
-                  declaration.required_permissions_json ?? "[]",
-                auth_required: declaration.auth_required ?? 1,
-                implementation_status:
-                  declaration.implementation_status ?? "implemented",
-              };
-            },
-          };
-        },
-      };
-    },
-  };
+							return {
+								method,
+								route_pattern: pathname,
+								required_permissions_json:
+									declaration.required_permissions_json ?? "[]",
+								auth_required: declaration.auth_required ?? 1,
+								implementation_status:
+									declaration.implementation_status ?? "implemented",
+							};
+						},
+					};
+				},
+			};
+		},
+	};
 }
 
 function requestFor(path, method = "GET") {
-  return new Request(`https://worker.test${path}`, { method });
+	return new Request(`https://worker.test${path}`, { method });
 }
 
 async function assertDeclaredRouteIsResolved() {
-  const env = {
-    RESEARCHOPS_D1: createD1({
-      required_permissions_json: requiredPermissions("audit.view"),
-      auth_required: 1,
-    }),
-  };
+	const env = {
+		RESEARCHOPS_D1: createD1({
+			required_permissions_json: requiredPermissions("audit.view"),
+			auth_required: 1,
+		}),
+	};
 
-  const declaration = await resolveRoutePermissionDeclaration(
-    requestFor("/api/audit/team-events"),
-    env,
-  );
+	const declaration = await resolveRoutePermissionDeclaration(
+		requestFor("/api/audit/team-events"),
+		env,
+	);
 
-  assert.equal(declaration.method, "GET");
-  assert.equal(declaration.routePattern, "/api/audit/team-events");
-  assert.deepEqual(declaration.requiredPermissions, ["audit.view"]);
-  assert.equal(declaration.authRequired, true);
+	assert.equal(declaration.method, "GET");
+	assert.equal(declaration.routePattern, "/api/audit/team-events");
+	assert.deepEqual(declaration.requiredPermissions, ["audit.view"]);
+	assert.equal(declaration.authRequired, true);
 }
 
 async function assertMissingRouteFailsClosed() {
-  const env = { RESEARCHOPS_D1: createD1(null) };
+	const env = { RESEARCHOPS_D1: createD1(null) };
 
-  try {
-    await assertRoutePermission(
-      requestFor("/api/unknown-protected-route"),
-      env,
-      {
-        authenticated: true,
-        permissions: [{ code: "audit.view" }],
-      },
-    );
-    assert.fail("Expected missing route permission declaration to fail closed");
-  } catch (error) {
-    const response = routePermissionErrorResponse(error);
-    assert.equal(response.status, 403);
+	try {
+		await assertRoutePermission(
+			requestFor("/api/unknown-protected-route"),
+			env,
+			{
+				authenticated: true,
+				permissions: [{ code: "audit.view" }],
+			},
+		);
+		assert.fail("Expected missing route permission declaration to fail closed");
+	} catch (error) {
+		const response = routePermissionErrorResponse(error);
+		assert.equal(response.status, 403);
 
-    const body = await response.json();
-    assert.equal(body.ok, false);
-    assert.equal(body.error, "route_permission_missing");
-    assert.equal(Object.hasOwn(body, "details"), false);
-  }
+		const body = await response.json();
+		assert.equal(body.ok, false);
+		assert.equal(body.error, "route_permission_missing");
+		assert.equal(Object.hasOwn(body, "details"), false);
+	}
 }
 
 async function assertMissingPermissionIsDeniedWithoutDetails() {
-  const env = {
-    RESEARCHOPS_D1: createD1({
-      required_permissions_json: requiredPermissions("safeguarding.audit.view"),
-      auth_required: 1,
-    }),
-  };
+	const env = {
+		RESEARCHOPS_D1: createD1({
+			required_permissions_json: requiredPermissions("safeguarding.audit.view"),
+			auth_required: 1,
+		}),
+	};
 
-  try {
-    await assertRoutePermission(requestFor("/api/safeguarding/audit"), env, {
-      authenticated: true,
-      permissions: [{ code: "audit.view" }],
-    });
-    assert.fail("Expected missing safeguarding permission to be denied");
-  } catch (error) {
-    const response = routePermissionErrorResponse(error);
-    assert.equal(response.status, 403);
+	try {
+		await assertRoutePermission(requestFor("/api/safeguarding/audit"), env, {
+			authenticated: true,
+			permissions: [{ code: "audit.view" }],
+		});
+		assert.fail("Expected missing safeguarding permission to be denied");
+	} catch (error) {
+		const response = routePermissionErrorResponse(error);
+		assert.equal(response.status, 403);
 
-    const body = await response.json();
-    assert.equal(body.ok, false);
-    assert.equal(body.error, "permission_denied");
-    assert.equal(Object.hasOwn(body, "details"), false);
-  }
+		const body = await response.json();
+		assert.equal(body.ok, false);
+		assert.equal(body.error, "permission_denied");
+		assert.equal(Object.hasOwn(body, "details"), false);
+	}
 }
 
 async function assertDiagnosticsCanIncludeMissingPermissionCodes() {
-  const env = {
-    RESEARCHOPS_D1: createD1({
-      required_permissions_json: requiredPermissions("role.assign"),
-      auth_required: 1,
-    }),
-  };
+	const env = {
+		RESEARCHOPS_D1: createD1({
+			required_permissions_json: requiredPermissions("role.assign"),
+			auth_required: 1,
+		}),
+	};
 
-  try {
-    await assertRoutePermission(
-      requestFor("/api/auth/role-assignments", "POST"),
-      env,
-      {
-        authenticated: true,
-        permissions: [],
-      },
-    );
-    assert.fail("Expected role assignment permission to be denied");
-  } catch (error) {
-    const response = routePermissionErrorResponse(error, {
-      includeDiagnostics: true,
-    });
-    assert.equal(response.status, 403);
+	try {
+		await assertRoutePermission(
+			requestFor("/api/auth/role-assignments", "POST"),
+			env,
+			{
+				authenticated: true,
+				permissions: [],
+			},
+		);
+		assert.fail("Expected role assignment permission to be denied");
+	} catch (error) {
+		const response = routePermissionErrorResponse(error, {
+			includeDiagnostics: true,
+		});
+		assert.equal(response.status, 403);
 
-    const body = await response.json();
-    assert.deepEqual(body.details.missingPermissions, ["role.assign"]);
-  }
+		const body = await response.json();
+		assert.deepEqual(body.details.missingPermissions, ["role.assign"]);
+	}
 }
 
 async function assertMatchingPermissionAllowsRoute() {
-  const env = {
-    RESEARCHOPS_D1: createD1({
-      required_permissions_json: requiredPermissions("audit.view"),
-      auth_required: 1,
-    }),
-  };
+	const env = {
+		RESEARCHOPS_D1: createD1({
+			required_permissions_json: requiredPermissions("audit.view"),
+			auth_required: 1,
+		}),
+	};
 
-  const declaration = await assertRoutePermission(
-    requestFor("/api/audit/team-events"),
-    env,
-    {
-      authenticated: true,
-      permissions: [{ code: "audit.view" }],
-    },
-  );
+	const declaration = await assertRoutePermission(
+		requestFor("/api/audit/team-events"),
+		env,
+		{
+			authenticated: true,
+			permissions: [{ code: "audit.view" }],
+		},
+	);
 
-  assert.equal(declaration.routePattern, "/api/audit/team-events");
-  assert.deepEqual(declaration.requiredPermissions, ["audit.view"]);
+	assert.equal(declaration.routePattern, "/api/audit/team-events");
+	assert.deepEqual(declaration.requiredPermissions, ["audit.view"]);
 }
 
 await assertDeclaredRouteIsResolved();

--- a/tests/auth-route-permissions.test.js
+++ b/tests/auth-route-permissions.test.js
@@ -58,10 +58,14 @@ async function assertMissingRouteFailsClosed() {
   const env = { RESEARCHOPS_D1: createD1(null) };
 
   try {
-    await assertRoutePermission(requestFor("/api/unknown-protected-route"), env, {
-      authenticated: true,
-      permissions: [{ code: "audit.view" }],
-    });
+    await assertRoutePermission(
+      requestFor("/api/unknown-protected-route"),
+      env,
+      {
+        authenticated: true,
+        permissions: [{ code: "audit.view" }],
+      },
+    );
     assert.fail("Expected missing route permission declaration to fail closed");
   } catch (error) {
     const response = routePermissionErrorResponse(error);


### PR DESCRIPTION
## Summary

Builds the first real authentication role-selection foundation for ResearchOps.

This PR adds:

- D1 control-plane migration for users, identities, teams, memberships, roles, permissions, assignments, permission exceptions, route declarations and audit tables
- seeded permissions, roles, role-permission mappings and route-permission declarations
- Cloudflare Access identity resolver using `Cf-Access-Jwt-Assertion`
- D1-backed route-permission helper
- `/api/me` and `/api/me/permissions` wiring through the real Access identity resolver and route-permission helper
- manual GitHub Actions workflow for applying the auth foundation migration to remote `researchops-d1`
- auth foundation route-state tests and route-permission tests
- validation wiring so the new auth tests run through `npm run validate`
- Cloudflare operations documentation
- `[reasoning]` markdown and JSON trace records for this large build

## Scope boundary

This PR does **not** claim that the live D1 database has been migrated.

The new manual workflow exists, but it has not been run in this chat. Live D1 table creation and seeding must only be claimed after workflow, Wrangler, or Cloudflare API evidence confirms it.

This PR also does not include:

- role-management UI
- role-assignment API implementation beyond route declaration
- personal data reveal UI
- safeguarding alert UI
- full route-permission wiring across all product routes
- Cloudflare Agents access-control decisions
- Airtable schema changes

## Key files

Implementation:

- `.github/workflows/apply-d1-auth-foundation.yml`
- `infra/cloudflare/migrations/0001_auth_foundation.sql`
- `infra/cloudflare/src/core/auth/access.js`
- `infra/cloudflare/src/core/auth/route-permissions.js`
- `infra/cloudflare/src/worker.js`
- `scripts/validate.sh`
- `tests/auth-foundation-route-state.test.js`
- `tests/auth-route-permissions.test.js`

Documentation and trace:

- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
- checkpoint trace files 010 to 017

## Validation

Not run locally in this assistant environment.

The branch wires the new auth tests into `scripts/validate.sh`, so CI should exercise them through `npm run validate`.

## Operational notes

Before live runtime use:

- configure Cloudflare Access audience and certificate/team-domain values
- confirm `RESEARCHOPS_D1` is bound to `researchops-d1`
- run the manual D1 workflow only after review and explicit release decision
- capture the successful workflow or Cloudflare API evidence in the trace before claiming live D1 migration completion

## Trace

The main trace is:

`docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`

The consolidated JSON trace is:

`docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`