### PR TITLE
Record live D1 authentication foundation migration evidence

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md
@@ -1,0 +1,57 @@
+# Agent trace checkpoint 033: live D1 migration branch created
+
+Branch: `feature/live-d1-auth-foundation-migration`
+
+## Trigger
+
+The user directed that D1 migration work must continue on a branch rather than by committing directly to `main`.
+
+## Branch created
+
+A new branch was created from `main` commit:
+
+```text
+5ee2a8f0c9caf248052c7152f5e0abb6ed01b2df
+```
+
+Branch name:
+
+```text
+feature/live-d1-auth-foundation-migration
+```
+
+## Purpose
+
+Use this branch to track live D1 migration execution evidence, runbook notes, and any follow-up corrections needed for the authentication role-selection D1 foundation.
+
+## Existing migration workflow
+
+The live D1 migration workflow already exists on `main` and therefore exists on this branch:
+
+```text
+.github/workflows/apply-d1-auth-foundation.yml
+```
+
+Required workflow inputs:
+
+```text
+confirm_database_name = researchops-d1
+confirm_operation = APPLY_AUTH_FOUNDATION
+run_post_apply_checks = true
+```
+
+## Tool boundary
+
+The current GitHub connector exposes repository and workflow inspection tools, but it does not expose a workflow-dispatch action.
+
+Therefore this assistant cannot directly start the manual GitHub Actions workflow from the available tool surface.
+
+## Evidence required after manual execution
+
+After the workflow is run, capture:
+
+- workflow run status
+- table list for `auth_%`
+- seed counts for `auth_permissions`, `auth_roles`, `auth_role_permissions` and `auth_route_permissions`
+
+Do not mark the live D1 migration complete until those checks are visible and successful.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-034-live-d1-migration-auth-failure.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-034-live-d1-migration-auth-failure.md
@@ -1,0 +1,124 @@
+# Agent trace checkpoint 034: live D1 migration authentication failure
+
+Branch: `feature/live-d1-auth-foundation-migration`
+
+## Trigger
+
+The user ran the manual `Apply D1 Authentication Foundation` workflow and provided the workflow log.
+
+## Workflow execution evidence
+
+The workflow started successfully and used the expected branch:
+
+```text
+feature/live-d1-auth-foundation-migration
+```
+
+The workflow checked out commit:
+
+```text
+5ee5636cdd38cd984033cbb810a6fa61714a4a32
+```
+
+The confirmation inputs passed:
+
+```text
+confirm_database_name = researchops-d1
+confirm_operation = APPLY_AUTH_FOUNDATION
+```
+
+The migration file was present:
+
+```text
+infra/cloudflare/migrations/0001_auth_foundation.sql
+```
+
+Wrangler version was:
+
+```text
+4.34.0
+```
+
+The remote D1 target was identified as:
+
+```text
+researchops-d1 (48b35a2e-52e8-4bc0-a8cf-88a7a1536f04)
+```
+
+This matches the D1 binding in `infra/cloudflare/wrangler.toml`.
+
+## Failure
+
+The migration failed at the remote D1 import call:
+
+```text
+A request to the Cloudflare API (/accounts/***/d1/database/48b35a2e-52e8-4bc0-a8cf-88a7a1536f04/import) failed.
+Authentication error [code: 10000]
+```
+
+Wrangler also reported:
+
+```text
+It looks like you are authenticating Wrangler via a custom API token set in an environment variable.
+Please ensure it has the correct permissions for this operation.
+```
+
+## Assessment
+
+The workflow reached the correct database and failed before applying the SQL import.
+
+This is not evidence that the D1 migration partially applied.
+
+Wrangler reported that failed import execution should return the database to its original state.
+
+The likely issue is the `CF_API_TOKEN` GitHub secret. The token is valid enough for Wrangler to identify the account context, but it is not authorised for the D1 import operation.
+
+## Required correction outside repository code
+
+Update the GitHub Actions secret used by the workflow:
+
+```text
+CF_API_TOKEN
+```
+
+The replacement Cloudflare API token should include D1 edit permission for the account that owns:
+
+```text
+researchops-d1
+```
+
+It should be scoped to the account containing database ID:
+
+```text
+48b35a2e-52e8-4bc0-a8cf-88a7a1536f04
+```
+
+The existing repository workflow also uses:
+
+```text
+CF_ACCOUNT_ID
+```
+
+That secret should continue to match the same account.
+
+## Do not mark complete yet
+
+The live D1 migration remains pending.
+
+Do not mark the migration as complete until a rerun succeeds and post-apply checks show:
+
+- `auth_%` table list
+- seeded counts for `auth_permissions`
+- seeded counts for `auth_roles`
+- seeded counts for `auth_role_permissions`
+- seeded counts for `auth_route_permissions`
+
+## Secondary warning
+
+Wrangler also warned:
+
+```text
+Unexpected fields found in observability field: "persist"
+```
+
+This did not cause the migration failure. It can be cleaned up separately, but it is not blocking the D1 authentication issue.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-035-live-d1-migration-success.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-035-live-d1-migration-success.md
@@ -1,0 +1,108 @@
+# Agent trace checkpoint 035: live D1 migration success
+
+Branch: `feature/live-d1-auth-foundation-migration`
+
+## Status
+
+The manual live D1 migration workflow has now succeeded.
+
+## Workflow evidence
+
+Workflow job:
+
+```text
+Apply authentication foundation to remote D1
+```
+
+Branch checked out by workflow:
+
+```text
+feature/live-d1-auth-foundation-migration
+```
+
+Commit checked out by workflow:
+
+```text
+5ee5636cdd38cd984033cbb810a6fa61714a4a32
+```
+
+Target database:
+
+```text
+researchops-d1
+```
+
+Target database ID:
+
+```text
+48b35a2e-52e8-4bc0-a8cf-88a7a1536f04
+```
+
+Migration file:
+
+```text
+infra/cloudflare/migrations/0001_auth_foundation.sql
+```
+
+Wrangler version:
+
+```text
+4.34.0
+```
+
+## Migration result
+
+The workflow executed the migration against the remote database.
+
+Wrangler reported:
+
+```text
+Total queries executed: 23
+Rows read: 30
+Rows written: 148
+success: true
+```
+
+The database changed successfully.
+
+## Authentication tables verified
+
+Post-apply checks confirmed these `auth_%` tables exist:
+
+```text
+auth_audit_events
+auth_events
+auth_identities
+auth_permission_exceptions
+auth_permissions
+auth_role_assignments
+auth_role_permissions
+auth_roles
+auth_route_permissions
+auth_team_memberships
+auth_teams
+auth_users
+```
+
+## Seed counts verified
+
+Post-apply seed checks returned:
+
+```text
+permissions: 17
+roles: 6
+role_permissions: 15
+route_permissions: 6
+```
+
+## Live migration state
+
+The live D1 authentication foundation migration is complete.
+
+## Remaining notes
+
+Wrangler still warns that `observability.persist` is an unexpected field in `infra/cloudflare/wrangler.toml`.
+
+That warning did not block the migration.
+
+Node.js 20 deprecation warnings were also reported for GitHub Actions compatibility handling. That warning did not block the migration.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json
@@ -4,21 +4,54 @@
 	"trigger_token_detected": "[reasoning]",
 	"date": "2026-05-08",
 	"repository": "kevinrapley/ResearchOps",
-	"active_branch": "feature/auth-foundation-real-d1-current-main",
+	"active_branch": "feature/live-d1-auth-foundation-migration",
 	"pull_request": {
 		"number": 215,
 		"url": "https://github.com/kevinrapley/ResearchOps/pull/215",
-		"state": "open"
+		"state": "merged"
 	},
 	"status": {
 		"repository_migration_created": true,
 		"manual_d1_apply_workflow_created": true,
-		"live_d1_migration_applied": false,
+		"live_d1_migration_applied": true,
+		"live_d1_migration_evidenced": true,
 		"pull_request_opened": true,
 		"prettier_root_cause_identified": true,
-		"prettier_root_cause": "Prettier reads repository .editorconfig by default. The repository requires tab indentation via indent_style = tab, while earlier temporary file checks were outside the repository tree and used Prettier space defaults.",
-		"format_automation_implemented": true,
-		"latest_format_automation_ci_confirmed": false
+		"format_automation_implemented": true
+	},
+	"live_d1_migration_result": {
+		"workflow_job": "Apply authentication foundation to remote D1",
+		"branch": "feature/live-d1-auth-foundation-migration",
+		"commit_checked_out": "5ee5636cdd38cd984033cbb810a6fa61714a4a32",
+		"database_name": "researchops-d1",
+		"database_id": "48b35a2e-52e8-4bc0-a8cf-88a7a1536f04",
+		"migration_file": "infra/cloudflare/migrations/0001_auth_foundation.sql",
+		"wrangler_version": "4.34.0",
+		"migration_success": true,
+		"total_queries_executed": 23,
+		"rows_read": 30,
+		"rows_written": 148,
+		"database_size_mb": "0.31",
+		"auth_tables_verified": [
+			"auth_audit_events",
+			"auth_events",
+			"auth_identities",
+			"auth_permission_exceptions",
+			"auth_permissions",
+			"auth_role_assignments",
+			"auth_role_permissions",
+			"auth_roles",
+			"auth_route_permissions",
+			"auth_team_memberships",
+			"auth_teams",
+			"auth_users"
+		],
+		"seed_counts_verified": {
+			"permissions": 17,
+			"roles": 6,
+			"role_permissions": 15,
+			"route_permissions": 6
+		}
 	},
 	"changed_files": {
 		"implementation": [
@@ -40,93 +73,34 @@
 		"trace_files": [
 			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md",
 			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-010-route-permission-wiring-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-011-route-permission-wiring-complete.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-012-cloudflare-operations-doc-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-013-cloudflare-operations-doc-complete.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-014-validation-wiring-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-015-validation-wiring-complete.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-016-trace-index-json-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-017-pr-readiness-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-018-lint-fix-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-019-lint-fix-complete.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-020-lint-fix-rerun-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-021-lint-fix-rerun-complete.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-022-lint-fix-escaped-json-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-023-lint-fix-json-fixture-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-025-prettier-tooling-findings.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-028-format-automation-plan.md",
-			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-029-format-automation-complete.md"
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-034-live-d1-migration-auth-failure.md",
+			"docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-035-live-d1-migration-success.md"
 		]
-	},
-	"prettier_automation": {
-		"explicit_config": {
-			"file": "prettier.config.mjs",
-			"content": "export default { useTabs: true, tabWidth: 2, endOfLine: \"lf\" };",
-			"purpose": "Make the formatting contract visible rather than relying only on .editorconfig."
-		},
-		"strict_check_workflow": {
-			"file": ".github/workflows/format-pr.yml",
-			"behaviour": "Run Prettier check. If it fails, run Prettier write in the runner, print the resulting git diff, upload prettier-fix.patch, then fail the workflow.",
-			"reason": "Future failures show the exact patch rather than only the filename."
-		},
-		"manual_repair_workflow": {
-			"file": ".github/workflows/format-branch.yml",
-			"trigger": "workflow_dispatch",
-			"behaviour": "Check out a named branch, run npm run format, commit and push formatting changes only when there is a diff.",
-			"reason": "Provides a controlled rescue path that commits exact Prettier output to the branch."
-		},
-		"ci_decision": {
-			"normal_lint_stays_strict": true,
-			"do_not_silently_run_prettier_write_before_lint": true,
-			"reason": "CI should detect formatting drift. Repair automation must commit exact output to the branch."
-		}
 	},
 	"checkpoints": [
 		{
-			"id": "026",
-			"title": "Prettier root cause plan",
+			"id": "033",
+			"title": "Live D1 migration branch created",
 			"status": "complete",
-			"summary": "Identified .editorconfig tab indentation as the true root cause and rejected CI auto-formatting as the primary validation fix."
+			"summary": "Created feature/live-d1-auth-foundation-migration to continue live migration work away from direct main commits."
 		},
 		{
-			"id": "027",
-			"title": "Prettier root cause fix complete",
-			"status": "committed_pending_ci_confirmation",
-			"files_changed": ["tests/auth-route-permissions.test.js"],
-			"summary": "Applied repository Prettier output with tab indentation to tests/auth-route-permissions.test.js."
+			"id": "034",
+			"title": "Live D1 migration authentication failure",
+			"status": "superseded_by_successful_rerun",
+			"summary": "First run reached the correct D1 database but failed on Cloudflare token authorisation before migration completion."
 		},
 		{
-			"id": "028",
-			"title": "Format automation plan",
+			"id": "035",
+			"title": "Live D1 migration success",
 			"status": "complete",
-			"summary": "Planned explicit Prettier config, diagnostic PR formatting workflow, and manual branch formatting workflow."
-		},
-		{
-			"id": "029",
-			"title": "Format automation complete",
-			"status": "committed_pending_ci_confirmation",
-			"files_changed": [
-				"prettier.config.mjs",
-				".github/workflows/format-pr.yml",
-				".github/workflows/format-branch.yml"
-			],
-			"summary": "Implemented the automation path: explicit Prettier tab config, exact patch output on PR formatting failure, and manual format-and-commit workflow."
+			"summary": "Successful rerun applied the migration to remote D1 and verified auth tables plus seed counts."
 		}
 	],
-	"real_d1_requirement": {
-		"migration_file": "infra/cloudflare/migrations/0001_auth_foundation.sql",
-		"manual_workflow": ".github/workflows/apply-d1-auth-foundation.yml",
-		"database_name": "researchops-d1",
-		"worker_binding": "RESEARCHOPS_D1",
-		"status": "repository_path_created_live_execution_not_claimed"
-	},
 	"residual_risks": [
-		"The latest format automation still needs repository-level CI confirmation.",
-		"The D1 migration has not yet been run in the live environment.",
-		"Route-permission helper is only wired into identity routes so far."
+		"Route-permission helper is only wired into identity routes so far.",
+		"Cloudflare Access runtime values still need to be configured before authenticated runtime use.",
+		"observability.persist warning remains in infra/cloudflare/wrangler.toml."
 	]
 }

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -7,32 +7,14 @@
 - Main markdown trace: `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
 - Consolidated JSON trace: [`authentication-role-selection-real-implementation-trace.json`](authentication-role-selection-real-implementation-trace.json)
 
-The checkpoint markdown files are used to keep this large build readable. Their captured events are also represented in the single consolidated JSON trace. Individual checkpoint JSON files are intentionally not created.
-
-## Run metadata
-
-- Trace ID: `atrace-20260508-authentication-role-selection-real-implementation`
-- Date: 2026-05-08
-- Repository: `kevinrapley/ResearchOps`
-- Active branch: `feature/auth-foundation-real-d1-current-main`
-- Pull request: `#215`
-- Base branch: `main`
-- Base commit at branch creation: `8305adeed3b7e4047f132bc8c50347ce47e6205f`
-- Trigger token detected: `[reasoning]`
-- Trace layer: `operational`
-
 ## Current status
 
-- PR #215 is open.
-- Live D1 migration has not been applied.
-- Repository migration and manual D1 workflow exist.
-- Authentication tests are wired into `npm run validate`.
-- CI repeatedly reported Prettier formatting failures in `tests/auth-route-permissions.test.js`.
-- Root cause is identified: Prettier reads `.editorconfig`, and this repository sets `indent_style = tab`.
-- Earlier temporary file checks were wrong because they ran outside the repository tree and missed `.editorconfig`.
-- `tests/auth-route-permissions.test.js` has been replaced with repository Prettier output using tabs.
-- The repository now has explicit Prettier automation to prevent repeated guesswork.
-- Repository-level CI has not yet confirmed the latest automation and formatting changes.
+- PR #215 has been merged into `main`.
+- Main branch formatting issue is reported as passing by the user.
+- The repository migration and manual D1 workflow exist on `main`.
+- A dedicated live D1 migration branch now exists: `feature/live-d1-auth-foundation-migration`.
+- The live D1 migration has not yet been evidenced as applied.
+- Checkpoint 033 records the migration branch creation and required workflow inputs.
 
 ## Checkpoint index
 
@@ -55,307 +37,62 @@ The checkpoint markdown files are used to keep this large build readable. Their 
 | 024 | [`authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md`](authentication-role-selection-checkpoint-024-lint-fix-json-fixture-complete.md) | Fixture improvement retained; root format fix superseded by 027 |
 | 025 | [`authentication-role-selection-checkpoint-025-prettier-tooling-findings.md`](authentication-role-selection-checkpoint-025-prettier-tooling-findings.md) | Superseded by 026 and 027 |
 | 026 | [`authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md`](authentication-role-selection-checkpoint-026-prettier-root-cause-plan.md) | Complete |
-| 027 | [`authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md`](authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md) | Committed; pending CI confirmation |
+| 027 | [`authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md`](authentication-role-selection-checkpoint-027-prettier-root-cause-fix-complete.md) | Complete |
 | 028 | [`authentication-role-selection-checkpoint-028-format-automation-plan.md`](authentication-role-selection-checkpoint-028-format-automation-plan.md) | Complete |
-| 029 | [`authentication-role-selection-checkpoint-029-format-automation-complete.md`](authentication-role-selection-checkpoint-029-format-automation-complete.md) | Committed; pending CI confirmation |
+| 029 | [`authentication-role-selection-checkpoint-029-format-automation-complete.md`](authentication-role-selection-checkpoint-029-format-automation-complete.md) | Complete |
+| 030 | [`authentication-role-selection-checkpoint-030-main-format-diagnostics-plan.md`](authentication-role-selection-checkpoint-030-main-format-diagnostics-plan.md) | Complete on `main` |
+| 031 | [`authentication-role-selection-checkpoint-031-main-format-diagnostics-complete.md`](authentication-role-selection-checkpoint-031-main-format-diagnostics-complete.md) | Complete on `main` |
+| 032 | [`authentication-role-selection-checkpoint-032-live-d1-migration-readiness.md`](authentication-role-selection-checkpoint-032-live-d1-migration-readiness.md) | Superseded by 033 |
+| 033 | [`authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md`](authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md) | Branch created; workflow ready for manual execution |
 
-## Files changed so far on this branch
+## Live D1 migration branch
 
-Implementation files:
-
-- `.github/workflows/apply-d1-auth-foundation.yml`
-- `.github/workflows/format-branch.yml`
-- `.github/workflows/format-pr.yml`
-- `infra/cloudflare/migrations/0001_auth_foundation.sql`
-- `infra/cloudflare/src/core/auth/access.js`
-- `infra/cloudflare/src/core/auth/route-permissions.js`
-- `infra/cloudflare/src/worker.js`
-- `prettier.config.mjs`
-- `scripts/validate.sh`
-- `tests/auth-foundation-route-state.test.js`
-- `tests/auth-route-permissions.test.js`
-
-Product and operational documentation:
-
-- `docs/product/26/05/08/authentication-role-selection-cloudflare-operations-2026-05-08.md`
-
-Agent trace files:
-
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
-- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`
-- checkpoint markdown files 010 to 029
-
-## Prettier failure and automation record
-
-### Repeated symptom
-
-CI repeatedly failed during:
-
-```bash
-prettier -c .
-```
-
-The reported file was always:
+Branch created:
 
 ```text
-tests/auth-route-permissions.test.js
+feature/live-d1-auth-foundation-migration
 ```
 
-### Root cause
+Created from `main` commit:
 
-Repository `.editorconfig` contains:
-
-```ini
-[*]
-indent_style = tab
-indent_size = 2
+```text
+5ee2a8f0c9caf248052c7152f5e0abb6ed01b2df
 ```
-
-Prettier reads `.editorconfig` by default. Therefore JavaScript files in this repository must use tab indentation unless a more specific override is introduced.
-
-Temporary standalone file checks outside the repository tree missed this rule. Those checks incorrectly passed because Prettier fell back to its default space indentation.
-
-### Exact file fix committed
-
-`tests/auth-route-permissions.test.js` was replaced with the Prettier 3.6.2 output produced when `.editorconfig` is present.
-
-The concrete fix is tab indentation.
-
-Before:
-
-```js
-import {
-  assertRoutePermission,
-  resolveRoutePermissionDeclaration,
-  routePermissionErrorResponse,
-} from "../infra/cloudflare/src/core/auth/route-permissions.js";
-```
-
-After:
-
-```js
-import {
-	assertRoutePermission,
-	resolveRoutePermissionDeclaration,
-	routePermissionErrorResponse,
-} from "../infra/cloudflare/src/core/auth/route-permissions.js";
-```
-
-The JSON fixture helper improvement from checkpoint 024 is retained:
-
-```js
-function requiredPermissions(...codes) {
-	return JSON.stringify(codes);
-}
-```
-
-### Automation implemented
-
-`prettier.config.mjs` makes the tab contract explicit:
-
-```js
-export default {
-	useTabs: true,
-	tabWidth: 2,
-	endOfLine: "lf",
-};
-```
-
-`.github/workflows/format-pr.yml` remains strict, but now captures the exact repair patch on failure:
-
-```bash
-./node_modules/.bin/prettier --write .
-git diff -- . > prettier-fix.patch
-cat prettier-fix.patch
-```
-
-The workflow uploads `prettier-fix.patch` as an artifact.
-
-`.github/workflows/format-branch.yml` is a manual `workflow_dispatch` repair path. It checks out a named branch, runs `npm run format`, and commits/pushes formatting changes only if there is a diff.
-
-### Workflow change decision
-
-The proposed workaround of adding `npx prettier --write .` before lint in normal CI should not be used as the primary validation fix.
-
-CI should detect formatting drift. It should not silently mutate the runner workspace without committing the change back to the branch.
-
-Correct practice is to run formatting before committing:
-
-```bash
-npm run format
-```
-
-or targeted:
-
-```bash
-npx prettier --write tests/auth-route-permissions.test.js
-```
-
-Both commands must be run from the repository root so `.editorconfig` and `prettier.config.mjs` are applied.
-
-## Authentication implementation checkpoints
-
-### D1 auth foundation migration
-
-File created:
-
-- `infra/cloudflare/migrations/0001_auth_foundation.sql`
 
 Purpose:
 
-- Create the D1 control-plane schema for real authentication and role selection.
-- Seed permissions, roles, role-permission mappings and route permission declarations.
+- track live D1 migration execution evidence
+- keep further D1 migration work off direct `main` commits
+- capture workflow output before marking live migration complete
 
-Live status:
+## Manual workflow to run
 
-- The migration has not been applied to the live `researchops-d1` database.
+Workflow:
 
-### Cloudflare Access identity resolver
+```text
+.github/workflows/apply-d1-auth-foundation.yml
+```
 
-File created:
+Required inputs:
 
-- `infra/cloudflare/src/core/auth/access.js`
+```text
+confirm_database_name = researchops-d1
+confirm_operation = APPLY_AUTH_FOUNDATION
+run_post_apply_checks = true
+```
 
-Purpose:
+## Tool boundary
 
-- Resolve a real authenticated identity from the `Cf-Access-Jwt-Assertion` header.
-- Validate Access JWT structure, signature, expiry and audience.
-- Map the provider identity to a D1 ResearchOps user.
-- Return active team, roles and permissions from D1.
+The available GitHub connector can inspect repository files, workflow logs, workflow jobs and artifacts, but it does not expose a workflow-dispatch action.
 
-Non-goals:
+Therefore the manual workflow must be started from GitHub Actions by a maintainer or through a tool surface with workflow-dispatch capability.
 
-- No mock identity behaviour.
-- No password authentication.
-- No role-management UI.
-- No Airtable schema change.
+## Evidence required before marking live migration complete
 
-### Worker route wiring
+After the workflow is run, capture:
 
-File modified:
+- workflow status
+- table list for `auth_%`
+- seed counts for `auth_permissions`, `auth_roles`, `auth_role_permissions` and `auth_route_permissions`
 
-- `infra/cloudflare/src/worker.js`
-
-Purpose:
-
-- Route `GET /api/me` and `GET /api/me/permissions` through the real Cloudflare Access identity resolver.
-- Add `X-ResearchOps-Team-Id` to allowed request headers.
-
-### Auth foundation route tests
-
-File created:
-
-- `tests/auth-foundation-route-state.test.js`
-
-Purpose:
-
-- Confirm identity routes fail closed without `Cf-Access-Jwt-Assertion`.
-- Confirm Worker route wiring sends `/api/me` and `/api/me/permissions` through `core/auth/access.js`.
-- Confirm no mock identity mode exists.
-- Confirm route-permission wiring and D1 migration structure.
-
-### Route-permission helper
-
-File created:
-
-- `infra/cloudflare/src/core/auth/route-permissions.js`
-
-Purpose:
-
-- Read route declarations from `auth_route_permissions` in D1.
-- Fail closed where no route permission declaration exists.
-- Check an authenticated context for required permissions.
-- Return ordinary permission-denied responses without exposing missing permission codes.
-
-Current boundary:
-
-- The helper is used by the identity routes.
-- The helper is not yet wired into all product routes.
-
-### Route-permission helper tests
-
-File created:
-
-- `tests/auth-route-permissions.test.js`
-
-Purpose:
-
-- Confirm declared route permissions can be resolved from a D1-style binding.
-- Confirm protected routes fail closed when no route declaration exists.
-- Confirm missing permissions are denied without exposing missing permission codes to ordinary users.
-- Confirm diagnostics can include missing permission codes only when explicitly requested.
-- Confirm a matching permission allows the route.
-
-### Controlled D1 migration workflow
-
-File created:
-
-- `.github/workflows/apply-d1-auth-foundation.yml`
-
-Purpose:
-
-- Provide a manual GitHub Actions path for applying `infra/cloudflare/migrations/0001_auth_foundation.sql` to remote `researchops-d1`.
-- Require explicit confirmation inputs: `researchops-d1` and `APPLY_AUTH_FOUNDATION`.
-- Use Wrangler `d1 execute` with `--remote`.
-- Run optional post-apply checks for tables and seed counts.
-
-Current boundary:
-
-- The workflow has not been run.
-- Live D1 has not been changed.
-
-## Real D1 implementation requirement
-
-The current SQL migration is a real D1 migration file, but creating the migration file in the repository is not the same as applying it to the live D1 database.
-
-The build includes a safe manual path to apply the migration to the real `researchops-d1` database bound as `RESEARCHOPS_D1` in `infra/cloudflare/wrangler.toml`.
-
-Required next implementation controls:
-
-- Run the manual workflow or use an equivalent direct Cloudflare API/Wrangler path before claiming real D1 tables exist.
-- Preserve seed records in the migration for permissions, roles, role-permission mappings and route permission declarations.
-- Capture workflow result or API output in this trace once the migration has actually run.
-
-## Validation status
-
-- Initial CI lint failed on Prettier formatting in `tests/auth-route-permissions.test.js`.
-- CI repeated the Prettier formatting failure for the same file.
-- Root cause identified as `.editorconfig` tab indentation.
-- `tests/auth-route-permissions.test.js` has been rewritten with repository Prettier tab output.
-- Formatting automation is now in place to expose or commit exact Prettier output.
-- CI has not yet confirmed that the repository-level check passes.
-- No live D1 migration has been run.
-
-## Process issue recorded
-
-`AGENTS.md` says commits should be incremental and atomic with a diff of no more than 300 lines.
-
-Current issues:
-
-- the Access identity resolver commit had more than 300 added lines
-- repeated formatting fixes were attempted without repository-root Prettier context
-
-Correction for future steps:
-
-- split future changes into smaller files and smaller commits
-- update trace before or alongside code changes
-- update both markdown and JSON trace records where a checkpoint changes the implementation state
-- for formatting failures, run Prettier from the repository root so `.editorconfig` and `prettier.config.mjs` apply
-- do not claim repository-level formatting success until CI or a real repository checkout confirms it
-
-## Pending next steps
-
-Candidate next steps:
-
-- wait for PR CI to rerun and inspect any new failure
-- if format still fails, use the new `prettier-fix.patch` artifact or run the manual `Format branch` workflow against `feature/auth-foundation-real-d1-current-main`
-- after CI confirms the format path, create permanent repository guidance from checkpoints 026 to 029
-- apply the D1 migration through the manual workflow after review or explicit release decision
-- wire route-permission checks into the next protected product endpoint in a narrow slice
-
-## Residual risks
-
-- Cloudflare Access JWT validation depends on environment configuration for Access certificates and audience.
-- The D1 migration has not yet been run in the live environment.
-- Route-permission helper is only wired into identity routes so far.
-- The latest format automation still needs repository-level CI confirmation.
+The live D1 migration remains pending until those checks are visible and successful.

--- a/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md
@@ -11,10 +11,11 @@
 
 - PR #215 has been merged into `main`.
 - Main branch formatting issue is reported as passing by the user.
-- The repository migration and manual D1 workflow exist on `main`.
-- A dedicated live D1 migration branch now exists: `feature/live-d1-auth-foundation-migration`.
-- The live D1 migration has not yet been evidenced as applied.
-- Checkpoint 033 records the migration branch creation and required workflow inputs.
+- A dedicated live D1 migration branch exists: `feature/live-d1-auth-foundation-migration`.
+- The first live D1 workflow run reached the correct database but failed on Cloudflare API token authorisation.
+- The follow-up live D1 workflow run succeeded.
+- The live D1 authentication foundation migration is now applied and evidenced.
+- Checkpoint 035 records the successful migration evidence, verified tables and verified seed counts.
 
 ## Checkpoint index
 
@@ -43,7 +44,9 @@
 | 030 | [`authentication-role-selection-checkpoint-030-main-format-diagnostics-plan.md`](authentication-role-selection-checkpoint-030-main-format-diagnostics-plan.md) | Complete on `main` |
 | 031 | [`authentication-role-selection-checkpoint-031-main-format-diagnostics-complete.md`](authentication-role-selection-checkpoint-031-main-format-diagnostics-complete.md) | Complete on `main` |
 | 032 | [`authentication-role-selection-checkpoint-032-live-d1-migration-readiness.md`](authentication-role-selection-checkpoint-032-live-d1-migration-readiness.md) | Superseded by 033 |
-| 033 | [`authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md`](authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md) | Branch created; workflow ready for manual execution |
+| 033 | [`authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md`](authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md) | Complete |
+| 034 | [`authentication-role-selection-checkpoint-034-live-d1-migration-auth-failure.md`](authentication-role-selection-checkpoint-034-live-d1-migration-auth-failure.md) | Superseded by successful rerun |
+| 035 | [`authentication-role-selection-checkpoint-035-live-d1-migration-success.md`](authentication-role-selection-checkpoint-035-live-d1-migration-success.md) | Complete |
 
 ## Live D1 migration branch
 
@@ -65,7 +68,7 @@ Purpose:
 - keep further D1 migration work off direct `main` commits
 - capture workflow output before marking live migration complete
 
-## Manual workflow to run
+## Manual workflow used
 
 Workflow:
 
@@ -73,7 +76,7 @@ Workflow:
 .github/workflows/apply-d1-auth-foundation.yml
 ```
 
-Required inputs:
+Inputs used:
 
 ```text
 confirm_database_name = researchops-d1
@@ -81,18 +84,121 @@ confirm_operation = APPLY_AUTH_FOUNDATION
 run_post_apply_checks = true
 ```
 
-## Tool boundary
+## First workflow run result
 
-The available GitHub connector can inspect repository files, workflow logs, workflow jobs and artifacts, but it does not expose a workflow-dispatch action.
+The first manual workflow run reached the expected remote database:
 
-Therefore the manual workflow must be started from GitHub Actions by a maintainer or through a tool surface with workflow-dispatch capability.
+```text
+researchops-d1 (48b35a2e-52e8-4bc0-a8cf-88a7a1536f04)
+```
 
-## Evidence required before marking live migration complete
+It failed during the remote D1 import call with:
 
-After the workflow is run, capture:
+```text
+Authentication error [code: 10000]
+```
 
-- workflow status
-- table list for `auth_%`
-- seed counts for `auth_permissions`, `auth_roles`, `auth_role_permissions` and `auth_route_permissions`
+Assessment:
 
-The live D1 migration remains pending until those checks are visible and successful.
+- the branch and workflow inputs were correct
+- the target D1 database was correct
+- the SQL migration was not evidenced as applied in that run
+- the blocker was Cloudflare API token authorisation for D1 import
+
+This failure is recorded in checkpoint 034.
+
+## Successful workflow rerun
+
+The follow-up workflow run succeeded against the same remote D1 database:
+
+```text
+researchops-d1 (48b35a2e-52e8-4bc0-a8cf-88a7a1536f04)
+```
+
+The workflow checked out:
+
+```text
+feature/live-d1-auth-foundation-migration
+```
+
+at commit:
+
+```text
+5ee5636cdd38cd984033cbb810a6fa61714a4a32
+```
+
+Migration file:
+
+```text
+infra/cloudflare/migrations/0001_auth_foundation.sql
+```
+
+Wrangler version:
+
+```text
+4.34.0
+```
+
+Migration result:
+
+```text
+Total queries executed: 23
+Rows read: 30
+Rows written: 148
+success: true
+```
+
+## Verified live D1 tables
+
+Post-apply checks confirmed these authentication tables exist:
+
+```text
+auth_audit_events
+auth_events
+auth_identities
+auth_permission_exceptions
+auth_permissions
+auth_role_assignments
+auth_role_permissions
+auth_roles
+auth_route_permissions
+auth_team_memberships
+auth_teams
+auth_users
+```
+
+## Verified live D1 seed counts
+
+Post-apply seed checks confirmed:
+
+```text
+permissions: 17
+roles: 6
+role_permissions: 15
+route_permissions: 6
+```
+
+## Live migration status
+
+The live D1 authentication foundation migration is complete.
+
+The evidence threshold has been met:
+
+- workflow reached the intended remote D1 database
+- SQL migration executed successfully
+- authentication tables exist
+- seeded permission, role, role-permission and route-permission counts were verified
+
+## Remaining risks and follow-up items
+
+- Route-permission helper is only wired into identity routes so far.
+- Cloudflare Access runtime values still need to be configured before authenticated runtime use.
+- `observability.persist` warning remains in `infra/cloudflare/wrangler.toml`.
+- GitHub Actions still reports Node.js 20 deprecation warnings in the runner context.
+
+## Next candidate work
+
+- Open a PR from `feature/live-d1-auth-foundation-migration` back to `main` to preserve the migration evidence trace.
+- Configure Cloudflare Access runtime values required by the Worker identity resolver.
+- Wire route-permission checks into the next protected product endpoint in a narrow slice.
+- Clean up the non-blocking `observability.persist` Wrangler warning in a separate PR.


### PR DESCRIPTION
## Summary

Records the live D1 authentication foundation migration evidence for the authentication role-selection work.

This PR adds and updates trace documentation for:

- creating `feature/live-d1-auth-foundation-migration` as the dedicated migration evidence branch
- the first failed manual migration attempt, which reached `researchops-d1` but failed with Cloudflare API authentication error `10000`
- the successful rerun of the manual migration workflow
- the verified remote D1 target: `researchops-d1` / `48b35a2e-52e8-4bc0-a8cf-88a7a1536f04`
- the successful migration result: 23 queries, 30 rows read, 148 rows written, `success: true`
- verified `auth_%` tables
- verified seed counts:
  - permissions: 17
  - roles: 6
  - role_permissions: 15
  - route_permissions: 6

## Files changed

- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-033-live-d1-migration-branch-created.md`
- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-034-live-d1-migration-auth-failure.md`
- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-checkpoint-035-live-d1-migration-success.md`
- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.md`
- `docs/agent-audit/reasoning/2026/05/08/authentication-role-selection-real-implementation-trace.json`

## Important boundary

This PR does not apply the D1 migration itself. The migration has already been run manually through the GitHub Actions workflow and is recorded here as operational evidence.

This PR is documentation and audit-trace work only.

## Residual risks recorded

- route-permission helper is only wired into identity routes so far
- Cloudflare Access runtime values still need to be configured before authenticated runtime use
- `observability.persist` warning remains in `infra/cloudflare/wrangler.toml`
- GitHub Actions still reports Node.js 20 deprecation warnings in the runner context

## Branch state note

Before opening this PR, branch comparison showed this branch was ahead of `main` by 6 commits and behind `main` by 6 commits. Review may require updating the branch from `main` before merge if GitHub reports conflicts.