### PR TITLE
Record auth runtime bootstrap live evidence

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-live-evidence.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-live-evidence.json
@@ -1,0 +1,75 @@
+{
+	"trace_id": "atrace-20260509-auth-runtime-bootstrap-live-evidence",
+	"trace_layer": "operational-evidence",
+	"date": "2026-05-09",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "trace/auth-runtime-bootstrap-evidence",
+	"related_pull_request": {
+		"number": 217,
+		"title": "Bootstrap authentication runtime admin access",
+		"merge_commit_sha": "cc2bc9c52523d0928a0f34a08ecbbef6d302fbc9",
+		"merged_at": "2026-05-09T00:36:24Z"
+	},
+	"runtime_workflow": {
+		"name": "Bootstrap D1 Auth Runtime",
+		"target_database": "researchops-d1",
+		"target_team": "team_researchops_core",
+		"run_status_reported_by_user": "succeeded"
+	},
+	"evidence_source": {
+		"type": "user-supplied runtime verification screenshots",
+		"screenshots_committed_to_repository": false,
+		"raw_email_committed_to_repository": false,
+		"provider_subject_committed_to_repository": false,
+		"cloudflare_secret_material_committed_to_repository": false
+	},
+	"auth_users_evidence": {
+		"record_count_observed": 1,
+		"account_status": "active",
+		"created_at": "2026-05-09T00:40:07.629Z",
+		"updated_at": "2026-05-09T00:40:07.629Z"
+	},
+	"permission_evidence": {
+		"active_roles": 2,
+		"permissions": 7,
+		"permission_exceptions": 0,
+		"scope": "team_researchops_core",
+		"roles": [
+			{
+				"role_key": "safeguarding_lead",
+				"permissions": [
+					"safeguarding.view",
+					"safeguarding.record",
+					"safeguarding.resolve",
+					"safeguarding.audit.view"
+				]
+			},
+			{
+				"role_key": "team_admin",
+				"permissions": [
+					"team.manage",
+					"role.assign",
+					"audit.view"
+				]
+			}
+		]
+	},
+	"safeguarding_role_note": {
+		"safeguarding_lead_present": true,
+		"interpretation": "Valid if the bootstrap workflow was intentionally run with safeguarding assignment enabled, or if an equivalent deliberate assignment was made.",
+		"follow_up_if_unintended": "Remove the safeguarding_lead assignment from the first admin."
+	},
+	"evidence_boundary": {
+		"d1_side_bootstrap_state_recorded": true,
+		"deployed_worker_api_verified_in_this_trace": false,
+		"endpoints_to_verify_next": [
+			"GET /api/me",
+			"GET /api/me/permissions"
+		]
+	},
+	"next_implementation_slice": {
+		"branch": "feature/auth-role-assignment-api",
+		"route": "POST /api/auth/role-assignments",
+		"purpose": "Allow an authenticated Team Admin with role.assign to assign roles to users in their active team and record the assignment in auth_audit_events."
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-live-evidence.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-live-evidence.md
@@ -1,0 +1,114 @@
+# Agent trace: auth runtime bootstrap live evidence
+
+This is a small evidence trace for the live authentication runtime bootstrap completed after PR #217 was merged.
+
+## Metadata
+
+- Date: 2026-05-09
+- Branch: `trace/auth-runtime-bootstrap-evidence`
+- Related PR: #217, `Bootstrap authentication runtime admin access`
+- PR #217 merge commit: `cc2bc9c52523d0928a0f34a08ecbbef6d302fbc9`
+- Runtime workflow: `Bootstrap D1 Auth Runtime`
+- Target database: `researchops-d1`
+- Target team: `team_researchops_core`
+
+## Status
+
+The first Team Admin was seeded through the `Bootstrap D1 Auth Runtime` workflow after PR #217 was merged into `main`.
+
+Runtime verification output supplied by the repository owner shows one active user profile in `auth_users` and active permissions scoped to `team_researchops_core`.
+
+## User evidence
+
+The `auth_users` verification showed:
+
+```text
+account_status = active
+created_at = 2026-05-09T00:40:07.629Z
+updated_at = 2026-05-09T00:40:07.629Z
+```
+
+The user email is deliberately not recorded in this repository trace.
+
+## Role and permission evidence
+
+The runtime permission check showed:
+
+```text
+active_roles = 2
+permissions = 7
+permission_exceptions = 0
+scope = team_researchops_core
+```
+
+Active roles:
+
+```text
+safeguarding_lead
+team_admin
+```
+
+Permissions confirmed for `safeguarding_lead`:
+
+```text
+safeguarding.view
+safeguarding.record
+safeguarding.resolve
+safeguarding.audit.view
+```
+
+Permissions confirmed for `team_admin`:
+
+```text
+team.manage
+role.assign
+audit.view
+```
+
+## Safeguarding role note
+
+The live bootstrap evidence shows the first admin holds `safeguarding_lead` as well as `team_admin`.
+
+This is valid only if the bootstrap workflow was intentionally run with safeguarding assignment enabled, or if an equivalent deliberate assignment was made.
+
+If safeguarding access was not intended, a follow-up role-removal operation should remove the `safeguarding_lead` assignment from the first admin.
+
+## Evidence boundary
+
+This trace records user-supplied runtime verification evidence.
+
+It does not include screenshots, raw email address, provider subject, or Cloudflare configuration values.
+
+This trace does not prove that `/api/me` and `/api/me/permissions` were called through the deployed Worker. It records D1-side bootstrap state and permission/role verification evidence.
+
+## Current authentication role-selection state
+
+The platform now has:
+
+- live D1 authentication foundation
+- active first admin user
+- active core team
+- active first admin team membership
+- active `team_admin` role
+- active `safeguarding_lead` role where intentionally assigned
+- runtime bootstrap workflow merged into `main`
+
+## Next implementation slice
+
+The next implementation slice should be:
+
+```text
+POST /api/auth/role-assignments
+```
+
+Purpose:
+
+- allow an authenticated Team Admin with `role.assign` to assign roles to users in their active team
+- record the role assignment in `auth_audit_events`
+- require explicit safeguards before assigning sensitive roles such as `safeguarding_lead`
+
+Recommended branch:
+
+```text
+feature/auth-role-assignment-api
+```


### PR DESCRIPTION
## Summary

Records the live evidence that the first Team Admin bootstrap was run after PR #217 merged.

This is a small audit-trace PR only.

## Evidence recorded

Adds:

```text
docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-live-evidence.md
docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-live-evidence.json
```

The trace records that user-supplied runtime verification showed:

- one active `auth_users` profile
- `account_status = active`
- `created_at = 2026-05-09T00:40:07.629Z`
- `updated_at = 2026-05-09T00:40:07.629Z`
- `2` active roles
- `7` permissions
- `0` permission exceptions
- scope `team_researchops_core`
- roles observed: `team_admin` and `safeguarding_lead`

## Privacy boundary

This PR deliberately does not commit:

- raw email address
- screenshots
- provider subject
- access-token claims
- Cloudflare configuration values
- secret material

## Safeguarding note

The evidence shows the first admin has `safeguarding_lead` as well as `team_admin`.

That is valid only if the bootstrap workflow was intentionally run with safeguarding assignment enabled, or if an equivalent deliberate assignment was made. If this was unintended, a follow-up role removal should remove `safeguarding_lead`.

## Boundary

This PR records D1-side bootstrap and role-permission evidence.

It does not independently prove a deployed Worker call to:

```text
GET /api/me
GET /api/me/permissions
```

Those endpoint checks remain the next operational verification step.