### PR TITLE
Implement authentication role assignment API

### DIFF
--- a/.github/workflows/apply-d1-auth-role-assignment-route.yml
+++ b/.github/workflows/apply-d1-auth-role-assignment-route.yml
@@ -1,0 +1,86 @@
+name: Apply D1 Auth Role Assignment Route
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_database_name:
+        description: Type researchops-d1 to confirm the target D1 database
+        required: true
+        type: string
+      confirm_operation:
+        description: Type APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE to mark the role assignment route implemented
+        required: true
+        type: string
+      run_post_apply_checks:
+        description: Run post-apply route declaration checks
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.34.0"
+  D1_DATABASE_NAME: "researchops-d1"
+  WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
+  ROLE_ASSIGNMENT_ROUTE_MIGRATION: "infra/cloudflare/migrations/0002_auth_role_assignment_route.sql"
+
+jobs:
+  apply:
+    name: Mark role assignment route implemented in remote D1
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+
+    steps:
+      - name: Confirm requested target
+        run: |
+          if [ "${{ inputs.confirm_database_name }}" != "${D1_DATABASE_NAME}" ]; then
+            echo "confirm_database_name must be ${D1_DATABASE_NAME}"
+            exit 1
+          fi
+
+          if [ "${{ inputs.confirm_operation }}" != "APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE" ]; then
+            echo "confirm_operation must be APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Check migration file exists
+        run: test -f "${ROLE_ASSIGNMENT_ROUTE_MIGRATION}"
+
+      - name: Apply role assignment route status migration to remote D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${ROLE_ASSIGNMENT_ROUTE_MIGRATION}"
+
+      - name: Verify role assignment route declaration
+        if: ${{ inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT method, route_pattern, required_permissions_json, auth_required, implementation_status FROM auth_route_permissions WHERE method = 'POST' AND route_pattern = '/api/auth/role-assignments';"

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json
@@ -1,0 +1,88 @@
+{
+	"trace_id": "atrace-20260509-auth-role-assignment-api-implementation",
+	"trace_layer": "operational",
+	"date": "2026-05-09",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "feature/auth-role-assignment-api",
+	"slice": {
+		"name": "auth-role-assignment-api",
+		"previous_slice": "auth runtime bootstrap live evidence",
+		"previous_slice_status": "complete and merged through PR #218"
+	},
+	"status": {
+		"implemented": true,
+		"pull_request_opened": false,
+		"route_status_workflow_run": false,
+		"deployed_worker_runtime_verified": false
+	},
+	"endpoint": {
+		"method": "POST",
+		"path": "/api/auth/role-assignments",
+		"required_permission": "role.assign"
+	},
+	"files_changed": [
+		"infra/cloudflare/src/core/auth/role-assignments.js",
+		"infra/cloudflare/src/worker.js",
+		"infra/cloudflare/migrations/0002_auth_role_assignment_route.sql",
+		".github/workflows/apply-d1-auth-role-assignment-route.yml",
+		"tests/auth-role-assignment-api-route-state.test.js",
+		"scripts/validate.sh",
+		"docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md",
+		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md",
+		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json"
+	],
+	"implementation": {
+		"route_handler": "infra/cloudflare/src/core/auth/role-assignments.js",
+		"worker_wiring": "infra/cloudflare/src/worker.js",
+		"behaviour": [
+			"resolve authenticated Cloudflare Access context",
+			"check D1 route permission declaration",
+			"require role.assign",
+			"validate request body",
+			"scope assignment to caller active team",
+			"require target user to be active team member",
+			"require explicit confirmation for sensitive roles",
+			"require extra explicit confirmation for safeguarding_lead",
+			"create or reactivate team-scoped role assignment",
+			"record auth audit event"
+		]
+	},
+	"request_contract": {
+		"target": "targetUserId or targetEmail",
+		"required": ["roleKey", "requestedReason"],
+		"optional": ["expiresAt"],
+		"sensitive_role_confirmation": "ASSIGN_SENSITIVE_ROLE",
+		"safeguarding_confirmation": "ASSIGN_SAFEGUARDING_LEAD"
+	},
+	"database_writes": {
+		"assignment_table": "auth_role_assignments",
+		"assignment_unique_key": ["user_id", "role_id", "scope_type", "scope_id"],
+		"audit_table": "auth_audit_events",
+		"audit_event_type": "auth.role_assignment.created",
+		"audit_permission_code": "role.assign"
+	},
+	"route_status_migration": {
+		"migration": "infra/cloudflare/migrations/0002_auth_role_assignment_route.sql",
+		"workflow": ".github/workflows/apply-d1-auth-role-assignment-route.yml",
+		"confirmation_inputs": {
+			"confirm_database_name": "researchops-d1",
+			"confirm_operation": "APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE"
+		}
+	},
+	"validation": {
+		"test": "tests/auth-role-assignment-api-route-state.test.js",
+		"wired_into": "scripts/validate.sh"
+	},
+	"boundaries": [
+		"No role-management UI is created in this slice.",
+		"No users or team memberships are created by this endpoint.",
+		"No cross-team assignment is supported.",
+		"No permission exceptions are assigned.",
+		"The route-status workflow is not run by this PR."
+	],
+	"next_steps_after_merge": [
+		"Run Apply D1 Auth Role Assignment Route from GitHub Actions.",
+		"Test POST /api/auth/role-assignments as the seeded Team Admin.",
+		"Record live endpoint evidence after runtime verification."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json
@@ -11,7 +11,7 @@
 	},
 	"status": {
 		"implemented": true,
-		"pull_request_opened": false,
+		"pull_request_opened": true,
 		"route_status_workflow_run": false,
 		"deployed_worker_runtime_verified": false
 	},
@@ -19,6 +19,11 @@
 		"method": "POST",
 		"path": "/api/auth/role-assignments",
 		"required_permission": "role.assign"
+	},
+	"pull_request": {
+		"number": 219,
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/219",
+		"state": "open"
 	},
 	"files_changed": [
 		"infra/cloudflare/src/core/auth/role-assignments.js",
@@ -39,16 +44,18 @@
 			"check D1 route permission declaration",
 			"require role.assign",
 			"validate request body",
+			"reject conflicting targetUserId and targetEmail values unless both resolve to the same user",
 			"scope assignment to caller active team",
 			"require target user to be active team member",
 			"require explicit confirmation for sensitive roles",
 			"require extra explicit confirmation for safeguarding_lead",
-			"create or reactivate team-scoped role assignment",
-			"record auth audit event"
+			"create or reactivate team-scoped role assignment and audit event in one D1 batch",
+			"fail closed if D1 batch writes are not available"
 		]
 	},
 	"request_contract": {
-		"target": "targetUserId or targetEmail",
+		"target": "targetUserId or targetEmail. If both are supplied, both must resolve to the same user.",
+		"target_conflict_error": "target_identifier_conflict",
 		"required": ["roleKey", "requestedReason"],
 		"optional": ["expiresAt"],
 		"sensitive_role_confirmation": "ASSIGN_SENSITIVE_ROLE",
@@ -59,8 +66,24 @@
 		"assignment_unique_key": ["user_id", "role_id", "scope_type", "scope_id"],
 		"audit_table": "auth_audit_events",
 		"audit_event_type": "auth.role_assignment.created",
-		"audit_permission_code": "role.assign"
+		"audit_permission_code": "role.assign",
+		"atomic_write_strategy": "The assignment statement and audit statement are executed together using db.batch([assignmentStatement, auditStatement]).",
+		"fail_closed_error_when_batch_unavailable": "role_assignment_transaction_unavailable"
 	},
+	"review_fixes": [
+		{
+			"priority": "P1",
+			"title": "Make role assignment and audit writes atomic",
+			"risk": "Separate writes could leave a role active without the required audit event if audit insertion failed after assignment insertion.",
+			"fix": "Prepare assignment and audit statements and execute them with D1 batch. Refuse to write when batch support is unavailable."
+		},
+		{
+			"priority": "P2",
+			"title": "Reject conflicting target identifiers",
+			"risk": "A stale hidden targetUserId could silently override a visible edited targetEmail and assign a role to the wrong user.",
+			"fix": "Resolve both identifiers when both are present and reject the request unless they resolve to the same user."
+		}
+	],
 	"route_status_migration": {
 		"migration": "infra/cloudflare/migrations/0002_auth_role_assignment_route.sql",
 		"workflow": ".github/workflows/apply-d1-auth-role-assignment-route.yml",
@@ -71,7 +94,11 @@
 	},
 	"validation": {
 		"test": "tests/auth-role-assignment-api-route-state.test.js",
-		"wired_into": "scripts/validate.sh"
+		"wired_into": "scripts/validate.sh",
+		"review_fix_coverage": [
+			"asserts conflicting target identifier rejection",
+			"asserts D1 batch is required for assignment and audit writes"
+		]
 	},
 	"boundaries": [
 		"No role-management UI is created in this slice.",

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md
@@ -63,6 +63,14 @@ requestedReason
 
 `expiresAt` is optional and must be a valid ISO-8601 date-time when provided.
 
+If both `targetUserId` and `targetEmail` are supplied, both must resolve to the same user. Otherwise, the request is rejected with:
+
+```text
+target_identifier_conflict
+```
+
+This prevents a stale hidden user ID from assigning the role to a different user than the visible email shown to an admin.
+
 ## Sensitive role guard
 
 Sensitive roles require explicit confirmation:
@@ -117,6 +125,34 @@ outcome = succeeded
 
 `is_safeguarding` is set when assigning `safeguarding_lead`.
 
+## Atomic write review fix
+
+A PR review comment identified that assignment and audit writes were originally separate D1 statements.
+
+That could leave a sensitive role active if the assignment write succeeded but the audit write failed.
+
+The handler now prepares both statements and writes them through:
+
+```text
+db.batch([assignmentStatement, auditStatement])
+```
+
+If `db.batch` is not available, the endpoint fails closed with:
+
+```text
+role_assignment_transaction_unavailable
+```
+
+This prevents the endpoint from making a role assignment when it cannot also make the required audit write safely.
+
+## Conflicting target identifier review fix
+
+A PR review comment identified that a request containing both `targetUserId` and `targetEmail` would previously use the user ID and ignore the email.
+
+The handler now resolves both identifiers when both are supplied and rejects the request unless they identify the same user.
+
+This prevents stale or mismatched UI state from assigning a role to an unintended user.
+
 ## D1 route-status migration
 
 A migration has been added:
@@ -149,7 +185,7 @@ A route-state test has been added:
 tests/auth-role-assignment-api-route-state.test.js
 ```
 
-The test checks Worker route wiring, authentication and route-permission use, active-team scoping, target user and reason validation, sensitive and safeguarding confirmation requirements, assignment writes, audit writes and D1 route-status migration intent.
+The test checks Worker route wiring, authentication and route-permission use, active-team scoping, target user and reason validation, sensitive and safeguarding confirmation requirements, atomic assignment/audit writes, conflicting target identifier rejection and D1 route-status migration intent.
 
 ## Product documentation
 

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md
@@ -1,0 +1,190 @@
+# Agent trace: auth role assignment API implementation
+
+Date: 2026-05-09
+
+Branch: `feature/auth-role-assignment-api`
+
+Slice: `auth-role-assignment-api`
+
+Previous slice: auth runtime bootstrap live evidence, merged through PR #218.
+
+## Purpose
+
+The first Team Admin has been bootstrapped in live D1. This slice adds the first managed role-assignment API so role access can move from manual bootstrap toward controlled application behaviour.
+
+Endpoint implemented:
+
+```text
+POST /api/auth/role-assignments
+```
+
+## Runtime route behaviour
+
+The Worker now wires `POST /api/auth/role-assignments` to:
+
+```text
+infra/cloudflare/src/core/auth/role-assignments.js
+```
+
+The handler:
+
+1. resolves the authenticated Cloudflare Access user
+2. resolves the active team context
+3. checks the D1 route-permission declaration
+4. requires the caller to hold `role.assign`
+5. validates the request body
+6. verifies the target user exists
+7. verifies the target user is an active member of the caller's active team
+8. creates or reactivates the role assignment at team scope
+9. records an audit event
+
+## Permission model
+
+The route uses the existing D1 route declaration:
+
+```text
+method = POST
+route_pattern = /api/auth/role-assignments
+required_permissions_json = ["role.assign"]
+```
+
+A user without `role.assign` receives `403` from the route-permission layer without internal diagnostic details.
+
+## Request requirements
+
+The request must include either `targetUserId` or `targetEmail`.
+
+It must also include:
+
+```text
+roleKey
+requestedReason
+```
+
+`expiresAt` is optional and must be a valid ISO-8601 date-time when provided.
+
+## Sensitive role guard
+
+Sensitive roles require explicit confirmation:
+
+```text
+sensitiveRoleConfirmation = ASSIGN_SENSITIVE_ROLE
+```
+
+The `safeguarding_lead` role also requires:
+
+```text
+safeguardingConfirmation = ASSIGN_SAFEGUARDING_LEAD
+```
+
+This prevents accidental escalation to sensitive or safeguarding access.
+
+## Scope boundary
+
+Role assignments are scoped to the caller's active team.
+
+The target user must already have an active membership in that team.
+
+This endpoint does not create users, teams or memberships.
+
+## Database writes
+
+Successful assignment writes to:
+
+```text
+auth_role_assignments
+```
+
+The write is idempotent against the unique key:
+
+```text
+(user_id, role_id, scope_type, scope_id)
+```
+
+Successful assignment also writes to:
+
+```text
+auth_audit_events
+```
+
+Audit event values include:
+
+```text
+event_type = auth.role_assignment.created
+permission_code = role.assign
+outcome = succeeded
+```
+
+`is_safeguarding` is set when assigning `safeguarding_lead`.
+
+## D1 route-status migration
+
+A migration has been added:
+
+```text
+infra/cloudflare/migrations/0002_auth_role_assignment_route.sql
+```
+
+It marks the D1 route declaration as implemented.
+
+A manual workflow has been added to apply this operational update after merge:
+
+```text
+.github/workflows/apply-d1-auth-role-assignment-route.yml
+```
+
+Required workflow inputs:
+
+```text
+confirm_database_name = researchops-d1
+confirm_operation = APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE
+run_post_apply_checks = true
+```
+
+## Validation
+
+A route-state test has been added:
+
+```text
+tests/auth-role-assignment-api-route-state.test.js
+```
+
+The test checks Worker route wiring, authentication and route-permission use, active-team scoping, target user and reason validation, sensitive and safeguarding confirmation requirements, assignment writes, audit writes and D1 route-status migration intent.
+
+## Product documentation
+
+Product documentation lives at:
+
+```text
+docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md
+```
+
+## Files changed in this slice
+
+- `infra/cloudflare/src/core/auth/role-assignments.js`
+- `infra/cloudflare/src/worker.js`
+- `infra/cloudflare/migrations/0002_auth_role_assignment_route.sql`
+- `.github/workflows/apply-d1-auth-role-assignment-route.yml`
+- `tests/auth-role-assignment-api-route-state.test.js`
+- `scripts/validate.sh`
+- `docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md`
+- `docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md`
+- `docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json`
+
+## Boundary
+
+This slice does not create a role-management UI.
+
+This slice does not create users or team memberships.
+
+This slice does not support cross-team role assignment.
+
+This slice does not assign permission exceptions.
+
+This slice does not run the route-status workflow.
+
+## Required operational follow-up after merge
+
+After merge, run `Apply D1 Auth Role Assignment Route` from GitHub Actions to mark the route declaration as implemented in live D1.
+
+Then test `POST /api/auth/role-assignments` as the seeded Team Admin.

--- a/docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md
+++ b/docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md
@@ -40,6 +40,12 @@ or:
 targetEmail
 ```
 
+If both are supplied, both identifiers must resolve to the same user. Otherwise, the endpoint rejects the request with:
+
+```text
+target_identifier_conflict
+```
+
 Required role field:
 
 ```text
@@ -108,6 +114,18 @@ outcome = succeeded
 
 Safeguarding lead assignment audit events are marked as safeguarding-related.
 
+## Atomic write behaviour
+
+The assignment and audit statements are prepared together and executed through D1 batch execution.
+
+If batch execution is not available, the endpoint fails closed with:
+
+```text
+role_assignment_transaction_unavailable
+```
+
+This prevents a role from being granted when the required audit event cannot be written safely.
+
 ## D1 route status migration
 
 A small migration marks the route declaration as implemented:
@@ -128,6 +146,13 @@ Required confirmation inputs:
 confirm_database_name = researchops-d1
 confirm_operation = APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE
 ```
+
+## Review hardening applied
+
+Two review comments were addressed before merge:
+
+- assignment and audit writes are now batch-bound so the endpoint does not knowingly grant access without recording the audit event
+- conflicting target identifiers are now rejected unless `targetUserId` and `targetEmail` resolve to the same user
 
 ## Boundary
 

--- a/docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md
+++ b/docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md
@@ -1,0 +1,152 @@
+# Authentication role assignment API
+
+Date: 2026-05-09
+
+## Purpose
+
+The authentication runtime bootstrap has created a real first Team Admin in D1. This slice adds the first managed role-assignment capability so that role changes no longer depend only on manual bootstrap SQL.
+
+The endpoint is:
+
+```text
+POST /api/auth/role-assignments
+```
+
+## Runtime behaviour
+
+The Worker route resolves the authenticated Cloudflare Access user, checks the active team context and then checks route permissions against D1.
+
+The route requires:
+
+```text
+role.assign
+```
+
+A caller without `role.assign` receives `403` without internal permission diagnostics.
+
+## Request body
+
+The endpoint accepts a JSON object.
+
+Required target field:
+
+```text
+targetUserId
+```
+
+or:
+
+```text
+targetEmail
+```
+
+Required role field:
+
+```text
+roleKey
+```
+
+Required reason field:
+
+```text
+requestedReason
+```
+
+Optional expiry field:
+
+```text
+expiresAt
+```
+
+## Sensitive role confirmation
+
+Sensitive roles require explicit confirmation.
+
+For any sensitive role, the request must include:
+
+```text
+sensitiveRoleConfirmation = ASSIGN_SENSITIVE_ROLE
+```
+
+For `safeguarding_lead`, the request must also include:
+
+```text
+safeguardingConfirmation = ASSIGN_SAFEGUARDING_LEAD
+```
+
+This prevents accidental assignment of high-risk access during the early role-management phase.
+
+## Scope
+
+Assignments created by this endpoint are scoped to the caller's active team.
+
+The target user must already be an active member of that team.
+
+This endpoint does not create users or team memberships.
+
+## Database writes
+
+The endpoint creates or reactivates records in:
+
+```text
+auth_role_assignments
+```
+
+It records each successful assignment in:
+
+```text
+auth_audit_events
+```
+
+The audit event uses:
+
+```text
+event_type = auth.role_assignment.created
+permission_code = role.assign
+outcome = succeeded
+```
+
+Safeguarding lead assignment audit events are marked as safeguarding-related.
+
+## D1 route status migration
+
+A small migration marks the route declaration as implemented:
+
+```text
+infra/cloudflare/migrations/0002_auth_role_assignment_route.sql
+```
+
+A manual workflow applies that route-status migration to remote D1:
+
+```text
+.github/workflows/apply-d1-auth-role-assignment-route.yml
+```
+
+Required confirmation inputs:
+
+```text
+confirm_database_name = researchops-d1
+confirm_operation = APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE
+```
+
+## Boundary
+
+This slice does not create a role-management UI.
+
+This slice does not create users.
+
+This slice does not create team memberships.
+
+This slice does not support cross-team assignment.
+
+This slice does not assign permission exceptions.
+
+## Operational follow-up after merge
+
+After merge, run the route-status workflow to update remote D1 from `deferred` to `implemented` for:
+
+```text
+POST /api/auth/role-assignments
+```
+
+Then test the endpoint as the seeded Team Admin with `role.assign`.

--- a/infra/cloudflare/migrations/0002_auth_role_assignment_route.sql
+++ b/infra/cloudflare/migrations/0002_auth_role_assignment_route.sql
@@ -1,0 +1,9 @@
+-- Authentication role-assignment API route activation
+-- Date: 2026-05-09
+-- Scope: mark POST /api/auth/role-assignments as implemented now the Worker route exists.
+
+UPDATE auth_route_permissions
+SET implementation_status = 'implemented'
+WHERE method = 'POST'
+	AND route_pattern = '/api/auth/role-assignments'
+	AND required_permissions_json = '["role.assign"]';

--- a/infra/cloudflare/src/core/auth/role-assignments.js
+++ b/infra/cloudflare/src/core/auth/role-assignments.js
@@ -1,10 +1,10 @@
-import { resolveAuthenticatedContext } from './access.js';
-import { assertRoutePermission, routePermissionErrorResponse } from './route-permissions.js';
+import { resolveAuthenticatedContext } from "./access.js";
+import { assertRoutePermission, routePermissionErrorResponse } from "./route-permissions.js";
 
 const JSON_HEADERS = {
-	'content-type': 'application/json; charset=utf-8',
-	'cache-control': 'no-store',
-	'x-content-type-options': 'nosniff',
+	"content-type": "application/json; charset=utf-8",
+	"cache-control": "no-store",
+	"x-content-type-options": "nosniff"
 };
 
 class RoleAssignmentError extends Error {
@@ -21,11 +21,11 @@ function jsonResponse(body, status = 200) {
 
 function dbFor(env = {}) {
 	const db = env.RESEARCHOPS_D1;
-	if (!db || typeof db.prepare !== 'function') {
+	if (!db || typeof db.prepare !== "function") {
 		throw new RoleAssignmentError(
 			503,
-			'role_assignment_store_unavailable',
-			'Role assignments cannot be changed right now.',
+			"role_assignment_store_unavailable",
+			"Role assignments cannot be changed right now."
 		);
 	}
 	return db;
@@ -35,26 +35,39 @@ function makeId(prefix) {
 	return `${prefix}_${crypto.randomUUID()}`;
 }
 
+function stableHash(value) {
+	let hash = 2166136261;
+	for (const char of String(value)) {
+		hash ^= char.charCodeAt(0);
+		hash = Math.imul(hash, 16777619);
+	}
+	return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function stableAssignmentId(userId, roleId, teamId) {
+	return `asn_${stableHash(`${userId}:${roleId}:${teamId}`)}`;
+}
+
 function normaliseEmail(email) {
-	return String(email || '')
+	return String(email || "")
 		.trim()
 		.toLowerCase();
 }
 
 function cleanText(value) {
-	return String(value || '').trim();
+	return String(value || "").trim();
 }
 
 async function readJson(request) {
 	try {
 		const body = await request.json();
-		if (!body || typeof body !== 'object' || Array.isArray(body)) {
-			throw new RoleAssignmentError(400, 'invalid_request_body', 'Request body must be a JSON object.');
+		if (!body || typeof body !== "object" || Array.isArray(body)) {
+			throw new RoleAssignmentError(400, "invalid_request_body", "Request body must be a JSON object.");
 		}
 		return body;
 	} catch (error) {
 		if (error instanceof RoleAssignmentError) throw error;
-		throw new RoleAssignmentError(400, 'invalid_json', 'Request body must be valid JSON.');
+		throw new RoleAssignmentError(400, "invalid_json", "Request body must be valid JSON.");
 	}
 }
 
@@ -65,8 +78,8 @@ function targetSelectorFor(body) {
 	if (!targetUserId && !targetEmail) {
 		throw new RoleAssignmentError(
 			400,
-			'target_required',
-			'Provide targetUserId or targetEmail for the user receiving the role.',
+			"target_required",
+			"Provide targetUserId or targetEmail for the user receiving the role."
 		);
 	}
 
@@ -76,7 +89,7 @@ function targetSelectorFor(body) {
 function requestedRoleKeyFor(body) {
 	const roleKey = cleanText(body.roleKey);
 	if (!roleKey) {
-		throw new RoleAssignmentError(400, 'role_required', 'Provide roleKey for the role to assign.');
+		throw new RoleAssignmentError(400, "role_required", "Provide roleKey for the role to assign.");
 	}
 	return roleKey;
 }
@@ -86,8 +99,8 @@ function requestedReasonFor(body) {
 	if (requestedReason.length < 12) {
 		throw new RoleAssignmentError(
 			400,
-			'role_assignment_reason_required',
-			'Provide a clear reason for assigning this role.',
+			"role_assignment_reason_required",
+			"Provide a clear reason for assigning this role."
 		);
 	}
 	return requestedReason;
@@ -101,8 +114,8 @@ function expiresAtFor(body) {
 	if (Number.isNaN(parsed)) {
 		throw new RoleAssignmentError(
 			400,
-			'invalid_expiry',
-			'expiresAt must be an ISO-8601 date-time when provided.',
+			"invalid_expiry",
+			"expiresAt must be an ISO-8601 date-time when provided."
 		);
 	}
 
@@ -113,8 +126,8 @@ function assertActiveTeam(context) {
 	if (!context.activeTeam?.id) {
 		throw new RoleAssignmentError(
 			403,
-			'active_team_required',
-			'Choose an active team before assigning roles.',
+			"active_team_required",
+			"Choose an active team before assigning roles."
 		);
 	}
 	return context.activeTeam;
@@ -125,19 +138,19 @@ function assertSensitiveRoleConfirmation(role, body) {
 	const roleIsSensitive = role.is_sensitive === 1 || role.approval_required === 1;
 	if (!roleIsSensitive) return;
 
-	if (body.sensitiveRoleConfirmation !== 'ASSIGN_SENSITIVE_ROLE') {
+	if (body.sensitiveRoleConfirmation !== "ASSIGN_SENSITIVE_ROLE") {
 		throw new RoleAssignmentError(
 			400,
-			'sensitive_role_confirmation_required',
-			'Confirm that this sensitive role assignment is intentional.',
+			"sensitive_role_confirmation_required",
+			"Confirm that this sensitive role assignment is intentional."
 		);
 	}
 
-	if (roleKey === 'safeguarding_lead' && body.safeguardingConfirmation !== 'ASSIGN_SAFEGUARDING_LEAD') {
+	if (roleKey === "safeguarding_lead" && body.safeguardingConfirmation !== "ASSIGN_SAFEGUARDING_LEAD") {
 		throw new RoleAssignmentError(
 			400,
-			'safeguarding_role_confirmation_required',
-			'Confirm that safeguarding lead access is intentionally required.',
+			"safeguarding_role_confirmation_required",
+			"Confirm that safeguarding lead access is intentionally required."
 		);
 	}
 }
@@ -154,26 +167,48 @@ async function readRole(db, roleKey) {
 		.first();
 }
 
-async function readTargetUser(db, targetUserId, targetEmail) {
-	let query = `
-		SELECT id, email, display_name, account_status
-		FROM auth_users
-		WHERE id = ?
-		LIMIT 1
-	`;
-	let value = targetUserId;
+async function readUserById(db, targetUserId) {
+	if (!targetUserId) return null;
+	return db
+		.prepare(`
+			SELECT id, email, display_name, account_status
+			FROM auth_users
+			WHERE id = ?
+			LIMIT 1
+		`)
+		.bind(targetUserId)
+		.first();
+}
 
-	if (!targetUserId && targetEmail) {
-		query = `
+async function readUserByEmail(db, targetEmail) {
+	if (!targetEmail) return null;
+	return db
+		.prepare(`
 			SELECT id, email, display_name, account_status
 			FROM auth_users
 			WHERE lower(email) = lower(?)
 			LIMIT 1
-		`;
-		value = targetEmail;
+		`)
+		.bind(targetEmail)
+		.first();
+}
+
+async function readTargetUser(db, targetUserId, targetEmail) {
+	const userById = await readUserById(db, targetUserId);
+	const userByEmail = await readUserByEmail(db, targetEmail);
+
+	if (targetUserId && targetEmail) {
+		if (!userById || !userByEmail || userById.id !== userByEmail.id) {
+			throw new RoleAssignmentError(
+				400,
+				"target_identifier_conflict",
+				"targetUserId and targetEmail must resolve to the same user."
+			);
+		}
+		return userById;
 	}
 
-	return db.prepare(query).bind(value).first();
+	return userById || userByEmail;
 }
 
 async function readActiveMembership(db, targetUserId, teamId) {
@@ -200,10 +235,8 @@ async function readAssignment(db, targetUserId, roleId, teamId) {
 		.first();
 }
 
-async function writeAssignment(db, context, targetUser, role, team, requestedReason, expiresAt) {
-	const assignmentId = makeId('asn');
-
-	await db
+function prepareAssignmentStatement(db, assignmentId, context, targetUser, role, team, requestedReason, expiresAt) {
+	return db
 		.prepare(`
 			INSERT INTO auth_role_assignments
 				(id, user_id, role_id, scope_type, scope_id, assignment_status, requested_reason, approved_by_user_id, approved_at, expires_at)
@@ -216,15 +249,12 @@ async function writeAssignment(db, context, targetUser, role, team, requestedRea
 				expires_at = excluded.expires_at,
 				updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 		`)
-		.bind(assignmentId, targetUser.id, role.id, team.id, requestedReason, context.user.id, expiresAt)
-		.run();
-
-	return readAssignment(db, targetUser.id, role.id, team.id);
+		.bind(assignmentId, targetUser.id, role.id, team.id, requestedReason, context.user.id, expiresAt);
 }
 
-async function writeAuditEvent(db, request, context, targetUser, role, team, requestedReason, assignment) {
+function prepareAuditStatement(db, request, context, targetUser, role, team, requestedReason, assignmentId) {
 	const url = new URL(request.url);
-	await db
+	return db
 		.prepare(`
 			INSERT INTO auth_audit_events
 				(id, event_type, actor_user_id, team_id, target_type, target_id, permission_code, route_path, outcome, is_safeguarding, metadata_json)
@@ -232,22 +262,56 @@ async function writeAuditEvent(db, request, context, targetUser, role, team, req
 				'role_key', ?,
 				'target_user_id', ?,
 				'requested_reason', ?,
-				'assignment_status', ?
+				'assignment_status', 'active'
 			))
 		`)
 		.bind(
-			makeId('audit'),
+			makeId("audit"),
 			context.user.id,
 			team.id,
-			assignment.id,
+			assignmentId,
 			url.pathname,
-			role.role_key === 'safeguarding_lead' ? 1 : 0,
+			role.role_key === "safeguarding_lead" ? 1 : 0,
 			role.role_key,
 			targetUser.id,
-			requestedReason,
-			assignment.assignment_status,
-		)
-		.run();
+			requestedReason
+		);
+}
+
+async function writeAssignmentWithAudit(db, request, context, targetUser, role, team, requestedReason, expiresAt) {
+	if (typeof db.batch !== "function") {
+		throw new RoleAssignmentError(
+			503,
+			"role_assignment_transaction_unavailable",
+			"Role assignment writes cannot be made safely right now."
+		);
+	}
+
+	const existingAssignment = await readAssignment(db, targetUser.id, role.id, team.id);
+	const assignmentId = existingAssignment?.id || stableAssignmentId(targetUser.id, role.id, team.id);
+	const assignmentStatement = prepareAssignmentStatement(
+		db,
+		assignmentId,
+		context,
+		targetUser,
+		role,
+		team,
+		requestedReason,
+		expiresAt
+	);
+	const auditStatement = prepareAuditStatement(
+		db,
+		request,
+		context,
+		targetUser,
+		role,
+		team,
+		requestedReason,
+		assignmentId
+	);
+
+	await db.batch([assignmentStatement, auditStatement]);
+	return readAssignment(db, targetUser.id, role.id, team.id);
 }
 
 async function assignRole(request, env, context, body) {
@@ -260,37 +324,45 @@ async function assignRole(request, env, context, body) {
 	const role = await readRole(db, roleKey);
 
 	if (!role) {
-		throw new RoleAssignmentError(404, 'role_not_found', 'The requested role does not exist.');
+		throw new RoleAssignmentError(404, "role_not_found", "The requested role does not exist.");
 	}
 
 	assertSensitiveRoleConfirmation(role, body);
 
 	const targetUser = await readTargetUser(db, targetUserId, targetEmail);
 	if (!targetUser) {
-		throw new RoleAssignmentError(404, 'target_user_not_found', 'The target user does not exist.');
+		throw new RoleAssignmentError(404, "target_user_not_found", "The target user does not exist.");
 	}
 
-	if (['suspended', 'closed'].includes(targetUser.account_status)) {
-		throw new RoleAssignmentError(409, 'target_user_inactive', 'The target user cannot receive roles.');
+	if (["suspended", "closed"].includes(targetUser.account_status)) {
+		throw new RoleAssignmentError(409, "target_user_inactive", "The target user cannot receive roles.");
 	}
 
 	const membership = await readActiveMembership(db, targetUser.id, team.id);
 	if (!membership) {
 		throw new RoleAssignmentError(
 			400,
-			'target_not_team_member',
-			'The target user must be an active member of the active team before a role can be assigned.',
+			"target_not_team_member",
+			"The target user must be an active member of the active team before a role can be assigned."
 		);
 	}
 
-	const assignment = await writeAssignment(db, context, targetUser, role, team, requestedReason, expiresAt);
-	await writeAuditEvent(db, request, context, targetUser, role, team, requestedReason, assignment);
+	const assignment = await writeAssignmentWithAudit(
+		db,
+		request,
+		context,
+		targetUser,
+		role,
+		team,
+		requestedReason,
+		expiresAt
+	);
 
 	return {
 		assignment,
 		role,
 		targetUser,
-		team,
+		team
 	};
 }
 
@@ -312,23 +384,23 @@ export async function handleRoleAssignmentsRoute(request, env) {
 				assignment: {
 					id: result.assignment.id,
 					status: result.assignment.assignment_status,
-					scopeType: 'team',
+					scopeType: "team",
 					scopeId: result.team.id,
-					expiresAt: result.assignment.expires_at,
+					expiresAt: result.assignment.expires_at
 				},
 				role: {
 					key: result.role.role_key,
 					label: result.role.label,
-					sensitive: result.role.is_sensitive === 1,
+					sensitive: result.role.is_sensitive === 1
 				},
 				targetUser: {
 					id: result.targetUser.id,
 					email: result.targetUser.email,
 					displayName: result.targetUser.display_name,
-					accountStatus: result.targetUser.account_status,
-				},
+					accountStatus: result.targetUser.account_status
+				}
 			},
-			201,
+			201
 		);
 	} catch (error) {
 		try {
@@ -346,10 +418,10 @@ export async function handleRoleAssignmentsRoute(request, env) {
 		return jsonResponse(
 			{
 				ok: false,
-				error: 'role_assignment_error',
-				message: 'Role assignment could not be completed.',
+				error: "role_assignment_error",
+				message: "Role assignment could not be completed."
 			},
-			500,
+			500
 		);
 	}
 }

--- a/infra/cloudflare/src/core/auth/role-assignments.js
+++ b/infra/cloudflare/src/core/auth/role-assignments.js
@@ -1,0 +1,355 @@
+import { resolveAuthenticatedContext } from './access.js';
+import { assertRoutePermission, routePermissionErrorResponse } from './route-permissions.js';
+
+const JSON_HEADERS = {
+	'content-type': 'application/json; charset=utf-8',
+	'cache-control': 'no-store',
+	'x-content-type-options': 'nosniff',
+};
+
+class RoleAssignmentError extends Error {
+	constructor(status, code, message) {
+		super(message);
+		this.status = status;
+		this.code = code;
+	}
+}
+
+function jsonResponse(body, status = 200) {
+	return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function dbFor(env = {}) {
+	const db = env.RESEARCHOPS_D1;
+	if (!db || typeof db.prepare !== 'function') {
+		throw new RoleAssignmentError(
+			503,
+			'role_assignment_store_unavailable',
+			'Role assignments cannot be changed right now.',
+		);
+	}
+	return db;
+}
+
+function makeId(prefix) {
+	return `${prefix}_${crypto.randomUUID()}`;
+}
+
+function normaliseEmail(email) {
+	return String(email || '')
+		.trim()
+		.toLowerCase();
+}
+
+function cleanText(value) {
+	return String(value || '').trim();
+}
+
+async function readJson(request) {
+	try {
+		const body = await request.json();
+		if (!body || typeof body !== 'object' || Array.isArray(body)) {
+			throw new RoleAssignmentError(400, 'invalid_request_body', 'Request body must be a JSON object.');
+		}
+		return body;
+	} catch (error) {
+		if (error instanceof RoleAssignmentError) throw error;
+		throw new RoleAssignmentError(400, 'invalid_json', 'Request body must be valid JSON.');
+	}
+}
+
+function targetSelectorFor(body) {
+	const targetUserId = cleanText(body.targetUserId);
+	const targetEmail = normaliseEmail(body.targetEmail);
+
+	if (!targetUserId && !targetEmail) {
+		throw new RoleAssignmentError(
+			400,
+			'target_required',
+			'Provide targetUserId or targetEmail for the user receiving the role.',
+		);
+	}
+
+	return { targetUserId, targetEmail };
+}
+
+function requestedRoleKeyFor(body) {
+	const roleKey = cleanText(body.roleKey);
+	if (!roleKey) {
+		throw new RoleAssignmentError(400, 'role_required', 'Provide roleKey for the role to assign.');
+	}
+	return roleKey;
+}
+
+function requestedReasonFor(body) {
+	const requestedReason = cleanText(body.requestedReason);
+	if (requestedReason.length < 12) {
+		throw new RoleAssignmentError(
+			400,
+			'role_assignment_reason_required',
+			'Provide a clear reason for assigning this role.',
+		);
+	}
+	return requestedReason;
+}
+
+function expiresAtFor(body) {
+	const expiresAt = cleanText(body.expiresAt);
+	if (!expiresAt) return null;
+
+	const parsed = Date.parse(expiresAt);
+	if (Number.isNaN(parsed)) {
+		throw new RoleAssignmentError(
+			400,
+			'invalid_expiry',
+			'expiresAt must be an ISO-8601 date-time when provided.',
+		);
+	}
+
+	return new Date(parsed).toISOString();
+}
+
+function assertActiveTeam(context) {
+	if (!context.activeTeam?.id) {
+		throw new RoleAssignmentError(
+			403,
+			'active_team_required',
+			'Choose an active team before assigning roles.',
+		);
+	}
+	return context.activeTeam;
+}
+
+function assertSensitiveRoleConfirmation(role, body) {
+	const roleKey = role.role_key;
+	const roleIsSensitive = role.is_sensitive === 1 || role.approval_required === 1;
+	if (!roleIsSensitive) return;
+
+	if (body.sensitiveRoleConfirmation !== 'ASSIGN_SENSITIVE_ROLE') {
+		throw new RoleAssignmentError(
+			400,
+			'sensitive_role_confirmation_required',
+			'Confirm that this sensitive role assignment is intentional.',
+		);
+	}
+
+	if (roleKey === 'safeguarding_lead' && body.safeguardingConfirmation !== 'ASSIGN_SAFEGUARDING_LEAD') {
+		throw new RoleAssignmentError(
+			400,
+			'safeguarding_role_confirmation_required',
+			'Confirm that safeguarding lead access is intentionally required.',
+		);
+	}
+}
+
+async function readRole(db, roleKey) {
+	return db
+		.prepare(`
+			SELECT id, role_key, label, description, is_sensitive, approval_required, default_expiry_days
+			FROM auth_roles
+			WHERE role_key = ?
+			LIMIT 1
+		`)
+		.bind(roleKey)
+		.first();
+}
+
+async function readTargetUser(db, targetUserId, targetEmail) {
+	let query = `
+		SELECT id, email, display_name, account_status
+		FROM auth_users
+		WHERE id = ?
+		LIMIT 1
+	`;
+	let value = targetUserId;
+
+	if (!targetUserId && targetEmail) {
+		query = `
+			SELECT id, email, display_name, account_status
+			FROM auth_users
+			WHERE lower(email) = lower(?)
+			LIMIT 1
+		`;
+		value = targetEmail;
+	}
+
+	return db.prepare(query).bind(value).first();
+}
+
+async function readActiveMembership(db, targetUserId, teamId) {
+	return db
+		.prepare(`
+			SELECT id, membership_status
+			FROM auth_team_memberships
+			WHERE user_id = ? AND team_id = ? AND membership_status = 'active'
+			LIMIT 1
+		`)
+		.bind(targetUserId, teamId)
+		.first();
+}
+
+async function readAssignment(db, targetUserId, roleId, teamId) {
+	return db
+		.prepare(`
+			SELECT id, assignment_status, requested_reason, approved_by_user_id, approved_at, expires_at
+			FROM auth_role_assignments
+			WHERE user_id = ? AND role_id = ? AND scope_type = 'team' AND scope_id = ?
+			LIMIT 1
+		`)
+		.bind(targetUserId, roleId, teamId)
+		.first();
+}
+
+async function writeAssignment(db, context, targetUser, role, team, requestedReason, expiresAt) {
+	const assignmentId = makeId('asn');
+
+	await db
+		.prepare(`
+			INSERT INTO auth_role_assignments
+				(id, user_id, role_id, scope_type, scope_id, assignment_status, requested_reason, approved_by_user_id, approved_at, expires_at)
+			VALUES (?, ?, ?, 'team', ?, 'active', ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), ?)
+			ON CONFLICT(user_id, role_id, scope_type, scope_id) DO UPDATE SET
+				assignment_status = 'active',
+				requested_reason = excluded.requested_reason,
+				approved_by_user_id = excluded.approved_by_user_id,
+				approved_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+				expires_at = excluded.expires_at,
+				updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+		`)
+		.bind(assignmentId, targetUser.id, role.id, team.id, requestedReason, context.user.id, expiresAt)
+		.run();
+
+	return readAssignment(db, targetUser.id, role.id, team.id);
+}
+
+async function writeAuditEvent(db, request, context, targetUser, role, team, requestedReason, assignment) {
+	const url = new URL(request.url);
+	await db
+		.prepare(`
+			INSERT INTO auth_audit_events
+				(id, event_type, actor_user_id, team_id, target_type, target_id, permission_code, route_path, outcome, is_safeguarding, metadata_json)
+			VALUES (?, 'auth.role_assignment.created', ?, ?, 'auth_role_assignment', ?, 'role.assign', ?, 'succeeded', ?, json_object(
+				'role_key', ?,
+				'target_user_id', ?,
+				'requested_reason', ?,
+				'assignment_status', ?
+			))
+		`)
+		.bind(
+			makeId('audit'),
+			context.user.id,
+			team.id,
+			assignment.id,
+			url.pathname,
+			role.role_key === 'safeguarding_lead' ? 1 : 0,
+			role.role_key,
+			targetUser.id,
+			requestedReason,
+			assignment.assignment_status,
+		)
+		.run();
+}
+
+async function assignRole(request, env, context, body) {
+	const db = dbFor(env);
+	const team = assertActiveTeam(context);
+	const { targetUserId, targetEmail } = targetSelectorFor(body);
+	const roleKey = requestedRoleKeyFor(body);
+	const requestedReason = requestedReasonFor(body);
+	const expiresAt = expiresAtFor(body);
+	const role = await readRole(db, roleKey);
+
+	if (!role) {
+		throw new RoleAssignmentError(404, 'role_not_found', 'The requested role does not exist.');
+	}
+
+	assertSensitiveRoleConfirmation(role, body);
+
+	const targetUser = await readTargetUser(db, targetUserId, targetEmail);
+	if (!targetUser) {
+		throw new RoleAssignmentError(404, 'target_user_not_found', 'The target user does not exist.');
+	}
+
+	if (['suspended', 'closed'].includes(targetUser.account_status)) {
+		throw new RoleAssignmentError(409, 'target_user_inactive', 'The target user cannot receive roles.');
+	}
+
+	const membership = await readActiveMembership(db, targetUser.id, team.id);
+	if (!membership) {
+		throw new RoleAssignmentError(
+			400,
+			'target_not_team_member',
+			'The target user must be an active member of the active team before a role can be assigned.',
+		);
+	}
+
+	const assignment = await writeAssignment(db, context, targetUser, role, team, requestedReason, expiresAt);
+	await writeAuditEvent(db, request, context, targetUser, role, team, requestedReason, assignment);
+
+	return {
+		assignment,
+		role,
+		targetUser,
+		team,
+	};
+}
+
+function roleAssignmentErrorResponse(error) {
+	if (!(error instanceof RoleAssignmentError)) throw error;
+	return jsonResponse({ ok: false, error: error.code, message: error.message }, error.status);
+}
+
+export async function handleRoleAssignmentsRoute(request, env) {
+	try {
+		const context = await resolveAuthenticatedContext(request, env);
+		await assertRoutePermission(request, env, context);
+		const body = await readJson(request);
+		const result = await assignRole(request, env, context, body);
+
+		return jsonResponse(
+			{
+				ok: true,
+				assignment: {
+					id: result.assignment.id,
+					status: result.assignment.assignment_status,
+					scopeType: 'team',
+					scopeId: result.team.id,
+					expiresAt: result.assignment.expires_at,
+				},
+				role: {
+					key: result.role.role_key,
+					label: result.role.label,
+					sensitive: result.role.is_sensitive === 1,
+				},
+				targetUser: {
+					id: result.targetUser.id,
+					email: result.targetUser.email,
+					displayName: result.targetUser.display_name,
+					accountStatus: result.targetUser.account_status,
+				},
+			},
+			201,
+		);
+	} catch (error) {
+		try {
+			return roleAssignmentErrorResponse(error);
+		} catch {}
+
+		try {
+			return routePermissionErrorResponse(error);
+		} catch {}
+
+		if (error?.status && error?.code) {
+			return jsonResponse({ ok: false, error: error.code, message: error.message }, error.status);
+		}
+
+		return jsonResponse(
+			{
+				ok: false,
+				error: 'role_assignment_error',
+				message: 'Role assignment could not be completed.',
+			},
+			500,
+		);
+	}
+}

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -1,4 +1,5 @@
 import { handleMeRoute } from "./core/auth/access.js";
+import { handleRoleAssignmentsRoute } from "./core/auth/role-assignments.js";
 import { handleRequest } from "./core/router.js";
 import { ResearchOpsService } from "./service/index.js";
 
@@ -165,6 +166,7 @@ export default {
 		try {
 			let result;
 			if (method === "GET" && (apiPath === "/api/me" || apiPath === "/api/me/permissions")) result = await handleMeRoute(request, env, apiPath);
+			else if (method === "POST" && apiPath === "/api/auth/role-assignments") result = await handleRoleAssignmentsRoute(request, env);
 			else if (method === "GET" && apiPath === "/api/projects") result = await handleProjects(request, env);
 			else if (apiPath.startsWith("/api/projects/")) result = await handleProjectRecord(request, env, apiPath);
 			else if (apiPath === "/api/synthesis" || apiPath.startsWith("/api/synthesis/")) result = await handleSynthesis(request, env, apiPath);

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -63,6 +63,9 @@ require_file "infra/cloudflare/src/worker.js"
 require_file "infra/cloudflare/src/core/router.js"
 require_file "infra/cloudflare/src/core/service.js"
 require_file "infra/cloudflare/src/service/index.js"
+require_file "infra/cloudflare/src/core/auth/role-assignments.js"
+require_file "infra/cloudflare/migrations/0002_auth_role_assignment_route.sql"
+require_file ".github/workflows/apply-d1-auth-role-assignment-route.yml"
 require_file "tests/govuk-design-system-baseline-route-state.test.js"
 require_file "tests/govuk-forms-application-route-state.test.js"
 require_file "tests/govuk-tables-summary-lists-application-route-state.test.js"
@@ -93,11 +96,15 @@ require_file "tests/participant-consent-route-state.test.js"
 require_file "tests/auth-foundation-route-state.test.js"
 require_file "tests/auth-route-permissions.test.js"
 require_file "tests/auth-runtime-bootstrap-route-state.test.js"
+require_file "tests/auth-role-assignment-api-route-state.test.js"
 require_file "scripts/auth-runtime-bootstrap.mjs"
 require_file ".github/workflows/bootstrap-d1-auth-runtime.yml"
 require_file "docs/product/26/05/09/auth-runtime-bootstrap-2026-05-09.md"
+require_file "docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-implementation-trace.md"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-implementation-trace.json"
+require_file "docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md"
+require_file "docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -237,6 +244,9 @@ node tests/auth-route-permissions.test.js
 
 info "checking authentication runtime bootstrap contract"
 node tests/auth-runtime-bootstrap-route-state.test.js
+
+info "checking authentication role assignment API contract"
+node tests/auth-role-assignment-api-route-state.test.js
 
 info "checking Projects API route contract"
 node tests/projects-route-contract.test.js

--- a/tests/auth-role-assignment-api-route-state.test.js
+++ b/tests/auth-role-assignment-api-route-state.test.js
@@ -36,6 +36,15 @@ function assertHandlerRequiresTargetRoleAndReason() {
 	assert.match(handlerSource, /target_user_not_found/);
 }
 
+function assertHandlerRejectsConflictingTargetIdentifiers() {
+	assert.match(handlerSource, /async function readUserById/);
+	assert.match(handlerSource, /async function readUserByEmail/);
+	assert.match(handlerSource, /const userById = await readUserById\(db, targetUserId\);/);
+	assert.match(handlerSource, /const userByEmail = await readUserByEmail\(db, targetEmail\);/);
+	assert.match(handlerSource, /target_identifier_conflict/);
+	assert.match(handlerSource, /targetUserId and targetEmail must resolve to the same user/);
+}
+
 function assertHandlerRequiresSensitiveRoleConfirmation() {
 	assert.match(handlerSource, /sensitiveRoleConfirmation/);
 	assert.match(handlerSource, /ASSIGN_SENSITIVE_ROLE/);
@@ -45,7 +54,13 @@ function assertHandlerRequiresSensitiveRoleConfirmation() {
 	assert.match(handlerSource, /safeguarding_role_confirmation_required/);
 }
 
-function assertHandlerWritesAssignmentAndAuditEvent() {
+function assertHandlerWritesAssignmentAndAuditEventAtomically() {
+	assert.match(handlerSource, /function prepareAssignmentStatement/);
+	assert.match(handlerSource, /function prepareAuditStatement/);
+	assert.match(handlerSource, /async function writeAssignmentWithAudit/);
+	assert.match(handlerSource, /typeof db\.batch !== "function"/);
+	assert.match(handlerSource, /role_assignment_transaction_unavailable/);
+	assert.match(handlerSource, /await db\.batch\(\[assignmentStatement, auditStatement\]\);/);
 	assert.match(handlerSource, /INSERT INTO auth_role_assignments/);
 	assert.match(handlerSource, /ON CONFLICT\(user_id, role_id, scope_type, scope_id\) DO UPDATE/);
 	assert.match(handlerSource, /INSERT INTO auth_audit_events/);
@@ -66,6 +81,7 @@ assertWorkerWiresRoleAssignmentRoute();
 assertHandlerUsesAuthenticationAndRoutePermission();
 assertHandlerScopesAssignmentsToActiveTeam();
 assertHandlerRequiresTargetRoleAndReason();
+assertHandlerRejectsConflictingTargetIdentifiers();
 assertHandlerRequiresSensitiveRoleConfirmation();
-assertHandlerWritesAssignmentAndAuditEvent();
+assertHandlerWritesAssignmentAndAuditEventAtomically();
 assertRouteStatusMigrationExists();

--- a/tests/auth-role-assignment-api-route-state.test.js
+++ b/tests/auth-role-assignment-api-route-state.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const workerSource = fs.readFileSync('infra/cloudflare/src/worker.js', 'utf8');
+const handlerSource = fs.readFileSync('infra/cloudflare/src/core/auth/role-assignments.js', 'utf8');
+const migrationSource = fs.readFileSync('infra/cloudflare/migrations/0002_auth_role_assignment_route.sql', 'utf8');
+
+function assertWorkerWiresRoleAssignmentRoute() {
+	assert.match(workerSource, /handleRoleAssignmentsRoute/);
+	assert.match(workerSource, /\.\/core\/auth\/role-assignments\.js/);
+	assert.match(workerSource, /method === "POST" && apiPath === "\/api\/auth\/role-assignments"/);
+}
+
+function assertHandlerUsesAuthenticationAndRoutePermission() {
+	assert.match(handlerSource, /resolveAuthenticatedContext/);
+	assert.match(handlerSource, /assertRoutePermission/);
+	assert.match(handlerSource, /routePermissionErrorResponse/);
+	assert.match(handlerSource, /readJson\(request\)/);
+}
+
+function assertHandlerScopesAssignmentsToActiveTeam() {
+	assert.match(handlerSource, /assertActiveTeam\(context\)/);
+	assert.match(handlerSource, /scope_type = 'team'/);
+	assert.match(handlerSource, /scope_id = \?/);
+	assert.match(handlerSource, /readActiveMembership/);
+	assert.match(handlerSource, /target_not_team_member/);
+}
+
+function assertHandlerRequiresTargetRoleAndReason() {
+	assert.match(handlerSource, /targetUserId/);
+	assert.match(handlerSource, /targetEmail/);
+	assert.match(handlerSource, /roleKey/);
+	assert.match(handlerSource, /requestedReason/);
+	assert.match(handlerSource, /role_assignment_reason_required/);
+	assert.match(handlerSource, /role_not_found/);
+	assert.match(handlerSource, /target_user_not_found/);
+}
+
+function assertHandlerRequiresSensitiveRoleConfirmation() {
+	assert.match(handlerSource, /sensitiveRoleConfirmation/);
+	assert.match(handlerSource, /ASSIGN_SENSITIVE_ROLE/);
+	assert.match(handlerSource, /sensitive_role_confirmation_required/);
+	assert.match(handlerSource, /safeguardingConfirmation/);
+	assert.match(handlerSource, /ASSIGN_SAFEGUARDING_LEAD/);
+	assert.match(handlerSource, /safeguarding_role_confirmation_required/);
+}
+
+function assertHandlerWritesAssignmentAndAuditEvent() {
+	assert.match(handlerSource, /INSERT INTO auth_role_assignments/);
+	assert.match(handlerSource, /ON CONFLICT\(user_id, role_id, scope_type, scope_id\) DO UPDATE/);
+	assert.match(handlerSource, /INSERT INTO auth_audit_events/);
+	assert.match(handlerSource, /auth\.role_assignment\.created/);
+	assert.match(handlerSource, /permission_code/);
+	assert.match(handlerSource, /role\.assign/);
+}
+
+function assertRouteStatusMigrationExists() {
+	assert.match(migrationSource, /UPDATE auth_route_permissions/);
+	assert.match(migrationSource, /implementation_status = 'implemented'/);
+	assert.match(migrationSource, /method = 'POST'/);
+	assert.match(migrationSource, /route_pattern = '\/api\/auth\/role-assignments'/);
+	assert.match(migrationSource, /required_permissions_json = '\["role.assign"\]'/);
+}
+
+assertWorkerWiresRoleAssignmentRoute();
+assertHandlerUsesAuthenticationAndRoutePermission();
+assertHandlerScopesAssignmentsToActiveTeam();
+assertHandlerRequiresTargetRoleAndReason();
+assertHandlerRequiresSensitiveRoleConfirmation();
+assertHandlerWritesAssignmentAndAuditEvent();
+assertRouteStatusMigrationExists();


### PR DESCRIPTION
## Summary

Implements the next authentication role-selection slice: `POST /api/auth/role-assignments`.

This PR adds the first managed role-assignment API so role access can move from manual bootstrap SQL toward controlled application behaviour.

## What changed

Adds:

```text
infra/cloudflare/src/core/auth/role-assignments.js
```

Wires the Worker route:

```text
POST /api/auth/role-assignments
```

Adds D1 route-status migration:

```text
infra/cloudflare/migrations/0002_auth_role_assignment_route.sql
```

Adds manual D1 workflow:

```text
.github/workflows/apply-d1-auth-role-assignment-route.yml
```

Adds route-state validation:

```text
tests/auth-role-assignment-api-route-state.test.js
```

Updates validation wiring:

```text
scripts/validate.sh
```

Adds product documentation and trace:

```text
docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md
docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md
docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json
```

## Runtime behaviour

The endpoint:

1. resolves the authenticated Cloudflare Access user
2. resolves the caller's active team
3. checks the D1 route-permission declaration
4. requires `role.assign`
5. validates `targetUserId` or `targetEmail`
6. rejects conflicting `targetUserId` and `targetEmail` values unless both resolve to the same user
7. validates `roleKey` and `requestedReason`
8. requires the target user to already be an active member of the caller's active team
9. creates or reactivates a team-scoped role assignment and audit event through a D1 batch write
10. fails closed if batch writes are not available

## Review hardening applied

Two review comments have been addressed.

### P1: make role assignment and audit writes atomic

The original implementation could write `auth_role_assignments` and then fail before writing `auth_audit_events`.

The handler now prepares the assignment and audit statements and executes them together with:

```text
db.batch([assignmentStatement, auditStatement])
```

If batch writes are not available, the endpoint fails closed with:

```text
role_assignment_transaction_unavailable
```

### P2: reject conflicting target identifiers

The original implementation used `targetUserId` when present and ignored `targetEmail`.

The handler now resolves both identifiers when both are supplied and rejects the request unless they resolve to the same user:

```text
target_identifier_conflict
```

## Sensitive role controls

Sensitive roles require:

```text
sensitiveRoleConfirmation = ASSIGN_SENSITIVE_ROLE
```

The `safeguarding_lead` role also requires:

```text
safeguardingConfirmation = ASSIGN_SAFEGUARDING_LEAD
```

## D1 operational follow-up after merge

After merge, run:

```text
Apply D1 Auth Role Assignment Route
```

with:

```text
confirm_database_name = researchops-d1
confirm_operation = APPLY_AUTH_ROLE_ASSIGNMENT_ROUTE
run_post_apply_checks = true
```

That marks the live D1 route declaration as implemented for:

```text
POST /api/auth/role-assignments
```

## Boundaries

This PR does not create a role-management UI.

This PR does not create users.

This PR does not create team memberships.

This PR does not support cross-team role assignment.

This PR does not assign permission exceptions.

This PR does not run the route-status workflow.

## Branch state note

GitHub currently reports this PR as mergeable.