### PR TITLE
Add Team Admin role assignment UI

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
@@ -4,6 +4,11 @@
 	"date": "2026-05-09",
 	"repository": "kevinrapley/ResearchOps",
 	"branch": "feature/auth-role-assignment-ui",
+	"pull_request": {
+		"number": 220,
+		"state": "open",
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/220"
+	},
 	"slice": {
 		"name": "auth-role-assignment-ui",
 		"previous_slice": "authentication role assignment API",
@@ -12,13 +17,15 @@
 	"status": {
 		"implemented": true,
 		"pull_request_opened": true,
-		"runtime_verified": false,
+		"runtime_verified": true,
 		"unit_test_fix_applied": true,
-		"feature_preview_api_origin_fix_applied": true
+		"feature_preview_api_origin_fix_applied": true,
+		"second_iteration_design_applied": true
 	},
 	"page": {
 		"path": "public/pages/team/role-assignments/index.html",
-		"route": "/pages/team/role-assignments/"
+		"route": "/pages/team/role-assignments/",
+		"title": "Assign a role to a team member"
 	},
 	"files_changed": [
 		"public/pages/team/role-assignments/index.html",
@@ -32,6 +39,32 @@
 		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md",
 		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json"
 	],
+	"second_iteration_design_changes": [
+		{
+			"change": "Removed prominent self-access panel from successful state.",
+			"reason": "The page should focus on assigning access to another person, not on displaying the admin's own roles."
+		},
+		{
+			"change": "Kept permission check but reduced successful state to compact team-scope copy.",
+			"reason": "Admins need to know the team scope; they do not need a diagnostic display of their own roles when authorised."
+		},
+		{
+			"change": "Set the email input to two-thirds width and moved user ID into a details component with a half-width input.",
+			"reason": "The visual affordance should match the expected content length and keep the normal path focused on human-readable email."
+		},
+		{
+			"change": "Replaced the role select with radios.",
+			"reason": "The roles are few, consequential and need visible descriptions at the point of decision."
+		},
+		{
+			"change": "Replaced arbitrary datetime input with governed duration radios and conditional day/month/year date input.",
+			"reason": "Role expiry is a governed access-period decision, not a timestamp-entry task."
+		},
+		{
+			"change": "Added check-and-confirm panel before POST.",
+			"reason": "The write action should not occur on ordinary form submit for a sensitive administrative task."
+		}
+	],
 	"client_behaviour": {
 		"loads_context_from": "GET /api/me",
 		"submits_to": "POST /api/auth/role-assignments",
@@ -42,10 +75,17 @@
 			"document.documentElement.dataset.apiOrigin",
 			"window.API_ORIGIN"
 		],
+		"successful_access_display": "team scope only",
+		"blocked_access_display": "blocking message and hidden form",
+		"write_flow": "form submit validates and renders review; confirm button performs POST",
 		"form_fields": [
 			"targetEmail",
 			"targetUserId",
 			"roleKey",
+			"durationPreset",
+			"expiryDay",
+			"expiryMonth",
+			"expiryYear",
 			"requestedReason",
 			"expiresAt",
 			"sensitiveRoleConfirmation",
@@ -60,6 +100,13 @@
 		"safeguarding_lead",
 		"team_admin"
 	],
+	"duration_options_visible_in_ui": [
+		"30 days",
+		"60 days",
+		"90 days",
+		"180 days",
+		"Until a specific date"
+	],
 	"sensitive_role_controls": {
 		"sensitiveRoleConfirmation": "ASSIGN_SENSITIVE_ROLE",
 		"safeguardingConfirmation": "ASSIGN_SAFEGUARDING_LEAD"
@@ -69,16 +116,20 @@
 		"wired_into": "scripts/validate.sh",
 		"checks": [
 			"page structure",
-			"role options",
+			"removal of self-access panel from successful state",
+			"team-scope messaging",
+			"role radios instead of select",
+			"governed duration radios",
+			"conditional custom date inputs",
 			"GET /api/me context loading",
-			"POST /api/auth/role-assignments submission",
+			"POST /api/auth/role-assignments submission only after confirmation",
 			"same-origin API calls by default",
 			"no hard-coded Worker API origin",
 			"role.assign gate",
 			"request contract fields",
 			"client validation messages",
 			"role metadata and permission codes",
-			"stylesheet hooks"
+			"stylesheet hooks for width affordance and review state"
 		]
 	},
 	"unit_test_failure": {
@@ -103,10 +154,28 @@
 			"Updated route-state tests to assert the Worker URL is not hard-coded."
 		]
 	},
+	"cloudflare_access_runtime_evidence": {
+		"source": "manual branch-preview retest reported by user",
+		"raw_personal_identifiers_committed": false,
+		"result": {
+			"api_me_ok": true,
+			"authenticated": true,
+			"provider": "cloudflare_access",
+			"active_team": "team_researchops_core",
+			"roles_observed": ["safeguarding_lead", "team_admin"],
+			"permissions_include_role_assign": true
+		},
+		"configuration_learning": [
+			"The original AUD value was a Pages web analytics tag, not an Access AUD.",
+			"CLOUDFLARE_ACCESS_TEAM_DOMAIN must not include https:// for the current Worker code path.",
+			"The Worker receives the Pages Access JWT through the Pages proxy path, so the Worker AUD value must align with the Pages Access application AUD for that route."
+		]
+	},
 	"boundaries": [
 		"No user search endpoint is created.",
 		"No users are created by this UI.",
 		"No team memberships are created by this UI.",
+		"The target user is not resolved before the check-and-confirm panel in this slice.",
 		"No full team member list is added.",
 		"No role removal is added.",
 		"No permission exceptions are supported.",
@@ -115,7 +184,10 @@
 	"next_steps_after_merge": [
 		"Deploy the page.",
 		"Open /pages/team/role-assignments/ with the seeded Team Admin account.",
-		"Confirm the page detects role.assign.",
+		"Confirm the page shows active team scope.",
+		"Confirm the page hides the form for users without role.assign.",
+		"Choose a non-sensitive role and governed duration.",
+		"Confirm the check-and-confirm panel appears before the write.",
 		"Assign a non-sensitive role to an existing active team member.",
 		"Verify auth_role_assignments and auth_audit_events."
 	]

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
@@ -20,7 +20,24 @@
 		"runtime_verified": true,
 		"unit_test_fix_applied": true,
 		"feature_preview_api_origin_fix_applied": true,
-		"second_iteration_design_applied": true
+		"second_iteration_design_applied": true,
+		"govuk_conformance_pass_applied": true,
+		"final_stabilisation_pass_applied": true,
+		"pr_mergeable_after_final_code_pass": true
+	},
+	"validation_status": {
+		"latest_checked_code_head": "1198b7aa51987ab0abe6a257eb7376c813d26b51",
+		"latest_checked_code_head_result": "success",
+		"successful_workflows_observed": [
+			"Format pull request",
+			"QA - Broken links (Lychee)",
+			"Accessibility audit (pa11y-ci)",
+			"Validate ResearchOps",
+			"qa-bdd",
+			"CI",
+			"Release Gate",
+			"Worker CI"
+		]
 	},
 	"page": {
 		"path": "public/pages/team/role-assignments/index.html",
@@ -39,6 +56,14 @@
 		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md",
 		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json"
 	],
+	"information_architecture": {
+		"area": "top-level Team administration",
+		"breadcrumb": "Home > Team administration",
+		"breadcrumb_before_main_landmark": true,
+		"removed_back_to_projects": true,
+		"removed_back_links": true,
+		"removed_clear_form_reset": true
+	},
 	"second_iteration_design_changes": [
 		{
 			"change": "Removed prominent self-access panel from successful state.",
@@ -53,15 +78,23 @@
 			"reason": "The visual affordance should match the expected content length and keep the normal path focused on human-readable email."
 		},
 		{
+			"change": "Removed the user ID example.",
+			"reason": "The UI should not surface internal bootstrap-looking identifiers as examples."
+		},
+		{
 			"change": "Replaced the role select with radios.",
 			"reason": "The roles are few, consequential and need visible descriptions at the point of decision."
+		},
+		{
+			"change": "Replaced technical permission-code display with plain-language abilities.",
+			"reason": "Admins need to understand what a role allows without reading implementation codes."
 		},
 		{
 			"change": "Replaced arbitrary datetime input with governed duration radios and conditional day/month/year date input.",
 			"reason": "Role expiry is a governed access-period decision, not a timestamp-entry task."
 		},
 		{
-			"change": "Added check-and-confirm panel before POST.",
+			"change": "Added check-and-confirm summary-list panel before POST.",
 			"reason": "The write action should not occur on ordinary form submit for a sensitive administrative task."
 		}
 	],
@@ -100,6 +133,20 @@
 		"safeguarding_lead",
 		"team_admin"
 	],
+	"role_ability_display": {
+		"format": "plain language abilities",
+		"technical_permission_codes_visible_to_user": false,
+		"technical_codes_removed_from_ui": [
+			"governed.create",
+			"governed.edit",
+			"governed.review",
+			"governed.approve",
+			"recommendation.own",
+			"safeguarding.view",
+			"safeguarding.audit.view",
+			"team.manage"
+		]
+	},
 	"duration_options_visible_in_ui": [
 		"30 days",
 		"60 days",
@@ -108,16 +155,33 @@
 		"Until a specific date"
 	],
 	"sensitive_role_controls": {
+		"pattern": "GOV.UK-style warning text plus checkbox fieldset",
 		"sensitiveRoleConfirmation": "ASSIGN_SENSITIVE_ROLE",
 		"safeguardingConfirmation": "ASSIGN_SAFEGUARDING_LEAD"
+	},
+	"govuk_component_conformance": {
+		"breadcrumbs": true,
+		"details_component": true,
+		"radios": true,
+		"date_input": true,
+		"warning_text": true,
+		"checkboxes": true,
+		"error_summary": true,
+		"summary_list_review": true,
+		"width_utility_affordance": true
 	},
 	"validation": {
 		"test": "tests/auth-role-assignment-ui-route-state.test.js",
 		"wired_into": "scripts/validate.sh",
 		"checks": [
 			"page structure",
+			"breadcrumb-based admin information architecture",
+			"breadcrumb placement before main landmark",
+			"removal of back links",
+			"removal of clear form reset control",
 			"removal of self-access panel from successful state",
 			"team-scope messaging",
+			"user ID details component without a user ID example",
 			"role radios instead of select",
 			"governed duration radios",
 			"conditional custom date inputs",
@@ -128,7 +192,9 @@
 			"role.assign gate",
 			"request contract fields",
 			"client validation messages",
-			"role metadata and permission codes",
+			"plain-language role abilities",
+			"absence of technical permission codes in the UI",
+			"GOV.UK warning text, checkbox and summary-list hooks",
 			"stylesheet hooks for width affordance and review state"
 		]
 	},
@@ -169,6 +235,17 @@
 			"The original AUD value was a Pages web analytics tag, not an Access AUD.",
 			"CLOUDFLARE_ACCESS_TEAM_DOMAIN must not include https:// for the current Worker code path.",
 			"The Worker receives the Pages Access JWT through the Pages proxy path, so the Worker AUD value must align with the Pages Access application AUD for that route."
+		]
+	},
+	"final_stabilisation_pass": {
+		"completed": true,
+		"changes": [
+			"Moved breadcrumb navigation before the main landmark.",
+			"Repaired role-assignment page markup after a compacted intermediate edit.",
+			"Removed a transient stray non-ASCII artefact introduced during editing.",
+			"Asserted breadcrumb placement in the route-state test.",
+			"Confirmed the PR was mergeable after the final code pass.",
+			"Confirmed the latest checked CI set was green."
 		]
 	},
 	"boundaries": [

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
@@ -11,8 +11,9 @@
 	},
 	"status": {
 		"implemented": true,
-		"pull_request_opened": false,
-		"runtime_verified": false
+		"pull_request_opened": true,
+		"runtime_verified": false,
+		"unit_test_fix_applied": true
 	},
 	"page": {
 		"path": "public/pages/team/role-assignments/index.html",
@@ -24,6 +25,8 @@
 		"public/css/auth-role-assignments.css",
 		"tests/auth-role-assignment-ui-route-state.test.js",
 		"scripts/validate.sh",
+		"visual-walkthrough.config.mjs",
+		"visual-walkthrough.operational-fixtures.mjs",
 		"docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md",
 		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md",
 		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json"
@@ -68,6 +71,18 @@
 			"client validation messages",
 			"role metadata and permission codes",
 			"stylesheet hooks"
+		]
+	},
+	"unit_test_failure": {
+		"test": "tests/visual-walkthrough-registry.test.js",
+		"message": "Expected visual walkthrough registry to include public route: /pages/team/role-assignments/index.html",
+		"cause": "The new public HTML route was not registered in visual-walkthrough.config.mjs.",
+		"fix": [
+			"Added teamRoleAssignments path to visual-walkthrough.operational-fixtures.mjs.",
+			"Added deterministic Team Admin /api/me fixture data.",
+			"Added route-specific teamRoleAssignments design risk.",
+			"Registered team-role-assignments in visual-walkthrough.config.mjs.",
+			"Configured the default walkthrough state to use the deterministic Team Admin context."
 		]
 	},
 	"boundaries": [

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
@@ -13,7 +13,8 @@
 		"implemented": true,
 		"pull_request_opened": true,
 		"runtime_verified": false,
-		"unit_test_fix_applied": true
+		"unit_test_fix_applied": true,
+		"feature_preview_api_origin_fix_applied": true
 	},
 	"page": {
 		"path": "public/pages/team/role-assignments/index.html",
@@ -36,6 +37,11 @@
 		"submits_to": "POST /api/auth/role-assignments",
 		"requires_permission": "role.assign",
 		"credentials_mode": "include",
+		"api_base_default": "same-origin empty string",
+		"api_base_override_sources": [
+			"document.documentElement.dataset.apiOrigin",
+			"window.API_ORIGIN"
+		],
 		"form_fields": [
 			"targetEmail",
 			"targetUserId",
@@ -66,6 +72,8 @@
 			"role options",
 			"GET /api/me context loading",
 			"POST /api/auth/role-assignments submission",
+			"same-origin API calls by default",
+			"no hard-coded Worker API origin",
 			"role.assign gate",
 			"request contract fields",
 			"client validation messages",
@@ -83,6 +91,16 @@
 			"Added route-specific teamRoleAssignments design risk.",
 			"Registered team-role-assignments in visual-walkthrough.config.mjs.",
 			"Configured the default walkthrough state to use the deterministic Team Admin context."
+		]
+	},
+	"feature_preview_failure": {
+		"reported_url": "https://b6e77d8b.researchops.pages.dev/pages/team/role-assignments/",
+		"reported_message": "Could not confirm your team role access. Load failed",
+		"cause": "The client forced Pages preview origins to call the Worker origin directly instead of using the Pages same-origin /api/* redirect proxy.",
+		"fix": [
+			"Changed the default API base to the same-origin empty string.",
+			"Kept explicit override support through document.documentElement.dataset.apiOrigin and window.API_ORIGIN.",
+			"Updated route-state tests to assert the Worker URL is not hard-coded."
 		]
 	},
 	"boundaries": [

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
@@ -1,0 +1,89 @@
+{
+	"trace_id": "atrace-20260509-auth-role-assignment-ui-implementation",
+	"trace_layer": "operational",
+	"date": "2026-05-09",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "feature/auth-role-assignment-ui",
+	"slice": {
+		"name": "auth-role-assignment-ui",
+		"previous_slice": "authentication role assignment API",
+		"previous_slice_status": "complete and merged through PR #219"
+	},
+	"status": {
+		"implemented": true,
+		"pull_request_opened": false,
+		"runtime_verified": false
+	},
+	"page": {
+		"path": "public/pages/team/role-assignments/index.html",
+		"route": "/pages/team/role-assignments/"
+	},
+	"files_changed": [
+		"public/pages/team/role-assignments/index.html",
+		"public/js/auth-role-assignment-page.js",
+		"public/css/auth-role-assignments.css",
+		"tests/auth-role-assignment-ui-route-state.test.js",
+		"scripts/validate.sh",
+		"docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md",
+		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md",
+		"docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json"
+	],
+	"client_behaviour": {
+		"loads_context_from": "GET /api/me",
+		"submits_to": "POST /api/auth/role-assignments",
+		"requires_permission": "role.assign",
+		"credentials_mode": "include",
+		"form_fields": [
+			"targetEmail",
+			"targetUserId",
+			"roleKey",
+			"requestedReason",
+			"expiresAt",
+			"sensitiveRoleConfirmation",
+			"safeguardingConfirmation"
+		]
+	},
+	"roles_visible_in_ui": [
+		"observer",
+		"researcher",
+		"research_lead",
+		"approver",
+		"safeguarding_lead",
+		"team_admin"
+	],
+	"sensitive_role_controls": {
+		"sensitiveRoleConfirmation": "ASSIGN_SENSITIVE_ROLE",
+		"safeguardingConfirmation": "ASSIGN_SAFEGUARDING_LEAD"
+	},
+	"validation": {
+		"test": "tests/auth-role-assignment-ui-route-state.test.js",
+		"wired_into": "scripts/validate.sh",
+		"checks": [
+			"page structure",
+			"role options",
+			"GET /api/me context loading",
+			"POST /api/auth/role-assignments submission",
+			"role.assign gate",
+			"request contract fields",
+			"client validation messages",
+			"role metadata and permission codes",
+			"stylesheet hooks"
+		]
+	},
+	"boundaries": [
+		"No user search endpoint is created.",
+		"No users are created by this UI.",
+		"No team memberships are created by this UI.",
+		"No full team member list is added.",
+		"No role removal is added.",
+		"No permission exceptions are supported.",
+		"The D1 route-status workflow is not run by this PR."
+	],
+	"next_steps_after_merge": [
+		"Deploy the page.",
+		"Open /pages/team/role-assignments/ with the seeded Team Admin account.",
+		"Confirm the page detects role.assign.",
+		"Assign a non-sensitive role to an existing active team member.",
+		"Verify auth_role_assignments and auth_audit_events."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
@@ -145,6 +145,7 @@ The test checks:
 - role selector options
 - use of `/api/me`
 - use of `/api/auth/role-assignments`
+- same-origin API calls by default
 - `credentials: "include"`
 - `role.assign` gate
 - request contract fields
@@ -185,6 +186,44 @@ Fix applied:
 - set its default state to use the deterministic Team Admin context
 
 This makes the new route visible to the visual walkthrough system rather than bypassing the test.
+
+## Feature preview API-origin fix
+
+Manual testing on the Cloudflare Pages feature-branch preview showed the page loaded but the current access panel displayed:
+
+```text
+Could not confirm your team role access.
+Load failed
+```
+
+Cause:
+
+The client forced `pages.dev` origins to call the Worker origin directly:
+
+```text
+https://rops-api.digikev-kevin-rapley.workers.dev
+```
+
+That bypassed the Pages `_redirects` same-origin `/api/*` proxy. In the browser, the call could fail before returning a normal JSON API error because the page was making a cross-origin authenticated request from the Pages preview.
+
+Fix applied:
+
+The default API base is now same-origin:
+
+```text
+API_BASE = document.documentElement.dataset.apiOrigin || window.API_ORIGIN || ""
+```
+
+This means feature previews call:
+
+```text
+/api/me
+/api/auth/role-assignments
+```
+
+on the same Pages preview origin, allowing `_redirects` to proxy to the Worker while keeping browser credentials and CORS behaviour aligned.
+
+The route-state test now asserts the client no longer hard-codes the Worker URL.
 
 ## Product documentation
 

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
@@ -1,0 +1,197 @@
+# Agent trace: auth role assignment UI implementation
+
+Date: 2026-05-09
+
+Branch: `feature/auth-role-assignment-ui`
+
+Slice: `auth-role-assignment-ui`
+
+Previous slice: authentication role assignment API, merged through PR #219.
+
+## Purpose
+
+A Team Admin account now exists in live D1 and the role-assignment API has been merged into `main`.
+
+This slice adds a first Team Admin user interface for assigning D1-backed roles to existing active team members.
+
+The page is:
+
+```text
+/pages/team/role-assignments/
+```
+
+## UI behaviour
+
+The page loads the current authenticated context with:
+
+```text
+GET /api/me
+```
+
+It enables role assignment only when the current active team context includes:
+
+```text
+role.assign
+```
+
+It submits assignments to:
+
+```text
+POST /api/auth/role-assignments
+```
+
+## Page implementation
+
+New page:
+
+```text
+public/pages/team/role-assignments/index.html
+```
+
+The page includes:
+
+- current access panel
+- target team member email field
+- optional target user ID field
+- role selector
+- role summary panel
+- requested reason textarea
+- optional expiry field
+- sensitive-role confirmation checkbox
+- Safeguarding Lead confirmation checkbox
+- error summary
+- success and error result panels
+
+## Client implementation
+
+New client script:
+
+```text
+public/js/auth-role-assignment-page.js
+```
+
+The script:
+
+- loads `/api/me`
+- detects `role.assign`
+- disables submission when role assignment is unavailable
+- presents seeded role metadata and permission codes
+- validates the form before POST
+- sends the API request body expected by the merged role-assignment API
+- shows success and error responses
+
+## Styling
+
+New stylesheet:
+
+```text
+public/css/auth-role-assignments.css
+```
+
+The stylesheet follows the existing GOV.UK-like ResearchOps page styling and Kevin's project CSS format.
+
+It covers:
+
+- current access panel states
+- role summary panel
+- sensitive confirmation blocks
+- success and error result panels
+
+## Request contract
+
+The UI sends:
+
+```text
+targetEmail
+targetUserId
+roleKey
+requestedReason
+expiresAt
+sensitiveRoleConfirmation
+safeguardingConfirmation
+```
+
+The API remains authoritative.
+
+If both target identifiers are supplied, the API requires them to resolve to the same user.
+
+## Sensitive role controls
+
+Sensitive roles require:
+
+```text
+sensitiveRoleConfirmation = ASSIGN_SENSITIVE_ROLE
+```
+
+The `safeguarding_lead` role additionally requires:
+
+```text
+safeguardingConfirmation = ASSIGN_SAFEGUARDING_LEAD
+```
+
+The UI shows these confirmations only when needed for the selected role.
+
+## Validation
+
+New route-state test:
+
+```text
+tests/auth-role-assignment-ui-route-state.test.js
+```
+
+The test checks:
+
+- page structure
+- role selector options
+- use of `/api/me`
+- use of `/api/auth/role-assignments`
+- `credentials: "include"`
+- `role.assign` gate
+- request contract fields
+- client validation messages
+- visible role metadata and permission codes
+- stylesheet hooks
+
+The test is wired into:
+
+```text
+scripts/validate.sh
+```
+
+## Product documentation
+
+Product documentation lives at:
+
+```text
+docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
+```
+
+## Boundary
+
+This slice does not create a user search endpoint.
+
+This slice does not create users.
+
+This slice does not create team memberships.
+
+This slice does not list all team members.
+
+This slice does not add role removal.
+
+This slice does not support permission exceptions.
+
+This slice does not run the D1 route-status workflow.
+
+## Required operational follow-up after merge
+
+After merge and deployment, test the page with the seeded Team Admin account.
+
+Recommended checks:
+
+1. open `/pages/team/role-assignments/`
+2. confirm the page detects `role.assign`
+3. assign a non-sensitive role to an existing active team member
+4. confirm success output
+5. confirm `auth_role_assignments` contains the role assignment
+6. confirm `auth_audit_events` contains `auth.role_assignment.created`
+7. attempt Safeguarding Lead without confirmations and confirm it is blocked

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
@@ -158,6 +158,34 @@ The test is wired into:
 scripts/validate.sh
 ```
 
+## Unit test failure fix
+
+The first CI unit-test run failed in:
+
+```text
+tests/visual-walkthrough-registry.test.js
+```
+
+Failure:
+
+```text
+Expected visual walkthrough registry to include public route: /pages/team/role-assignments/index.html
+```
+
+Cause:
+
+The new public page had been added, but the visual walkthrough registry had not been updated. The registry test discovers every public HTML page and requires each non-excluded route to have a registered walkthrough page entry.
+
+Fix applied:
+
+- added `teamRoleAssignments` to `operationalPaths`
+- added deterministic Team Admin `/api/me` fixture data to `visual-walkthrough.operational-fixtures.mjs`
+- added a route-specific `teamRoleAssignments` design-risk entry
+- registered `team-role-assignments` in `visual-walkthrough.config.mjs`
+- set its default state to use the deterministic Team Admin context
+
+This makes the new route visible to the visual walkthrough system rather than bypassing the test.
+
 ## Product documentation
 
 Product documentation lives at:

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
@@ -4,6 +4,8 @@ Date: 2026-05-09
 
 Branch: `feature/auth-role-assignment-ui`
 
+Pull request: #220
+
 Slice: `auth-role-assignment-ui`
 
 Previous slice: authentication role assignment API, merged through PR #219.
@@ -12,13 +14,19 @@ Previous slice: authentication role assignment API, merged through PR #219.
 
 A Team Admin account now exists in live D1 and the role-assignment API has been merged into `main`.
 
-This slice adds a first Team Admin user interface for assigning D1-backed roles to existing active team members.
+This slice adds a Team Admin user interface for assigning D1-backed roles to existing active team members.
 
 The page is:
 
 ```text
 /pages/team/role-assignments/
 ```
+
+## Implementation status
+
+The first iteration proved the plumbing. It loaded `/api/me`, detected `role.assign` and submitted to `POST /api/auth/role-assignments`.
+
+The second iteration reworks the page as a safer administrative journey rather than a diagnostic form.
 
 ## UI behaviour
 
@@ -34,7 +42,23 @@ It enables role assignment only when the current active team context includes:
 role.assign
 ```
 
-It submits assignments to:
+If the user can assign roles, the page shows compact team scope instead of a prominent self-access panel:
+
+```text
+You are assigning roles in ResearchOps Core Team.
+```
+
+If the user cannot assign roles, the form is hidden and the page shows a blocking message.
+
+The form submit action does not write to D1. It validates the inputs and shows a check-and-confirm panel.
+
+The write only happens when the admin selects:
+
+```text
+Confirm and assign role
+```
+
+The final write uses:
 
 ```text
 POST /api/auth/role-assignments
@@ -42,29 +66,98 @@ POST /api/auth/role-assignments
 
 ## Page implementation
 
-New page:
+Page:
 
 ```text
 public/pages/team/role-assignments/index.html
 ```
 
-The page includes:
+The second iteration page includes:
 
-- current access panel
-- target team member email field
-- optional target user ID field
-- role selector
-- role summary panel
-- requested reason textarea
-- optional expiry field
+- compact team-scope panel
+- team member email field
+- user ID field inside a details component
+- role radios with role descriptions
+- role summary panel with permission codes
+- governed access-duration radios
+- conditional day, month and year expiry date input
+- audit reason textarea
 - sensitive-role confirmation checkbox
 - Safeguarding Lead confirmation checkbox
 - error summary
+- check-and-confirm panel
 - success and error result panels
+
+## Design decision: remove self-access panel
+
+The first iteration showed a large “Your current access” panel.
+
+That was useful for proving authentication, but it made the page talk about the admin when the task is to assign access to another person.
+
+The second iteration keeps the permission check but reduces the successful state to team scope.
+
+This shifts the page from an authentication diagnostic to a role-assignment task.
+
+## Design decision: email and user ID affordance
+
+The email field is the primary path and uses a two-thirds width input.
+
+The user ID field is treated as a secondary escape route and is hidden inside:
+
+```text
+Use a user ID instead
+```
+
+The user ID field uses a half-width input.
+
+This reflects the likely content length and reduces accidental use of internal identifiers.
+
+## Design decision: role radios instead of select
+
+The first iteration used a select.
+
+The second iteration uses radios so all role choices and short descriptions are visible at the point of decision.
+
+Roles shown:
+
+- Observer
+- Researcher
+- Research Lead
+- Approver
+- Safeguarding Lead
+- Team Admin
+
+The selected role still updates a visible role summary and permission-code panel.
+
+## Design decision: governed duration instead of arbitrary date-time
+
+The first iteration used a free `datetime-local` input and helper text that said leaving it blank meant no expiry date.
+
+That was misleading because the system is intended to govern role assignment through expiry policy.
+
+The second iteration asks:
+
+```text
+How long should this role last?
+```
+
+The admin must choose one of:
+
+- 30 days
+- 60 days
+- 90 days
+- 180 days
+- Until a specific date
+
+No option is pre-selected.
+
+If the admin chooses a specific date, the UI reveals day, month and year fields. It does not ask for time. The client treats expiry as the end of the selected day.
+
+The client converts the chosen duration into `expiresAt` for the API request. The server remains authoritative.
 
 ## Client implementation
 
-New client script:
+Client script:
 
 ```text
 public/js/auth-role-assignment-page.js
@@ -74,28 +167,38 @@ The script:
 
 - loads `/api/me`
 - detects `role.assign`
-- disables submission when role assignment is unavailable
-- presents seeded role metadata and permission codes
-- validates the form before POST
-- sends the API request body expected by the merged role-assignment API
+- hides the form when role assignment is unavailable
+- shows team scope when role assignment is available
+- presents role metadata and permission codes
+- reveals sensitive-role confirmations only when needed
+- reveals custom expiry date inputs only when “Until a specific date” is selected
+- validates the form before the check-and-confirm panel
+- prevents POST during ordinary form submit
+- builds the review summary
+- sends the API request only from the confirm button
 - shows success and error responses
 
 ## Styling
 
-New stylesheet:
+Stylesheet:
 
 ```text
 public/css/auth-role-assignments.css
 ```
 
-The stylesheet follows the existing GOV.UK-like ResearchOps page styling and Kevin's project CSS format.
+Second iteration styling covers:
 
-It covers:
-
-- current access panel states
-- role summary panel
+- compact team-scope panel
+- blocked-access state
+- two-thirds width email field
+- half-width user ID field
+- two-thirds width reason textarea
+- radio layout
+- GOV.UK-style date input sizing
 - sensitive confirmation blocks
+- check-and-confirm panel
 - success and error result panels
+- responsive full-width behaviour on small screens
 
 ## Request contract
 
@@ -133,16 +236,20 @@ The UI shows these confirmations only when needed for the selected role.
 
 ## Validation
 
-New route-state test:
+Route-state test:
 
 ```text
 tests/auth-role-assignment-ui-route-state.test.js
 ```
 
-The test checks:
+The test now checks:
 
 - page structure
-- role selector options
+- removal of the self-access panel from the successful state
+- team-scope messaging
+- role radios instead of select
+- governed duration radios
+- conditional custom date inputs
 - use of `/api/me`
 - use of `/api/auth/role-assignments`
 - same-origin API calls by default
@@ -150,14 +257,31 @@ The test checks:
 - `role.assign` gate
 - request contract fields
 - client validation messages
+- check-and-confirm before POST
 - visible role metadata and permission codes
-- stylesheet hooks
+- stylesheet hooks for width affordance and review state
 
 The test is wired into:
 
 ```text
 scripts/validate.sh
 ```
+
+## Visual walkthrough registry
+
+The visual walkthrough registry was previously updated to include:
+
+```text
+/pages/team/role-assignments/index.html
+```
+
+The second iteration updates the walkthrough state to wait for:
+
+```text
+You are assigning roles in
+```
+
+rather than the removed first-iteration access message.
 
 ## Unit test failure fix
 
@@ -189,7 +313,7 @@ This makes the new route visible to the visual walkthrough system rather than by
 
 ## Feature preview API-origin fix
 
-Manual testing on the Cloudflare Pages feature-branch preview showed the page loaded but the current access panel displayed:
+Manual testing on the Cloudflare Pages feature-branch preview showed the page loaded but the first iteration current access panel displayed:
 
 ```text
 Could not confirm your team role access.
@@ -223,7 +347,30 @@ This means feature previews call:
 
 on the same Pages preview origin, allowing `_redirects` to proxy to the Worker while keeping browser credentials and CORS behaviour aligned.
 
-The route-state test now asserts the client no longer hard-codes the Worker URL.
+The route-state test asserts the client no longer hard-codes the Worker URL.
+
+## Cloudflare Access runtime evidence
+
+Manual retesting on the branch preview later confirmed:
+
+```text
+GET /api/me
+```
+
+returned:
+
+```text
+ok = true
+authenticated = true
+provider = cloudflare_access
+active team = team_researchops_core
+roles include Safeguarding Lead and Team Admin
+permissions include role.assign
+```
+
+This evidence showed the page could detect the seeded Team Admin context once Cloudflare Access AUD and team-domain configuration were corrected outside this repository.
+
+Raw personal identifiers are not committed in this trace.
 
 ## Product documentation
 
@@ -241,6 +388,8 @@ This slice does not create users.
 
 This slice does not create team memberships.
 
+This slice does not resolve the target user before the check-and-confirm panel.
+
 This slice does not list all team members.
 
 This slice does not add role removal.
@@ -256,9 +405,12 @@ After merge and deployment, test the page with the seeded Team Admin account.
 Recommended checks:
 
 1. open `/pages/team/role-assignments/`
-2. confirm the page detects `role.assign`
-3. assign a non-sensitive role to an existing active team member
-4. confirm success output
-5. confirm `auth_role_assignments` contains the role assignment
-6. confirm `auth_audit_events` contains `auth.role_assignment.created`
-7. attempt Safeguarding Lead without confirmations and confirm it is blocked
+2. confirm the page shows active team scope
+3. confirm the page hides the form for users without `role.assign`
+4. choose a non-sensitive role and a governed duration
+5. confirm the check-and-confirm panel appears before the write
+6. assign a non-sensitive role to an existing active team member
+7. confirm success output
+8. confirm `auth_role_assignments` contains the role assignment
+9. confirm `auth_audit_events` contains `auth.role_assignment.created`
+10. attempt Safeguarding Lead without confirmations and confirm it is blocked

--- a/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
@@ -12,7 +12,7 @@ Previous slice: authentication role assignment API, merged through PR #219.
 
 ## Purpose
 
-A Team Admin account now exists in live D1 and the role-assignment API has been merged into `main`.
+A Team Admin account exists in live D1 and the role-assignment API has been merged into `main`.
 
 This slice adds a Team Admin user interface for assigning D1-backed roles to existing active team members.
 
@@ -26,7 +26,28 @@ The page is:
 
 The first iteration proved the plumbing. It loaded `/api/me`, detected `role.assign` and submitted to `POST /api/auth/role-assignments`.
 
-The second iteration reworks the page as a safer administrative journey rather than a diagnostic form.
+The second iteration reworked the page as a safer administrative journey rather than a diagnostic form.
+
+The final PR #220 pass tightened the page against GOV.UK component conventions, removed the remaining project-level navigation, moved breadcrumbs before the main landmark, removed technical permission codes from the user-facing UI and locked those choices into route-state tests.
+
+## Final validation status
+
+The latest checked PR head was:
+
+```text
+1198b7aa51987ab0abe6a257eb7376c813d26b51
+```
+
+GitHub Actions for that head reported success for:
+
+- Format pull request
+- QA — Broken links (Lychee)
+- Accessibility audit (pa11y-ci)
+- Validate ResearchOps
+- qa-bdd
+- CI
+- Release Gate
+- Worker CI
 
 ## UI behaviour
 
@@ -72,29 +93,52 @@ Page:
 public/pages/team/role-assignments/index.html
 ```
 
-The second iteration page includes:
+The page includes:
 
+- breadcrumb navigation before the main landmark
 - compact team-scope panel
 - team member email field
 - user ID field inside a details component
 - role radios with role descriptions
-- role summary panel with permission codes
+- role summary panel with plain-language abilities
 - governed access-duration radios
 - conditional day, month and year expiry date input
 - audit reason textarea
 - sensitive-role confirmation checkbox
 - Safeguarding Lead confirmation checkbox
 - error summary
-- check-and-confirm panel
+- check-and-confirm summary list
 - success and error result panels
+
+## Design decision: top-level admin information architecture
+
+The page is now treated as a top-level administration area for the ResearchOps installation.
+
+The page uses breadcrumb navigation:
+
+```text
+Home > Team administration
+```
+
+The previous `Back to projects` link has been removed. No other back button or back link is shown.
+
+The `Clear form` reset button has also been removed because clearing the whole form is not a primary user need and creates avoidable accidental-reset risk.
+
+The breadcrumb is placed before:
+
+```text
+<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+```
+
+The route-state test now asserts this ordering so the page does not regress to breadcrumbs inside the main landmark.
 
 ## Design decision: remove self-access panel
 
-The first iteration showed a large “Your current access” panel.
+The first iteration showed a large `Your current access` panel.
 
 That was useful for proving authentication, but it made the page talk about the admin when the task is to assign access to another person.
 
-The second iteration keeps the permission check but reduces the successful state to team scope.
+The current page keeps the permission check but reduces the successful state to team scope.
 
 This shifts the page from an authentication diagnostic to a role-assignment task.
 
@@ -108,6 +152,8 @@ The user ID field is treated as a secondary escape route and is hidden inside:
 Use a user ID instead
 ```
 
+No user ID example is shown. The copy tells admins to use the user ID only when copied from ResearchOps.
+
 The user ID field uses a half-width input.
 
 This reflects the likely content length and reduces accidental use of internal identifiers.
@@ -116,7 +162,7 @@ This reflects the likely content length and reduces accidental use of internal i
 
 The first iteration used a select.
 
-The second iteration uses radios so all role choices and short descriptions are visible at the point of decision.
+The current page uses radios so all role choices and short descriptions are visible at the point of decision.
 
 Roles shown:
 
@@ -127,7 +173,9 @@ Roles shown:
 - Safeguarding Lead
 - Team Admin
 
-The selected role still updates a visible role summary and permission-code panel.
+The selected role updates a visible role summary.
+
+The summary now shows plain-language abilities only. It does not show technical permission codes such as `governed.create`, `governed.edit`, `safeguarding.view` or `team.manage`.
 
 ## Design decision: governed duration instead of arbitrary date-time
 
@@ -135,7 +183,7 @@ The first iteration used a free `datetime-local` input and helper text that said
 
 That was misleading because the system is intended to govern role assignment through expiry policy.
 
-The second iteration asks:
+The current page asks:
 
 ```text
 How long should this role last?
@@ -155,6 +203,18 @@ If the admin chooses a specific date, the UI reveals day, month and year fields.
 
 The client converts the chosen duration into `expiresAt` for the API request. The server remains authoritative.
 
+## Design decision: GOV.UK component conformance pass
+
+The final pass tightened the markup and styles around GOV.UK component conventions:
+
+- breadcrumb navigation replaces the back link
+- details component uses `govuk-details__summary` and `govuk-details__summary-text`
+- role and duration choices use GOV.UK radio markup
+- sensitive confirmations use GOV.UK-style warning text plus checkbox fieldsets
+- the check-and-confirm state uses summary-list classes
+- width utility classes are used for two-thirds and one-half input widths
+- plain-language role abilities replace technical permission codes
+
 ## Client implementation
 
 Client script:
@@ -169,12 +229,12 @@ The script:
 - detects `role.assign`
 - hides the form when role assignment is unavailable
 - shows team scope when role assignment is available
-- presents role metadata and permission codes
+- presents role metadata as plain-language abilities
 - reveals sensitive-role confirmations only when needed
-- reveals custom expiry date inputs only when “Until a specific date” is selected
+- reveals custom expiry date inputs only when `Until a specific date` is selected
 - validates the form before the check-and-confirm panel
 - prevents POST during ordinary form submit
-- builds the review summary
+- builds the GOV.UK summary-list review state
 - sends the API request only from the confirm button
 - shows success and error responses
 
@@ -186,17 +246,19 @@ Stylesheet:
 public/css/auth-role-assignments.css
 ```
 
-Second iteration styling covers:
+Current styling covers:
 
 - compact team-scope panel
 - blocked-access state
 - two-thirds width email field
 - half-width user ID field
 - two-thirds width reason textarea
-- radio layout
+- GOV.UK details arrow affordance
+- radio label and hint alignment
 - GOV.UK-style date input sizing
-- sensitive confirmation blocks
-- check-and-confirm panel
+- GOV.UK-style warning text
+- checkbox confirmation blocks
+- summary-list review state
 - success and error result panels
 - responsive full-width behaviour on small screens
 
@@ -245,8 +307,13 @@ tests/auth-role-assignment-ui-route-state.test.js
 The test now checks:
 
 - page structure
+- breadcrumb-based admin information architecture
+- breadcrumb placement before the main landmark
+- removal of back links
+- removal of the clear form reset control
 - removal of the self-access panel from the successful state
 - team-scope messaging
+- user ID details component without a user ID example
 - role radios instead of select
 - governed duration radios
 - conditional custom date inputs
@@ -258,7 +325,9 @@ The test now checks:
 - request contract fields
 - client validation messages
 - check-and-confirm before POST
-- visible role metadata and permission codes
+- plain-language role abilities
+- absence of technical permission codes in the UI
+- GOV.UK warning text, checkbox and summary-list hooks
 - stylesheet hooks for width affordance and review state
 
 The test is wired into:
@@ -275,7 +344,7 @@ The visual walkthrough registry was previously updated to include:
 /pages/team/role-assignments/index.html
 ```
 
-The second iteration updates the walkthrough state to wait for:
+The walkthrough state waits for:
 
 ```text
 You are assigning roles in
@@ -371,6 +440,19 @@ permissions include role.assign
 This evidence showed the page could detect the seeded Team Admin context once Cloudflare Access AUD and team-domain configuration were corrected outside this repository.
 
 Raw personal identifiers are not committed in this trace.
+
+## Final stabilisation pass
+
+A final stabilisation pass was completed on PR #220.
+
+It:
+
+- moved breadcrumb navigation before the main landmark
+- repaired the role-assignment page markup after a compacted intermediate edit
+- removed a transient stray non-ASCII artefact introduced during editing
+- asserted breadcrumb placement in the route-state test
+- confirmed the PR was mergeable after the pass
+- confirmed the latest checked CI set was green
 
 ## Product documentation
 

--- a/docs/agent-audit/reasoning/2026/05/10/auth-role-assignment-ui-radio-hint-amendment-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/10/auth-role-assignment-ui-radio-hint-amendment-trace.json
@@ -1,0 +1,56 @@
+{
+	"trace_id": "atrace-20260510-auth-role-assignment-ui-radio-hint-amendment",
+	"trace_layer": "operational",
+	"date": "2026-05-10",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "feature/auth-role-assignment-ui",
+	"pull_request": {
+		"number": 220,
+		"state": "open",
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/220"
+	},
+	"trigger": "[reasoning]",
+	"request_interpreted": [
+		"Keep GOV.UK radio structure on the role-assignment page.",
+		"Fix the radio click and tap target issue.",
+		"Keep useful role hint text inside each radio item.",
+		"Make radio hint text select the associated radio through JavaScript.",
+		"Keep the selected role summary to the ability-list pattern.",
+		"Record the continuation in docs/agent-audit/reasoning."
+	],
+	"files_checked": [
+		"public/pages/team/role-assignments/index.html",
+		"public/css/auth-role-assignments.css",
+		"public/css/govuk/govuk-frontend-v6.css",
+		"public/js/auth-role-assignment-page.js",
+		"tests/auth-role-assignment-ui-route-state.test.js"
+	],
+	"implementation": {
+		"radio_markup": "GOV.UK radio item structure with input, label and hint.",
+		"page_css_boundary": "Page CSS does not recreate GOV.UK radio input, label pseudo-element, focus or checked-state rules.",
+		"hint_click_behaviour": "Form-level click listener selects the associated radio when a govuk-radios__hint is clicked or tapped.",
+		"selected_role_summary": "Renders 'This role can:' followed by bullet points only."
+	},
+	"commits_recorded": [
+		"8b41c22873448abe33b31b8d7f84de9341fab400",
+		"98272427ed2ba1ecabfe66ad5f75bde204a255a7",
+		"dda4848249db0325df2e4c05278d41da18679486",
+		"d20758015c97521c3f7b30df6cc1df5c971a2d68",
+		"664acf8901b75f3b4fb236b6d30a797a356736d7",
+		"ab52cf23b71ca3edc147db07d53c7d6d18a53473"
+	],
+	"validation_encoded": [
+		"GOV.UK radio markup is used.",
+		"Role hints are present.",
+		"Role hints are selectable through JavaScript.",
+		"Selected-role summary uses ability bullets only.",
+		"Page-specific CSS does not recreate GOV.UK radio internals.",
+		"Technical permission codes remain absent from the user-facing UI."
+	],
+	"status_at_trace_write": {
+		"pr_open": true,
+		"pr_merged": false,
+		"checked_head_before_trace_file": "ab52cf23b71ca3edc147db07d53c7d6d18a53473",
+		"ci_needed_after_latest_commits": true
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/10/auth-role-assignment-ui-radio-hint-amendment-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/10/auth-role-assignment-ui-radio-hint-amendment-trace.md
@@ -1,0 +1,108 @@
+# Agent trace: auth role assignment UI radio hint amendment
+
+Date: 2026-05-10
+
+Branch: `feature/auth-role-assignment-ui`
+
+Pull request: #220
+
+## Trigger
+
+The user included `[reasoning]`. This trace records the implementation audit for the PR #220 continuation.
+
+## Request interpreted
+
+The continuation addressed the role-assignment radio controls.
+
+The required outcome was:
+
+- keep GOV.UK radio structure
+- fix the click and tap target problem
+- keep useful role hint text inside each radio item
+- make radio hint text select the associated radio
+- remove repeated role capability text from the selected-role summary
+- update tests and audit trace rather than ending the PR work early
+
+## Evidence checked
+
+Repository files checked:
+
+- `public/pages/team/role-assignments/index.html`
+- `public/css/auth-role-assignments.css`
+- `public/css/govuk/govuk-frontend-v6.css`
+- `public/js/auth-role-assignment-page.js`
+- `tests/auth-role-assignment-ui-route-state.test.js`
+
+GOV.UK Design System radios guidance was also checked. It supports radio item hints and says item hints should be short.
+
+## Findings
+
+The page stylesheet was recreating GOV.UK radio internals under `.auth-role-assignment-radios`.
+
+That duplicated the GOV.UK component layer and likely caused the spacing and click-target fault.
+
+The role hints were useful context and should remain.
+
+The selected role summary should only show:
+
+```text
+This role can:
+```
+
+followed by capability bullets.
+
+## Implementation applied
+
+The page now keeps GOV.UK radio markup with:
+
+```text
+.govuk-radios
+.govuk-radios__item
+.govuk-radios__input
+.govuk-radios__label
+.govuk-radios__hint
+```
+
+The page stylesheet no longer recreates radio input, label pseudo-element, focus or checked-state rules.
+
+The client keeps hint text clickable by listening for clicks on `.govuk-radios__hint`, finding the related radio input, setting it checked, and dispatching a bubbling `change` event.
+
+The selected role summary now renders capability bullets only.
+
+## Commits recorded
+
+Normal commits applied during this continuation included:
+
+```text
+8b41c22873448abe33b31b8d7f84de9341fab400
+98272427ed2ba1ecabfe66ad5f75bde204a255a7
+dda4848249db0325df2e4c05278d41da18679486
+d20758015c97521c3f7b30df6cc1df5c971a2d68
+664acf8901b75f3b4fb236b6d30a797a356736d7
+ab52cf23b71ca3edc147db07d53c7d6d18a53473
+```
+
+Two intermediate HTML edits were found to be malformed and then corrected by a normal follow-up commit.
+
+## Validation encoded
+
+`tests/auth-role-assignment-ui-route-state.test.js` now asserts:
+
+- GOV.UK radio markup is used
+- role hints are present
+- role hint text is clickable or tappable through JavaScript
+- the selected-role summary uses only the ability list pattern
+- page-specific CSS does not recreate GOV.UK radio internals
+- technical permission codes remain absent from the user-facing UI
+
+## Current status at trace write
+
+PR #220 remained open and unmerged.
+
+The checked head before this trace file was added was:
+
+```text
+ab52cf23b71ca3edc147db07d53c7d6d18a53473
+```
+
+CI still needed to rerun after the latest commits.

--- a/docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
+++ b/docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
@@ -1,0 +1,174 @@
+# Authentication role assignment UI
+
+Date: 2026-05-09
+
+## Purpose
+
+A Team Admin account now exists in live D1. The role-assignment API has been merged into `main`, but applying roles through raw endpoint calls is not a usable operating model.
+
+This slice adds a first Team Admin UI for assigning D1-backed roles to existing team members.
+
+The page is:
+
+```text
+/pages/team/role-assignments/
+```
+
+## User need
+
+As a Team Admin, I need to assign a role to an existing team member, so that role changes can be made through a governed interface rather than manual SQL or ad hoc API calls.
+
+## Implemented page
+
+The page contains:
+
+- current signed-in user and active team status
+- role-assignment form
+- target member email field
+- optional target user ID field
+- role selector
+- role summary panel
+- audit reason textarea
+- optional expiry field
+- sensitive-role confirmation checkbox
+- Safeguarding Lead confirmation checkbox
+- GOV.UK-style error summary
+- success and error result panels
+
+## Runtime behaviour
+
+The page checks the signed-in user's current access by calling:
+
+```text
+GET /api/me
+```
+
+The client enables the submit button only when the active team context includes:
+
+```text
+role.assign
+```
+
+The page submits role assignments to:
+
+```text
+POST /api/auth/role-assignments
+```
+
+## Request contract
+
+The UI sends:
+
+```text
+targetEmail
+targetUserId
+roleKey
+requestedReason
+expiresAt
+sensitiveRoleConfirmation
+safeguardingConfirmation
+```
+
+The API accepts either `targetEmail` or `targetUserId`. If both are sent, the API requires both to resolve to the same user.
+
+## Sensitive role controls
+
+For sensitive roles, the user must tick:
+
+```text
+I confirm this sensitive role assignment is intentional.
+```
+
+This sends:
+
+```text
+sensitiveRoleConfirmation = ASSIGN_SENSITIVE_ROLE
+```
+
+For `safeguarding_lead`, the user must also tick:
+
+```text
+I confirm Safeguarding Lead access is required.
+```
+
+This sends:
+
+```text
+safeguardingConfirmation = ASSIGN_SAFEGUARDING_LEAD
+```
+
+## Roles shown
+
+The first UI supports assigning the seeded D1 roles:
+
+- Observer
+- Researcher
+- Research Lead
+- Approver
+- Safeguarding Lead
+- Team Admin
+
+The UI shows the role description and permission codes before submission.
+
+## Validation
+
+The client validates before POST:
+
+- at least one target identifier exists
+- role is selected
+- requested reason is at least 12 characters
+- expiry date is parseable when provided
+- sensitive confirmation is present for sensitive roles
+- safeguarding confirmation is present for Safeguarding Lead
+
+The server remains authoritative.
+
+## Accessibility and GOV.UK pattern use
+
+The page uses:
+
+- `govuk-error-summary`
+- form groups with labels, hints and error messages
+- fieldsets for sensitive confirmations
+- visible role summary before submission
+- `aria-live` regions for status and result messages
+- `aria-busy` while checking current access
+
+## Boundary
+
+This slice does not create a user search endpoint.
+
+This slice does not create users.
+
+This slice does not create team memberships.
+
+This slice does not list all team members.
+
+This slice does not add role removal.
+
+This slice does not support permission exceptions.
+
+This slice does not replace the D1 route-status workflow. The route declaration still needs the operational workflow if live D1 has not already been marked implemented.
+
+## Files
+
+```text
+public/pages/team/role-assignments/index.html
+public/js/auth-role-assignment-page.js
+public/css/auth-role-assignments.css
+tests/auth-role-assignment-ui-route-state.test.js
+```
+
+## Operational follow-up
+
+After merge and deployment, verify the page with the seeded Team Admin account.
+
+Recommended checks:
+
+1. open `/pages/team/role-assignments/`
+2. confirm the page detects `role.assign`
+3. assign a non-sensitive role to an existing active team member
+4. confirm success output
+5. confirm `auth_role_assignments` contains the role assignment
+6. confirm `auth_audit_events` contains `auth.role_assignment.created`
+7. attempt Safeguarding Lead without confirmations and confirm it is blocked

--- a/docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
+++ b/docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
@@ -6,7 +6,7 @@ Date: 2026-05-09
 
 A Team Admin account now exists in live D1. The role-assignment API has been merged into `main`, but applying roles through raw endpoint calls is not a usable operating model.
 
-This slice adds a first Team Admin UI for assigning D1-backed roles to existing team members.
+This slice adds a Team Admin UI for assigning D1-backed roles to existing team members.
 
 The page is:
 
@@ -18,21 +18,36 @@ The page is:
 
 As a Team Admin, I need to assign a role to an existing team member, so that role changes can be made through a governed interface rather than manual SQL or ad hoc API calls.
 
+## Second iteration design changes
+
+The second iteration changes the page from an authentication diagnostic plus form into a safer administrative task flow.
+
+The prominent “Your current access” panel has been removed from the successful state. The page still checks `/api/me`, but it now only shows a compact team-scope statement when the user can assign roles.
+
+The default successful state says which team the admin is managing:
+
+```text
+You are assigning roles in ResearchOps Core Team.
+```
+
+If the user cannot assign roles, the page shows a blocking message instead of the form.
+
 ## Implemented page
 
 The page contains:
 
-- current signed-in user and active team status
-- role-assignment form
-- target member email field
-- optional target user ID field
-- role selector
-- role summary panel
+- compact team-scope panel
+- team member email field
+- user ID field hidden inside a details component
+- role radios with role descriptions
+- role summary panel with permission codes
+- governed access-duration radios
+- conditional date input for a specific expiry date
 - audit reason textarea
-- optional expiry field
 - sensitive-role confirmation checkbox
 - Safeguarding Lead confirmation checkbox
 - GOV.UK-style error summary
+- check-and-confirm panel
 - success and error result panels
 
 ## Runtime behaviour
@@ -43,13 +58,21 @@ The page checks the signed-in user's current access by calling:
 GET /api/me
 ```
 
-The client enables the submit button only when the active team context includes:
+The client enables the form only when the active team context includes:
 
 ```text
 role.assign
 ```
 
-The page submits role assignments to:
+The form submit action does not immediately write to D1. It validates the form and shows a check-and-confirm panel first.
+
+The write only happens when the admin selects:
+
+```text
+Confirm and assign role
+```
+
+The page then submits to:
 
 ```text
 POST /api/auth/role-assignments
@@ -70,6 +93,61 @@ safeguardingConfirmation
 ```
 
 The API accepts either `targetEmail` or `targetUserId`. If both are sent, the API requires both to resolve to the same user.
+
+## Team member fields
+
+The email field is the primary target identifier and uses a two-thirds width.
+
+The user ID field is hidden inside a details component labelled:
+
+```text
+Use a user ID instead
+```
+
+This keeps the normal path focused on the human-readable sign-in email address while preserving an escape route for known user IDs.
+
+The user ID field uses a half-width input because user IDs are shorter and more structured than email addresses.
+
+## Role selection
+
+The role selector is now a set of radios rather than a select.
+
+This makes every available role visible at the point of decision and allows each role to carry a short description.
+
+The first UI supports assigning the seeded D1 roles:
+
+- Observer
+- Researcher
+- Research Lead
+- Approver
+- Safeguarding Lead
+- Team Admin
+
+The UI shows the selected role description and permission codes before confirmation.
+
+## Access duration
+
+The first iteration used an arbitrary date-time field and helper text that implied no expiry date.
+
+That was incorrect for a governed role-assignment model. The second iteration asks:
+
+```text
+How long should this role last?
+```
+
+The admin must choose one of:
+
+- 30 days
+- 60 days
+- 90 days
+- 180 days
+- Until a specific date
+
+The standard maximum is described as 180 days. No duration is pre-selected.
+
+If the admin chooses a specific date, the page reveals a GOV.UK-style day, month and year date input. The UI treats the expiry as the end of the selected day, rather than asking for an arbitrary time.
+
+The client converts the selected duration or date into `expiresAt` for the API request. The server remains authoritative.
 
 ## Sensitive role controls
 
@@ -97,27 +175,15 @@ This sends:
 safeguardingConfirmation = ASSIGN_SAFEGUARDING_LEAD
 ```
 
-## Roles shown
-
-The first UI supports assigning the seeded D1 roles:
-
-- Observer
-- Researcher
-- Research Lead
-- Approver
-- Safeguarding Lead
-- Team Admin
-
-The UI shows the role description and permission codes before submission.
-
 ## Validation
 
-The client validates before POST:
+The client validates before showing the check-and-confirm panel:
 
 - at least one target identifier exists
 - role is selected
+- access duration is selected
+- custom expiry date is real when used
 - requested reason is at least 12 characters
-- expiry date is parseable when provided
 - sensitive confirmation is present for sensitive roles
 - safeguarding confirmation is present for Safeguarding Lead
 
@@ -129,9 +195,13 @@ The page uses:
 
 - `govuk-error-summary`
 - form groups with labels, hints and error messages
+- radios for single-choice role and duration decisions
+- details component affordance for the secondary user ID path
+- GOV.UK-style date input for specific expiry dates
 - fieldsets for sensitive confirmations
-- visible role summary before submission
-- `aria-live` regions for status and result messages
+- visible role summary before confirmation
+- check-and-confirm panel before POST
+- `aria-live` regions for team-scope and result messages
 - `aria-busy` while checking current access
 
 ## Boundary
@@ -141,6 +211,8 @@ This slice does not create a user search endpoint.
 This slice does not create users.
 
 This slice does not create team memberships.
+
+This slice does not resolve the target user before the check-and-confirm panel.
 
 This slice does not list all team members.
 
@@ -166,9 +238,11 @@ After merge and deployment, verify the page with the seeded Team Admin account.
 Recommended checks:
 
 1. open `/pages/team/role-assignments/`
-2. confirm the page detects `role.assign`
-3. assign a non-sensitive role to an existing active team member
-4. confirm success output
-5. confirm `auth_role_assignments` contains the role assignment
-6. confirm `auth_audit_events` contains `auth.role_assignment.created`
-7. attempt Safeguarding Lead without confirmations and confirm it is blocked
+2. confirm the page shows the active team scope
+3. confirm the form is available only when `role.assign` is present
+4. assign a non-sensitive role to an existing active team member
+5. confirm the check-and-confirm panel appears before the write
+6. confirm success output
+7. confirm `auth_role_assignments` contains the role assignment
+8. confirm `auth_audit_events` contains `auth.role_assignment.created`
+9. attempt Safeguarding Lead without confirmations and confirm it is blocked

--- a/docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
+++ b/docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
@@ -18,11 +18,25 @@ The page is:
 
 As a Team Admin, I need to assign a role to an existing team member, so that role changes can be made through a governed interface rather than manual SQL or ad hoc API calls.
 
-## Second iteration design changes
+## Information architecture
 
-The second iteration changes the page from an authentication diagnostic plus form into a safer administrative task flow.
+This page is now treated as part of top-level Team administration for the ResearchOps installation.
 
-The prominent “Your current access” panel has been removed from the successful state. The page still checks `/api/me`, but it now only shows a compact team-scope statement when the user can assign roles.
+The page uses breadcrumb navigation:
+
+```text
+Home > Team administration
+```
+
+The previous `Back to projects` link has been removed. Role assignment is not a project-level task.
+
+No other back button or back link is shown on this page.
+
+## Iteration summary
+
+The page has moved from an authentication diagnostic plus form into a safer administrative task flow.
+
+The prominent `Your current access` panel has been removed from the successful state. The page still checks `/api/me`, but it now only shows a compact team-scope statement when the user can assign roles.
 
 The default successful state says which team the admin is managing:
 
@@ -36,18 +50,19 @@ If the user cannot assign roles, the page shows a blocking message instead of th
 
 The page contains:
 
+- breadcrumb navigation
 - compact team-scope panel
 - team member email field
 - user ID field hidden inside a details component
 - role radios with role descriptions
-- role summary panel with permission codes
+- role summary panel with plain-language abilities
 - governed access-duration radios
 - conditional date input for a specific expiry date
 - audit reason textarea
 - sensitive-role confirmation checkbox
 - Safeguarding Lead confirmation checkbox
 - GOV.UK-style error summary
-- check-and-confirm panel
+- check-and-confirm summary list
 - success and error result panels
 
 ## Runtime behaviour
@@ -96,7 +111,7 @@ The API accepts either `targetEmail` or `targetUserId`. If both are sent, the AP
 
 ## Team member fields
 
-The email field is the primary target identifier and uses a two-thirds width.
+The email field is the primary target identifier and uses a two-thirds width input.
 
 The user ID field is hidden inside a details component labelled:
 
@@ -104,7 +119,7 @@ The user ID field is hidden inside a details component labelled:
 Use a user ID instead
 ```
 
-This keeps the normal path focused on the human-readable sign-in email address while preserving an escape route for known user IDs.
+No user ID example is shown. The admin is told to use this field only if they copied the user ID from ResearchOps.
 
 The user ID field uses a half-width input because user IDs are shorter and more structured than email addresses.
 
@@ -114,7 +129,7 @@ The role selector is now a set of radios rather than a select.
 
 This makes every available role visible at the point of decision and allows each role to carry a short description.
 
-The first UI supports assigning the seeded D1 roles:
+The UI supports assigning the seeded D1 roles:
 
 - Observer
 - Researcher
@@ -123,13 +138,13 @@ The first UI supports assigning the seeded D1 roles:
 - Safeguarding Lead
 - Team Admin
 
-The UI shows the selected role description and permission codes before confirmation.
+The selected role summary shows plain-language abilities only. It does not show technical permission codes such as `governed.create` or `safeguarding.view`.
 
 ## Access duration
 
 The first iteration used an arbitrary date-time field and helper text that implied no expiry date.
 
-That was incorrect for a governed role-assignment model. The second iteration asks:
+That was incorrect for a governed role-assignment model. The current page asks:
 
 ```text
 How long should this role last?
@@ -151,6 +166,8 @@ The client converts the selected duration or date into `expiresAt` for the API r
 
 ## Sensitive role controls
 
+Sensitive role confirmation now uses a GOV.UK-style warning text block followed by a checkbox fieldset.
+
 For sensitive roles, the user must tick:
 
 ```text
@@ -166,7 +183,7 @@ sensitiveRoleConfirmation = ASSIGN_SENSITIVE_ROLE
 For `safeguarding_lead`, the user must also tick:
 
 ```text
-I confirm Safeguarding Lead access is required.
+I confirm this person needs Safeguarding Lead access.
 ```
 
 This sends:
@@ -174,6 +191,28 @@ This sends:
 ```text
 safeguardingConfirmation = ASSIGN_SAFEGUARDING_LEAD
 ```
+
+## Check and confirm
+
+The check-and-confirm state uses summary-list style rows.
+
+The admin can review:
+
+- team member email
+- user ID, if provided
+- team
+- role
+- access duration
+- expiry date
+- reason
+
+The actual D1 write only happens after the admin selects:
+
+```text
+Confirm and assign role
+```
+
+The previous `Clear form` reset button has been removed.
 
 ## Validation
 
@@ -193,14 +232,16 @@ The server remains authoritative.
 
 The page uses:
 
+- `govuk-breadcrumbs`
 - `govuk-error-summary`
 - form groups with labels, hints and error messages
 - radios for single-choice role and duration decisions
 - details component affordance for the secondary user ID path
 - GOV.UK-style date input for specific expiry dates
-- fieldsets for sensitive confirmations
+- warning text for sensitive access consequences
+- checkbox fieldsets for sensitive confirmations
 - visible role summary before confirmation
-- check-and-confirm panel before POST
+- summary-list style check-and-confirm panel before POST
 - `aria-live` regions for team-scope and result messages
 - `aria-busy` while checking current access
 

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -1,0 +1,95 @@
+/* ==========================================================================
+   Auth role assignment page
+   Service:    Home Office Biometrics — ResearchOps
+   Scope:      Team role assignment UI
+   ========================================================================== */
+
+.auth-role-assignment-page__header {
+	margin-bottom: 30px;
+	}
+
+.auth-role-assignment-status {
+	margin-bottom: 30px;
+	}
+
+.auth-role-assignment-status__panel {
+	max-width: 760px;
+	padding: 20px;
+	border: 2px solid #b1b4b6;
+	background: #f3f2f1;
+	}
+
+.auth-role-assignment-status__panel--ready {
+	border-color: #00703c;
+	background: #f3fff7;
+	}
+
+.auth-role-assignment-status__panel--blocked {
+	border-color: #d4351c;
+	background: #fff7f7;
+	}
+
+.auth-role-assignment-status__panel p:last-child {
+	margin-bottom: 0;
+	}
+
+.auth-role-assignment-summary {
+	margin-bottom: 20px;
+	padding: 20px;
+	border-left: 5px solid #1d70b8;
+	background: #f3f2f1;
+	}
+
+.auth-role-assignment-summary .govuk-heading-s {
+	margin-top: 0;
+	}
+
+.auth-role-assignment-summary__permissions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	margin: 0 0 15px;
+	padding: 0;
+	list-style: none;
+	}
+
+.auth-role-assignment-summary__permissions li {
+	margin: 0;
+	}
+
+.auth-role-assignment-sensitive {
+	margin-bottom: 20px;
+	padding: 20px;
+	border-left: 5px solid #f47738;
+	background: #fff7f0;
+	}
+
+.auth-role-assignment-result {
+	max-width: 760px;
+	margin-top: 30px;
+	padding: 20px;
+	border: 5px solid #1d70b8;
+	}
+
+.auth-role-assignment-result--success {
+	border-color: #00703c;
+	background: #f3fff7;
+	}
+
+.auth-role-assignment-result--error {
+	border-color: #d4351c;
+	background: #fff7f7;
+	}
+
+.auth-role-assignment-result .govuk-heading-m {
+	margin-top: 0;
+	}
+
+code {
+	padding: 2px 4px;
+	background: #f3f2f1;
+	font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+	font-size: 0.95em;
+	}
+
+/* transparency begins in the cascade */

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -1,4 +1,4 @@
-/* ==========================================================================
+/* ============================================================================
    Auth role assignment page
    Service:    Home Office Biometrics — ResearchOps
    Scope:      Team role assignment UI
@@ -8,32 +8,96 @@
 	margin-bottom: 30px;
 	}
 
-.auth-role-assignment-status {
+.auth-role-assignment-scope {
 	margin-bottom: 30px;
 	}
 
-.auth-role-assignment-status__panel {
+.auth-role-assignment-scope__panel {
 	max-width: 760px;
-	padding: 20px;
-	border: 2px solid #b1b4b6;
+	padding: 15px 20px;
+	border-left: 5px solid #1d70b8;
 	background: #f3f2f1;
 	}
 
-.auth-role-assignment-status__panel--ready {
-	border-color: #00703c;
-	background: #f3fff7;
-	}
-
-.auth-role-assignment-status__panel--blocked {
-	border-color: #d4351c;
+.auth-role-assignment-scope__panel--blocked {
+	border-left-color: #d4351c;
 	background: #fff7f7;
 	}
 
-.auth-role-assignment-status__panel p:last-child {
+.auth-role-assignment-scope__panel p:last-child {
 	margin-bottom: 0;
 	}
 
+.auth-role-assignment-section {
+	margin-bottom: 35px;
+	}
+
+.auth-role-assignment-input {
+	max-width: 100%;
+	}
+
+.auth-role-assignment-input--email {
+	width: 66.66%;
+	}
+
+.auth-role-assignment-input--user-id {
+	width: 50%;
+	}
+
+.auth-role-assignment-textarea {
+	width: 66.66%;
+	max-width: 100%;
+	}
+
+.auth-role-assignment-details {
+	max-width: 760px;
+	margin-bottom: 25px;
+	}
+
+.auth-role-assignment-details .govuk-details__summary {
+	display: inline-block;
+	margin-bottom: 10px;
+	color: #1d70b8;
+	cursor: pointer;
+	text-decoration: underline;
+	}
+
+.auth-role-assignment-details .govuk-details__text {
+	padding: 15px 20px;
+	border-left: 5px solid #b1b4b6;
+	}
+
+.auth-role-assignment-radios {
+	max-width: 760px;
+	}
+
+.auth-role-assignment-radios .govuk-radios__item {
+	position: relative;
+	min-height: 40px;
+	margin-bottom: 15px;
+	padding-left: 42px;
+	}
+
+.auth-role-assignment-radios .govuk-radios__input {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 32px;
+	height: 32px;
+	}
+
+.auth-role-assignment-radios .govuk-radios__label {
+	display: block;
+	font-weight: 700;
+	}
+
+.auth-role-assignment-radios .govuk-radios__hint {
+	margin-top: 3px;
+	color: #505a5f;
+	}
+
 .auth-role-assignment-summary {
+	max-width: 760px;
 	margin-bottom: 20px;
 	padding: 20px;
 	border-left: 5px solid #1d70b8;
@@ -57,11 +121,80 @@
 	margin: 0;
 	}
 
+.auth-role-assignment-custom-date {
+	max-width: 500px;
+	margin-top: 20px;
+	}
+
+.auth-role-assignment-custom-date .govuk-date-input {
+	display: flex;
+	gap: 15px;
+	align-items: flex-start;
+	}
+
+.auth-role-assignment-custom-date .govuk-date-input__item {
+	margin-right: 0;
+	}
+
+.govuk-input--width-2 {
+	max-width: 4.5em;
+	}
+
+.govuk-input--width-4 {
+	max-width: 6em;
+	}
+
 .auth-role-assignment-sensitive {
+	max-width: 760px;
 	margin-bottom: 20px;
 	padding: 20px;
 	border-left: 5px solid #f47738;
 	background: #fff7f0;
+	}
+
+.auth-role-assignment-warning {
+	margin-bottom: 15px;
+	}
+
+.auth-role-assignment-warning strong {
+	display: block;
+	margin-bottom: 5px;
+	}
+
+.auth-role-assignment-warning p:last-child {
+	margin-bottom: 0;
+	}
+
+.auth-role-assignment-review {
+	max-width: 760px;
+	margin-top: 30px;
+	padding: 20px;
+	border: 2px solid #1d70b8;
+	background: #f3f2f1;
+	}
+
+.auth-role-assignment-review .govuk-heading-l {
+	margin-top: 0;
+	}
+
+.auth-role-assignment-review__list {
+	margin: 0 0 25px;
+	}
+
+.auth-role-assignment-review__row {
+	display: grid;
+	gap: 15px;
+	grid-template-columns: minmax(140px, 1fr) 2fr;
+	padding: 10px 0;
+	border-bottom: 1px solid #b1b4b6;
+	}
+
+.auth-role-assignment-review__row dt {
+	font-weight: 700;
+	}
+
+.auth-role-assignment-review__row dd {
+	margin: 0;
 	}
 
 .auth-role-assignment-result {
@@ -90,6 +223,18 @@ code {
 	background: #f3f2f1;
 	font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
 	font-size: 0.95em;
+	}
+
+@media (max-width: 640px) {
+	.auth-role-assignment-input--email,
+	.auth-role-assignment-input--user-id,
+	.auth-role-assignment-textarea {
+		width: 100%;
+		}
+
+	.auth-role-assignment-review__row {
+		grid-template-columns: 1fr;
+		}
 	}
 
 /* transparency begins in the cascade */

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -4,12 +4,14 @@
    Scope:      Team role assignment UI
    ========================================================================== */
 
-.govuk-\!-width-two-thirds {
+.govuk-\!-width-two-thirds,
+[class~="govuk-!-width-two-thirds"] {
 	width: 66.66% !important;
 	max-width: 100%;
 	}
 
-.govuk-\!-width-one-half {
+.govuk-\!-width-one-half,
+[class~="govuk-!-width-one-half"] {
 	width: 50% !important;
 	max-width: 100%;
 	}
@@ -118,44 +120,96 @@
 	border-left: 5px solid #b1b4b6;
 	}
 
-.auth-role-assignment-radios {
+.auth-role-assignment-radios,
+.auth-role-assignment-checkboxes {
 	max-width: 760px;
 	}
 
 .auth-role-assignment-radios .govuk-radios__item {
-	display: grid;
-	gap: 2px 10px;
-	grid-template-columns: 32px 1fr;
-	align-items: start;
+	display: block;
+	position: relative;
 	min-height: 40px;
-	margin-bottom: 15px;
+	margin-bottom: 10px;
+	padding-left: 40px;
+	clear: left;
 	}
 
 .auth-role-assignment-radios .govuk-radios__input {
-	grid-column: 1;
-	grid-row: 1 / span 2;
-	width: 32px;
-	height: 32px;
+	position: absolute;
+	z-index: 1;
+	top: -2px;
+	left: -2px;
+	width: 44px;
+	height: 44px;
 	margin: 0;
+	opacity: 0;
+	cursor: pointer;
 	}
 
 .auth-role-assignment-radios .govuk-radios__label {
-	grid-column: 2;
-	grid-row: 1;
+	display: inline-block;
 	margin-bottom: 0;
-	padding-top: 3px;
+	padding: 8px 15px 5px;
+	cursor: pointer;
+	touch-action: manipulation;
 	font-weight: 700;
+	line-height: 1.25;
+	}
+
+.auth-role-assignment-radios .govuk-radios__label::before {
+	content: "";
+	box-sizing: border-box;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 40px;
+	height: 40px;
+	border: 2px solid currentColor;
+	border-radius: 50%;
+	background: transparent;
+	}
+
+.auth-role-assignment-radios .govuk-radios__label::after {
+	content: "";
+	position: absolute;
+	top: 10px;
+	left: 10px;
+	width: 0;
+	height: 0;
+	border: 10px solid currentColor;
+	border-radius: 50%;
+	opacity: 0;
+	background: currentColor;
+	}
+
+.auth-role-assignment-radios .govuk-radios__input:focus + .govuk-radios__label::before {
+	border-width: 4px;
+	outline: 3px solid transparent;
+	outline-offset: 1px;
+	box-shadow: 0 0 0 4px #ffdd00;
+	}
+
+.auth-role-assignment-radios .govuk-radios__input:checked + .govuk-radios__label::after {
+	opacity: 1;
 	}
 
 .auth-role-assignment-radios .govuk-radios__hint {
-	grid-column: 2;
-	grid-row: 2;
-	margin: 0;
+	display: block;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding-right: 15px;
+	padding-left: 15px;
 	color: #505a5f;
+	line-height: 1.25;
+	}
+
+.auth-role-assignment-radios .govuk-radios__hint[data-clicks-radio="true"] {
+	cursor: pointer;
 	}
 
 .auth-role-assignment-summary {
 	max-width: 760px;
+	margin-top: 20px;
 	margin-bottom: 20px;
 	padding: 20px;
 	border-left: 5px solid #1d70b8;
@@ -164,6 +218,11 @@
 
 .auth-role-assignment-summary .govuk-heading-s {
 	margin-top: 0;
+	margin-bottom: 10px;
+	}
+
+.auth-role-assignment-summary p:last-child {
+	margin-bottom: 0;
 	}
 
 .auth-role-assignment-summary__abilities {
@@ -235,6 +294,9 @@
 .auth-role-assignment-sensitive {
 	max-width: 760px;
 	margin-bottom: 20px;
+	padding: 0;
+	border: 0;
+	background: transparent;
 	}
 
 .auth-role-assignment-review {
@@ -304,7 +366,9 @@ code {
 
 @media (max-width: 640px) {
 	.govuk-\!-width-two-thirds,
-	.govuk-\!-width-one-half {
+	.govuk-\!-width-one-half,
+	[class~="govuk-!-width-two-thirds"],
+	[class~="govuk-!-width-one-half"] {
 		width: 100% !important;
 		}
 

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -125,84 +125,6 @@
 	max-width: 760px;
 	}
 
-.auth-role-assignment-radios .govuk-radios__item {
-	display: block;
-	position: relative;
-	min-height: 40px;
-	margin-bottom: 10px;
-	padding-left: 40px;
-	clear: left;
-	}
-
-.auth-role-assignment-radios .govuk-radios__input {
-	position: absolute;
-	z-index: 1;
-	top: -2px;
-	left: -2px;
-	width: 44px;
-	height: 44px;
-	margin: 0;
-	opacity: 0;
-	cursor: pointer;
-	}
-
-.auth-role-assignment-radios .govuk-radios__label {
-	display: inline-block;
-	margin-bottom: 0;
-	padding: 8px 15px 5px;
-	cursor: pointer;
-	touch-action: manipulation;
-	font-weight: 700;
-	line-height: 1.25;
-	}
-
-.auth-role-assignment-radios .govuk-radios__label::before {
-	content: "";
-	box-sizing: border-box;
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 40px;
-	height: 40px;
-	border: 2px solid currentColor;
-	border-radius: 50%;
-	background: transparent;
-	}
-
-.auth-role-assignment-radios .govuk-radios__label::after {
-	content: "";
-	position: absolute;
-	top: 10px;
-	left: 10px;
-	width: 0;
-	height: 0;
-	border: 10px solid currentColor;
-	border-radius: 50%;
-	opacity: 0;
-	background: currentColor;
-	}
-
-.auth-role-assignment-radios .govuk-radios__input:focus + .govuk-radios__label::before {
-	border-width: 4px;
-	outline: 3px solid transparent;
-	outline-offset: 1px;
-	box-shadow: 0 0 0 4px #ffdd00;
-	}
-
-.auth-role-assignment-radios .govuk-radios__input:checked + .govuk-radios__label::after {
-	opacity: 1;
-	}
-
-.auth-role-assignment-radios .govuk-radios__hint {
-	display: block;
-	margin-top: 0;
-	margin-bottom: 0;
-	padding-right: 15px;
-	padding-left: 15px;
-	color: #505a5f;
-	line-height: 1.25;
-	}
-
 .auth-role-assignment-radios .govuk-radios__hint[data-clicks-radio="true"] {
 	cursor: pointer;
 	}
@@ -216,17 +138,12 @@
 	background: #f3f2f1;
 	}
 
-.auth-role-assignment-summary .govuk-heading-s {
-	margin-top: 0;
-	margin-bottom: 10px;
-	}
-
 .auth-role-assignment-summary p:last-child {
 	margin-bottom: 0;
 	}
 
 .auth-role-assignment-summary__abilities {
-	margin-bottom: 15px;
+	margin-bottom: 0;
 	}
 
 .auth-role-assignment-custom-date {

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -4,6 +4,39 @@
    Scope:      Team role assignment UI
    ========================================================================== */
 
+.govuk-\!-width-two-thirds {
+	width: 66.66% !important;
+	max-width: 100%;
+	}
+
+.govuk-\!-width-one-half {
+	width: 50% !important;
+	max-width: 100%;
+	}
+
+.govuk-list {
+	margin-top: 0;
+	margin-bottom: 15px;
+	padding-left: 0;
+	}
+
+.govuk-list--bullet {
+	padding-left: 20px;
+	list-style-type: disc;
+	}
+
+.govuk-visually-hidden {
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	margin: -1px !important;
+	padding: 0 !important;
+	overflow: hidden !important;
+	clip: rect(0 0 0 0) !important;
+	white-space: nowrap !important;
+	border: 0 !important;
+	}
+
 .auth-role-assignment-page__header {
 	margin-bottom: 30px;
 	}
@@ -32,34 +65,52 @@
 	margin-bottom: 35px;
 	}
 
-.auth-role-assignment-input {
-	max-width: 100%;
-	}
-
-.auth-role-assignment-input--email {
-	width: 66.66%;
-	}
-
-.auth-role-assignment-input--user-id {
-	width: 50%;
-	}
-
-.auth-role-assignment-textarea {
-	width: 66.66%;
-	max-width: 100%;
-	}
-
 .auth-role-assignment-details {
 	max-width: 760px;
 	margin-bottom: 25px;
 	}
 
 .auth-role-assignment-details .govuk-details__summary {
+	position: relative;
 	display: inline-block;
 	margin-bottom: 10px;
+	padding-left: 25px;
 	color: #1d70b8;
 	cursor: pointer;
 	text-decoration: underline;
+	}
+
+.auth-role-assignment-details .govuk-details__summary::-webkit-details-marker {
+	display: none;
+	}
+
+.auth-role-assignment-details .govuk-details__summary::marker {
+	content: "";
+	}
+
+.auth-role-assignment-details .govuk-details__summary::before {
+	content: "";
+	position: absolute;
+	top: 4px;
+	left: 0;
+	border-color: transparent transparent transparent currentColor;
+	border-style: solid;
+	border-width: 7px 0 7px 12px;
+	}
+
+.auth-role-assignment-details[open] .govuk-details__summary::before {
+	top: 7px;
+	border-color: currentColor transparent transparent transparent;
+	border-width: 12px 7px 0;
+	}
+
+.auth-role-assignment-details .govuk-details__summary:focus {
+	background-color: #ffdd00;
+	color: #0b0c0c;
+	outline: 3px solid #ffdd00;
+	outline-offset: 0;
+	box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+	text-decoration: none;
 	}
 
 .auth-role-assignment-details .govuk-details__text {
@@ -72,27 +123,34 @@
 	}
 
 .auth-role-assignment-radios .govuk-radios__item {
-	position: relative;
+	display: grid;
+	gap: 2px 10px;
+	grid-template-columns: 32px 1fr;
+	align-items: start;
 	min-height: 40px;
 	margin-bottom: 15px;
-	padding-left: 42px;
 	}
 
 .auth-role-assignment-radios .govuk-radios__input {
-	position: absolute;
-	top: 0;
-	left: 0;
+	grid-column: 1;
+	grid-row: 1 / span 2;
 	width: 32px;
 	height: 32px;
+	margin: 0;
 	}
 
 .auth-role-assignment-radios .govuk-radios__label {
-	display: block;
+	grid-column: 2;
+	grid-row: 1;
+	margin-bottom: 0;
+	padding-top: 3px;
 	font-weight: 700;
 	}
 
 .auth-role-assignment-radios .govuk-radios__hint {
-	margin-top: 3px;
+	grid-column: 2;
+	grid-row: 2;
+	margin: 0;
 	color: #505a5f;
 	}
 
@@ -108,17 +166,8 @@
 	margin-top: 0;
 	}
 
-.auth-role-assignment-summary__permissions {
-	display: flex;
-	gap: 8px;
-	flex-wrap: wrap;
-	margin: 0 0 15px;
-	padding: 0;
-	list-style: none;
-	}
-
-.auth-role-assignment-summary__permissions li {
-	margin: 0;
+.auth-role-assignment-summary__abilities {
+	margin-bottom: 15px;
 	}
 
 .auth-role-assignment-custom-date {
@@ -144,25 +193,48 @@
 	max-width: 6em;
 	}
 
+.govuk-warning-text {
+	position: relative;
+	min-height: 35px;
+	margin-bottom: 20px;
+	padding-left: 45px;
+	}
+
+.govuk-warning-text__icon {
+	position: absolute;
+	top: -3px;
+	left: 0;
+	display: inline-block;
+	width: 35px;
+	height: 35px;
+	border-radius: 50%;
+	background: #0b0c0c;
+	color: #ffffff;
+	font-weight: 700;
+	line-height: 35px;
+	text-align: center;
+	}
+
+.govuk-warning-text__text {
+	display: block;
+	font-weight: 700;
+	}
+
+.govuk-warning-text__assistive {
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	margin: -1px !important;
+	padding: 0 !important;
+	overflow: hidden !important;
+	clip: rect(0 0 0 0) !important;
+	white-space: nowrap !important;
+	border: 0 !important;
+	}
+
 .auth-role-assignment-sensitive {
 	max-width: 760px;
 	margin-bottom: 20px;
-	padding: 20px;
-	border-left: 5px solid #f47738;
-	background: #fff7f0;
-	}
-
-.auth-role-assignment-warning {
-	margin-bottom: 15px;
-	}
-
-.auth-role-assignment-warning strong {
-	display: block;
-	margin-bottom: 5px;
-	}
-
-.auth-role-assignment-warning p:last-child {
-	margin-bottom: 0;
 	}
 
 .auth-role-assignment-review {
@@ -177,24 +249,29 @@
 	margin-top: 0;
 	}
 
-.auth-role-assignment-review__list {
+.govuk-summary-list {
 	margin: 0 0 25px;
 	}
 
-.auth-role-assignment-review__row {
+.govuk-summary-list__row {
 	display: grid;
 	gap: 15px;
-	grid-template-columns: minmax(140px, 1fr) 2fr;
+	grid-template-columns: minmax(140px, 1fr) 2fr auto;
 	padding: 10px 0;
 	border-bottom: 1px solid #b1b4b6;
 	}
 
-.auth-role-assignment-review__row dt {
+.govuk-summary-list__key {
 	font-weight: 700;
 	}
 
-.auth-role-assignment-review__row dd {
+.govuk-summary-list__value,
+.govuk-summary-list__actions {
 	margin: 0;
+	}
+
+.govuk-summary-list__actions {
+	text-align: right;
 	}
 
 .auth-role-assignment-result {
@@ -226,14 +303,17 @@ code {
 	}
 
 @media (max-width: 640px) {
-	.auth-role-assignment-input--email,
-	.auth-role-assignment-input--user-id,
-	.auth-role-assignment-textarea {
-		width: 100%;
+	.govuk-\!-width-two-thirds,
+	.govuk-\!-width-one-half {
+		width: 100% !important;
 		}
 
-	.auth-role-assignment-review__row {
+	.govuk-summary-list__row {
 		grid-template-columns: 1fr;
+		}
+
+	.govuk-summary-list__actions {
+		text-align: left;
 		}
 	}
 

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -8,76 +8,76 @@ const CONFIG = Object.freeze({
 	API_BASE:
 		document.documentElement?.dataset?.apiOrigin ||
 		window.API_ORIGIN ||
-		(location.hostname.endsWith('pages.dev') ? 'https://rops-api.digikev-kevin-rapley.workers.dev' : location.origin),
+		(location.hostname.endsWith("pages.dev") ? "https://rops-api.digikev-kevin-rapley.workers.dev" : location.origin),
 	FETCH_TIMEOUT_MS: 12000,
-	CACHE: 'no-store',
+	CACHE: "no-store",
 });
 
 const ROLE_DETAILS = Object.freeze({
 	observer: {
-		label: 'Observer',
-		description: 'Can observe low-risk research context without participant personal data reveal.',
+		label: "Observer",
+		description: "Can observe low-risk research context without participant personal data reveal.",
 		sensitive: false,
 		permissions: [],
 	},
 	researcher: {
-		label: 'Researcher',
-		description: 'Can create and edit governed research records.',
+		label: "Researcher",
+		description: "Can create and edit governed research records.",
 		sensitive: false,
-		permissions: ['governed.create', 'governed.edit'],
+		permissions: ["governed.create", "governed.edit"],
 	},
 	research_lead: {
-		label: 'Research Lead',
-		description: 'Can create, edit and review governed research records.',
+		label: "Research Lead",
+		description: "Can create, edit and review governed research records.",
 		sensitive: true,
-		permissions: ['governed.create', 'governed.edit', 'governed.review'],
+		permissions: ["governed.create", "governed.edit", "governed.review"],
 	},
 	approver: {
-		label: 'Approver',
-		description: 'Can approve governed research records and own accepted recommendations.',
+		label: "Approver",
+		description: "Can approve governed research records and own accepted recommendations.",
 		sensitive: true,
-		permissions: ['governed.review', 'governed.approve', 'recommendation.own'],
+		permissions: ["governed.review", "governed.approve", "recommendation.own"],
 	},
 	safeguarding_lead: {
-		label: 'Safeguarding Lead',
-		description: 'Can view, record, resolve and audit safeguarding concerns.',
+		label: "Safeguarding Lead",
+		description: "Can view, record, resolve and audit safeguarding concerns.",
 		sensitive: true,
 		safeguarding: true,
-		permissions: ['safeguarding.view', 'safeguarding.record', 'safeguarding.resolve', 'safeguarding.audit.view'],
+		permissions: ["safeguarding.view", "safeguarding.record", "safeguarding.resolve", "safeguarding.audit.view"],
 	},
 	team_admin: {
-		label: 'Team Admin',
-		description: 'Can manage team membership, role assignment and general audit oversight.',
+		label: "Team Admin",
+		description: "Can manage team membership, role assignment and general audit oversight.",
 		sensitive: true,
-		permissions: ['team.manage', 'role.assign', 'audit.view'],
+		permissions: ["team.manage", "role.assign", "audit.view"],
 	},
 });
 
 const dom = {
-	context: document.getElementById('auth-context'),
-	form: document.getElementById('role-assignment-form'),
-	errorSummary: document.getElementById('role-assignment-error-summary'),
-	errorList: document.getElementById('role-assignment-error-list'),
-	result: document.getElementById('role-assignment-result'),
-	roleKey: document.getElementById('role-key'),
-	roleSummary: document.getElementById('role-summary'),
-	sensitiveFieldset: document.getElementById('sensitive-role-fieldset'),
-	safeguardingFieldset: document.getElementById('safeguarding-fieldset'),
-	submit: document.getElementById('submit-role-assignment'),
+	context: document.getElementById("auth-context"),
+	form: document.getElementById("role-assignment-form"),
+	errorSummary: document.getElementById("role-assignment-error-summary"),
+	errorList: document.getElementById("role-assignment-error-list"),
+	result: document.getElementById("role-assignment-result"),
+	roleKey: document.getElementById("role-key"),
+	roleSummary: document.getElementById("role-summary"),
+	sensitiveFieldset: document.getElementById("sensitive-role-fieldset"),
+	safeguardingFieldset: document.getElementById("safeguarding-fieldset"),
+	submit: document.getElementById("submit-role-assignment"),
 };
 
 function escapeHtml(value) {
-	return String(value ?? '')
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/\"/g, '&quot;')
-		.replace(/'/g, '&#39;');
+	return String(value ?? "")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/\"/g, "&quot;")
+		.replace(/'/g, "&#39;");
 }
 
 function setBusy(element, isBusy) {
 	if (!element) return;
-	element.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+	element.setAttribute("aria-busy", isBusy ? "true" : "false");
 }
 
 function setDisabled(isDisabled) {
@@ -90,16 +90,16 @@ function endpoint(path) {
 
 async function fetchJson(path, options = {}) {
 	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort('timeout'), CONFIG.FETCH_TIMEOUT_MS);
+	const timer = setTimeout(() => controller.abort("timeout"), CONFIG.FETCH_TIMEOUT_MS);
 
 	try {
 		const response = await fetch(endpoint(path), {
 			cache: CONFIG.CACHE,
-			credentials: 'include',
+			credentials: "include",
 			signal: controller.signal,
 			...options,
 			headers: {
-				accept: 'application/json',
+				accept: "application/json",
 				...(options.headers || {}),
 			},
 		});
@@ -108,7 +108,7 @@ async function fetchJson(path, options = {}) {
 		try {
 			data = text ? JSON.parse(text) : {};
 		} catch {
-			data = { ok: false, error: 'invalid_json_response', message: text };
+			data = { ok: false, error: "invalid_json_response", message: text };
 		}
 		return { ok: response.ok, status: response.status, data };
 	} finally {
@@ -129,15 +129,15 @@ function renderAuthContext(data) {
 	const user = data.user || {};
 	const activeTeam = data.activeTeam || {};
 	const permissions = permissionCodes(data.permissions);
-	const canAssignRoles = permissions.has('role.assign');
+	const canAssignRoles = permissions.has("role.assign");
 	const roles = roleLabels(data.roles || []);
 
-	dom.context.classList.toggle('auth-role-assignment-status__panel--ready', canAssignRoles);
-	dom.context.classList.toggle('auth-role-assignment-status__panel--blocked', !canAssignRoles);
+	dom.context.classList.toggle("auth-role-assignment-status__panel--ready", canAssignRoles);
+	dom.context.classList.toggle("auth-role-assignment-status__panel--blocked", !canAssignRoles);
 	dom.context.innerHTML = `
-<p class="govuk-body"><strong>${escapeHtml(user.displayName || user.email || 'Signed-in user')}</strong></p>
-<p class="govuk-body">Active team: <code>${escapeHtml(activeTeam.id || 'No active team')}</code></p>
-<p class="govuk-body">Current roles: ${roles.length ? escapeHtml(roles.join(', ')) : 'No active roles'}</p>
+<p class="govuk-body"><strong>${escapeHtml(user.displayName || user.email || "Signed-in user")}</strong></p>
+<p class="govuk-body">Active team: <code>${escapeHtml(activeTeam.id || "No active team")}</code></p>
+<p class="govuk-body">Current roles: ${roles.length ? escapeHtml(roles.join(", ")) : "No active roles"}</p>
 ${canAssignRoles ? '<p class="govuk-body">You can assign team roles because you have <code>role.assign</code>.</p>' : '<p class="govuk-body">You cannot assign team roles because <code>role.assign</code> is not available in this team.</p>'}
 `;
 	setDisabled(!canAssignRoles);
@@ -145,7 +145,7 @@ ${canAssignRoles ? '<p class="govuk-body">You can assign team roles because you 
 
 function renderAuthContextError(error) {
 	if (!dom.context) return;
-	dom.context.classList.add('auth-role-assignment-status__panel--blocked');
+	dom.context.classList.add("auth-role-assignment-status__panel--blocked");
 	dom.context.innerHTML = `
 <p class="govuk-body"><strong>Could not confirm your team role access.</strong></p>
 <p class="govuk-body">${escapeHtml(error?.message || error)}</p>
@@ -163,14 +163,14 @@ function renderRoleSummary() {
 
 	if (!detail) {
 		dom.roleSummary.hidden = true;
-		dom.roleSummary.innerHTML = '';
+		dom.roleSummary.innerHTML = "";
 		dom.sensitiveFieldset.hidden = true;
 		dom.safeguardingFieldset.hidden = true;
 		return;
 	}
 
 	const permissions = detail.permissions.length
-		? `<ul class="auth-role-assignment-summary__permissions">${detail.permissions.map((permission) => `<li><code>${escapeHtml(permission)}</code></li>`).join('')}</ul>`
+		? `<ul class="auth-role-assignment-summary__permissions">${detail.permissions.map((permission) => `<li><code>${escapeHtml(permission)}</code></li>`).join("")}</ul>`
 		: '<p class="govuk-body">This role currently has no direct permissions.</p>';
 
 	dom.roleSummary.hidden = false;
@@ -178,23 +178,23 @@ function renderRoleSummary() {
 <h3 class="govuk-heading-s">${escapeHtml(detail.label)}</h3>
 <p class="govuk-body">${escapeHtml(detail.description)}</p>
 ${permissions}
-${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</strong></p>' : ''}
+${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</strong></p>' : ""}
 `;
 	dom.sensitiveFieldset.hidden = !detail.sensitive;
 	dom.safeguardingFieldset.hidden = !detail.safeguarding;
 }
 
 function clearFieldErrors() {
-	document.querySelectorAll('.govuk-form-group--error').forEach((element) => {
-		element.classList.remove('govuk-form-group--error');
+	document.querySelectorAll(".govuk-form-group--error").forEach((element) => {
+		element.classList.remove("govuk-form-group--error");
 	});
-	document.querySelectorAll('.govuk-error-message').forEach((element) => {
+	document.querySelectorAll(".govuk-error-message").forEach((element) => {
 		element.hidden = true;
-		element.textContent = '';
+		element.textContent = "";
 	});
 	if (dom.errorSummary && dom.errorList) {
 		dom.errorSummary.hidden = true;
-		dom.errorList.innerHTML = '';
+		dom.errorList.innerHTML = "";
 	}
 }
 
@@ -206,7 +206,7 @@ function showErrors(errors) {
 	for (const error of errors) {
 		const group = document.getElementById(`${error.field}-group`) || document.getElementById(`${error.field}-fieldset`);
 		const message = document.getElementById(`${error.field}-error`);
-		if (group) group.classList.add('govuk-form-group--error');
+		if (group) group.classList.add("govuk-form-group--error");
 		if (message) {
 			message.hidden = false;
 			message.textContent = `Error: ${error.message}`;
@@ -216,7 +216,7 @@ function showErrors(errors) {
 	if (dom.errorSummary && dom.errorList) {
 		dom.errorList.innerHTML = errors
 			.map((error) => `<li><a href="${escapeHtml(error.href)}">${escapeHtml(error.message)}</a></li>`)
-			.join('');
+			.join("");
 		dom.errorSummary.hidden = false;
 		dom.errorSummary.focus();
 	}
@@ -225,13 +225,13 @@ function showErrors(errors) {
 function formValues() {
 	const data = new FormData(dom.form);
 	return {
-		targetEmail: String(data.get('targetEmail') || '').trim(),
-		targetUserId: String(data.get('targetUserId') || '').trim(),
-		roleKey: String(data.get('roleKey') || '').trim(),
-		requestedReason: String(data.get('requestedReason') || '').trim(),
-		expiresAt: String(data.get('expiresAt') || '').trim(),
-		sensitiveRoleConfirmation: data.get('sensitiveRoleConfirmation') || '',
-		safeguardingConfirmation: data.get('safeguardingConfirmation') || '',
+		targetEmail: String(data.get("targetEmail") || "").trim(),
+		targetUserId: String(data.get("targetUserId") || "").trim(),
+		roleKey: String(data.get("roleKey") || "").trim(),
+		requestedReason: String(data.get("requestedReason") || "").trim(),
+		expiresAt: String(data.get("expiresAt") || "").trim(),
+		sensitiveRoleConfirmation: data.get("sensitiveRoleConfirmation") || "",
+		safeguardingConfirmation: data.get("safeguardingConfirmation") || "",
 	};
 }
 
@@ -240,27 +240,27 @@ function validate(values) {
 	const detail = roleDetail(values.roleKey);
 
 	if (!values.targetEmail && !values.targetUserId) {
-		addError(errors, 'target-email', 'Enter a team member email or user ID.', '#target-email');
+		addError(errors, "target-email", "Enter a team member email or user ID.", "#target-email");
 	}
 
 	if (!values.roleKey) {
-		addError(errors, 'role-key', 'Select a role to assign.', '#role-key');
+		addError(errors, "role-key", "Select a role to assign.", "#role-key");
 	}
 
 	if (values.requestedReason.length < 12) {
-		addError(errors, 'requested-reason', 'Enter a reason of at least 12 characters.', '#requested-reason');
+		addError(errors, "requested-reason", "Enter a reason of at least 12 characters.", "#requested-reason");
 	}
 
 	if (values.expiresAt && Number.isNaN(Date.parse(values.expiresAt))) {
-		addError(errors, 'expires-at', 'Enter a valid expiry date and time.', '#expires-at');
+		addError(errors, "expires-at", "Enter a valid expiry date and time.", "#expires-at");
 	}
 
-	if (detail?.sensitive && values.sensitiveRoleConfirmation !== 'ASSIGN_SENSITIVE_ROLE') {
-		addError(errors, 'sensitive-role', 'Confirm the sensitive role assignment.', '#sensitive-role-confirmation');
+	if (detail?.sensitive && values.sensitiveRoleConfirmation !== "ASSIGN_SENSITIVE_ROLE") {
+		addError(errors, "sensitive-role", "Confirm the sensitive role assignment.", "#sensitive-role-confirmation");
 	}
 
-	if (detail?.safeguarding && values.safeguardingConfirmation !== 'ASSIGN_SAFEGUARDING_LEAD') {
-		addError(errors, 'safeguarding', 'Confirm Safeguarding Lead access is required.', '#safeguarding-confirmation');
+	if (detail?.safeguarding && values.safeguardingConfirmation !== "ASSIGN_SAFEGUARDING_LEAD") {
+		addError(errors, "safeguarding", "Confirm Safeguarding Lead access is required.", "#safeguarding-confirmation");
 	}
 
 	return errors;
@@ -288,7 +288,7 @@ function showResult(data) {
 	const assignment = data.assignment || {};
 
 	dom.result.hidden = false;
-	dom.result.className = 'auth-role-assignment-result auth-role-assignment-result--success';
+	dom.result.className = "auth-role-assignment-result auth-role-assignment-result--success";
 	dom.result.innerHTML = `
 <h2 class="govuk-heading-m">Role assigned</h2>
 <p class="govuk-body"><strong>${escapeHtml(role.label || role.key)}</strong> was assigned to ${escapeHtml(targetUser.displayName || targetUser.email || targetUser.id)}.</p>
@@ -301,11 +301,11 @@ function showResult(data) {
 function showServerError(data, status) {
 	if (!dom.result) return;
 	dom.result.hidden = false;
-	dom.result.className = 'auth-role-assignment-result auth-role-assignment-result--error';
+	dom.result.className = "auth-role-assignment-result auth-role-assignment-result--error";
 	dom.result.innerHTML = `
 <h2 class="govuk-heading-m">Role was not assigned</h2>
 <p class="govuk-body">${escapeHtml(data?.message || `Request failed with status ${status}`)}</p>
-${data?.error ? `<p class="govuk-body">Error code: <code>${escapeHtml(data.error)}</code></p>` : ''}
+${data?.error ? `<p class="govuk-body">Error code: <code>${escapeHtml(data.error)}</code></p>` : ""}
 `;
 }
 
@@ -323,9 +323,9 @@ async function handleSubmit(event) {
 
 	setDisabled(true);
 	try {
-		const response = await fetchJson('/api/auth/role-assignments', {
-			method: 'POST',
-			headers: { 'content-type': 'application/json' },
+		const response = await fetchJson("/api/auth/role-assignments", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
 			body: JSON.stringify(requestBody(values)),
 		});
 
@@ -348,7 +348,7 @@ async function initAuthContext() {
 	if (!dom.context) return;
 	setBusy(dom.context, true);
 	try {
-		const response = await fetchJson('/api/me');
+		const response = await fetchJson("/api/me");
 		if (!response.ok || !response.data?.ok) {
 			throw new Error(response.data?.message || `Could not load /api/me (${response.status})`);
 		}
@@ -362,9 +362,9 @@ async function initAuthContext() {
 
 function init() {
 	if (!dom.form) return;
-	dom.roleKey?.addEventListener('change', renderRoleSummary);
-	dom.form.addEventListener('submit', handleSubmit);
-	dom.form.addEventListener('reset', () => {
+	dom.roleKey?.addEventListener("change", renderRoleSummary);
+	dom.form.addEventListener("submit", handleSubmit);
+	dom.form.addEventListener("reset", () => {
 		window.setTimeout(() => {
 			clearFieldErrors();
 			renderRoleSummary();

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -13,31 +13,26 @@ const CONFIG = Object.freeze({
 const ROLE_DETAILS = Object.freeze({
 	observer: {
 		label: "Observer",
-		description: "Can observe low-risk research context without seeing participant personal data.",
 		sensitive: false,
 		abilities: ["Observe low-risk research context without seeing participant personal data."],
 	},
 	researcher: {
 		label: "Researcher",
-		description: "Can create and update governed research records.",
 		sensitive: false,
 		abilities: ["Create governed research records.", "Update governed research records."],
 	},
 	research_lead: {
 		label: "Research Lead",
-		description: "Can create, update and review governed research records.",
 		sensitive: true,
 		abilities: ["Create governed research records.", "Update governed research records.", "Review governed research records."],
 	},
 	approver: {
 		label: "Approver",
-		description: "Can review and approve governed research records.",
 		sensitive: true,
 		abilities: ["Review governed research records.", "Approve governed research records.", "Own accepted recommendations."],
 	},
 	safeguarding_lead: {
 		label: "Safeguarding Lead",
-		description: "Can view, record, resolve and audit safeguarding concerns.",
 		sensitive: true,
 		safeguarding: true,
 		abilities: [
@@ -49,7 +44,6 @@ const ROLE_DETAILS = Object.freeze({
 	},
 	team_admin: {
 		label: "Team Admin",
-		description: "Can manage team membership, role assignment and general audit oversight.",
 		sensitive: true,
 		abilities: ["Manage team members and team settings.", "Assign roles.", "View general audit events."],
 	},
@@ -203,18 +197,12 @@ function renderRoleSummary() {
 		return;
 	}
 
-	const abilities = detail.abilities.length
+	dom.roleSummary.hidden = false;
+	dom.roleSummary.innerHTML = detail.abilities.length
 		? `<p class="govuk-body">This role can:</p><ul class="govuk-list govuk-list--bullet auth-role-assignment-summary__abilities">${detail.abilities
 				.map((ability) => `<li>${escapeHtml(ability)}</li>`)
 				.join("")}</ul>`
 		: '<p class="govuk-body">This role does not add any direct capabilities.</p>';
-
-	dom.roleSummary.hidden = false;
-	dom.roleSummary.innerHTML = `
-<h3 class="govuk-heading-s">${escapeHtml(detail.label)}</h3>
-${abilities}
-${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</strong></p>' : ""}
-`;
 	dom.sensitiveFieldset.hidden = !detail.sensitive;
 	dom.safeguardingFieldset.hidden = !detail.safeguarding;
 }

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -212,7 +212,6 @@ function renderRoleSummary() {
 	dom.roleSummary.hidden = false;
 	dom.roleSummary.innerHTML = `
 <h3 class="govuk-heading-s">${escapeHtml(detail.label)}</h3>
-<p class="govuk-body">${escapeHtml(detail.description)}</p>
 ${abilities}
 ${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</strong></p>' : ""}
 `;
@@ -223,6 +222,16 @@ ${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</s
 function renderDurationControls() {
 	if (!dom.customExpiryDateGroup) return;
 	dom.customExpiryDateGroup.hidden = selectedDurationPreset() !== "custom";
+}
+
+function makeRadioHintSelectable(event) {
+	const hint = event.target.closest(".auth-role-assignment-radios .govuk-radios__hint");
+	if (!hint) return;
+	const item = hint.closest(".govuk-radios__item");
+	const input = item?.querySelector(".govuk-radios__input");
+	if (!input || input.disabled) return;
+	input.checked = true;
+	input.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
 function clearFieldErrors() {
@@ -520,6 +529,10 @@ function init() {
 	document
 		.querySelectorAll('input[name="durationPreset"]')
 		.forEach((input) => input.addEventListener("change", renderDurationControls));
+	document.querySelectorAll(".auth-role-assignment-radios .govuk-radios__hint").forEach((hint) => {
+		hint.dataset.clicksRadio = "true";
+	});
+	dom.form.addEventListener("click", makeRadioHintSelectable);
 	dom.form.addEventListener("submit", prepareReview);
 	dom.confirm?.addEventListener("click", submitAssignment);
 	dom.change?.addEventListener("click", () => {

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -5,10 +5,7 @@
  */
 
 const CONFIG = Object.freeze({
-	API_BASE:
-		document.documentElement?.dataset?.apiOrigin ||
-		window.API_ORIGIN ||
-		(location.hostname.endsWith("pages.dev") ? "https://rops-api.digikev-kevin-rapley.workers.dev" : location.origin),
+	API_BASE: document.documentElement?.dataset?.apiOrigin || window.API_ORIGIN || "",
 	FETCH_TIMEOUT_MS: 12000,
 	CACHE: "no-store",
 });

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -50,17 +50,36 @@ const ROLE_DETAILS = Object.freeze({
 	},
 });
 
+const DURATION_LABELS = Object.freeze({
+	30: "30 days",
+	60: "60 days",
+	90: "90 days",
+	180: "180 days",
+	custom: "Until a specific date",
+});
+
+const state = {
+	context: null,
+	reviewValues: null,
+	reviewBody: null,
+};
+
 const dom = {
 	context: document.getElementById("auth-context"),
 	form: document.getElementById("role-assignment-form"),
+	formSection: document.getElementById("role-assignment-form-section"),
 	errorSummary: document.getElementById("role-assignment-error-summary"),
 	errorList: document.getElementById("role-assignment-error-list"),
 	result: document.getElementById("role-assignment-result"),
-	roleKey: document.getElementById("role-key"),
 	roleSummary: document.getElementById("role-summary"),
 	sensitiveFieldset: document.getElementById("sensitive-role-fieldset"),
 	safeguardingFieldset: document.getElementById("safeguarding-fieldset"),
+	customExpiryDateGroup: document.getElementById("custom-expiry-date-group"),
 	submit: document.getElementById("submit-role-assignment"),
+	review: document.getElementById("role-assignment-review"),
+	reviewBody: document.getElementById("role-assignment-review-body"),
+	confirm: document.getElementById("confirm-role-assignment"),
+	change: document.getElementById("change-role-assignment"),
 };
 
 function escapeHtml(value) {
@@ -79,6 +98,7 @@ function setBusy(element, isBusy) {
 
 function setDisabled(isDisabled) {
 	if (dom.submit) dom.submit.disabled = isDisabled;
+	if (dom.confirm) dom.confirm.disabled = isDisabled;
 }
 
 function endpoint(path) {
@@ -117,46 +137,58 @@ function permissionCodes(permissions) {
 	return new Set((permissions || []).map((permission) => permission.code).filter(Boolean));
 }
 
-function roleLabels(roles) {
-	return (roles || []).map((role) => role.label || role.key).filter(Boolean);
+function activeTeamLabel(context) {
+	return context?.activeTeam?.name || context?.activeTeam?.id || "No active team";
 }
 
 function renderAuthContext(data) {
 	if (!dom.context) return;
-	const user = data.user || {};
-	const activeTeam = data.activeTeam || {};
+	state.context = data;
 	const permissions = permissionCodes(data.permissions);
 	const canAssignRoles = permissions.has("role.assign");
-	const roles = roleLabels(data.roles || []);
+	const activeTeam = data.activeTeam || {};
 
-	dom.context.classList.toggle("auth-role-assignment-status__panel--ready", canAssignRoles);
-	dom.context.classList.toggle("auth-role-assignment-status__panel--blocked", !canAssignRoles);
-	dom.context.innerHTML = `
-<p class="govuk-body"><strong>${escapeHtml(user.displayName || user.email || "Signed-in user")}</strong></p>
-<p class="govuk-body">Active team: <code>${escapeHtml(activeTeam.id || "No active team")}</code></p>
-<p class="govuk-body">Current roles: ${roles.length ? escapeHtml(roles.join(", ")) : "No active roles"}</p>
-${canAssignRoles ? '<p class="govuk-body">You can assign team roles because you have <code>role.assign</code>.</p>' : '<p class="govuk-body">You cannot assign team roles because <code>role.assign</code> is not available in this team.</p>'}
+	dom.context.classList.toggle("auth-role-assignment-scope__panel--blocked", !canAssignRoles);
+	dom.context.innerHTML = canAssignRoles
+		? `
+<p class="govuk-body">You are assigning roles in <strong>${escapeHtml(activeTeam.name || activeTeam.id || "your active team")}</strong>.</p>
+`
+		: `
+<p class="govuk-body"><strong>You cannot assign roles.</strong></p>
+<p class="govuk-body">You do not have permission to assign roles for ${escapeHtml(activeTeam.name || activeTeam.id || "this team")}.</p>
 `;
 	setDisabled(!canAssignRoles);
+	if (dom.form) dom.form.hidden = !canAssignRoles;
+	if (dom.review) dom.review.hidden = true;
 }
 
 function renderAuthContextError(error) {
 	if (!dom.context) return;
-	dom.context.classList.add("auth-role-assignment-status__panel--blocked");
+	dom.context.classList.add("auth-role-assignment-scope__panel--blocked");
 	dom.context.innerHTML = `
-<p class="govuk-body"><strong>Could not confirm your team role access.</strong></p>
+<p class="govuk-body"><strong>You cannot assign roles.</strong></p>
 <p class="govuk-body">${escapeHtml(error?.message || error)}</p>
 `;
 	setDisabled(true);
+	if (dom.form) dom.form.hidden = true;
+	if (dom.review) dom.review.hidden = true;
 }
 
 function roleDetail(roleKey) {
 	return ROLE_DETAILS[roleKey] || null;
 }
 
+function selectedRoleKey() {
+	return document.querySelector('input[name="roleKey"]:checked')?.value || "";
+}
+
+function selectedDurationPreset() {
+	return document.querySelector('input[name="durationPreset"]:checked')?.value || "";
+}
+
 function renderRoleSummary() {
-	if (!dom.roleKey || !dom.roleSummary || !dom.sensitiveFieldset || !dom.safeguardingFieldset) return;
-	const detail = roleDetail(dom.roleKey.value);
+	if (!dom.roleSummary || !dom.sensitiveFieldset || !dom.safeguardingFieldset) return;
+	const detail = roleDetail(selectedRoleKey());
 
 	if (!detail) {
 		dom.roleSummary.hidden = true;
@@ -181,9 +213,15 @@ ${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</s
 	dom.safeguardingFieldset.hidden = !detail.safeguarding;
 }
 
+function renderDurationControls() {
+	if (!dom.customExpiryDateGroup) return;
+	dom.customExpiryDateGroup.hidden = selectedDurationPreset() !== "custom";
+}
+
 function clearFieldErrors() {
-	document.querySelectorAll(".govuk-form-group--error").forEach((element) => {
+	document.querySelectorAll(".govuk-form-group--error, .govuk-fieldset--error").forEach((element) => {
 		element.classList.remove("govuk-form-group--error");
+		element.classList.remove("govuk-fieldset--error");
 	});
 	document.querySelectorAll(".govuk-error-message").forEach((element) => {
 		element.hidden = true;
@@ -199,11 +237,17 @@ function addError(errors, field, message, href) {
 	errors.push({ field, message, href });
 }
 
+function groupElementFor(field) {
+	return document.getElementById(`${field}-group`) || document.getElementById(`${field}-fieldset`);
+}
+
 function showErrors(errors) {
 	for (const error of errors) {
-		const group = document.getElementById(`${error.field}-group`) || document.getElementById(`${error.field}-fieldset`);
+		const group = groupElementFor(error.field);
 		const message = document.getElementById(`${error.field}-error`);
-		if (group) group.classList.add("govuk-form-group--error");
+		if (group) {
+			group.classList.add(group.tagName === "FIELDSET" ? "govuk-fieldset--error" : "govuk-form-group--error");
+		}
 		if (message) {
 			message.hidden = false;
 			message.textContent = `Error: ${error.message}`;
@@ -224,12 +268,51 @@ function formValues() {
 	return {
 		targetEmail: String(data.get("targetEmail") || "").trim(),
 		targetUserId: String(data.get("targetUserId") || "").trim(),
-		roleKey: String(data.get("roleKey") || "").trim(),
+		roleKey: selectedRoleKey(),
 		requestedReason: String(data.get("requestedReason") || "").trim(),
-		expiresAt: String(data.get("expiresAt") || "").trim(),
+		durationPreset: selectedDurationPreset(),
+		expiryDay: String(data.get("expiryDay") || "").trim(),
+		expiryMonth: String(data.get("expiryMonth") || "").trim(),
+		expiryYear: String(data.get("expiryYear") || "").trim(),
 		sensitiveRoleConfirmation: data.get("sensitiveRoleConfirmation") || "",
 		safeguardingConfirmation: data.get("safeguardingConfirmation") || "",
 	};
+}
+
+function customDateParts(values) {
+	const day = Number(values.expiryDay);
+	const month = Number(values.expiryMonth);
+	const year = Number(values.expiryYear);
+
+	if (!Number.isInteger(day) || !Number.isInteger(month) || !Number.isInteger(year)) return null;
+	const date = new Date(year, month - 1, day, 23, 59, 59, 999);
+	if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+	return date;
+}
+
+function expiresAtFor(values) {
+	if (["30", "60", "90", "180"].includes(values.durationPreset)) {
+		const date = new Date();
+		date.setDate(date.getDate() + Number(values.durationPreset));
+		date.setHours(23, 59, 59, 999);
+		return date;
+	}
+
+	if (values.durationPreset === "custom") {
+		return customDateParts(values);
+	}
+
+	return null;
+}
+
+function expiryLabelFor(values) {
+	const expiry = expiresAtFor(values);
+	if (!expiry) return "Not set";
+	return expiry.toLocaleDateString("en-GB", {
+		day: "numeric",
+		month: "long",
+		year: "numeric",
+	});
 }
 
 function validate(values) {
@@ -237,23 +320,27 @@ function validate(values) {
 	const detail = roleDetail(values.roleKey);
 
 	if (!values.targetEmail && !values.targetUserId) {
-		addError(errors, "target-email", "Enter a team member email or user ID.", "#target-email");
+		addError(errors, "target-email", "Enter a team member’s email address or user ID.", "#target-email");
 	}
 
 	if (!values.roleKey) {
-		addError(errors, "role-key", "Select a role to assign.", "#role-key");
+		addError(errors, "role-key", "Select the role they need.", "#role-key-observer");
+	}
+
+	if (!values.durationPreset) {
+		addError(errors, "role-duration", "Select how long this role should last.", "#duration-30");
+	}
+
+	if (values.durationPreset === "custom" && !customDateParts(values)) {
+		addError(errors, "custom-expiry-date", "Enter a real expiry date.", "#expiry-day");
 	}
 
 	if (values.requestedReason.length < 12) {
-		addError(errors, "requested-reason", "Enter a reason of at least 12 characters.", "#requested-reason");
-	}
-
-	if (values.expiresAt && Number.isNaN(Date.parse(values.expiresAt))) {
-		addError(errors, "expires-at", "Enter a valid expiry date and time.", "#expires-at");
+		addError(errors, "requested-reason", "Enter why you are assigning this role.", "#requested-reason");
 	}
 
 	if (detail?.sensitive && values.sensitiveRoleConfirmation !== "ASSIGN_SENSITIVE_ROLE") {
-		addError(errors, "sensitive-role", "Confirm the sensitive role assignment.", "#sensitive-role-confirmation");
+		addError(errors, "sensitive-role", "Confirm this sensitive role assignment is intentional.", "#sensitive-role-confirmation");
 	}
 
 	if (detail?.safeguarding && values.safeguardingConfirmation !== "ASSIGN_SAFEGUARDING_LEAD") {
@@ -264,6 +351,7 @@ function validate(values) {
 }
 
 function requestBody(values) {
+	const expiry = expiresAtFor(values);
 	const body = {
 		roleKey: values.roleKey,
 		requestedReason: values.requestedReason,
@@ -271,11 +359,54 @@ function requestBody(values) {
 
 	if (values.targetEmail) body.targetEmail = values.targetEmail;
 	if (values.targetUserId) body.targetUserId = values.targetUserId;
-	if (values.expiresAt) body.expiresAt = new Date(values.expiresAt).toISOString();
+	if (expiry) body.expiresAt = expiry.toISOString();
 	if (values.sensitiveRoleConfirmation) body.sensitiveRoleConfirmation = values.sensitiveRoleConfirmation;
 	if (values.safeguardingConfirmation) body.safeguardingConfirmation = values.safeguardingConfirmation;
 
 	return body;
+}
+
+function reviewSummaryRows(values) {
+	const detail = roleDetail(values.roleKey) || {};
+	return [
+		["Team member email", values.targetEmail || "Not provided"],
+		["User ID", values.targetUserId || "Not provided"],
+		["Team", activeTeamLabel(state.context)],
+		["Role", detail.label || values.roleKey],
+		["Access duration", DURATION_LABELS[values.durationPreset] || "Not set"],
+		["Expiry date", expiryLabelFor(values)],
+		["Reason", values.requestedReason],
+	];
+}
+
+function renderReview(values) {
+	if (!dom.review || !dom.reviewBody) return;
+	const rows = reviewSummaryRows(values)
+		.map(
+			([key, value]) => `
+<div class="auth-role-assignment-review__row">
+	<dt>${escapeHtml(key)}</dt>
+	<dd>${escapeHtml(value)}</dd>
+</div>
+`
+		)
+		.join("");
+
+	state.reviewValues = values;
+	state.reviewBody = requestBody(values);
+	dom.reviewBody.innerHTML = `
+<dl class="auth-role-assignment-review__list">
+${rows}
+</dl>
+`;
+	dom.review.hidden = false;
+	dom.review.focus();
+}
+
+function hideReview() {
+	state.reviewValues = null;
+	state.reviewBody = null;
+	if (dom.review) dom.review.hidden = true;
 }
 
 function showResult(data) {
@@ -306,9 +437,10 @@ ${data?.error ? `<p class="govuk-body">Error code: <code>${escapeHtml(data.error
 `;
 }
 
-async function handleSubmit(event) {
+function prepareReview(event) {
 	event.preventDefault();
 	clearFieldErrors();
+	hideReview();
 	if (dom.result) dom.result.hidden = true;
 
 	const values = formValues();
@@ -318,12 +450,18 @@ async function handleSubmit(event) {
 		return;
 	}
 
+	renderReview(values);
+}
+
+async function submitAssignment() {
+	if (!state.reviewBody) return;
+
 	setDisabled(true);
 	try {
 		const response = await fetchJson("/api/auth/role-assignments", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
-			body: JSON.stringify(requestBody(values)),
+			body: JSON.stringify(state.reviewBody),
 		});
 
 		if (!response.ok || !response.data?.ok) {
@@ -334,6 +472,8 @@ async function handleSubmit(event) {
 		showResult(response.data);
 		dom.form.reset();
 		renderRoleSummary();
+		renderDurationControls();
+		hideReview();
 	} catch (error) {
 		showServerError({ message: error?.message || error }, 0);
 	} finally {
@@ -359,16 +499,27 @@ async function initAuthContext() {
 
 function init() {
 	if (!dom.form) return;
-	dom.roleKey?.addEventListener("change", renderRoleSummary);
-	dom.form.addEventListener("submit", handleSubmit);
+	document.querySelectorAll('input[name="roleKey"]').forEach((input) => input.addEventListener("change", renderRoleSummary));
+	document
+		.querySelectorAll('input[name="durationPreset"]')
+		.forEach((input) => input.addEventListener("change", renderDurationControls));
+	dom.form.addEventListener("submit", prepareReview);
+	dom.confirm?.addEventListener("click", submitAssignment);
+	dom.change?.addEventListener("click", () => {
+		hideReview();
+		dom.form.focus?.();
+	});
 	dom.form.addEventListener("reset", () => {
 		window.setTimeout(() => {
 			clearFieldErrors();
 			renderRoleSummary();
+			renderDurationControls();
+			hideReview();
 			if (dom.result) dom.result.hidden = true;
 		}, 0);
 	});
 	renderRoleSummary();
+	renderDurationControls();
 	initAuthContext();
 }
 
@@ -377,6 +528,8 @@ init();
 window.__ropsAuthRoleAssignmentPage = Object.freeze({
 	CONFIG,
 	ROLE_DETAILS,
+	DURATION_LABELS,
 	validate,
 	requestBody,
+	expiresAtFor,
 });

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -1,0 +1,385 @@
+/**
+ * @file public/js/auth-role-assignment-page.js
+ * @module AuthRoleAssignmentPage
+ * @summary Team Admin UI for assigning D1-backed ResearchOps roles.
+ */
+
+const CONFIG = Object.freeze({
+	API_BASE:
+		document.documentElement?.dataset?.apiOrigin ||
+		window.API_ORIGIN ||
+		(location.hostname.endsWith('pages.dev') ? 'https://rops-api.digikev-kevin-rapley.workers.dev' : location.origin),
+	FETCH_TIMEOUT_MS: 12000,
+	CACHE: 'no-store',
+});
+
+const ROLE_DETAILS = Object.freeze({
+	observer: {
+		label: 'Observer',
+		description: 'Can observe low-risk research context without participant personal data reveal.',
+		sensitive: false,
+		permissions: [],
+	},
+	researcher: {
+		label: 'Researcher',
+		description: 'Can create and edit governed research records.',
+		sensitive: false,
+		permissions: ['governed.create', 'governed.edit'],
+	},
+	research_lead: {
+		label: 'Research Lead',
+		description: 'Can create, edit and review governed research records.',
+		sensitive: true,
+		permissions: ['governed.create', 'governed.edit', 'governed.review'],
+	},
+	approver: {
+		label: 'Approver',
+		description: 'Can approve governed research records and own accepted recommendations.',
+		sensitive: true,
+		permissions: ['governed.review', 'governed.approve', 'recommendation.own'],
+	},
+	safeguarding_lead: {
+		label: 'Safeguarding Lead',
+		description: 'Can view, record, resolve and audit safeguarding concerns.',
+		sensitive: true,
+		safeguarding: true,
+		permissions: ['safeguarding.view', 'safeguarding.record', 'safeguarding.resolve', 'safeguarding.audit.view'],
+	},
+	team_admin: {
+		label: 'Team Admin',
+		description: 'Can manage team membership, role assignment and general audit oversight.',
+		sensitive: true,
+		permissions: ['team.manage', 'role.assign', 'audit.view'],
+	},
+});
+
+const dom = {
+	context: document.getElementById('auth-context'),
+	form: document.getElementById('role-assignment-form'),
+	errorSummary: document.getElementById('role-assignment-error-summary'),
+	errorList: document.getElementById('role-assignment-error-list'),
+	result: document.getElementById('role-assignment-result'),
+	roleKey: document.getElementById('role-key'),
+	roleSummary: document.getElementById('role-summary'),
+	sensitiveFieldset: document.getElementById('sensitive-role-fieldset'),
+	safeguardingFieldset: document.getElementById('safeguarding-fieldset'),
+	submit: document.getElementById('submit-role-assignment'),
+};
+
+function escapeHtml(value) {
+	return String(value ?? '')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/\"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
+function setBusy(element, isBusy) {
+	if (!element) return;
+	element.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+}
+
+function setDisabled(isDisabled) {
+	if (dom.submit) dom.submit.disabled = isDisabled;
+}
+
+function endpoint(path) {
+	return `${CONFIG.API_BASE}${path}`;
+}
+
+async function fetchJson(path, options = {}) {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort('timeout'), CONFIG.FETCH_TIMEOUT_MS);
+
+	try {
+		const response = await fetch(endpoint(path), {
+			cache: CONFIG.CACHE,
+			credentials: 'include',
+			signal: controller.signal,
+			...options,
+			headers: {
+				accept: 'application/json',
+				...(options.headers || {}),
+			},
+		});
+		const text = await response.text();
+		let data = {};
+		try {
+			data = text ? JSON.parse(text) : {};
+		} catch {
+			data = { ok: false, error: 'invalid_json_response', message: text };
+		}
+		return { ok: response.ok, status: response.status, data };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function permissionCodes(permissions) {
+	return new Set((permissions || []).map((permission) => permission.code).filter(Boolean));
+}
+
+function roleLabels(roles) {
+	return (roles || []).map((role) => role.label || role.key).filter(Boolean);
+}
+
+function renderAuthContext(data) {
+	if (!dom.context) return;
+	const user = data.user || {};
+	const activeTeam = data.activeTeam || {};
+	const permissions = permissionCodes(data.permissions);
+	const canAssignRoles = permissions.has('role.assign');
+	const roles = roleLabels(data.roles || []);
+
+	dom.context.classList.toggle('auth-role-assignment-status__panel--ready', canAssignRoles);
+	dom.context.classList.toggle('auth-role-assignment-status__panel--blocked', !canAssignRoles);
+	dom.context.innerHTML = `
+<p class="govuk-body"><strong>${escapeHtml(user.displayName || user.email || 'Signed-in user')}</strong></p>
+<p class="govuk-body">Active team: <code>${escapeHtml(activeTeam.id || 'No active team')}</code></p>
+<p class="govuk-body">Current roles: ${roles.length ? escapeHtml(roles.join(', ')) : 'No active roles'}</p>
+${canAssignRoles ? '<p class="govuk-body">You can assign team roles because you have <code>role.assign</code>.</p>' : '<p class="govuk-body">You cannot assign team roles because <code>role.assign</code> is not available in this team.</p>'}
+`;
+	setDisabled(!canAssignRoles);
+}
+
+function renderAuthContextError(error) {
+	if (!dom.context) return;
+	dom.context.classList.add('auth-role-assignment-status__panel--blocked');
+	dom.context.innerHTML = `
+<p class="govuk-body"><strong>Could not confirm your team role access.</strong></p>
+<p class="govuk-body">${escapeHtml(error?.message || error)}</p>
+`;
+	setDisabled(true);
+}
+
+function roleDetail(roleKey) {
+	return ROLE_DETAILS[roleKey] || null;
+}
+
+function renderRoleSummary() {
+	if (!dom.roleKey || !dom.roleSummary || !dom.sensitiveFieldset || !dom.safeguardingFieldset) return;
+	const detail = roleDetail(dom.roleKey.value);
+
+	if (!detail) {
+		dom.roleSummary.hidden = true;
+		dom.roleSummary.innerHTML = '';
+		dom.sensitiveFieldset.hidden = true;
+		dom.safeguardingFieldset.hidden = true;
+		return;
+	}
+
+	const permissions = detail.permissions.length
+		? `<ul class="auth-role-assignment-summary__permissions">${detail.permissions.map((permission) => `<li><code>${escapeHtml(permission)}</code></li>`).join('')}</ul>`
+		: '<p class="govuk-body">This role currently has no direct permissions.</p>';
+
+	dom.roleSummary.hidden = false;
+	dom.roleSummary.innerHTML = `
+<h3 class="govuk-heading-s">${escapeHtml(detail.label)}</h3>
+<p class="govuk-body">${escapeHtml(detail.description)}</p>
+${permissions}
+${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</strong></p>' : ''}
+`;
+	dom.sensitiveFieldset.hidden = !detail.sensitive;
+	dom.safeguardingFieldset.hidden = !detail.safeguarding;
+}
+
+function clearFieldErrors() {
+	document.querySelectorAll('.govuk-form-group--error').forEach((element) => {
+		element.classList.remove('govuk-form-group--error');
+	});
+	document.querySelectorAll('.govuk-error-message').forEach((element) => {
+		element.hidden = true;
+		element.textContent = '';
+	});
+	if (dom.errorSummary && dom.errorList) {
+		dom.errorSummary.hidden = true;
+		dom.errorList.innerHTML = '';
+	}
+}
+
+function addError(errors, field, message, href) {
+	errors.push({ field, message, href });
+}
+
+function showErrors(errors) {
+	for (const error of errors) {
+		const group = document.getElementById(`${error.field}-group`) || document.getElementById(`${error.field}-fieldset`);
+		const message = document.getElementById(`${error.field}-error`);
+		if (group) group.classList.add('govuk-form-group--error');
+		if (message) {
+			message.hidden = false;
+			message.textContent = `Error: ${error.message}`;
+		}
+	}
+
+	if (dom.errorSummary && dom.errorList) {
+		dom.errorList.innerHTML = errors
+			.map((error) => `<li><a href="${escapeHtml(error.href)}">${escapeHtml(error.message)}</a></li>`)
+			.join('');
+		dom.errorSummary.hidden = false;
+		dom.errorSummary.focus();
+	}
+}
+
+function formValues() {
+	const data = new FormData(dom.form);
+	return {
+		targetEmail: String(data.get('targetEmail') || '').trim(),
+		targetUserId: String(data.get('targetUserId') || '').trim(),
+		roleKey: String(data.get('roleKey') || '').trim(),
+		requestedReason: String(data.get('requestedReason') || '').trim(),
+		expiresAt: String(data.get('expiresAt') || '').trim(),
+		sensitiveRoleConfirmation: data.get('sensitiveRoleConfirmation') || '',
+		safeguardingConfirmation: data.get('safeguardingConfirmation') || '',
+	};
+}
+
+function validate(values) {
+	const errors = [];
+	const detail = roleDetail(values.roleKey);
+
+	if (!values.targetEmail && !values.targetUserId) {
+		addError(errors, 'target-email', 'Enter a team member email or user ID.', '#target-email');
+	}
+
+	if (!values.roleKey) {
+		addError(errors, 'role-key', 'Select a role to assign.', '#role-key');
+	}
+
+	if (values.requestedReason.length < 12) {
+		addError(errors, 'requested-reason', 'Enter a reason of at least 12 characters.', '#requested-reason');
+	}
+
+	if (values.expiresAt && Number.isNaN(Date.parse(values.expiresAt))) {
+		addError(errors, 'expires-at', 'Enter a valid expiry date and time.', '#expires-at');
+	}
+
+	if (detail?.sensitive && values.sensitiveRoleConfirmation !== 'ASSIGN_SENSITIVE_ROLE') {
+		addError(errors, 'sensitive-role', 'Confirm the sensitive role assignment.', '#sensitive-role-confirmation');
+	}
+
+	if (detail?.safeguarding && values.safeguardingConfirmation !== 'ASSIGN_SAFEGUARDING_LEAD') {
+		addError(errors, 'safeguarding', 'Confirm Safeguarding Lead access is required.', '#safeguarding-confirmation');
+	}
+
+	return errors;
+}
+
+function requestBody(values) {
+	const body = {
+		roleKey: values.roleKey,
+		requestedReason: values.requestedReason,
+	};
+
+	if (values.targetEmail) body.targetEmail = values.targetEmail;
+	if (values.targetUserId) body.targetUserId = values.targetUserId;
+	if (values.expiresAt) body.expiresAt = new Date(values.expiresAt).toISOString();
+	if (values.sensitiveRoleConfirmation) body.sensitiveRoleConfirmation = values.sensitiveRoleConfirmation;
+	if (values.safeguardingConfirmation) body.safeguardingConfirmation = values.safeguardingConfirmation;
+
+	return body;
+}
+
+function showResult(data) {
+	if (!dom.result) return;
+	const role = data.role || {};
+	const targetUser = data.targetUser || {};
+	const assignment = data.assignment || {};
+
+	dom.result.hidden = false;
+	dom.result.className = 'auth-role-assignment-result auth-role-assignment-result--success';
+	dom.result.innerHTML = `
+<h2 class="govuk-heading-m">Role assigned</h2>
+<p class="govuk-body"><strong>${escapeHtml(role.label || role.key)}</strong> was assigned to ${escapeHtml(targetUser.displayName || targetUser.email || targetUser.id)}.</p>
+<p class="govuk-body">Assignment ID: <code>${escapeHtml(assignment.id)}</code></p>
+<p class="govuk-body">Scope: <code>${escapeHtml(assignment.scopeId)}</code></p>
+`;
+	dom.result.focus?.();
+}
+
+function showServerError(data, status) {
+	if (!dom.result) return;
+	dom.result.hidden = false;
+	dom.result.className = 'auth-role-assignment-result auth-role-assignment-result--error';
+	dom.result.innerHTML = `
+<h2 class="govuk-heading-m">Role was not assigned</h2>
+<p class="govuk-body">${escapeHtml(data?.message || `Request failed with status ${status}`)}</p>
+${data?.error ? `<p class="govuk-body">Error code: <code>${escapeHtml(data.error)}</code></p>` : ''}
+`;
+}
+
+async function handleSubmit(event) {
+	event.preventDefault();
+	clearFieldErrors();
+	if (dom.result) dom.result.hidden = true;
+
+	const values = formValues();
+	const errors = validate(values);
+	if (errors.length) {
+		showErrors(errors);
+		return;
+	}
+
+	setDisabled(true);
+	try {
+		const response = await fetchJson('/api/auth/role-assignments', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(requestBody(values)),
+		});
+
+		if (!response.ok || !response.data?.ok) {
+			showServerError(response.data, response.status);
+			return;
+		}
+
+		showResult(response.data);
+		dom.form.reset();
+		renderRoleSummary();
+	} catch (error) {
+		showServerError({ message: error?.message || error }, 0);
+	} finally {
+		setDisabled(false);
+	}
+}
+
+async function initAuthContext() {
+	if (!dom.context) return;
+	setBusy(dom.context, true);
+	try {
+		const response = await fetchJson('/api/me');
+		if (!response.ok || !response.data?.ok) {
+			throw new Error(response.data?.message || `Could not load /api/me (${response.status})`);
+		}
+		renderAuthContext(response.data);
+	} catch (error) {
+		renderAuthContextError(error);
+	} finally {
+		setBusy(dom.context, false);
+	}
+}
+
+function init() {
+	if (!dom.form) return;
+	dom.roleKey?.addEventListener('change', renderRoleSummary);
+	dom.form.addEventListener('submit', handleSubmit);
+	dom.form.addEventListener('reset', () => {
+		window.setTimeout(() => {
+			clearFieldErrors();
+			renderRoleSummary();
+			if (dom.result) dom.result.hidden = true;
+		}, 0);
+	});
+	renderRoleSummary();
+	initAuthContext();
+}
+
+init();
+
+window.__ropsAuthRoleAssignmentPage = Object.freeze({
+	CONFIG,
+	ROLE_DETAILS,
+	validate,
+	requestBody,
+});

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -13,40 +13,45 @@ const CONFIG = Object.freeze({
 const ROLE_DETAILS = Object.freeze({
 	observer: {
 		label: "Observer",
-		description: "Can observe low-risk research context without participant personal data reveal.",
+		description: "Can observe low-risk research context without seeing participant personal data.",
 		sensitive: false,
-		permissions: [],
+		abilities: ["Observe low-risk research context without seeing participant personal data."],
 	},
 	researcher: {
 		label: "Researcher",
-		description: "Can create and edit governed research records.",
+		description: "Can create and update governed research records.",
 		sensitive: false,
-		permissions: ["governed.create", "governed.edit"],
+		abilities: ["Create governed research records.", "Update governed research records."],
 	},
 	research_lead: {
 		label: "Research Lead",
-		description: "Can create, edit and review governed research records.",
+		description: "Can create, update and review governed research records.",
 		sensitive: true,
-		permissions: ["governed.create", "governed.edit", "governed.review"],
+		abilities: ["Create governed research records.", "Update governed research records.", "Review governed research records."],
 	},
 	approver: {
 		label: "Approver",
-		description: "Can approve governed research records and own accepted recommendations.",
+		description: "Can review and approve governed research records.",
 		sensitive: true,
-		permissions: ["governed.review", "governed.approve", "recommendation.own"],
+		abilities: ["Review governed research records.", "Approve governed research records.", "Own accepted recommendations."],
 	},
 	safeguarding_lead: {
 		label: "Safeguarding Lead",
 		description: "Can view, record, resolve and audit safeguarding concerns.",
 		sensitive: true,
 		safeguarding: true,
-		permissions: ["safeguarding.view", "safeguarding.record", "safeguarding.resolve", "safeguarding.audit.view"],
+		abilities: [
+			"View restricted safeguarding details.",
+			"Record safeguarding observations.",
+			"Resolve safeguarding concerns.",
+			"View safeguarding audit events.",
+		],
 	},
 	team_admin: {
 		label: "Team Admin",
 		description: "Can manage team membership, role assignment and general audit oversight.",
 		sensitive: true,
-		permissions: ["team.manage", "role.assign", "audit.view"],
+		abilities: ["Manage team members and team settings.", "Assign roles.", "View general audit events."],
 	},
 });
 
@@ -198,15 +203,17 @@ function renderRoleSummary() {
 		return;
 	}
 
-	const permissions = detail.permissions.length
-		? `<ul class="auth-role-assignment-summary__permissions">${detail.permissions.map((permission) => `<li><code>${escapeHtml(permission)}</code></li>`).join("")}</ul>`
-		: '<p class="govuk-body">This role currently has no direct permissions.</p>';
+	const abilities = detail.abilities.length
+		? `<p class="govuk-body">This role can:</p><ul class="govuk-list govuk-list--bullet auth-role-assignment-summary__abilities">${detail.abilities
+				.map((ability) => `<li>${escapeHtml(ability)}</li>`)
+				.join("")}</ul>`
+		: '<p class="govuk-body">This role does not add any direct capabilities.</p>';
 
 	dom.roleSummary.hidden = false;
 	dom.roleSummary.innerHTML = `
 <h3 class="govuk-heading-s">${escapeHtml(detail.label)}</h3>
 <p class="govuk-body">${escapeHtml(detail.description)}</p>
-${permissions}
+${abilities}
 ${detail.sensitive ? '<p class="govuk-body"><strong>This is a sensitive role.</strong></p>' : ""}
 `;
 	dom.sensitiveFieldset.hidden = !detail.sensitive;
@@ -320,7 +327,7 @@ function validate(values) {
 	const detail = roleDetail(values.roleKey);
 
 	if (!values.targetEmail && !values.targetUserId) {
-		addError(errors, "target-email", "Enter a team member’s email address or user ID.", "#target-email");
+		addError(errors, "target-email", "Enter a team member's email address or user ID.", "#target-email");
 	}
 
 	if (!values.roleKey) {
@@ -369,24 +376,34 @@ function requestBody(values) {
 function reviewSummaryRows(values) {
 	const detail = roleDetail(values.roleKey) || {};
 	return [
-		["Team member email", values.targetEmail || "Not provided"],
-		["User ID", values.targetUserId || "Not provided"],
-		["Team", activeTeamLabel(state.context)],
-		["Role", detail.label || values.roleKey],
-		["Access duration", DURATION_LABELS[values.durationPreset] || "Not set"],
-		["Expiry date", expiryLabelFor(values)],
-		["Reason", values.requestedReason],
+		["Team member email", values.targetEmail || "Not provided", "#target-email"],
+		["User ID", values.targetUserId || "Not provided", "#target-user-id"],
+		["Team", activeTeamLabel(state.context), ""],
+		["Role", detail.label || values.roleKey, "#role-key-observer"],
+		["Access duration", DURATION_LABELS[values.durationPreset] || "Not set", "#duration-30"],
+		["Expiry date", expiryLabelFor(values), values.durationPreset === "custom" ? "#expiry-day" : "#duration-custom"],
+		["Reason", values.requestedReason, "#requested-reason"],
 	];
+}
+
+function renderSummaryAction(key, href) {
+	if (!href) return '<dd class="govuk-summary-list__actions"></dd>';
+	return `
+<dd class="govuk-summary-list__actions">
+	<a class="govuk-link" href="${escapeHtml(href)}">Change<span class="govuk-visually-hidden"> ${escapeHtml(key.toLowerCase())}</span></a>
+</dd>
+`;
 }
 
 function renderReview(values) {
 	if (!dom.review || !dom.reviewBody) return;
 	const rows = reviewSummaryRows(values)
 		.map(
-			([key, value]) => `
-<div class="auth-role-assignment-review__row">
-	<dt>${escapeHtml(key)}</dt>
-	<dd>${escapeHtml(value)}</dd>
+			([key, value, href]) => `
+<div class="govuk-summary-list__row">
+	<dt class="govuk-summary-list__key">${escapeHtml(key)}</dt>
+	<dd class="govuk-summary-list__value">${escapeHtml(value)}</dd>
+	${renderSummaryAction(key, href)}
 </div>
 `
 		)
@@ -395,7 +412,7 @@ function renderReview(values) {
 	state.reviewValues = values;
 	state.reviewBody = requestBody(values);
 	dom.reviewBody.innerHTML = `
-<dl class="auth-role-assignment-review__list">
+<dl class="govuk-summary-list auth-role-assignment-review__list">
 ${rows}
 </dl>
 `;
@@ -508,15 +525,6 @@ function init() {
 	dom.change?.addEventListener("click", () => {
 		hideReview();
 		dom.form.focus?.();
-	});
-	dom.form.addEventListener("reset", () => {
-		window.setTimeout(() => {
-			clearFieldErrors();
-			renderRoleSummary();
-			renderDurationControls();
-			hideReview();
-			if (dom.result) dom.result.hidden = true;
-		}, 0);
 	});
 	renderRoleSummary();
 	renderDurationControls();

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -16,14 +16,16 @@
 <body>
 	<noscript><a class="govuk-skip-link" href="#main-content">Skip to main content</a></noscript>
 	<x-include src="/partials/header.html" vars='{"active":"Team administration","subtitle":"Manage team role access"}'></x-include>
+	<div class="govuk-width-container">
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/">Home</a></li>
+				<li class="govuk-breadcrumbs__list-item">Team administration</li>
+			</ol>
+		</nav>
+	</div>
 	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 		<div class="govuk-width-container">
-			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-				<ol class="govuk-breadcrumbs__list">
-					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/">Home</a></li>
-					<li class="govuk-breadcrumbs__list-item">Team administration</li>
-				</ol>
-			</nav>
 			<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
 				<h2 class="govuk-error-summary__title">There is a problem</h2>
 				<div class="govuk-error-summary__body"><ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul></div>
@@ -102,7 +104,7 @@
 									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
 										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
 										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>
-										<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
+					اق				<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
 										<div class="govuk-date-input" id="custom-expiry-date">
 											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" /></div></div>
 											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" /></div></div>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -37,12 +37,7 @@
 					<li class="govuk-breadcrumbs__list-item">
 						<a class="govuk-breadcrumbs__link" href="/">Home</a>
 					</li>
-					<li class="govuk-breadcrumbs__list-item">
-						<a class="govuk-breadcrumbs__link" href="/pages/admin/">Team administration</a>
-					</li>
-					<li class="govuk-breadcrumbs__list-item">
-						<a class="govuk-breadcrumbs__link" href="/pages/admin/roles/">Roles</a>
-					</li>
+					<li class="govuk-breadcrumbs__list-item">Team administration</li>
 				</ol>
 			</nav>
 
@@ -174,7 +169,7 @@
 											<div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div>
 										</div>
 
-										<div class="govuk-radios__item">
+					אַ				<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" />
 											<label class="govuk-label govuk-radios__label" for="duration-90">90 days</label>
 											<div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div>
@@ -184,7 +179,7 @@
 											<input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" />
 											<label class="govuk-label govuk-radios__label" for="duration-180">180 days</label>
 											<div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div>
-					اق					</div>
+										</div>
 
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" />

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-frontend-v6.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/auth-role-assignments.css" media="screen" />
 	<script type="module" src="/components/layout.js" defer></script>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -89,12 +89,30 @@
 									<div class="govuk-hint" id="role-key-hint">Start with the lowest role that gives the person what they need.</div>
 									<p class="govuk-error-message" id="role-key-error" hidden></p>
 									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-key-hint">
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" /><label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label><div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without seeing participant personal data.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" /><label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label><div class="govuk-hint govuk-radios__hint">Can create and update governed research records.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" /><label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label><div class="govuk-hint govuk-radios__hint">Can create, update and review governed research records.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" /><label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label><div class="govuk-hint govuk-radios__hint">Can review and approve governed research records.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" /><label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead</label><div class="govuk-hint govuk-radios__hint">Can view, record, resolve and audit safeguarding concerns.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" /><label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label><div class="govuk-hint govuk-radios__hint">Can manage team membership, role assignment and general audit oversight.</div></div>
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" />
+											<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label>
+										</div>
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" />
+											<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label>
+										</div>
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" />
+											<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label>
+										</div>
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" />
+											<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label>
+										</div>
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" />
+											<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead</label>
+										</div>
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" />
+											<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label>
+										</div>
 									</div>
 								</fieldset>
 								<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -58,7 +58,6 @@
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
 						<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
-
 						<form id="role-assignment-form" novalidate>
 							<section class="auth-role-assignment-section" aria-labelledby="team-member-section-title">
 								<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
@@ -68,7 +67,6 @@
 									<p class="govuk-error-message" id="target-email-error" hidden></p>
 									<input class="govuk-input govuk-!-width-two-thirds" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
 								</div>
-
 								<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
 									<summary class="govuk-details__summary"><span class="govuk-details__summary-text">Use a user ID instead</span></summary>
 									<div class="govuk-details__text">
@@ -138,7 +136,7 @@
 										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" /><label class="govuk-label govuk-radios__label" for="duration-custom">Until a specific date</label><div class="govuk-hint govuk-radios__hint">Use for contractors, secondments or known assignment end dates.</div></div>
 									</div>
 								</fieldset>
-					עט				<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
+								<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
 									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
 										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
 										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -1,11 +1,9 @@
 <!doctype html>
 <html lang="en">
-
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Assign a role to a team member - ResearchOps Demo Suite</title>
-
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
@@ -13,41 +11,23 @@
 	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 	<link rel="stylesheet" href="/css/screen.css" media="screen" />
 	<link rel="stylesheet" href="/css/auth-role-assignments.css" media="screen" />
-
 	<script type="module" src="/components/layout.js" defer></script>
 </head>
-
 <body>
-	<noscript>
-		<a class="govuk-skip-link" href="#main-content">Skip to main content</a>
-	</noscript>
-
-	<x-include
-		src="/partials/header.html"
-		vars='{
-			"active":"Team administration",
-			"subtitle":"Manage team role access"
-		}'>
-	</x-include>
-
+	<noscript><a class="govuk-skip-link" href="#main-content">Skip to main content</a></noscript>
+	<x-include src="/partials/header.html" vars='{"active":"Team administration","subtitle":"Manage team role access"}'></x-include>
 	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 		<div class="govuk-width-container">
 			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
 				<ol class="govuk-breadcrumbs__list">
-					<li class="govuk-breadcrumbs__list-item">
-						<a class="govuk-breadcrumbs__link" href="/">Home</a>
-					</li>
+					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/">Home</a></li>
 					<li class="govuk-breadcrumbs__list-item">Team administration</li>
 				</ol>
 			</nav>
-
 			<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
 				<h2 class="govuk-error-summary__title">There is a problem</h2>
-				<div class="govuk-error-summary__body">
-					<ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul>
-				</div>
+				<div class="govuk-error-summary__body"><ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul></div>
 			</div>
-
 			<header class="page-intro auth-role-assignment-page__header">
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
@@ -58,37 +38,27 @@
 					</div>
 				</div>
 			</header>
-
 			<section class="auth-role-assignment-scope" aria-labelledby="team-scope-title">
 				<h2 class="govuk-heading-m" id="team-scope-title">Team scope</h2>
-				<div id="auth-context" class="auth-role-assignment-scope__panel" aria-live="polite" aria-busy="true">
-					<p class="govuk-body">Checking which team you can manage.</p>
-				</div>
+				<div id="auth-context" class="auth-role-assignment-scope__panel" aria-live="polite" aria-busy="true"><p class="govuk-body">Checking which team you can manage.</p></div>
 			</section>
-
 			<section aria-labelledby="assign-role-form-title" id="role-assignment-form-section">
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
 						<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
-
 						<form id="role-assignment-form" novalidate>
 							<section class="auth-role-assignment-section" aria-labelledby="team-member-section-title">
 								<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
-
 								<div class="govuk-form-group" id="target-email-group">
 									<label class="govuk-label govuk-label--s" for="target-email">Team member's email address</label>
 									<div class="govuk-hint" id="target-email-hint">Use the email address they use to sign in.</div>
 									<p class="govuk-error-message" id="target-email-error" hidden></p>
 									<input class="govuk-input govuk-!-width-two-thirds" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
 								</div>
-
 								<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
-									<summary class="govuk-details__summary">
-										<span class="govuk-details__summary-text">Use a user ID instead</span>
-									</summary>
+									<summary class="govuk-details__summary"><span class="govuk-details__summary-text">Use a user ID instead</span></summary>
 									<div class="govuk-details__text">
 										<p class="govuk-body">Only use this if you copied the user ID from ResearchOps. If you enter both an email address and a user ID, they must belong to the same person.</p>
-
 										<div class="govuk-form-group" id="target-user-id-group">
 											<label class="govuk-label" for="target-user-id">User ID</label>
 											<p class="govuk-error-message" id="target-user-id-error" hidden></p>
@@ -97,133 +67,52 @@
 									</div>
 								</details>
 							</section>
-
 							<section class="auth-role-assignment-section" aria-labelledby="role-section-title">
 								<h3 class="govuk-heading-m" id="role-section-title">2. Role</h3>
-
 								<fieldset class="govuk-fieldset" id="role-key-group">
 									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What role do they need?</legend>
 									<div class="govuk-hint" id="role-key-hint">Start with the lowest role that gives the person what they need.</div>
 									<p class="govuk-error-message" id="role-key-error" hidden></p>
-
 									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-key-hint">
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" />
-											<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label>
-											<div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without seeing participant personal data.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" />
-											<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label>
-											<div class="govuk-hint govuk-radios__hint">Can create and update governed research records.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" />
-											<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label>
-											<div class="govuk-hint govuk-radios__hint">Can create, update and review governed research records.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" />
-											<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label>
-											<div class="govuk-hint govuk-radios__hint">Can review and approve governed research records.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" />
-											<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead</label>
-											<div class="govuk-hint govuk-radios__hint">Can view, record, resolve and audit safeguarding concerns.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" />
-											<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label>
-											<div class="govuk-hint govuk-radios__hint">Can manage team membership, role assignment and general audit oversight.</div>
-										</div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" /><label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label><div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without seeing participant personal data.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" /><label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label><div class="govuk-hint govuk-radios__hint">Can create and update governed research records.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" /><label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label><div class="govuk-hint govuk-radios__hint">Can create, update and review governed research records.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" /><label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label><div class="govuk-hint govuk-radios__hint">Can review and approve governed research records.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" /><label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead</label><div class="govuk-hint govuk-radios__hint">Can view, record, resolve and audit safeguarding concerns.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" /><label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label><div class="govuk-hint govuk-radios__hint">Can manage team membership, role assignment and general audit oversight.</div></div>
 									</div>
 								</fieldset>
-
 								<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
 							</section>
-
 							<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
 								<h3 class="govuk-heading-m" id="duration-section-title">3. Access duration</h3>
-
 								<fieldset class="govuk-fieldset" id="role-duration-group">
 									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">How long should this role last?</legend>
 									<div class="govuk-hint" id="role-duration-hint">Choose a governed access period. The standard maximum is 180 days.</div>
 									<p class="govuk-error-message" id="role-duration-error" hidden></p>
-
 									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-duration-hint">
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="duration-30" name="durationPreset" type="radio" value="30" />
-											<label class="govuk-label govuk-radios__label" for="duration-30">30 days</label>
-											<div class="govuk-hint govuk-radios__hint">Use for short support tasks or temporary cover.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="duration-60" name="durationPreset" type="radio" value="60" />
-											<label class="govuk-label govuk-radios__label" for="duration-60">60 days</label>
-											<div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" />
-											<label class="govuk-label govuk-radios__label" for="duration-90">90 days</label>
-											<div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" />
-											<label class="govuk-label govuk-radios__label" for="duration-180">180 days</label>
-											<div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div>
-										</div>
-
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" />
-											<label class="govuk-label govuk-radios__label" for="duration-custom">Until a specific date</label>
-											<div class="govuk-hint govuk-radios__hint">Use for contractors, secondments or known assignment end dates.</div>
-										</div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-30" name="durationPreset" type="radio" value="30" /><label class="govuk-label govuk-radios__label" for="duration-30">30 days</label><div class="govuk-hint govuk-radios__hint">Use for short support tasks or temporary cover.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-60" name="durationPreset" type="radio" value="60" /><label class="govuk-label govuk-radios__label" for="duration-60">60 days</label><div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" /><label class="govuk-label govuk-radios__label" for="duration-90">90 days</label><div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" /><label class="govuk-label govuk-radios__label" for="duration-180">180 days</label><div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" /><label class="govuk-label govuk-radios__label" for="duration-custom">Until a specific date</label><div class="govuk-hint govuk-radios__hint">Use for contractors, secondments or known assignment end dates.</div></div>
 									</div>
 								</fieldset>
-
 								<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
 									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
 										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
 										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>
 										<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
-
 										<div class="govuk-date-input" id="custom-expiry-date">
-											<div class="govuk-date-input__item">
-												<div class="govuk-form-group">
-													<label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label>
-													<input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" />
-												</div>
-											</div>
-
-											<div class="govuk-date-input__item">
-												<div class="govuk-form-group">
-													<label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label>
-													<input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" />
-												</div>
-											</div>
-
-											<div class="govuk-date-input__item">
-												<div class="govuk-form-group">
-													<label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label>
-					答							<input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" />
-												</div>
-											</div>
+											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" /></div></div>
+											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" /></div></div>
+											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label><input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" /></div></div>
 										</div>
 									</fieldset>
 								</div>
 							</section>
-
 							<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
 								<h3 class="govuk-heading-m" id="reason-section-title">4. Reason</h3>
-
 								<div class="govuk-form-group" id="requested-reason-group">
 									<label class="govuk-label govuk-label--s" for="requested-reason">Why are you assigning this role?</label>
 									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, "Joining the research team for the May assisted digital study".</div>
@@ -231,73 +120,37 @@
 									<textarea class="govuk-textarea govuk-!-width-two-thirds" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
 								</div>
 							</section>
-
 							<div class="govuk-form-group auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
 								<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
 									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
-									<div class="govuk-warning-text" id="sensitive-role-hint">
-										<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-										<strong class="govuk-warning-text__text">
-											<span class="govuk-warning-text__assistive">Warning</span>
-											This role gives access to sensitive records or administrative controls.
-										</strong>
-									</div>
+									<div class="govuk-warning-text" id="sensitive-role-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>This role gives access to sensitive records or administrative controls.</strong></div>
 									<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
-									<div class="govuk-checkboxes" data-module="govuk-checkboxes">
-										<div class="govuk-checkboxes__item">
-											<input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" />
-											<label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label>
-										</div>
-									</div>
+									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" /><label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label></div></div>
 								</fieldset>
 							</div>
-
 							<div class="govuk-form-group auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
 								<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
 									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
-									<div class="govuk-warning-text" id="safeguarding-hint">
-										<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-										<strong class="govuk-warning-text__text">
-											<span class="govuk-warning-text__assistive">Warning</span>
-											Safeguarding Lead can view restricted safeguarding details and close safeguarding concerns.
-										</strong>
-									</div>
+									<div class="govuk-warning-text" id="safeguarding-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Safeguarding Lead can view restricted safeguarding details and close safeguarding concerns.</strong></div>
 									<p class="govuk-error-message" id="safeguarding-error" hidden></p>
-									<div class="govuk-checkboxes" data-module="govuk-checkboxes">
-										<div class="govuk-checkboxes__item">
-											<input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" />
-											<label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm this person needs Safeguarding Lead access.</label>
-										</div>
-									</div>
+									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" /><label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm this person needs Safeguarding Lead access.</label></div></div>
 								</fieldset>
 							</div>
-
-							<div class="govuk-button-group">
-								<button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button>
-							</div>
+							<div class="govuk-button-group"><button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button></div>
 						</form>
-
 						<section id="role-assignment-review" class="auth-role-assignment-review" aria-labelledby="role-assignment-review-title" tabindex="-1" hidden>
 							<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
 							<p class="govuk-body">The system will confirm the person exists and is an active member of this team when you assign the role.</p>
 							<div id="role-assignment-review-body"></div>
-							<div class="govuk-button-group">
-								<button class="govuk-button" type="button" id="confirm-role-assignment">Confirm and assign role</button>
-								<button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">Change details</button>
-							</div>
+							<div class="govuk-button-group"><button class="govuk-button" type="button" id="confirm-role-assignment">Confirm and assign role</button><button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">Change details</button></div>
 						</section>
-
 						<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
 					</div>
 				</div>
 			</section>
 		</div>
 	</main>
-
-	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'>
-	</x-include>
-
+	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
 	<script type="module" src="/js/auth-role-assignment-page.js"></script>
 </body>
-
 </html>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Assign a role to a team member — ResearchOps Demo Suite</title>
+	<title>Assign a role to a team member - ResearchOps Demo Suite</title>
 
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
@@ -76,7 +76,7 @@
 								<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
 
 								<div class="govuk-form-group" id="target-email-group">
-									<label class="govuk-label govuk-label--s" for="target-email">Team member’s email address</label>
+									<label class="govuk-label govuk-label--s" for="target-email">Team member's email address</label>
 									<div class="govuk-hint" id="target-email-hint">Use the email address they use to sign in.</div>
 									<p class="govuk-error-message" id="target-email-error" hidden></p>
 									<input class="govuk-input govuk-!-width-two-thirds" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
@@ -169,7 +169,7 @@
 											<div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div>
 										</div>
 
-					אַ				<div class="govuk-radios__item">
+										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" />
 											<label class="govuk-label govuk-radios__label" for="duration-90">90 days</label>
 											<div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div>
@@ -213,7 +213,7 @@
 											<div class="govuk-date-input__item">
 												<div class="govuk-form-group">
 													<label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label>
-													<input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" />
+					答							<input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" />
 												</div>
 											</div>
 										</div>
@@ -226,7 +226,7 @@
 
 								<div class="govuk-form-group" id="requested-reason-group">
 									<label class="govuk-label govuk-label--s" for="requested-reason">Why are you assigning this role?</label>
-									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, “Joining the research team for the May assisted digital study”.</div>
+									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, "Joining the research team for the May assisted digital study".</div>
 									<p class="govuk-error-message" id="requested-reason-error" hidden></p>
 									<textarea class="govuk-textarea govuk-!-width-two-thirds" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
 								</div>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -25,14 +25,26 @@
 	<x-include
 		src="/partials/header.html"
 		vars='{
-			"active":"Projects",
+			"active":"Team administration",
 			"subtitle":"Manage team role access"
 		}'>
 	</x-include>
 
 	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 		<div class="govuk-width-container">
-			<a class="govuk-back-link" href="/pages/projects/">Back to projects</a>
+			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+				<ol class="govuk-breadcrumbs__list">
+					<li class="govuk-breadcrumbs__list-item">
+						<a class="govuk-breadcrumbs__link" href="/">Home</a>
+					</li>
+					<li class="govuk-breadcrumbs__list-item">
+						<a class="govuk-breadcrumbs__link" href="/pages/admin/">Team administration</a>
+					</li>
+					<li class="govuk-breadcrumbs__list-item">
+						<a class="govuk-breadcrumbs__link" href="/pages/admin/roles/">Roles</a>
+					</li>
+				</ol>
+			</nav>
 
 			<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
 				<h2 class="govuk-error-summary__title">There is a problem</h2>
@@ -72,19 +84,20 @@
 									<label class="govuk-label govuk-label--s" for="target-email">Team member’s email address</label>
 									<div class="govuk-hint" id="target-email-hint">Use the email address they use to sign in.</div>
 									<p class="govuk-error-message" id="target-email-error" hidden></p>
-									<input class="govuk-input auth-role-assignment-input auth-role-assignment-input--email" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
+									<input class="govuk-input govuk-!-width-two-thirds" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
 								</div>
 
 								<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
-									<summary class="govuk-details__summary">Use a user ID instead</summary>
+									<summary class="govuk-details__summary">
+										<span class="govuk-details__summary-text">Use a user ID instead</span>
+									</summary>
 									<div class="govuk-details__text">
 										<p class="govuk-body">Only use this if you copied the user ID from ResearchOps. If you enter both an email address and a user ID, they must belong to the same person.</p>
 
 										<div class="govuk-form-group" id="target-user-id-group">
 											<label class="govuk-label" for="target-user-id">User ID</label>
-											<div class="govuk-hint" id="target-user-id-hint">For example, <code>usr_bootstrap_...</code></div>
 											<p class="govuk-error-message" id="target-user-id-error" hidden></p>
-											<input class="govuk-input auth-role-assignment-input auth-role-assignment-input--user-id" id="target-user-id" name="targetUserId" type="text" aria-describedby="target-user-id-hint" />
+											<input class="govuk-input govuk-!-width-one-half" id="target-user-id" name="targetUserId" type="text" />
 										</div>
 									</div>
 								</details>
@@ -98,23 +111,23 @@
 									<div class="govuk-hint" id="role-key-hint">Start with the lowest role that gives the person what they need.</div>
 									<p class="govuk-error-message" id="role-key-error" hidden></p>
 
-									<div class="govuk-radios auth-role-assignment-radios" aria-describedby="role-key-hint">
+									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-key-hint">
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" />
 											<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label>
-											<div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without participant personal data reveal.</div>
+											<div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without seeing participant personal data.</div>
 										</div>
 
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" />
 											<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label>
-											<div class="govuk-hint govuk-radios__hint">Can create and edit governed research records.</div>
+											<div class="govuk-hint govuk-radios__hint">Can create and update governed research records.</div>
 										</div>
 
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" />
 											<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label>
-											<div class="govuk-hint govuk-radios__hint">Can create, edit and review governed research records.</div>
+											<div class="govuk-hint govuk-radios__hint">Can create, update and review governed research records.</div>
 										</div>
 
 										<div class="govuk-radios__item">
@@ -148,7 +161,7 @@
 									<div class="govuk-hint" id="role-duration-hint">Choose a governed access period. The standard maximum is 180 days.</div>
 									<p class="govuk-error-message" id="role-duration-error" hidden></p>
 
-									<div class="govuk-radios auth-role-assignment-radios" aria-describedby="role-duration-hint">
+									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-duration-hint">
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="duration-30" name="durationPreset" type="radio" value="30" />
 											<label class="govuk-label govuk-radios__label" for="duration-30">30 days</label>
@@ -171,7 +184,7 @@
 											<input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" />
 											<label class="govuk-label govuk-radios__label" for="duration-180">180 days</label>
 											<div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div>
-										</div>
+					اق					</div>
 
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" />
@@ -220,36 +233,52 @@
 									<label class="govuk-label govuk-label--s" for="requested-reason">Why are you assigning this role?</label>
 									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, “Joining the research team for the May assisted digital study”.</div>
 									<p class="govuk-error-message" id="requested-reason-error" hidden></p>
-									<textarea class="govuk-textarea auth-role-assignment-textarea" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
+									<textarea class="govuk-textarea govuk-!-width-two-thirds" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
 								</div>
 							</section>
 
-							<fieldset class="govuk-fieldset auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
-								<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
-								<div class="auth-role-assignment-warning" role="note">
-									<strong>Warning</strong>
-									<p class="govuk-body">This role gives access to sensitive records or administrative controls.</p>
-								</div>
-								<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
-								<div class="govuk-checkboxes__item">
-									<input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" />
-									<label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label>
-								</div>
-							</fieldset>
+							<div class="govuk-form-group auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
+								<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
+									<div class="govuk-warning-text" id="sensitive-role-hint">
+										<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+										<strong class="govuk-warning-text__text">
+											<span class="govuk-warning-text__assistive">Warning</span>
+											This role gives access to sensitive records or administrative controls.
+										</strong>
+									</div>
+									<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
+									<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+										<div class="govuk-checkboxes__item">
+											<input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" />
+											<label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label>
+										</div>
+									</div>
+								</fieldset>
+							</div>
 
-							<fieldset class="govuk-fieldset auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
-								<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
-								<div class="govuk-hint">Safeguarding Lead can view, record, resolve and audit safeguarding concerns.</div>
-								<p class="govuk-error-message" id="safeguarding-error" hidden></p>
-								<div class="govuk-checkboxes__item">
-									<input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" />
-									<label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm Safeguarding Lead access is required.</label>
-								</div>
-							</fieldset>
+							<div class="govuk-form-group auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
+								<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
+									<div class="govuk-warning-text" id="safeguarding-hint">
+										<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+										<strong class="govuk-warning-text__text">
+											<span class="govuk-warning-text__assistive">Warning</span>
+											Safeguarding Lead can view restricted safeguarding details and close safeguarding concerns.
+										</strong>
+									</div>
+									<p class="govuk-error-message" id="safeguarding-error" hidden></p>
+									<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+										<div class="govuk-checkboxes__item">
+											<input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" />
+											<label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm this person needs Safeguarding Lead access.</label>
+										</div>
+									</div>
+								</fieldset>
+							</div>
 
 							<div class="govuk-button-group">
 								<button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button>
-								<button class="govuk-button govuk-button--secondary" type="reset">Clear form</button>
 							</div>
 						</form>
 

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -115,4 +115,89 @@
 											<div class="govuk-hint govuk-radios__hint">Can view, record, resolve and audit safeguarding concerns.</div>
 										</div>
 										<div class="govuk-radios__item">
-					あと?}}        ...  
+											<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" />
+											<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label>
+											<div class="govuk-hint govuk-radios__hint">Can manage team membership, role assignment and general audit oversight.</div>
+										</div>
+									</div>
+								</fieldset>
+								<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
+							</section>
+
+							<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
+								<h3 class="govuk-heading-m" id="duration-section-title">3. Access duration</h3>
+								<fieldset class="govuk-fieldset" id="role-duration-group">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">How long should this role last?</legend>
+									<div class="govuk-hint" id="role-duration-hint">Choose a governed access period. The standard maximum is 180 days.</div>
+									<p class="govuk-error-message" id="role-duration-error" hidden></p>
+									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-duration-hint">
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-30" name="durationPreset" type="radio" value="30" /><label class="govuk-label govuk-radios__label" for="duration-30">30 days</label><div class="govuk-hint govuk-radios__hint">Use for short support tasks or temporary cover.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-60" name="durationPreset" type="radio" value="60" /><label class="govuk-label govuk-radios__label" for="duration-60">60 days</label><div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" /><label class="govuk-label govuk-radios__label" for="duration-90">90 days</label><div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" /><label class="govuk-label govuk-radios__label" for="duration-180">180 days</label><div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div></div>
+										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" /><label class="govuk-label govuk-radios__label" for="duration-custom">Until a specific date</label><div class="govuk-hint govuk-radios__hint">Use for contractors, secondments or known assignment end dates.</div></div>
+									</div>
+								</fieldset>
+					עט				<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
+									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
+										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
+										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>
+										<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
+										<div class="govuk-date-input" id="custom-expiry-date">
+											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" /></div></div>
+											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" /></div></div>
+											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label><input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" /></div></div>
+										</div>
+									</fieldset>
+								</div>
+							</section>
+
+							<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
+								<h3 class="govuk-heading-m" id="reason-section-title">4. Reason</h3>
+								<div class="govuk-form-group" id="requested-reason-group">
+									<label class="govuk-label govuk-label--s" for="requested-reason">Why are you assigning this role?</label>
+									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, "Joining the research team for the May assisted digital study".</div>
+									<p class="govuk-error-message" id="requested-reason-error" hidden></p>
+									<textarea class="govuk-textarea govuk-!-width-two-thirds" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
+								</div>
+							</section>
+
+							<div class="govuk-form-group auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
+								<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
+									<div class="govuk-warning-text" id="sensitive-role-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>This role gives access to sensitive records or administrative controls.</strong></div>
+									<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
+									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" /><label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label></div></div>
+								</fieldset>
+							</div>
+
+							<div class="govuk-form-group auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
+								<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
+									<div class="govuk-warning-text" id="safeguarding-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Safeguarding Lead can view restricted safeguarding details and close safeguarding concerns.</strong></div>
+									<p class="govuk-error-message" id="safeguarding-error" hidden></p>
+									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" /><label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm this person needs Safeguarding Lead access.</label></div></div>
+								</fieldset>
+							</div>
+
+							<div class="govuk-button-group"><button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button></div>
+						</form>
+
+						<section id="role-assignment-review" class="auth-role-assignment-review" aria-labelledby="role-assignment-review-title" tabindex="-1" hidden>
+							<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
+							<p class="govuk-body">The system will confirm the person exists and is an active member of this team when you assign the role.</p>
+							<div id="role-assignment-review-body"></div>
+							<div class="govuk-button-group"><button class="govuk-button" type="button" id="confirm-role-assignment">Confirm and assign role</button><button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">Change details</button></div>
+						</section>
+
+						<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
+					</div>
+				</div>
+			</section>
+		</div>
+	</main>
+
+	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
+	<script type="module" src="/js/auth-role-assignment-page.js"></script>
+</body>
+</html>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Assign team roles — ResearchOps Demo Suite</title>
+
+	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<link rel="stylesheet" href="/css/auth-role-assignments.css" media="screen" />
+
+	<script type="module" src="/components/layout.js" defer></script>
+</head>
+
+<body>
+	<noscript>
+		<a class="govuk-skip-link" href="#main-content">Skip to main content</a>
+	</noscript>
+
+	<x-include
+		src="/partials/header.html"
+		vars='{
+			"active":"Projects",
+			"subtitle":"Manage team role access"
+		}'>
+	</x-include>
+
+	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+		<div class="govuk-width-container">
+			<a class="govuk-back-link" href="/pages/projects/">Back to projects</a>
+
+			<header class="page-intro auth-role-assignment-page__header">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<span class="govuk-caption-l">Team administration</span>
+						<h1 class="govuk-heading-xl" id="role-assignment-title">Assign team roles</h1>
+						<p class="lede">Give an existing team member a role within your active ResearchOps team.</p>
+						<p class="govuk-body">The user must already exist and be an active member of your team. Sensitive roles need explicit confirmation before they can be assigned.</p>
+					</div>
+				</div>
+			</header>
+
+			<section class="auth-role-assignment-status" aria-labelledby="signed-in-status-title">
+				<h2 class="govuk-heading-m" id="signed-in-status-title">Your current access</h2>
+				<div id="auth-context" class="auth-role-assignment-status__panel" aria-live="polite" aria-busy="true">
+					<p class="govuk-body">Checking your team role access.</p>
+				</div>
+			</section>
+
+			<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
+				<h2 class="govuk-error-summary__title">There is a problem</h2>
+				<div class="govuk-error-summary__body">
+					<ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul>
+				</div>
+			</div>
+
+			<section aria-labelledby="assign-role-form-title">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
+
+						<form id="role-assignment-form" novalidate>
+							<div class="govuk-form-group" id="target-email-group">
+								<label class="govuk-label govuk-label--s" for="target-email">Team member email</label>
+								<div class="govuk-hint" id="target-email-hint">Use the email address linked to the member's Cloudflare Access sign-in.</div>
+								<p class="govuk-error-message" id="target-email-error" hidden></p>
+								<input class="govuk-input" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
+							</div>
+
+							<div class="govuk-form-group" id="target-user-id-group">
+								<label class="govuk-label" for="target-user-id">User ID, if known</label>
+								<div class="govuk-hint" id="target-user-id-hint">Optional. If you provide both email and user ID, they must resolve to the same user.</div>
+								<p class="govuk-error-message" id="target-user-id-error" hidden></p>
+								<input class="govuk-input" id="target-user-id" name="targetUserId" type="text" aria-describedby="target-user-id-hint" />
+							</div>
+
+							<div class="govuk-form-group" id="role-key-group">
+								<label class="govuk-label govuk-label--s" for="role-key">Role to assign</label>
+								<div class="govuk-hint" id="role-key-hint">Start with the lowest role that gives the person what they need.</div>
+								<p class="govuk-error-message" id="role-key-error" hidden></p>
+								<select class="govuk-select" id="role-key" name="roleKey" aria-describedby="role-key-hint">
+									<option value="">Select a role</option>
+									<option value="observer">Observer</option>
+									<option value="researcher">Researcher</option>
+									<option value="research_lead">Research Lead</option>
+									<option value="approver">Approver</option>
+									<option value="safeguarding_lead">Safeguarding Lead</option>
+									<option value="team_admin">Team Admin</option>
+								</select>
+							</div>
+
+							<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
+
+							<div class="govuk-form-group" id="requested-reason-group">
+								<label class="govuk-label govuk-label--s" for="requested-reason">Reason for assigning this role</label>
+								<div class="govuk-hint" id="requested-reason-hint">Write a short audit-ready reason. For example, “Joining the research team for the May study”.</div>
+								<p class="govuk-error-message" id="requested-reason-error" hidden></p>
+								<textarea class="govuk-textarea" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
+							</div>
+
+							<div class="govuk-form-group" id="expires-at-group">
+								<label class="govuk-label" for="expires-at">Expiry date and time, if needed</label>
+								<div class="govuk-hint" id="expires-at-hint">Optional. Leave blank for no expiry date.</div>
+								<p class="govuk-error-message" id="expires-at-error" hidden></p>
+								<input class="govuk-input" id="expires-at" name="expiresAt" type="datetime-local" aria-describedby="expires-at-hint" />
+							</div>
+
+							<fieldset class="govuk-fieldset auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
+								<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
+								<div class="govuk-hint">Some roles give access to sensitive records or administrative controls.</div>
+								<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
+								<div class="govuk-checkboxes__item">
+									<input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" />
+									<label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label>
+								</div>
+							</fieldset>
+
+							<fieldset class="govuk-fieldset auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
+								<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
+								<div class="govuk-hint">Safeguarding Lead can view, record, resolve and audit safeguarding concerns.</div>
+								<p class="govuk-error-message" id="safeguarding-error" hidden></p>
+								<div class="govuk-checkboxes__item">
+									<input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" />
+									<label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm Safeguarding Lead access is required.</label>
+								</div>
+							</fieldset>
+
+							<div class="govuk-button-group">
+								<button class="govuk-button" type="submit" id="submit-role-assignment">Assign role</button>
+								<button class="govuk-button govuk-button--secondary" type="reset">Clear form</button>
+							</div>
+						</form>
+
+						<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
+					</div>
+				</div>
+			</section>
+		</div>
+	</main>
+
+	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'>
+	</x-include>
+
+	<script type="module" src="/js/auth-role-assignment-page.js"></script>
+</body>
+
+</html>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Assign team roles — ResearchOps Demo Suite</title>
+	<title>Assign a role to a team member — ResearchOps Demo Suite</title>
 
 	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
 	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
@@ -34,24 +34,6 @@
 		<div class="govuk-width-container">
 			<a class="govuk-back-link" href="/pages/projects/">Back to projects</a>
 
-			<header class="page-intro auth-role-assignment-page__header">
-				<div class="govuk-grid-row">
-					<div class="govuk-grid-column-two-thirds">
-						<span class="govuk-caption-l">Team administration</span>
-						<h1 class="govuk-heading-xl" id="role-assignment-title">Assign team roles</h1>
-						<p class="lede">Give an existing team member a role within your active ResearchOps team.</p>
-						<p class="govuk-body">The user must already exist and be an active member of your team. Sensitive roles need explicit confirmation before they can be assigned.</p>
-					</div>
-				</div>
-			</header>
-
-			<section class="auth-role-assignment-status" aria-labelledby="signed-in-status-title">
-				<h2 class="govuk-heading-m" id="signed-in-status-title">Your current access</h2>
-				<div id="auth-context" class="auth-role-assignment-status__panel" aria-live="polite" aria-busy="true">
-					<p class="govuk-body">Checking your team role access.</p>
-				</div>
-			</section>
-
 			<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
 				<h2 class="govuk-error-summary__title">There is a problem</h2>
 				<div class="govuk-error-summary__body">
@@ -59,60 +41,195 @@
 				</div>
 			</div>
 
-			<section aria-labelledby="assign-role-form-title">
+			<header class="page-intro auth-role-assignment-page__header">
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-two-thirds">
+						<span class="govuk-caption-l">Team administration</span>
+						<h1 class="govuk-heading-xl" id="role-assignment-title">Assign a role to a team member</h1>
+						<p class="lede">Use this page to give an existing team member access to a role in ResearchOps.</p>
+						<p class="govuk-body">Only assign the lowest role they need to do their work. Role changes are recorded in the audit log.</p>
+					</div>
+				</div>
+			</header>
+
+			<section class="auth-role-assignment-scope" aria-labelledby="team-scope-title">
+				<h2 class="govuk-heading-m" id="team-scope-title">Team scope</h2>
+				<div id="auth-context" class="auth-role-assignment-scope__panel" aria-live="polite" aria-busy="true">
+					<p class="govuk-body">Checking which team you can manage.</p>
+				</div>
+			</section>
+
+			<section aria-labelledby="assign-role-form-title" id="role-assignment-form-section">
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
 						<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
 
 						<form id="role-assignment-form" novalidate>
-							<div class="govuk-form-group" id="target-email-group">
-								<label class="govuk-label govuk-label--s" for="target-email">Team member email</label>
-								<div class="govuk-hint" id="target-email-hint">Use the email address linked to the member's Cloudflare Access sign-in.</div>
-								<p class="govuk-error-message" id="target-email-error" hidden></p>
-								<input class="govuk-input" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
-							</div>
+							<section class="auth-role-assignment-section" aria-labelledby="team-member-section-title">
+								<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
 
-							<div class="govuk-form-group" id="target-user-id-group">
-								<label class="govuk-label" for="target-user-id">User ID, if known</label>
-								<div class="govuk-hint" id="target-user-id-hint">Optional. If you provide both email and user ID, they must resolve to the same user.</div>
-								<p class="govuk-error-message" id="target-user-id-error" hidden></p>
-								<input class="govuk-input" id="target-user-id" name="targetUserId" type="text" aria-describedby="target-user-id-hint" />
-							</div>
+								<div class="govuk-form-group" id="target-email-group">
+									<label class="govuk-label govuk-label--s" for="target-email">Team member’s email address</label>
+									<div class="govuk-hint" id="target-email-hint">Use the email address they use to sign in.</div>
+									<p class="govuk-error-message" id="target-email-error" hidden></p>
+									<input class="govuk-input auth-role-assignment-input auth-role-assignment-input--email" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
+								</div>
 
-							<div class="govuk-form-group" id="role-key-group">
-								<label class="govuk-label govuk-label--s" for="role-key">Role to assign</label>
-								<div class="govuk-hint" id="role-key-hint">Start with the lowest role that gives the person what they need.</div>
-								<p class="govuk-error-message" id="role-key-error" hidden></p>
-								<select class="govuk-select" id="role-key" name="roleKey" aria-describedby="role-key-hint">
-									<option value="">Select a role</option>
-									<option value="observer">Observer</option>
-									<option value="researcher">Researcher</option>
-									<option value="research_lead">Research Lead</option>
-									<option value="approver">Approver</option>
-									<option value="safeguarding_lead">Safeguarding Lead</option>
-									<option value="team_admin">Team Admin</option>
-								</select>
-							</div>
+								<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
+									<summary class="govuk-details__summary">Use a user ID instead</summary>
+									<div class="govuk-details__text">
+										<p class="govuk-body">Only use this if you copied the user ID from ResearchOps. If you enter both an email address and a user ID, they must belong to the same person.</p>
 
-							<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
+										<div class="govuk-form-group" id="target-user-id-group">
+											<label class="govuk-label" for="target-user-id">User ID</label>
+											<div class="govuk-hint" id="target-user-id-hint">For example, <code>usr_bootstrap_...</code></div>
+											<p class="govuk-error-message" id="target-user-id-error" hidden></p>
+											<input class="govuk-input auth-role-assignment-input auth-role-assignment-input--user-id" id="target-user-id" name="targetUserId" type="text" aria-describedby="target-user-id-hint" />
+										</div>
+									</div>
+								</details>
+							</section>
 
-							<div class="govuk-form-group" id="requested-reason-group">
-								<label class="govuk-label govuk-label--s" for="requested-reason">Reason for assigning this role</label>
-								<div class="govuk-hint" id="requested-reason-hint">Write a short audit-ready reason. For example, “Joining the research team for the May study”.</div>
-								<p class="govuk-error-message" id="requested-reason-error" hidden></p>
-								<textarea class="govuk-textarea" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
-							</div>
+							<section class="auth-role-assignment-section" aria-labelledby="role-section-title">
+								<h3 class="govuk-heading-m" id="role-section-title">2. Role</h3>
 
-							<div class="govuk-form-group" id="expires-at-group">
-								<label class="govuk-label" for="expires-at">Expiry date and time, if needed</label>
-								<div class="govuk-hint" id="expires-at-hint">Optional. Leave blank for no expiry date.</div>
-								<p class="govuk-error-message" id="expires-at-error" hidden></p>
-								<input class="govuk-input" id="expires-at" name="expiresAt" type="datetime-local" aria-describedby="expires-at-hint" />
-							</div>
+								<fieldset class="govuk-fieldset" id="role-key-group">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What role do they need?</legend>
+									<div class="govuk-hint" id="role-key-hint">Start with the lowest role that gives the person what they need.</div>
+									<p class="govuk-error-message" id="role-key-error" hidden></p>
+
+									<div class="govuk-radios auth-role-assignment-radios" aria-describedby="role-key-hint">
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" />
+											<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label>
+											<div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without participant personal data reveal.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" />
+											<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label>
+											<div class="govuk-hint govuk-radios__hint">Can create and edit governed research records.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" />
+											<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label>
+											<div class="govuk-hint govuk-radios__hint">Can create, edit and review governed research records.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" />
+											<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label>
+											<div class="govuk-hint govuk-radios__hint">Can review and approve governed research records.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" />
+											<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead</label>
+											<div class="govuk-hint govuk-radios__hint">Can view, record, resolve and audit safeguarding concerns.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" />
+											<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label>
+											<div class="govuk-hint govuk-radios__hint">Can manage team membership, role assignment and general audit oversight.</div>
+										</div>
+									</div>
+								</fieldset>
+
+								<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
+							</section>
+
+							<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
+								<h3 class="govuk-heading-m" id="duration-section-title">3. Access duration</h3>
+
+								<fieldset class="govuk-fieldset" id="role-duration-group">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">How long should this role last?</legend>
+									<div class="govuk-hint" id="role-duration-hint">Choose a governed access period. The standard maximum is 180 days.</div>
+									<p class="govuk-error-message" id="role-duration-error" hidden></p>
+
+									<div class="govuk-radios auth-role-assignment-radios" aria-describedby="role-duration-hint">
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="duration-30" name="durationPreset" type="radio" value="30" />
+											<label class="govuk-label govuk-radios__label" for="duration-30">30 days</label>
+											<div class="govuk-hint govuk-radios__hint">Use for short support tasks or temporary cover.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="duration-60" name="durationPreset" type="radio" value="60" />
+											<label class="govuk-label govuk-radios__label" for="duration-60">60 days</label>
+											<div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" />
+											<label class="govuk-label govuk-radios__label" for="duration-90">90 days</label>
+											<div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" />
+											<label class="govuk-label govuk-radios__label" for="duration-180">180 days</label>
+											<div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div>
+										</div>
+
+										<div class="govuk-radios__item">
+											<input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" />
+											<label class="govuk-label govuk-radios__label" for="duration-custom">Until a specific date</label>
+											<div class="govuk-hint govuk-radios__hint">Use for contractors, secondments or known assignment end dates.</div>
+										</div>
+									</div>
+								</fieldset>
+
+								<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
+									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
+										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
+										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>
+										<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
+
+										<div class="govuk-date-input" id="custom-expiry-date">
+											<div class="govuk-date-input__item">
+												<div class="govuk-form-group">
+													<label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label>
+													<input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" />
+												</div>
+											</div>
+
+											<div class="govuk-date-input__item">
+												<div class="govuk-form-group">
+													<label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label>
+													<input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" />
+												</div>
+											</div>
+
+											<div class="govuk-date-input__item">
+												<div class="govuk-form-group">
+													<label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label>
+													<input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" />
+												</div>
+											</div>
+										</div>
+									</fieldset>
+								</div>
+							</section>
+
+							<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
+								<h3 class="govuk-heading-m" id="reason-section-title">4. Reason</h3>
+
+								<div class="govuk-form-group" id="requested-reason-group">
+									<label class="govuk-label govuk-label--s" for="requested-reason">Why are you assigning this role?</label>
+									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, “Joining the research team for the May assisted digital study”.</div>
+									<p class="govuk-error-message" id="requested-reason-error" hidden></p>
+									<textarea class="govuk-textarea auth-role-assignment-textarea" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
+								</div>
+							</section>
 
 							<fieldset class="govuk-fieldset auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
 								<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
-								<div class="govuk-hint">Some roles give access to sensitive records or administrative controls.</div>
+								<div class="auth-role-assignment-warning" role="note">
+									<strong>Warning</strong>
+									<p class="govuk-body">This role gives access to sensitive records or administrative controls.</p>
+								</div>
 								<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
 								<div class="govuk-checkboxes__item">
 									<input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" />
@@ -131,10 +248,20 @@
 							</fieldset>
 
 							<div class="govuk-button-group">
-								<button class="govuk-button" type="submit" id="submit-role-assignment">Assign role</button>
+								<button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button>
 								<button class="govuk-button govuk-button--secondary" type="reset">Clear form</button>
 							</div>
 						</form>
+
+						<section id="role-assignment-review" class="auth-role-assignment-review" aria-labelledby="role-assignment-review-title" tabindex="-1" hidden>
+							<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
+							<p class="govuk-body">The system will confirm the person exists and is an active member of this team when you assign the role.</p>
+							<div id="role-assignment-review-body"></div>
+							<div class="govuk-button-group">
+								<button class="govuk-button" type="button" id="confirm-role-assignment">Confirm and assign role</button>
+								<button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">Change details</button>
+							</div>
+						</section>
 
 						<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
 					</div>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -92,106 +92,27 @@
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" />
 											<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label>
+											<div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without seeing participant personal data.</div>
 										</div>
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" />
 											<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label>
+											<div class="govuk-hint govuk-radios__hint">Can create and update governed research records.</div>
 										</div>
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" />
 											<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label>
+											<div class="govuk-hint govuk-radios__hint">Can create, update and review governed research records.</div>
 										</div>
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" />
 											<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label>
+											<div class="govuk-hint govuk-radios__hint">Can review and approve governed research records.</div>
 										</div>
 										<div class="govuk-radios__item">
 											<input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" />
 											<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead</label>
+											<div class="govuk-hint govuk-radios__hint">Can view, record, resolve and audit safeguarding concerns.</div>
 										</div>
 										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" />
-											<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label>
-										</div>
-									</div>
-								</fieldset>
-								<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
-							</section>
-
-							<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
-								<h3 class="govuk-heading-m" id="duration-section-title">3. Access duration</h3>
-								<fieldset class="govuk-fieldset" id="role-duration-group">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">How long should this role last?</legend>
-									<div class="govuk-hint" id="role-duration-hint">Choose a governed access period. The standard maximum is 180 days.</div>
-									<p class="govuk-error-message" id="role-duration-error" hidden></p>
-									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-duration-hint">
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-30" name="durationPreset" type="radio" value="30" /><label class="govuk-label govuk-radios__label" for="duration-30">30 days</label><div class="govuk-hint govuk-radios__hint">Use for short support tasks or temporary cover.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-60" name="durationPreset" type="radio" value="60" /><label class="govuk-label govuk-radios__label" for="duration-60">60 days</label><div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" /><label class="govuk-label govuk-radios__label" for="duration-90">90 days</label><div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" /><label class="govuk-label govuk-radios__label" for="duration-180">180 days</label><div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" /><label class="govuk-label govuk-radios__label" for="duration-custom">Until a specific date</label><div class="govuk-hint govuk-radios__hint">Use for contractors, secondments or known assignment end dates.</div></div>
-									</div>
-								</fieldset>
-								<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
-									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
-										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
-										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>
-										<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
-										<div class="govuk-date-input" id="custom-expiry-date">
-											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" /></div></div>
-											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" /></div></div>
-											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label><input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" /></div></div>
-										</div>
-									</fieldset>
-								</div>
-							</section>
-
-							<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
-								<h3 class="govuk-heading-m" id="reason-section-title">4. Reason</h3>
-								<div class="govuk-form-group" id="requested-reason-group">
-									<label class="govuk-label govuk-label--s" for="requested-reason">Why are you assigning this role?</label>
-									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, "Joining the research team for the May assisted digital study".</div>
-									<p class="govuk-error-message" id="requested-reason-error" hidden></p>
-									<textarea class="govuk-textarea govuk-!-width-two-thirds" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
-								</div>
-							</section>
-
-							<div class="govuk-form-group auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
-								<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
-									<div class="govuk-warning-text" id="sensitive-role-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>This role gives access to sensitive records or administrative controls.</strong></div>
-									<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
-									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" /><label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label></div></div>
-								</fieldset>
-							</div>
-
-							<div class="govuk-form-group auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
-								<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
-									<div class="govuk-warning-text" id="safeguarding-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Safeguarding Lead can view restricted safeguarding details and close safeguarding concerns.</strong></div>
-									<p class="govuk-error-message" id="safeguarding-error" hidden></p>
-									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" /><label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm this person needs Safeguarding Lead access.</label></div></div>
-								</fieldset>
-							</div>
-
-							<div class="govuk-button-group"><button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button></div>
-						</form>
-
-						<section id="role-assignment-review" class="auth-role-assignment-review" aria-labelledby="role-assignment-review-title" tabindex="-1" hidden>
-							<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
-							<p class="govuk-body">The system will confirm the person exists and is an active member of this team when you assign the role.</p>
-							<div id="role-assignment-review-body"></div>
-							<div class="govuk-button-group"><button class="govuk-button" type="button" id="confirm-role-assignment">Confirm and assign role</button><button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">Change details</button></div>
-						</section>
-
-						<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
-					</div>
-				</div>
-			</section>
-		</div>
-	</main>
-
-	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
-	<script type="module" src="/js/auth-role-assignment-page.js"></script>
-</body>
-</html>
+					あと?}}        ...  

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -16,6 +16,7 @@
 <body>
 	<noscript><a class="govuk-skip-link" href="#main-content">Skip to main content</a></noscript>
 	<x-include src="/partials/header.html" vars='{"active":"Team administration","subtitle":"Manage team role access"}'></x-include>
+
 	<div class="govuk-width-container">
 		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
 			<ol class="govuk-breadcrumbs__list">
@@ -24,12 +25,16 @@
 			</ol>
 		</nav>
 	</div>
+
 	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 		<div class="govuk-width-container">
 			<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
 				<h2 class="govuk-error-summary__title">There is a problem</h2>
-				<div class="govuk-error-summary__body"><ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul></div>
+				<div class="govuk-error-summary__body">
+					<ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul>
+				</div>
 			</div>
+
 			<header class="page-intro auth-role-assignment-page__header">
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
@@ -40,14 +45,19 @@
 					</div>
 				</div>
 			</header>
+
 			<section class="auth-role-assignment-scope" aria-labelledby="team-scope-title">
 				<h2 class="govuk-heading-m" id="team-scope-title">Team scope</h2>
-				<div id="auth-context" class="auth-role-assignment-scope__panel" aria-live="polite" aria-busy="true"><p class="govuk-body">Checking which team you can manage.</p></div>
+				<div id="auth-context" class="auth-role-assignment-scope__panel" aria-live="polite" aria-busy="true">
+					<p class="govuk-body">Checking which team you can manage.</p>
+				</div>
 			</section>
+
 			<section aria-labelledby="assign-role-form-title" id="role-assignment-form-section">
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
 						<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
+
 						<form id="role-assignment-form" novalidate>
 							<section class="auth-role-assignment-section" aria-labelledby="team-member-section-title">
 								<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
@@ -57,6 +67,7 @@
 									<p class="govuk-error-message" id="target-email-error" hidden></p>
 									<input class="govuk-input govuk-!-width-two-thirds" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
 								</div>
+
 								<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
 									<summary class="govuk-details__summary"><span class="govuk-details__summary-text">Use a user ID instead</span></summary>
 									<div class="govuk-details__text">
@@ -69,6 +80,7 @@
 									</div>
 								</details>
 							</section>
+
 							<section class="auth-role-assignment-section" aria-labelledby="role-section-title">
 								<h3 class="govuk-heading-m" id="role-section-title">2. Role</h3>
 								<fieldset class="govuk-fieldset" id="role-key-group">
@@ -86,6 +98,7 @@
 								</fieldset>
 								<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
 							</section>
+
 							<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
 								<h3 class="govuk-heading-m" id="duration-section-title">3. Access duration</h3>
 								<fieldset class="govuk-fieldset" id="role-duration-group">
@@ -104,7 +117,7 @@
 									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
 										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
 										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>
-					اق				<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
+										<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
 										<div class="govuk-date-input" id="custom-expiry-date">
 											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" /></div></div>
 											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" /></div></div>
@@ -113,6 +126,7 @@
 									</fieldset>
 								</div>
 							</section>
+
 							<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
 								<h3 class="govuk-heading-m" id="reason-section-title">4. Reason</h3>
 								<div class="govuk-form-group" id="requested-reason-group">
@@ -122,6 +136,7 @@
 									<textarea class="govuk-textarea govuk-!-width-two-thirds" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
 								</div>
 							</section>
+
 							<div class="govuk-form-group auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
 								<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
 									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
@@ -130,6 +145,7 @@
 									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" /><label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label></div></div>
 								</fieldset>
 							</div>
+
 							<div class="govuk-form-group auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
 								<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
 									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
@@ -138,20 +154,24 @@
 									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" /><label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm this person needs Safeguarding Lead access.</label></div></div>
 								</fieldset>
 							</div>
+
 							<div class="govuk-button-group"><button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button></div>
 						</form>
+
 						<section id="role-assignment-review" class="auth-role-assignment-review" aria-labelledby="role-assignment-review-title" tabindex="-1" hidden>
 							<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
 							<p class="govuk-body">The system will confirm the person exists and is an active member of this team when you assign the role.</p>
 							<div id="role-assignment-review-body"></div>
 							<div class="govuk-button-group"><button class="govuk-button" type="button" id="confirm-role-assignment">Confirm and assign role</button><button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">Change details</button></div>
 						</section>
+
 						<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
 					</div>
 				</div>
 			</section>
 		</div>
 	</main>
+
 	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
 	<script type="module" src="/js/auth-role-assignment-page.js"></script>
 </body>

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -48,6 +48,9 @@ require_file "public/css/govuk/govuk-buttons.css"
 require_file "public/css/govuk/govuk-forms.css"
 require_file "public/css/govuk/govuk-tables.css"
 require_file "public/css/govuk/govuk-page-chrome.css"
+require_file "public/css/auth-role-assignments.css"
+require_file "public/js/auth-role-assignment-page.js"
+require_file "public/pages/team/role-assignments/index.html"
 require_file "docs/performance/initial-load-audit.md"
 require_file "docs/performance/performance-inventory-tooling.md"
 require_file "docs/design-system/govuk-compliance-audit.md"
@@ -97,14 +100,18 @@ require_file "tests/auth-foundation-route-state.test.js"
 require_file "tests/auth-route-permissions.test.js"
 require_file "tests/auth-runtime-bootstrap-route-state.test.js"
 require_file "tests/auth-role-assignment-api-route-state.test.js"
+require_file "tests/auth-role-assignment-ui-route-state.test.js"
 require_file "scripts/auth-runtime-bootstrap.mjs"
 require_file ".github/workflows/bootstrap-d1-auth-runtime.yml"
 require_file "docs/product/26/05/09/auth-runtime-bootstrap-2026-05-09.md"
 require_file "docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md"
+require_file "docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-implementation-trace.md"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-implementation-trace.json"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.json"
+require_file "docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md"
+require_file "docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json"
 require_dir "infra/cloudflare/src/service"
 
 info "checking package.json scripts"
@@ -247,6 +254,9 @@ node tests/auth-runtime-bootstrap-route-state.test.js
 
 info "checking authentication role assignment API contract"
 node tests/auth-role-assignment-api-route-state.test.js
+
+info "checking authentication role assignment UI contract"
+node tests/auth-role-assignment-ui-route-state.test.js
 
 info "checking Projects API route contract"
 node tests/projects-route-contract.test.js

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -25,6 +25,7 @@ function assertPageStructure() {
 	assert.match(pageSource, /id="safeguarding-confirmation"/);
 	assert.match(pageSource, /id="role-assignment-review"/);
 	assert.match(pageSource, /id="confirm-role-assignment"/);
+	assert.match(pageSource, /Confirm and assign role/);
 	assert.match(pageSource, /id="role-assignment-result"/);
 	assert.match(pageSource, /\/js\/auth-role-assignment-page\.js/);
 	assert.match(pageSource, /\/css\/auth-role-assignments\.css/);
@@ -101,7 +102,6 @@ function assertNoPostBeforeConfirm() {
 	assert.match(scriptSource, /async function submitAssignment\(\)/);
 	assert.match(scriptSource, /dom\.form\.addEventListener\("submit", prepareReview\)/);
 	assert.match(scriptSource, /dom\.confirm\?\.addEventListener\("click", submitAssignment\)/);
-	assert.match(scriptSource, /Confirm and assign role/);
 }
 
 function assertRoleMetadataIsVisibleClientSide() {

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -6,7 +6,7 @@ const scriptSource = fs.readFileSync('public/js/auth-role-assignment-page.js', '
 const styleSource = fs.readFileSync('public/css/auth-role-assignments.css', 'utf8');
 
 function assertPageStructure() {
-	assert.match(pageSource, /<title>Assign a role to a team member — ResearchOps Demo Suite<\/title>/);
+	assert.match(pageSource, /<title>Assign a role to a team member [-—] ResearchOps Demo Suite<\/title>/);
 	assert.match(pageSource, /id="role-assignment-title"/);
 	assert.match(pageSource, /Assign a role to a team member/);
 	assert.match(pageSource, /id="auth-context"/);
@@ -31,12 +31,29 @@ function assertPageStructure() {
 	assert.match(pageSource, /\/css\/auth-role-assignments\.css/);
 }
 
+function assertTopLevelAdminInformationArchitecture() {
+	assert.match(pageSource, /govuk-breadcrumbs/);
+	assert.match(pageSource, />Home</);
+	assert.match(pageSource, />Team administration</);
+	assert.doesNotMatch(pageSource, /govuk-back-link/);
+	assert.doesNotMatch(pageSource, /Back to projects/);
+	assert.doesNotMatch(pageSource, /type="reset"/);
+	assert.doesNotMatch(pageSource, /Clear form/);
+}
+
 function assertCurrentAccessPanelIsReducedToTeamScope() {
 	assert.doesNotMatch(pageSource, /Your current access/);
 	assert.match(pageSource, /Team scope/);
 	assert.match(scriptSource, /You are assigning roles in/);
 	assert.match(scriptSource, /You cannot assign roles/);
 	assert.doesNotMatch(scriptSource, /Current roles:/);
+}
+
+function assertUserIdUsesDetailsWithoutExample() {
+	assert.match(pageSource, /govuk-details__summary-text/);
+	assert.match(pageSource, /Use a user ID instead/);
+	assert.doesNotMatch(pageSource, /usr_bootstrap/);
+	assert.doesNotMatch(pageSource, /For example, <code>/);
 }
 
 function assertRoleOptionsUseRadios() {
@@ -87,7 +104,7 @@ function assertClientBuildsCorrectRequestContract() {
 
 function assertClientValidatesBeforeReview() {
 	assert.match(scriptSource, /function validate\(values\)/);
-	assert.match(scriptSource, /Enter a team member’s email address or user ID/);
+	assert.match(scriptSource, /Enter a team member's email address or user ID/);
 	assert.match(scriptSource, /Select the role they need/);
 	assert.match(scriptSource, /Select how long this role should last/);
 	assert.match(scriptSource, /Enter a real expiry date/);
@@ -104,41 +121,59 @@ function assertNoPostBeforeConfirm() {
 	assert.match(scriptSource, /dom\.confirm\?\.addEventListener\("click", submitAssignment\)/);
 }
 
-function assertRoleMetadataIsVisibleClientSide() {
-	assert.match(scriptSource, /const ROLE_DETAILS = Object\.freeze/);
-	assert.match(scriptSource, /governed\.create/);
-	assert.match(scriptSource, /governed\.edit/);
-	assert.match(scriptSource, /governed\.review/);
-	assert.match(scriptSource, /governed\.approve/);
-	assert.match(scriptSource, /recommendation\.own/);
-	assert.match(scriptSource, /safeguarding\.view/);
-	assert.match(scriptSource, /safeguarding\.audit\.view/);
-	assert.match(scriptSource, /team\.manage/);
-	assert.match(scriptSource, /role\.assign/);
+function assertRoleAbilitiesArePlainLanguage() {
+	assert.match(scriptSource, /abilities/);
+	assert.match(scriptSource, /View restricted safeguarding details/);
+	assert.match(scriptSource, /Record safeguarding observations/);
+	assert.match(scriptSource, /Resolve safeguarding concerns/);
+	assert.match(scriptSource, /View safeguarding audit events/);
+	assert.match(scriptSource, /Manage team members and team settings/);
+	assert.match(scriptSource, /Assign roles/);
+	assert.match(scriptSource, /View general audit events/);
+	assert.doesNotMatch(scriptSource, /governed\.create/);
+	assert.doesNotMatch(scriptSource, /governed\.edit/);
+	assert.doesNotMatch(scriptSource, /governed\.review/);
+	assert.doesNotMatch(scriptSource, /governed\.approve/);
+	assert.doesNotMatch(scriptSource, /recommendation\.own/);
+	assert.doesNotMatch(scriptSource, /safeguarding\.view/);
+	assert.doesNotMatch(scriptSource, /safeguarding\.audit\.view/);
+	assert.doesNotMatch(scriptSource, /team\.manage/);
+	assert.doesNotMatch(pageSource, /governed\.create/);
+	assert.doesNotMatch(pageSource, /safeguarding\.view/);
+}
+
+function assertGOVUKComponentMarkup() {
+	assert.match(pageSource, /govuk-warning-text/);
+	assert.match(pageSource, /govuk-checkboxes/);
+	assert.match(scriptSource, /govuk-summary-list/);
+	assert.match(scriptSource, /govuk-summary-list__row/);
+	assert.match(scriptSource, /govuk-summary-list__actions/);
 }
 
 function assertStylesExist() {
 	assert.match(styleSource, /\.auth-role-assignment-scope__panel/);
-	assert.match(styleSource, /\.auth-role-assignment-input--email/);
-	assert.match(styleSource, /width: 66\.66%/);
-	assert.match(styleSource, /\.auth-role-assignment-input--user-id/);
-	assert.match(styleSource, /width: 50%/);
+	assert.match(styleSource, /width-two-thirds/);
+	assert.match(styleSource, /width-one-half/);
+	assert.match(styleSource, /govuk-details__summary::before/);
 	assert.match(styleSource, /\.auth-role-assignment-radios/);
 	assert.match(styleSource, /\.auth-role-assignment-custom-date/);
-	assert.match(styleSource, /\.auth-role-assignment-sensitive/);
-	assert.match(styleSource, /\.auth-role-assignment-review/);
+	assert.match(styleSource, /govuk-warning-text/);
+	assert.match(styleSource, /govuk-summary-list/);
 	assert.match(styleSource, /\.auth-role-assignment-result--success/);
 	assert.match(styleSource, /\.auth-role-assignment-result--error/);
 	assert.match(styleSource, /transparency begins in the cascade/);
 }
 
 assertPageStructure();
+assertTopLevelAdminInformationArchitecture();
 assertCurrentAccessPanelIsReducedToTeamScope();
+assertUserIdUsesDetailsWithoutExample();
 assertRoleOptionsUseRadios();
 assertDurationModelUsesGovernedPresets();
 assertClientUsesAuthAndAssignmentEndpoints();
 assertClientBuildsCorrectRequestContract();
 assertClientValidatesBeforeReview();
 assertNoPostBeforeConfirm();
-assertRoleMetadataIsVisibleClientSide();
+assertRoleAbilitiesArePlainLanguage();
+assertGOVUKComponentMarkup();
 assertStylesExist();

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -32,7 +32,13 @@ function assertPageStructure() {
 }
 
 function assertTopLevelAdminInformationArchitecture() {
+	const breadcrumbIndex = pageSource.indexOf('class="govuk-breadcrumbs"');
+	const mainIndex = pageSource.indexOf('<main class="govuk-main-wrapper"');
+
 	assert.match(pageSource, /govuk-breadcrumbs/);
+	assert.ok(breadcrumbIndex > -1, 'Expected breadcrumb navigation to exist');
+	assert.ok(mainIndex > -1, 'Expected main landmark to exist');
+	assert.ok(breadcrumbIndex < mainIndex, 'Expected breadcrumb navigation to sit before main');
 	assert.match(pageSource, />Home</);
 	assert.match(pageSource, />Team administration</);
 	assert.doesNotMatch(pageSource, /govuk-back-link/);

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const pageSource = fs.readFileSync('public/pages/team/role-assignments/index.html', 'utf8');
+const scriptSource = fs.readFileSync('public/js/auth-role-assignment-page.js', 'utf8');
+const styleSource = fs.readFileSync('public/css/auth-role-assignments.css', 'utf8');
+
+function assertPageStructure() {
+	assert.match(pageSource, /<title>Assign team roles — ResearchOps Demo Suite<\/title>/);
+	assert.match(pageSource, /id="role-assignment-title"/);
+	assert.match(pageSource, /id="auth-context"/);
+	assert.match(pageSource, /id="role-assignment-error-summary"/);
+	assert.match(pageSource, /id="role-assignment-form"/);
+	assert.match(pageSource, /id="target-email"/);
+	assert.match(pageSource, /id="target-user-id"/);
+	assert.match(pageSource, /id="role-key"/);
+	assert.match(pageSource, /id="requested-reason"/);
+	assert.match(pageSource, /id="expires-at"/);
+	assert.match(pageSource, /id="sensitive-role-confirmation"/);
+	assert.match(pageSource, /id="safeguarding-confirmation"/);
+	assert.match(pageSource, /id="role-assignment-result"/);
+	assert.match(pageSource, /\/js\/auth-role-assignment-page\.js/);
+	assert.match(pageSource, /\/css\/auth-role-assignments\.css/);
+}
+
+function assertRoleOptions() {
+	assert.match(pageSource, /value="observer"/);
+	assert.match(pageSource, /value="researcher"/);
+	assert.match(pageSource, /value="research_lead"/);
+	assert.match(pageSource, /value="approver"/);
+	assert.match(pageSource, /value="safeguarding_lead"/);
+	assert.match(pageSource, /value="team_admin"/);
+}
+
+function assertClientUsesAuthAndAssignmentEndpoints() {
+	assert.match(scriptSource, /credentials: "include"/);
+	assert.match(scriptSource, /fetchJson\("\/api\/me"\)/);
+	assert.match(scriptSource, /fetchJson\("\/api\/auth\/role-assignments"/);
+	assert.match(scriptSource, /permissions\.has\("role\.assign"\)/);
+	assert.match(scriptSource, /setDisabled\(!canAssignRoles\)/);
+}
+
+function assertClientBuildsCorrectRequestContract() {
+	assert.match(scriptSource, /targetEmail/);
+	assert.match(scriptSource, /targetUserId/);
+	assert.match(scriptSource, /roleKey/);
+	assert.match(scriptSource, /requestedReason/);
+	assert.match(scriptSource, /expiresAt/);
+	assert.match(scriptSource, /sensitiveRoleConfirmation/);
+	assert.match(scriptSource, /ASSIGN_SENSITIVE_ROLE/);
+	assert.match(scriptSource, /safeguardingConfirmation/);
+	assert.match(scriptSource, /ASSIGN_SAFEGUARDING_LEAD/);
+}
+
+function assertClientValidatesBeforePost() {
+	assert.match(scriptSource, /function validate\(values\)/);
+	assert.match(scriptSource, /Enter a team member email or user ID/);
+	assert.match(scriptSource, /Select a role to assign/);
+	assert.match(scriptSource, /Enter a reason of at least 12 characters/);
+	assert.match(scriptSource, /Confirm the sensitive role assignment/);
+	assert.match(scriptSource, /Confirm Safeguarding Lead access is required/);
+}
+
+function assertRoleMetadataIsVisibleClientSide() {
+	assert.match(scriptSource, /const ROLE_DETAILS = Object\.freeze/);
+	assert.match(scriptSource, /governed\.create/);
+	assert.match(scriptSource, /governed\.edit/);
+	assert.match(scriptSource, /governed\.review/);
+	assert.match(scriptSource, /governed\.approve/);
+	assert.match(scriptSource, /recommendation\.own/);
+	assert.match(scriptSource, /safeguarding\.view/);
+	assert.match(scriptSource, /safeguarding\.audit\.view/);
+	assert.match(scriptSource, /team\.manage/);
+	assert.match(scriptSource, /role\.assign/);
+}
+
+function assertStylesExist() {
+	assert.match(styleSource, /\.auth-role-assignment-status__panel/);
+	assert.match(styleSource, /\.auth-role-assignment-status__panel--ready/);
+	assert.match(styleSource, /\.auth-role-assignment-status__panel--blocked/);
+	assert.match(styleSource, /\.auth-role-assignment-summary/);
+	assert.match(styleSource, /\.auth-role-assignment-sensitive/);
+	assert.match(styleSource, /\.auth-role-assignment-result--success/);
+	assert.match(styleSource, /\.auth-role-assignment-result--error/);
+	assert.match(styleSource, /transparency begins in the cascade/);
+}
+
+assertPageStructure();
+assertRoleOptions();
+assertClientUsesAuthAndAssignmentEndpoints();
+assertClientBuildsCorrectRequestContract();
+assertClientValidatesBeforePost();
+assertRoleMetadataIsVisibleClientSide();
+assertStylesExist();

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -6,30 +6,60 @@ const scriptSource = fs.readFileSync('public/js/auth-role-assignment-page.js', '
 const styleSource = fs.readFileSync('public/css/auth-role-assignments.css', 'utf8');
 
 function assertPageStructure() {
-	assert.match(pageSource, /<title>Assign team roles — ResearchOps Demo Suite<\/title>/);
+	assert.match(pageSource, /<title>Assign a role to a team member — ResearchOps Demo Suite<\/title>/);
 	assert.match(pageSource, /id="role-assignment-title"/);
+	assert.match(pageSource, /Assign a role to a team member/);
 	assert.match(pageSource, /id="auth-context"/);
 	assert.match(pageSource, /id="role-assignment-error-summary"/);
 	assert.match(pageSource, /id="role-assignment-form"/);
 	assert.match(pageSource, /id="target-email"/);
+	assert.match(pageSource, /id="target-user-id-details"/);
 	assert.match(pageSource, /id="target-user-id"/);
-	assert.match(pageSource, /id="role-key"/);
+	assert.match(pageSource, /id="role-key-observer"/);
+	assert.match(pageSource, /id="duration-30"/);
+	assert.match(pageSource, /id="duration-custom"/);
+	assert.match(pageSource, /id="custom-expiry-date-group"/);
+	assert.match(pageSource, /id="expiry-day"/);
 	assert.match(pageSource, /id="requested-reason"/);
-	assert.match(pageSource, /id="expires-at"/);
 	assert.match(pageSource, /id="sensitive-role-confirmation"/);
 	assert.match(pageSource, /id="safeguarding-confirmation"/);
+	assert.match(pageSource, /id="role-assignment-review"/);
+	assert.match(pageSource, /id="confirm-role-assignment"/);
 	assert.match(pageSource, /id="role-assignment-result"/);
 	assert.match(pageSource, /\/js\/auth-role-assignment-page\.js/);
 	assert.match(pageSource, /\/css\/auth-role-assignments\.css/);
 }
 
-function assertRoleOptions() {
-	assert.match(pageSource, /value="observer"/);
-	assert.match(pageSource, /value="researcher"/);
-	assert.match(pageSource, /value="research_lead"/);
-	assert.match(pageSource, /value="approver"/);
-	assert.match(pageSource, /value="safeguarding_lead"/);
-	assert.match(pageSource, /value="team_admin"/);
+function assertCurrentAccessPanelIsReducedToTeamScope() {
+	assert.doesNotMatch(pageSource, /Your current access/);
+	assert.match(pageSource, /Team scope/);
+	assert.match(scriptSource, /You are assigning roles in/);
+	assert.match(scriptSource, /You cannot assign roles/);
+	assert.doesNotMatch(scriptSource, /Current roles:/);
+}
+
+function assertRoleOptionsUseRadios() {
+	assert.doesNotMatch(pageSource, /<select class="govuk-select" id="role-key"/);
+	assert.match(pageSource, /name="roleKey" type="radio" value="observer"/);
+	assert.match(pageSource, /name="roleKey" type="radio" value="researcher"/);
+	assert.match(pageSource, /name="roleKey" type="radio" value="research_lead"/);
+	assert.match(pageSource, /name="roleKey" type="radio" value="approver"/);
+	assert.match(pageSource, /name="roleKey" type="radio" value="safeguarding_lead"/);
+	assert.match(pageSource, /name="roleKey" type="radio" value="team_admin"/);
+	assert.match(pageSource, /Start with the lowest role that gives the person what they need/);
+}
+
+function assertDurationModelUsesGovernedPresets() {
+	assert.doesNotMatch(pageSource, /type="datetime-local"/);
+	assert.match(pageSource, /How long should this role last\?/);
+	assert.match(pageSource, /name="durationPreset" type="radio" value="30"/);
+	assert.match(pageSource, /name="durationPreset" type="radio" value="60"/);
+	assert.match(pageSource, /name="durationPreset" type="radio" value="90"/);
+	assert.match(pageSource, /name="durationPreset" type="radio" value="180"/);
+	assert.match(pageSource, /name="durationPreset" type="radio" value="custom"/);
+	assert.match(pageSource, /Access ends at the end of the selected day/);
+	assert.match(scriptSource, /const DURATION_LABELS = Object\.freeze/);
+	assert.match(scriptSource, /expiresAtFor/);
 }
 
 function assertClientUsesAuthAndAssignmentEndpoints() {
@@ -54,13 +84,24 @@ function assertClientBuildsCorrectRequestContract() {
 	assert.match(scriptSource, /ASSIGN_SAFEGUARDING_LEAD/);
 }
 
-function assertClientValidatesBeforePost() {
+function assertClientValidatesBeforeReview() {
 	assert.match(scriptSource, /function validate\(values\)/);
-	assert.match(scriptSource, /Enter a team member email or user ID/);
-	assert.match(scriptSource, /Select a role to assign/);
-	assert.match(scriptSource, /Enter a reason of at least 12 characters/);
-	assert.match(scriptSource, /Confirm the sensitive role assignment/);
+	assert.match(scriptSource, /Enter a team member’s email address or user ID/);
+	assert.match(scriptSource, /Select the role they need/);
+	assert.match(scriptSource, /Select how long this role should last/);
+	assert.match(scriptSource, /Enter a real expiry date/);
+	assert.match(scriptSource, /Enter why you are assigning this role/);
+	assert.match(scriptSource, /Confirm this sensitive role assignment is intentional/);
 	assert.match(scriptSource, /Confirm Safeguarding Lead access is required/);
+}
+
+function assertNoPostBeforeConfirm() {
+	assert.match(scriptSource, /function prepareReview\(event\)/);
+	assert.match(scriptSource, /function renderReview\(values\)/);
+	assert.match(scriptSource, /async function submitAssignment\(\)/);
+	assert.match(scriptSource, /dom\.form\.addEventListener\("submit", prepareReview\)/);
+	assert.match(scriptSource, /dom\.confirm\?\.addEventListener\("click", submitAssignment\)/);
+	assert.match(scriptSource, /Confirm and assign role/);
 }
 
 function assertRoleMetadataIsVisibleClientSide() {
@@ -77,20 +118,27 @@ function assertRoleMetadataIsVisibleClientSide() {
 }
 
 function assertStylesExist() {
-	assert.match(styleSource, /\.auth-role-assignment-status__panel/);
-	assert.match(styleSource, /\.auth-role-assignment-status__panel--ready/);
-	assert.match(styleSource, /\.auth-role-assignment-status__panel--blocked/);
-	assert.match(styleSource, /\.auth-role-assignment-summary/);
+	assert.match(styleSource, /\.auth-role-assignment-scope__panel/);
+	assert.match(styleSource, /\.auth-role-assignment-input--email/);
+	assert.match(styleSource, /width: 66\.66%/);
+	assert.match(styleSource, /\.auth-role-assignment-input--user-id/);
+	assert.match(styleSource, /width: 50%/);
+	assert.match(styleSource, /\.auth-role-assignment-radios/);
+	assert.match(styleSource, /\.auth-role-assignment-custom-date/);
 	assert.match(styleSource, /\.auth-role-assignment-sensitive/);
+	assert.match(styleSource, /\.auth-role-assignment-review/);
 	assert.match(styleSource, /\.auth-role-assignment-result--success/);
 	assert.match(styleSource, /\.auth-role-assignment-result--error/);
 	assert.match(styleSource, /transparency begins in the cascade/);
 }
 
 assertPageStructure();
-assertRoleOptions();
+assertCurrentAccessPanelIsReducedToTeamScope();
+assertRoleOptionsUseRadios();
+assertDurationModelUsesGovernedPresets();
 assertClientUsesAuthAndAssignmentEndpoints();
 assertClientBuildsCorrectRequestContract();
-assertClientValidatesBeforePost();
+assertClientValidatesBeforeReview();
+assertNoPostBeforeConfirm();
 assertRoleMetadataIsVisibleClientSide();
 assertStylesExist();

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 const pageSource = fs.readFileSync('public/pages/team/role-assignments/index.html', 'utf8');
 const scriptSource = fs.readFileSync('public/js/auth-role-assignment-page.js', 'utf8');
 const styleSource = fs.readFileSync('public/css/auth-role-assignments.css', 'utf8');
+const govukFrontendSource = fs.readFileSync('public/css/govuk/govuk-frontend-v6.css', 'utf8');
 
 function assertPageStructure() {
 	assert.match(pageSource, /<title>Assign a role to a team member [-—] ResearchOps Demo Suite<\/title>/);
@@ -62,15 +63,41 @@ function assertUserIdUsesDetailsWithoutExample() {
 	assert.doesNotMatch(pageSource, /For example, <code>/);
 }
 
-function assertRoleOptionsUseRadios() {
+function assertRoleOptionsUseGOVUKRadios() {
 	assert.doesNotMatch(pageSource, /<select class="govuk-select" id="role-key"/);
-	assert.match(pageSource, /name="roleKey" type="radio" value="observer"/);
-	assert.match(pageSource, /name="roleKey" type="radio" value="researcher"/);
-	assert.match(pageSource, /name="roleKey" type="radio" value="research_lead"/);
-	assert.match(pageSource, /name="roleKey" type="radio" value="approver"/);
-	assert.match(pageSource, /name="roleKey" type="radio" value="safeguarding_lead"/);
-	assert.match(pageSource, /name="roleKey" type="radio" value="team_admin"/);
+	assert.match(pageSource, /<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-key-hint">/);
+	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer<\/label>/);
+	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher<\/label>/);
+	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead<\/label>/);
+	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver<\/label>/);
+	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead<\/label>/);
+	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin<\/label>/);
 	assert.match(pageSource, /Start with the lowest role that gives the person what they need/);
+}
+
+function assertRoleRadiosDoNotRepeatAbilityCopy() {
+	const roleSection = pageSource.slice(pageSource.indexOf('id="role-section-title"'), pageSource.indexOf('id="duration-section-title"'));
+
+	assert.doesNotMatch(roleSection, /govuk-radios__hint/);
+	assert.doesNotMatch(roleSection, /Can observe low-risk research context without seeing participant personal data/);
+	assert.doesNotMatch(roleSection, /Can create and update governed research records/);
+	assert.doesNotMatch(roleSection, /Can view, record, resolve and audit safeguarding concerns/);
+	assert.doesNotMatch(roleSection, /Can manage team membership, role assignment and general audit oversight/);
+	assert.doesNotMatch(scriptSource, /description:/);
+	assert.doesNotMatch(scriptSource, /<h3 class="govuk-heading-s">/);
+	assert.doesNotMatch(scriptSource, /This is a sensitive role/);
+	assert.match(scriptSource, /This role can:/);
+}
+
+function assertPageStylesDoNotRecreateGOVUKRadioInternals() {
+	assert.match(govukFrontendSource, /\.govuk-radios__item/);
+	assert.match(govukFrontendSource, /\.govuk-radios__input/);
+	assert.match(govukFrontendSource, /\.govuk-radios__label::before/);
+	assert.match(govukFrontendSource, /\.govuk-radios__input:checked \+ \.govuk-radios__label::after/);
+	assert.doesNotMatch(styleSource, /\.auth-role-assignment-radios \.govuk-radios__item/);
+	assert.doesNotMatch(styleSource, /\.auth-role-assignment-radios \.govuk-radios__input/);
+	assert.doesNotMatch(styleSource, /\.auth-role-assignment-radios \.govuk-radios__label::before/);
+	assert.doesNotMatch(styleSource, /\.auth-role-assignment-radios \.govuk-radios__label::after/);
 }
 
 function assertDurationModelUsesGovernedPresets() {
@@ -174,7 +201,9 @@ assertPageStructure();
 assertTopLevelAdminInformationArchitecture();
 assertCurrentAccessPanelIsReducedToTeamScope();
 assertUserIdUsesDetailsWithoutExample();
-assertRoleOptionsUseRadios();
+assertRoleOptionsUseGOVUKRadios();
+assertRoleRadiosDoNotRepeatAbilityCopy();
+assertPageStylesDoNotRecreateGOVUKRadioInternals();
 assertDurationModelUsesGovernedPresets();
 assertClientUsesAuthAndAssignmentEndpoints();
 assertClientBuildsCorrectRequestContract();

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -33,6 +33,8 @@ function assertRoleOptions() {
 }
 
 function assertClientUsesAuthAndAssignmentEndpoints() {
+	assert.match(scriptSource, /API_BASE: document\.documentElement\?\.dataset\?\.apiOrigin \|\| window\.API_ORIGIN \|\| ""/);
+	assert.doesNotMatch(scriptSource, /https:\/\/rops-api\.digikev-kevin-rapley\.workers\.dev/);
 	assert.match(scriptSource, /credentials: "include"/);
 	assert.match(scriptSource, /fetchJson\("\/api\/me"\)/);
 	assert.match(scriptSource, /fetchJson\("\/api\/auth\/role-assignments"/);

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -75,18 +75,30 @@ function assertRoleOptionsUseGOVUKRadios() {
 	assert.match(pageSource, /Start with the lowest role that gives the person what they need/);
 }
 
-function assertRoleRadiosDoNotRepeatAbilityCopy() {
+function assertRoleRadioHintsAreUsefulAndClickable() {
 	const roleSection = pageSource.slice(pageSource.indexOf('id="role-section-title"'), pageSource.indexOf('id="duration-section-title"'));
 
-	assert.doesNotMatch(roleSection, /govuk-radios__hint/);
-	assert.doesNotMatch(roleSection, /Can observe low-risk research context without seeing participant personal data/);
-	assert.doesNotMatch(roleSection, /Can create and update governed research records/);
-	assert.doesNotMatch(roleSection, /Can view, record, resolve and audit safeguarding concerns/);
-	assert.doesNotMatch(roleSection, /Can manage team membership, role assignment and general audit oversight/);
+	assert.match(roleSection, /govuk-radios__hint/);
+	assert.match(roleSection, /Can observe low-risk research context without seeing participant personal data/);
+	assert.match(roleSection, /Can create and update governed research records/);
+	assert.match(roleSection, /Can create, update and review governed research records/);
+	assert.match(roleSection, /Can review and approve governed research records/);
+	assert.match(roleSection, /Can view, record, resolve and audit safeguarding concerns/);
+	assert.match(roleSection, /Can manage team membership, role assignment and general audit oversight/);
+	assert.match(scriptSource, /function makeRadioHintSelectable\(event\)/);
+	assert.match(scriptSource, /event\.target\.closest\("\.auth-role-assignment-radios \.govuk-radios__hint"\)/);
+	assert.match(scriptSource, /input\.checked = true/);
+	assert.match(scriptSource, /input\.dispatchEvent\(new Event\("change", \{ bubbles: true \}\)\)/);
+	assert.match(scriptSource, /hint\.dataset\.clicksRadio = "true"/);
+	assert.match(scriptSource, /dom\.form\.addEventListener\("click", makeRadioHintSelectable\)/);
+}
+
+function assertSelectedRoleSummaryUsesAbilityListOnly() {
 	assert.doesNotMatch(scriptSource, /description:/);
 	assert.doesNotMatch(scriptSource, /<h3 class="govuk-heading-s">/);
 	assert.doesNotMatch(scriptSource, /This is a sensitive role/);
 	assert.match(scriptSource, /This role can:/);
+	assert.match(scriptSource, /auth-role-assignment-summary__abilities/);
 }
 
 function assertPageStylesDoNotRecreateGOVUKRadioInternals() {
@@ -202,7 +214,8 @@ assertTopLevelAdminInformationArchitecture();
 assertCurrentAccessPanelIsReducedToTeamScope();
 assertUserIdUsesDetailsWithoutExample();
 assertRoleOptionsUseGOVUKRadios();
-assertRoleRadiosDoNotRepeatAbilityCopy();
+assertRoleRadioHintsAreUsefulAndClickable();
+assertSelectedRoleSummaryUsesAbilityListOnly();
 assertPageStylesDoNotRecreateGOVUKRadioInternals();
 assertDurationModelUsesGovernedPresets();
 assertClientUsesAuthAndAssignmentEndpoints();

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -458,17 +458,17 @@ export const visualWalkthroughConfig = {
 		},
 		{
 			id: 'team-role-assignments',
-			title: 'Assign team roles',
+			title: 'Assign a role to a team member',
 			group: 'Team administration',
 			path: '/pages/team/role-assignments/index.html',
 			description: 'Team Admin role assignment page.',
 			designRisk: operationalDesignRisks.teamRoleAssignments,
 			defaultState: operationalDefaultState({
-				title: 'Role assignment form with Team Admin access',
+				title: 'Role assignment form with Team Admin scope',
 				description:
-					'Role assignment page captured with a deterministic Team Admin context so role.assign gating, sensitive-role copy and audit-reason fields can be reviewed.',
+					'Role assignment page captured with a deterministic Team Admin context so team scope, role.assign gating, role radios, duration choices, sensitive-role copy and audit-reason fields can be reviewed.',
 				path: operationalPaths.teamRoleAssignments,
-				waitForText: 'You can assign team roles because you have',
+				waitForText: 'You are assigning roles in',
 			}),
 		},
 		{

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -457,6 +457,21 @@ export const visualWalkthroughConfig = {
 			states: participantConsentVisualStates,
 		},
 		{
+			id: 'team-role-assignments',
+			title: 'Assign team roles',
+			group: 'Team administration',
+			path: '/pages/team/role-assignments/index.html',
+			description: 'Team Admin role assignment page.',
+			designRisk: operationalDesignRisks.teamRoleAssignments,
+			defaultState: operationalDefaultState({
+				title: 'Role assignment form with Team Admin access',
+				description:
+					'Role assignment page captured with a deterministic Team Admin context so role.assign gating, sensitive-role copy and audit-reason fields can be reviewed.',
+				path: operationalPaths.teamRoleAssignments,
+				waitForText: 'You can assign team roles because you have',
+			}),
+		},
+		{
 			id: 'search',
 			title: 'Search',
 			group: 'Utilities',

--- a/visual-walkthrough.operational-fixtures.mjs
+++ b/visual-walkthrough.operational-fixtures.mjs
@@ -8,6 +8,8 @@
 export const operationalProjectId = 'recVisualProject001';
 export const operationalStudyId = 'recVisualStudy001';
 export const operationalParticipantId = 'recVisualParticipant001';
+export const operationalAuthUserId = 'usr_visual_team_admin';
+export const operationalAuthTeamId = 'team_researchops_core';
 
 export const operationalPaths = {
 	projectDashboard: `/pages/project-dashboard/?id=${operationalProjectId}`,
@@ -21,6 +23,7 @@ export const operationalPaths = {
 	studyParticipants: `/pages/study/participants/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
 	studySession: `/pages/study/session/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
 	studyConsentForms: `/pages/study/consent-forms/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
+	teamRoleAssignments: '/pages/team/role-assignments/',
 };
 
 export const operationalProject = {
@@ -154,8 +157,68 @@ export const operationalSessions = [
 	},
 ];
 
+export const operationalAuthContext = {
+	ok: true,
+	authenticated: true,
+	provider: 'cloudflare_access',
+	user: {
+		id: operationalAuthUserId,
+		email: 'team.admin@example.gov.uk',
+		displayName: 'Team Admin',
+		accountStatus: 'active',
+	},
+	activeTeam: {
+		id: operationalAuthTeamId,
+		name: 'ResearchOps Core',
+	},
+	teams: [
+		{
+			id: operationalAuthTeamId,
+			name: 'ResearchOps Core',
+		},
+	],
+	roles: [
+		{
+			key: 'team_admin',
+			label: 'Team Admin',
+			description: 'Can manage team membership, roles and general audit oversight.',
+			sensitive: true,
+			scopeType: 'team',
+			scopeId: operationalAuthTeamId,
+		},
+	],
+	permissions: [
+		{
+			code: 'team.manage',
+			label: 'Manage team membership',
+			description: 'Can manage team members and team settings.',
+			sensitive: true,
+			reserved: false,
+		},
+		{
+			code: 'role.assign',
+			label: 'Assign roles',
+			description: 'Can assign or approve role access where policy permits.',
+			sensitive: true,
+			reserved: false,
+		},
+		{
+			code: 'audit.view',
+			label: 'View audit events',
+			description: 'Can view general audit events.',
+			sensitive: true,
+			reserved: false,
+		},
+	],
+};
+
 export function operationalMockRoutes() {
 	return [
+		{
+			url: /\/api\/me(?:\?.*)?$/,
+			method: 'GET',
+			body: operationalAuthContext,
+		},
 		{
 			url: /\/api\/projects(?:\?.*)?$/,
 			method: 'GET',
@@ -324,6 +387,11 @@ export const operationalDesignRisks = {
 		'Participant consent screens may not separate setup blockers, participant selection and auditable consent recording clearly enough.',
 		'Research may proceed without clear, current and reviewable consent evidence.',
 		'Capture both blocker and ready states with deterministic study fixtures and review accessible status messaging.'
+	),
+	teamRoleAssignments: risk(
+		'The role-assignment UI may make sensitive access changes feel routine without enough target-user certainty, permission visibility or audit-ready justification.',
+		'Team Admins could grant powerful roles to the wrong person or miss the consequences of Safeguarding Lead and Team Admin access.',
+		'Review target identifier behaviour, sensitive-role confirmations, error recovery, visible permission codes and audit-reason copy with the seeded Team Admin context.'
 	),
 	search: risk(
 		'Search may return visually plausible results without making scope, result type and relevance clear.',


### PR DESCRIPTION
## Summary

Builds the Team Admin UI for assigning D1-backed authentication roles.

This follows PR #219, which merged the `POST /api/auth/role-assignments` API.

## Current iteration changes

This PR now includes the role-assignment page, a GOV.UK component conformance pass, and a further radio-control amendment.

The page is framed as a safer administrative task rather than an authentication diagnostic plus form.

The latest amendment keeps the useful hint text inside each role radio item, restores the correct GOV.UK radio structure, removes route-specific CSS that recreated GOV.UK radio internals, and makes radio hint text select the associated radio through JavaScript.

## What changed

Adds and iterates the page:

```text
public/pages/team/role-assignments/index.html
```

Adds and iterates the page client:

```text
public/js/auth-role-assignment-page.js
```

Adds page-specific styling:

```text
public/css/auth-role-assignments.css
```

Adds and updates validation coverage:

```text
tests/auth-role-assignment-ui-route-state.test.js
```

Updates visual walkthrough registration:

```text
visual-walkthrough.config.mjs
visual-walkthrough.operational-fixtures.mjs
```

Adds product documentation and trace:

```text
docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md
docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.md
docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-ui-implementation-trace.json
docs/agent-audit/reasoning/2026/05/10/auth-role-assignment-ui-radio-hint-amendment-trace.md
docs/agent-audit/reasoning/2026/05/10/auth-role-assignment-ui-radio-hint-amendment-trace.json
```

## Runtime behaviour

The page:

1. loads the current authenticated user context from `GET /api/me`
2. detects whether the active team context includes `role.assign`
3. shows compact team scope when the user can assign roles
4. hides the form and shows a blocking message when the user cannot assign roles
5. uses same-origin `/api/*` calls by default for Pages preview compatibility
6. uses GOV.UK radio markup for role selection
7. shows useful role hint text inside each radio item
8. makes radio hint text click or tap select the associated radio
9. shows detailed role capability bullets only in the selected-role summary under `This role can:`
10. validates required form fields before review
11. shows a check-and-confirm panel before any write
12. sends role assignment requests to `POST /api/auth/role-assignments` only from the confirm button
13. requires sensitive-role confirmation for sensitive roles
14. requires additional Safeguarding Lead confirmation for `safeguarding_lead`
15. shows success and error results to the user

## Key design changes

### Reduced self-access status

The first iteration showed a large “Your current access” panel.

That has been removed from the successful state. The page still checks permissions, but successful users now see compact team scope:

```text
You are assigning roles in ResearchOps Core Team.
```

### Email and user ID affordance

The team member email field is now the primary path and uses a two-thirds width input.

The user ID field is secondary and hidden inside a details component:

```text
Use a user ID instead
```

The user ID field uses a half-width input.

### GOV.UK role radios

The role select has been replaced with GOV.UK radios.

Roles shown:

- Observer
- Researcher
- Research Lead
- Approver
- Safeguarding Lead
- Team Admin

Each role option has a short hint. Selecting a role shows the detailed capability list separately under:

```text
This role can:
```

The route-state test now asserts that page-specific CSS does not recreate GOV.UK radio internals.

### Governed duration instead of arbitrary date-time

The arbitrary `datetime-local` field has been replaced with governed duration radios:

- 30 days
- 60 days
- 90 days
- 180 days
- Until a specific date

No duration is preselected.

If “Until a specific date” is selected, the page reveals a GOV.UK-style day, month and year date input. The client treats expiry as the end of the selected day.

### Check-and-confirm before write

The form submit action now validates and renders a check-and-confirm panel. It does not write to D1.

The write action only happens when the admin selects:

```text
Confirm and assign role
```

## Access configuration evidence

Manual branch-preview testing confirmed `/api/me` can return:

```text
ok = true
authenticated = true
provider = cloudflare_access
active team = team_researchops_core
permissions include role.assign
```

The repository trace records the Access configuration learning without committing raw personal identifiers.

## Boundaries

This PR does not create a user search endpoint.

This PR does not create users.

This PR does not create team memberships.

This PR does not resolve the target user before the check-and-confirm panel.

This PR does not list all team members.

This PR does not add role removal.

This PR does not support permission exceptions.

This PR does not run the D1 route-status workflow.

## Operational follow-up after merge

After merge and deployment:

1. open `/pages/team/role-assignments/` as the seeded Team Admin
2. confirm the page shows active team scope
3. confirm the form is hidden for users without `role.assign`
4. choose a non-sensitive role and governed duration
5. confirm the check-and-confirm panel appears before the write
6. assign a non-sensitive role to an existing active team member
7. confirm `auth_role_assignments` contains the assignment
8. confirm `auth_audit_events` contains `auth.role_assignment.created`
9. attempt Safeguarding Lead without confirmations and confirm it is blocked