### PR TITLE
Validate agent traces in repository validation

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -71,6 +71,7 @@ require_file "scripts/agent-operating-model/load-operating-model.mjs"
 require_file "scripts/agent-operating-model/run-behavioural-evals.mjs"
 require_file "scripts/agent-operating-model/validate-bundle-registry.mjs"
 require_file "scripts/agent-operating-model/validate-operating-model.mjs"
+require_file "scripts/agent-trace/validate-traces.mjs"
 require_file "public/_headers"
 require_file "public/css/govuk/govuk-buttons.css"
 require_file "public/css/govuk/govuk-forms.css"
@@ -148,7 +149,7 @@ import fs from 'node:fs';
 
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const scripts = pkg.scripts || {};
-const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'agent:evals', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
+const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'agent:evals', 'trace:validate', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
 const missing = required.filter((name) => !scripts[name]);
 
 if (missing.length) {
@@ -172,6 +173,9 @@ node scripts/agent-operating-model/validate-operating-model.mjs
 
 info "checking behavioural operating-model evals"
 node scripts/agent-operating-model/run-behavioural-evals.mjs >/dev/null
+
+info "checking agent traces"
+node scripts/agent-trace/validate-traces.mjs
 
 info "checking Wrangler assets directory"
 node --input-type=module <<'NODE'


### PR DESCRIPTION
## Summary

Adds agent trace validation to the main repository validation path.

This follows from the operating-model gap review after PR #227 was merged.

## Branch

```text
chore/validate-agent-traces
```

## Current head

```text
48026f23c7bdfc93a555a13465c88b9da8816511
```

## Main change

Updates `scripts/validate.sh` to:

- require `scripts/agent-trace/validate-traces.mjs`
- require the `trace:validate` package script in the validation script-list check
- run `node scripts/agent-trace/validate-traces.mjs` during repository validation

## Why

`trace:validate` already existed in `package.json`, but `scripts/validate.sh` did not invoke it.

That meant malformed raw trace files under:

```text
.agent-traces/raw/**/*.jsonl
```

would not fail the main repository validation gate.

`validate-traces.mjs` is safe to run when no raw trace files exist. It reports `Validated 0 trace file(s).` and exits successfully.

## Gap review outcome

The following reported gaps were checked against current `main` after PR #227:

- `task-signal-catalog.json` version skew: not current. The catalog is now `1.1.0`.
- `runtime-or-deployment-change` orphaned signal: not current. It is mapped to `conditional-cloudflare` in `selection-rules.json`.
- `validate-operating-model.mjs` not in CI: not current. It is invoked by `scripts/validate.sh`, and the Validate ResearchOps workflow runs `npm run validate`.
- trace validation not in CI: valid. This PR addresses that.

## Validation observed

For current head:

```text
48026f23c7bdfc93a555a13465c88b9da8816511
```

The following workflows completed successfully:

- Format pull request
- qa-bdd
- Validate ResearchOps
- QA — Broken links (Lychee)
- CI
- Accessibility audit (pa11y-ci)
- Release Gate
- Worker CI

## Boundaries

No trace promotion behaviour is introduced here.

No branch history has been rewritten.

No merge has been attempted.