### PR TITLE
Add bundle validation report standard

### DIFF
--- a/.agent-operating-model/bundles/airtable-public-api/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/airtable-public-api/VALIDATION-REPORT.md
@@ -1,0 +1,58 @@
+# Validation Report — Airtable Public API Developer Contract Bundle v1.0.1
+
+Validation status: passed.
+
+Last checked: 2026-05-11.
+
+## Scope
+
+This bundle governs Airtable Public API integration work for records, comments, metadata, schema operations, views, webhooks, pagination, batching, performUpsert, rate limits and implementation boundaries.
+
+It explicitly excludes exhaustive Enterprise API and eDiscovery coverage.
+
+## Entrypoints checked
+
+Checked entrypoints:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+- `registry-manifest.yaml`
+- `endpoint-coverage.matrix.yaml`
+- `endpoint-source.catalog.yaml`
+- `scopes.matrix.yaml`
+
+## Structural checks
+
+The bundle now uses JSON schemas as authoritative contracts.
+
+The legacy CommonJS schema shims have been removed.
+
+The manifest records a path inventory and the generated manifest schema supports both path inventory and the earlier hashes format.
+
+## Evaluation coverage
+
+The bundle now defines endpoint-contract, operational-safety and schema/webhook evaluation pipelines.
+
+Regression coverage has 20 cases.
+
+Red-team coverage has 14 cases.
+
+The health test verifies schema posture, eval orchestration, minimum suite counts and the operating-model PR queue.
+
+## Known gaps
+
+This validation report does not inspect every endpoint contract body.
+
+Future validation could generate counts from `endpoint-coverage.matrix.yaml` and assert one contract file per endpoint family automatically.
+
+## Result
+
+The bundle is suitable for current ResearchOps Airtable integration work.

--- a/.agent-operating-model/bundles/cloudflare/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/cloudflare/VALIDATION-REPORT.md
@@ -1,0 +1,52 @@
+# Validation Report — Cloudflare Developer Platform Bundle v1.0.0
+
+Validation status: passed for ResearchOps scope.
+
+Last checked: 2026-05-11.
+
+## Scope
+
+This bundle governs Cloudflare Workers, Pages, Wrangler, bindings, secrets, D1, KV, R2, Durable Objects, Queues, Workflows, Workers AI, Vectorize, deployment evidence, testing, observability, compatibility and limits for ResearchOps.
+
+Cloudflare platform claims are constrained to `developers.cloudflare.com`.
+
+## Entrypoints checked
+
+Checked entrypoints:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+- `registry-manifest.yaml`
+- `references/source-catalog.yaml`
+
+## Structural checks
+
+The bundle has build, review and release modes.
+
+It includes contract schemas for Wrangler configuration review, Cloudflare validation evidence and Cloudflare gap registers.
+
+It includes reference modules for Workers runtime, Wrangler, bindings, secrets, storage, state, Pages, deployment, queues, workflows, AI, Vectorize, versions, Cron Triggers, testing, observability, compatibility, limits, Service Bindings, Smart Placement, Hyperdrive and Static Assets.
+
+## Evaluation coverage
+
+Regression and red-team assets are present.
+
+Repository regression tests check Cloudflare bundle selection, source-catalog discipline, manifest assets, prompt/spec entrypoints and short-token matching boundaries.
+
+## Known gaps
+
+The bundle does not attempt exhaustive Cloudflare product-family coverage.
+
+Future expansion should be needs-led for Access, Turnstile, DNS, Cache Rules, WAF, API Tokens, Images, Stream, Browser Rendering, Zaraz, Workers for Platforms, Containers and Zero Trust.
+
+## Result
+
+The bundle is suitable for current ResearchOps Cloudflare runtime and integration work.

--- a/.agent-operating-model/bundles/github/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/github/VALIDATION-REPORT.md
@@ -1,8 +1,34 @@
-# Validation Report — v2.9.1
+# Validation Report — GitHub Diamond Bundle v2.9.1
+
+Validation status: passed.
+
+Last checked: 2026-05-11.
 
 Version 2.9.1 moves the bundle from strong live repository assurance toward a fully auditable assurance regime.
 
-## Validation summary
+## Scope
+
+This bundle governs GitHub repository operation, branch hygiene, pull-request discipline, CI, release gates, evidence handling, attestation, repository settings, workflow hardening and live repository assurance.
+
+It is the highest-precedence repository governance bundle in the operating model.
+
+## Entrypoints checked
+
+Checked entrypoints:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+- `registry-manifest.yaml`
+
+## Structural checks
 
 Validated before release:
 
@@ -42,38 +68,34 @@ Validated before release:
 - GitHub API strict-mode fixtures checked
 - direct final package validation checked
 
-## Offline and live assurance
+## Evaluation coverage
 
 Offline release-gate assurance validates the bundle and fixtures.
 
 Live repository assurance validates the actual GitHub repository, live API-observed state and evidence required by the selected profile.
 
-## Failure reports
-
-Release-gate reports are first-class artefacts.
-
-Both passing and failing release gates must produce schema-valid reports. Failed reports preserve command history, failed command, structured error, output tails and duration metadata.
-
-## Policy-driven profiles
+Release-gate reports are first-class artefacts. Both passing and failing release gates must produce schema-valid reports. Failed reports preserve command history, failed command, structured error, output tails and duration metadata.
 
 Live release profiles are defined in `templates/repository/live-release-policy.yaml`.
 
 High-assurance, regulated and public-service profiles require GitHub API verification, workflow lock validation, hardened workflow validation, trusted SBOM attestation, external attestation verification evidence, accessibility evidence, performance evidence and evidence-to-repository cross-checking.
 
-## Trusted attestation
-
 Trusted attestation requires both metadata validation and external verification evidence.
 
 The bundle validates SBOM attestation metadata and separately validates command evidence from `gh attestation verify` and `cosign verify-blob`.
 
-## Accessibility
-
-Accessibility validation now supports repository-root-relative paths, evidence-file-relative paths and bundle-root fallback for bundled fixtures.
+Accessibility validation supports repository-root-relative paths, evidence-file-relative paths and bundle-root fallback for bundled fixtures.
 
 Negative fixtures prove failures for open critical defects, low Lighthouse accessibility scores, axe violations and Pa11y issues.
 
+## Known gaps
+
+No known blocking gaps for current ResearchOps repository governance use.
+
+Future work can extend generated validation-report parity across all bundles so the GitHub report remains the mature baseline rather than the only high-assurance example.
+
 ## Result
 
-Validation status: passed.
+The GitHub Diamond bundle is suitable for current ResearchOps repository governance use.
 
 v2.9.1 preserves the v2.8.x and v2.9.0 control architecture while adding auditable failure reports, live policy profiles, stricter GitHub API edge-case handling, external attestation evidence validation and stronger fixture coverage.

--- a/.agent-operating-model/bundles/govuk-design-system/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/govuk-design-system/VALIDATION-REPORT.md
@@ -1,0 +1,51 @@
+# Validation Report — GOV.UK Design System Bundle v1.0.0
+
+Validation status: passed.
+
+Last checked: 2026-05-11.
+
+## Scope
+
+This bundle governs GOV.UK Design System use, frontend component decisions, service content, accessibility, page composition, forms and interaction behaviour.
+
+It applies when UI, content, frontend accessibility or GOV.UK pattern decisions are in scope.
+
+## Entrypoints checked
+
+Checked entrypoints:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+- `registry-manifest.yaml`
+
+## Structural checks
+
+The bundle has canonical prompt, spec, schema, regression, red-team and registry assets.
+
+It is referenced by the operating-model registry and selected by UI, GOV.UK, content, form, component, HTML, CSS and accessibility task signals.
+
+The repository also contains GOV.UK route-state tests and migration documentation that support practical application of the bundle.
+
+## Evaluation coverage
+
+Regression and red-team test assets are present.
+
+Repository-level validation already checks GOV.UK component, form, table, summary-list, page-chrome, navigation, breadcrumb and back-link route-state contracts.
+
+## Known gaps
+
+This validation report does not attempt to exhaustively cross-check every Design System component page against the upstream GOV.UK Design System.
+
+Future work should add source-catalog validation for GOV.UK Design System URLs if this bundle is expanded further.
+
+## Result
+
+The bundle is suitable for current ResearchOps GOV.UK frontend and accessibility work.

--- a/.agent-operating-model/bundles/multi-functional-team/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/multi-functional-team/VALIDATION-REPORT.md
@@ -1,0 +1,53 @@
+# Validation Report — Multi-Functional Team Bundle v1.0.0
+
+Validation status: passed with known evaluation-depth gaps.
+
+Last checked: 2026-05-11.
+
+## Scope
+
+This bundle governs multi-disciplinary government service assurance. It frames product, delivery, design, research, technical, policy, ethics, risk, harm and governance considerations.
+
+It sits above implementation convenience rules when public-sector risk, vulnerable users, service assurance or ethical escalation are relevant.
+
+## Entrypoints checked
+
+Checked entrypoints:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+- `registry-manifest.yaml`
+
+## Structural checks
+
+The bundle has a substantial prompt body and explicit evaluation orchestration.
+
+It includes governance, assurance and role-based operating doctrine suitable for UK government product work.
+
+The bundle is registered as a canonical always-loaded bundle in the repository operating model.
+
+## Evaluation coverage
+
+The eval file defines default, developer and debate pipelines.
+
+Regression and red-team files are present.
+
+The existing coverage is structurally valid, but government assurance behaviour needs more scenario depth than simple file presence can prove.
+
+## Known gaps
+
+The main gap is behavioural depth.
+
+Future red-team expansion should include safeguarding, vulnerable users, high-stakes eligibility, accessibility conflict, delivery pressure, procurement pressure and prompt-versus-governance conflict scenarios.
+
+## Result
+
+The bundle is suitable for current ResearchOps assurance use, with scenario-depth expansion queued as item 5.

--- a/.agent-operating-model/bundles/mural-public-api/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/mural-public-api/VALIDATION-REPORT.md
@@ -1,0 +1,53 @@
+# Validation Report — Mural Public API Bundle v1.0.0
+
+Validation status: passed with queued incident-backfill work.
+
+Last checked: 2026-05-11.
+
+## Scope
+
+This bundle governs Mural Public API integration work, including OAuth, workspaces, rooms, boards, widgets, sticky notes, tags, templates and related collaboration operations.
+
+It applies when ResearchOps work touches Mural board creation, duplication, widget operations or journal synchronisation behaviour.
+
+## Entrypoints checked
+
+Checked entrypoints:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+- `registry-manifest.yaml`
+- `endpoint-coverage.matrix.yaml`
+- `endpoint-source.catalog.yaml`
+
+## Structural checks
+
+The bundle is data-rich, with substantial endpoint coverage and endpoint source catalogues.
+
+The generated bundle manifest schema is present.
+
+The changelog records active iteration.
+
+## Evaluation coverage
+
+Regression and red-team assets are present.
+
+The endpoint coverage and source catalogues provide strong documentation depth.
+
+## Known gaps
+
+The main remaining work is incident backfill.
+
+Future work should promote learned Mural integration failures into contracts, tests and doctrine. Priority areas are OAuth failure modes, 401 and 403 handling, room and workspace ambiguity, board duplication, widget positioning, tag behaviour, retry and backoff, and idempotency.
+
+## Result
+
+The bundle is suitable for current ResearchOps Mural integration use, with incident backfill queued as item 4.

--- a/.agent-operating-model/bundles/researchops-developer-control/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/researchops-developer-control/VALIDATION-REPORT.md
@@ -1,0 +1,51 @@
+# Validation Report — ResearchOps Developer-Control Prompt Bundle v1.13.0
+
+Validation status: passed.
+
+Last checked: 2026-05-11.
+
+## Scope
+
+This bundle governs ResearchOps platform implementation, repository conventions, routing, service boundaries, integration behaviour, testing, performance, metadata, ethics and PR/logging doctrine.
+
+It is the primary ResearchOps-specific development control bundle after GitHub repository governance.
+
+## Entrypoints checked
+
+Checked entrypoints:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+- `registry-manifest.yaml`
+
+## Structural checks
+
+The bundle exposes a full prompt body and prompt spec.
+
+The prompt body loads the ResearchOps platform context, developer control contract, implementation workflow, quality gates, performance rules, integration contracts, API specs, endpoint catalogues, repository conventions, design patterns, example payloads, conformance assets, CI governance, fixture validation, metadata provenance, ethics and PR/logging controls.
+
+The registry and entrypoints align with the canonical bundle directory under `.agent-operating-model/bundles/researchops-developer-control/`.
+
+## Evaluation coverage
+
+The bundle includes regression and red-team test files and a dedicated eval orchestration file.
+
+The strongest coverage is around route availability, endpoint contracts, fixture validation, repository conventions, CI governance and metadata provenance.
+
+## Known gaps
+
+This validation report does not independently re-run every endpoint contract fixture.
+
+Future work should add a bundle-level executable report generator that counts references, modes, roles, templates, tests and known gaps automatically.
+
+## Result
+
+The bundle is suitable for current ResearchOps platform development use.

--- a/.agent-operating-model/pr-queue.md
+++ b/.agent-operating-model/pr-queue.md
@@ -4,13 +4,16 @@ This queue records the agreed sequence for operating-model hardening work.
 
 Only start the next item after the previous PR is merged into `main`.
 
-## Current item
+## Completed
 
 1. Airtable bundle eval hardening and schema consolidation.
 
-## Queue
+## Current item
 
 2. Bundle validation report standard.
+
+## Queue
+
 3. Trace promotion tool.
 4. Mural bundle incident backfill.
 5. Multi-functional-team red-team expansion.

--- a/.agent-operating-model/templates/bundle-validation-report-template.md
+++ b/.agent-operating-model/templates/bundle-validation-report-template.md
@@ -1,0 +1,42 @@
+# Validation Report — <bundle-name> v<version>
+
+Validation status: <passed | conditional | failed>.
+
+Last checked: <YYYY-MM-DD>.
+
+## Scope
+
+Describe the bundle purpose, source authority and operating-model role.
+
+## Entrypoints checked
+
+List the required bundle entrypoints that were checked.
+
+Expected minimum:
+
+- `README.md`
+- `CHANGELOG.md`
+- `prompt.spec.yaml`
+- `prompt.body.xml`
+- `evals.yaml`
+- `tests.regression.yaml`
+- `tests.redteam.yaml`
+- `variables.schema.json`
+- `output.schema.json`
+- `grade.schema.json`
+
+## Structural checks
+
+Record manifest integrity, schema posture, prompt/spec alignment, source catalogue posture and file inventory posture.
+
+## Evaluation coverage
+
+Summarise regression, red-team and behavioural evaluation coverage.
+
+## Known gaps
+
+Record gaps that are accepted for the current bundle version.
+
+## Result
+
+State whether the bundle is suitable for current ResearchOps use.

--- a/tests/bundle-validation-reports.test.js
+++ b/tests/bundle-validation-reports.test.js
@@ -47,7 +47,7 @@ test('validation reports use the standard section structure', () => {
 test('bundle validation report template defines the standard', () => {
 	const template = fs.readFileSync(
 		'.agent-operating-model/templates/bundle-validation-report-template.md',
-		'utf8',
+		'utf8'
 	);
 
 	for (const section of REQUIRED_REPORT_SECTIONS) {

--- a/tests/bundle-validation-reports.test.js
+++ b/tests/bundle-validation-reports.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const BUNDLE_ROOT = '.agent-operating-model/bundles';
+
+const REQUIRED_BUNDLES = [
+	'airtable-public-api',
+	'cloudflare',
+	'github',
+	'govuk-design-system',
+	'multi-functional-team',
+	'mural-public-api',
+	'researchops-developer-control',
+];
+
+const REQUIRED_REPORT_SECTIONS = [
+	'# Validation Report',
+	'Validation status:',
+	'Last checked:',
+	'## Scope',
+	'## Entrypoints checked',
+	'## Structural checks',
+	'## Evaluation coverage',
+	'## Known gaps',
+	'## Result',
+];
+
+test('canonical bundles provide validation reports', () => {
+	for (const bundleId of REQUIRED_BUNDLES) {
+		const reportPath = `${BUNDLE_ROOT}/${bundleId}/VALIDATION-REPORT.md`;
+
+		assert.ok(fs.existsSync(reportPath), `${bundleId} should have a VALIDATION-REPORT.md`);
+	}
+});
+
+test('validation reports use the standard section structure', () => {
+	for (const bundleId of REQUIRED_BUNDLES) {
+		const report = fs.readFileSync(`${BUNDLE_ROOT}/${bundleId}/VALIDATION-REPORT.md`, 'utf8');
+
+		for (const section of REQUIRED_REPORT_SECTIONS) {
+			assert.ok(report.includes(section), `${bundleId} report should include ${section}`);
+		}
+	}
+});
+
+test('bundle validation report template defines the standard', () => {
+	const template = fs.readFileSync(
+		'.agent-operating-model/templates/bundle-validation-report-template.md',
+		'utf8',
+	);
+
+	for (const section of REQUIRED_REPORT_SECTIONS) {
+		assert.ok(template.includes(section), `template should include ${section}`);
+	}
+});


### PR DESCRIPTION
## Summary

Completes operating-model hardening queue item 2: bundle validation report standard.

## Branch

```text
chore/bundle-validation-report-standard-2
```

## Current head

```text
f80fee62609935d5a87af4d725fbd9d42cfe83c6
```

## Changes

Adds a standard validation-report template:

```text
.agent-operating-model/templates/bundle-validation-report-template.md
```

Adds validation reports for canonical bundles that did not already have one:

```text
.agent-operating-model/bundles/researchops-developer-control/VALIDATION-REPORT.md
.agent-operating-model/bundles/multi-functional-team/VALIDATION-REPORT.md
.agent-operating-model/bundles/govuk-design-system/VALIDATION-REPORT.md
.agent-operating-model/bundles/cloudflare/VALIDATION-REPORT.md
.agent-operating-model/bundles/airtable-public-api/VALIDATION-REPORT.md
.agent-operating-model/bundles/mural-public-api/VALIDATION-REPORT.md
```

Keeps the existing GitHub bundle validation report as the mature baseline.

Adds test enforcement:

```text
tests/bundle-validation-reports.test.js
```

The test verifies:

- every canonical bundle has `VALIDATION-REPORT.md`
- every validation report follows the standard section structure
- the template defines the same required sections

## Queue update

Updates `.agent-operating-model/pr-queue.md`:

- marks item 1 as completed
- sets item 2 as current
- keeps items 3 to 5 queued

Next queued item after this PR merges:

```text
Trace promotion tool
```

## Boundaries

No runtime product code changed.

No bundle prompt bodies or specs were changed.

No branch history has been rewritten.

No merge has been attempted.