### PR TITLE
Validate reporting site manifest and screenshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "audit:performance": "bash ./scripts/performance-audit.sh",
     "audit:performance:write": "bash ./scripts/performance-audit.sh --write docs/performance/performance-inventory.md",
     "audit:security": "bash ./scripts/security-audit-policy.sh",
+    "reports:validate": "node scripts/validate-reports-site.mjs",
     "agent:model": "node scripts/agent-operating-model/load-operating-model.mjs",
     "agent:model:validate": "node scripts/agent-operating-model/validate-operating-model.mjs",
     "agent:bundles:validate": "node scripts/agent-operating-model/validate-bundle-registry.mjs",

--- a/scripts/validate-reports-site.mjs
+++ b/scripts/validate-reports-site.mjs
@@ -1,0 +1,188 @@
+/**
+ * @file validate-reports-site.mjs
+ * @module ValidateReportsSite
+ * @summary Validates the committed visual walkthrough reporting site artefacts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function fail(message) {
+	throw new Error(`reports-site: ${message}`);
+}
+
+function assertFile(filePath, label = filePath) {
+	if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+		fail(`missing required file: ${label}`);
+	}
+}
+
+function readJson(filePath, rootDir) {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf8"));
+	} catch (error) {
+		fail(`invalid JSON in ${path.relative(rootDir, filePath)}: ${error.message}`);
+	}
+}
+
+function countFailures(manifest) {
+	let failures = 0;
+
+	for (const page of manifest.pages ?? []) {
+		for (const state of page.states ?? []) {
+			if (state.status && state.status !== "captured") {
+				failures += 1;
+			}
+
+			for (const capture of state.captures ?? []) {
+				if (capture.status && capture.status !== "captured") {
+					failures += 1;
+				}
+			}
+		}
+	}
+
+	return failures;
+}
+
+function collectCaptures(manifest) {
+	return (manifest.pages ?? []).flatMap((page) =>
+		(page.states ?? []).flatMap((state) =>
+			(state.captures ?? []).map((capture) => ({ page, state, capture })),
+		),
+	);
+}
+
+function collectFiles(directoryPath, rootPath = directoryPath) {
+	if (!fs.existsSync(directoryPath)) {
+		fail(`missing required directory: ${path.relative(ROOT_DIR, directoryPath)}`);
+	}
+
+	return fs.readdirSync(directoryPath, { withFileTypes: true }).flatMap((entry) => {
+		const entryPath = path.join(directoryPath, entry.name);
+
+		if (entry.isDirectory()) {
+			return collectFiles(entryPath, rootPath);
+		}
+
+		if (!entry.isFile()) {
+			return [];
+		}
+
+		return path.relative(rootPath, entryPath).replaceAll(path.sep, "/");
+	});
+}
+
+function validateReportsSite({ rootDir = ROOT_DIR } = {}) {
+	const reportsDir = path.join(rootDir, "reports-site");
+	const manifestPath = path.join(reportsDir, "manifest.json");
+	const indexPath = path.join(reportsDir, "index.html");
+
+	assertFile(indexPath, "reports-site/index.html");
+	assertFile(manifestPath, "reports-site/manifest.json");
+
+	const indexHtml = fs.readFileSync(indexPath, "utf8");
+	const manifest = readJson(manifestPath, rootDir);
+
+	if (!indexHtml.includes("ResearchOps application visual walkthrough")) {
+		fail("index.html does not contain the reporting site title");
+	}
+
+	if (!indexHtml.includes("screenshots/")) {
+		fail("index.html does not contain screenshot references");
+	}
+
+	if (!Array.isArray(manifest.pages) || manifest.pages.length === 0) {
+		fail("manifest.pages must contain at least one page");
+	}
+
+	if (!Array.isArray(manifest.profiles) || manifest.profiles.length === 0) {
+		fail("manifest.profiles must contain at least one profile");
+	}
+
+	const pages = manifest.pages;
+	const states = pages.flatMap((page) => page.states ?? []);
+	const captures = collectCaptures(manifest);
+
+	if (manifest.pageCount !== pages.length) {
+		fail(`pageCount mismatch: expected ${pages.length}, got ${manifest.pageCount}`);
+	}
+
+	if (manifest.stateCount !== states.length) {
+		fail(`stateCount mismatch: expected ${states.length}, got ${manifest.stateCount}`);
+	}
+
+	if (manifest.captureCount !== captures.length) {
+		fail(`captureCount mismatch: expected ${captures.length}, got ${manifest.captureCount}`);
+	}
+
+	const failureCount = countFailures(manifest);
+
+	if (manifest.failureCount !== failureCount) {
+		fail(`failureCount mismatch: expected ${failureCount}, got ${manifest.failureCount}`);
+	}
+
+	const profileIds = new Set(manifest.profiles.map((profile) => profile.id));
+	const profileCaptureCounts = new Map([...profileIds].map((profileId) => [profileId, 0]));
+	const screenshotPaths = new Set();
+
+	for (const { page, state, capture } of captures) {
+		if (!capture.profile || !profileIds.has(capture.profile)) {
+			fail(`capture has unknown profile for page ${page.id}, state ${state.id}`);
+		}
+
+		if (!capture.screenshot) {
+			fail(`capture is missing screenshot for page ${page.id}, state ${state.id}, profile ${capture.profile}`);
+		}
+
+		if (path.isAbsolute(capture.screenshot) || capture.screenshot.includes("..")) {
+			fail(`unsafe screenshot path: ${capture.screenshot}`);
+		}
+
+		const screenshotPath = path.join(reportsDir, capture.screenshot);
+		assertFile(screenshotPath, capture.screenshot);
+
+		if (!indexHtml.includes(capture.screenshot)) {
+			fail(`index.html does not reference screenshot from manifest: ${capture.screenshot}`);
+		}
+
+		screenshotPaths.add(capture.screenshot);
+		profileCaptureCounts.set(capture.profile, (profileCaptureCounts.get(capture.profile) ?? 0) + 1);
+	}
+
+	for (const profileId of profileIds) {
+		const count = profileCaptureCounts.get(profileId) ?? 0;
+
+		if (manifest.failureCount === 0 && count !== states.length) {
+			fail(`profile ${profileId} has ${count} captures for ${states.length} states`);
+		}
+	}
+
+	const screenshotFiles = collectFiles(path.join(reportsDir, "screenshots"), reportsDir);
+
+	for (const screenshotFile of screenshotFiles) {
+		if (!screenshotPaths.has(screenshotFile)) {
+			fail(`screenshot file is not referenced by manifest captures: ${screenshotFile}`);
+		}
+	}
+
+	return {
+		captures: captures.length,
+		pages: pages.length,
+		profiles: [...profileIds],
+		screenshots: screenshotPaths.size,
+		states: states.length,
+	};
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	const result = validateReportsSite();
+	console.log(
+		`reports-site: validated ${result.pages} pages, ${result.states} states, ${result.captures} captures`,
+	);
+}
+
+export { validateReportsSite };

--- a/scripts/validate-reports-site.mjs
+++ b/scripts/validate-reports-site.mjs
@@ -28,19 +28,28 @@ function readJson(filePath, rootDir) {
 	}
 }
 
+function isFailedStatus(status) {
+	return Boolean(status && status !== "captured");
+}
+
 function countFailures(manifest) {
+	if (Array.isArray(manifest.failures)) {
+		return manifest.failures.length;
+	}
+
 	let failures = 0;
 
 	for (const page of manifest.pages ?? []) {
 		for (const state of page.states ?? []) {
-			if (state.status && state.status !== "captured") {
-				failures += 1;
+			const failedCaptures = (state.captures ?? []).filter((capture) => isFailedStatus(capture.status));
+
+			if (failedCaptures.length > 0) {
+				failures += failedCaptures.length;
+				continue;
 			}
 
-			for (const capture of state.captures ?? []) {
-				if (capture.status && capture.status !== "captured") {
-					failures += 1;
-				}
+			if (isFailedStatus(state.status)) {
+				failures += 1;
 			}
 		}
 	}
@@ -134,7 +143,13 @@ function validateReportsSite({ rootDir = ROOT_DIR } = {}) {
 			fail(`capture has unknown profile for page ${page.id}, state ${state.id}`);
 		}
 
+		profileCaptureCounts.set(capture.profile, (profileCaptureCounts.get(capture.profile) ?? 0) + 1);
+
 		if (!capture.screenshot) {
+			if (isFailedStatus(capture.status)) {
+				continue;
+			}
+
 			fail(`capture is missing screenshot for page ${page.id}, state ${state.id}, profile ${capture.profile}`);
 		}
 
@@ -150,7 +165,6 @@ function validateReportsSite({ rootDir = ROOT_DIR } = {}) {
 		}
 
 		screenshotPaths.add(capture.screenshot);
-		profileCaptureCounts.set(capture.profile, (profileCaptureCounts.get(capture.profile) ?? 0) + 1);
 	}
 
 	for (const profileId of profileIds) {

--- a/tests/reports-site-validation.test.js
+++ b/tests/reports-site-validation.test.js
@@ -21,64 +21,60 @@ test('failed capture reports match visual walkthrough failure semantics', () => 
 	const screenshotsDir = path.join(reportsDir, 'screenshots', 'desktop');
 	const screenshotPath = path.join(screenshotsDir, 'home__default.png');
 	const relativeScreenshotPath = 'screenshots/desktop/home__default.png';
-
-	fs.mkdirSync(screenshotsDir, { recursive: true });
-	fs.writeFileSync(screenshotPath, 'fake screenshot bytes');
-	fs.writeFileSync(
-		path.join(reportsDir, 'index.html'),
-		`<!doctype html><title>ResearchOps application visual walkthrough</title><img src="${relativeScreenshotPath}" />`,
-	);
-	fs.writeFileSync(
-		path.join(reportsDir, 'manifest.json'),
-		JSON.stringify(
+	const indexHtml = [
+		'<!doctype html>',
+		'<title>ResearchOps application visual walkthrough</title>',
+		`<img src="${relativeScreenshotPath}" />`,
+	].join('');
+	const manifest = {
+		captureCount: 2,
+		failureCount: 1,
+		failures: [
 			{
-				captureCount: 2,
-				failureCount: 1,
-				failures: [
+				message: 'HTTP 500 for test route',
+				page: 'home',
+				profile: 'mobile',
+				state: 'default',
+			},
+		],
+		pageCount: 1,
+		pages: [
+			{
+				id: 'home',
+				states: [
 					{
-						message: 'HTTP 500 for test route',
-						page: 'home',
-						profile: 'mobile',
-						state: 'default',
-					},
-				],
-				pageCount: 1,
-				pages: [
-					{
-						id: 'home',
-						states: [
+						captures: [
 							{
-								captures: [
-									{
-										profile: 'desktop',
-										screenshot: relativeScreenshotPath,
-										status: 'captured',
-									},
-									{
-										profile: 'mobile',
-										status: 'failed',
-									},
-								],
-								id: 'default',
+								profile: 'desktop',
+								screenshot: relativeScreenshotPath,
+								status: 'captured',
+							},
+							{
+								profile: 'mobile',
 								status: 'failed',
 							},
 						],
+						id: 'default',
+						status: 'failed',
 					},
 				],
-				profiles: [
-					{
-						id: 'desktop',
-					},
-					{
-						id: 'mobile',
-					},
-				],
-				stateCount: 1,
 			},
-			null,
-			2,
-		),
-	);
+		],
+		profiles: [
+			{
+				id: 'desktop',
+			},
+			{
+				id: 'mobile',
+			},
+		],
+		stateCount: 1,
+	};
+
+	fs.mkdirSync(screenshotsDir, { recursive: true });
+	fs.writeFileSync(screenshotPath, 'fake screenshot bytes');
+	fs.writeFileSync(path.join(reportsDir, 'index.html'), indexHtml);
+	fs.writeFileSync(path.join(reportsDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
 
 	const result = validateReportsSite({ rootDir });
 

--- a/tests/reports-site-validation.test.js
+++ b/tests/reports-site-validation.test.js
@@ -1,13 +1,13 @@
-import assert from "node:assert/strict";
-import test from "node:test";
-import { validateReportsSite } from "../scripts/validate-reports-site.mjs";
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateReportsSite } from '../scripts/validate-reports-site.mjs';
 
-test("committed reporting site manifest and screenshots are coherent", () => {
+test('committed reporting site manifest and screenshots are coherent', () => {
 	const result = validateReportsSite();
 
 	assert.equal(result.pages, 22);
 	assert.equal(result.states, 39);
 	assert.equal(result.captures, 78);
-	assert.deepEqual(result.profiles.sort(), ["desktop", "mobile"]);
+	assert.deepEqual(result.profiles.sort(), ['desktop', 'mobile']);
 	assert.equal(result.screenshots, 78);
 });

--- a/tests/reports-site-validation.test.js
+++ b/tests/reports-site-validation.test.js
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 import { validateReportsSite } from '../scripts/validate-reports-site.mjs';
 
@@ -10,4 +13,77 @@ test('committed reporting site manifest and screenshots are coherent', () => {
 	assert.equal(result.captures, 78);
 	assert.deepEqual(result.profiles.sort(), ['desktop', 'mobile']);
 	assert.equal(result.screenshots, 78);
+});
+
+test('failed capture reports match visual walkthrough failure semantics', () => {
+	const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reports-site-validation-'));
+	const reportsDir = path.join(rootDir, 'reports-site');
+	const screenshotsDir = path.join(reportsDir, 'screenshots', 'desktop');
+	const screenshotPath = path.join(screenshotsDir, 'home__default.png');
+	const relativeScreenshotPath = 'screenshots/desktop/home__default.png';
+
+	fs.mkdirSync(screenshotsDir, { recursive: true });
+	fs.writeFileSync(screenshotPath, 'fake screenshot bytes');
+	fs.writeFileSync(
+		path.join(reportsDir, 'index.html'),
+		`<!doctype html><title>ResearchOps application visual walkthrough</title><img src="${relativeScreenshotPath}" />`,
+	);
+	fs.writeFileSync(
+		path.join(reportsDir, 'manifest.json'),
+		JSON.stringify(
+			{
+				captureCount: 2,
+				failureCount: 1,
+				failures: [
+					{
+						message: 'HTTP 500 for test route',
+						page: 'home',
+						profile: 'mobile',
+						state: 'default',
+					},
+				],
+				pageCount: 1,
+				pages: [
+					{
+						id: 'home',
+						states: [
+							{
+								captures: [
+									{
+										profile: 'desktop',
+										screenshot: relativeScreenshotPath,
+										status: 'captured',
+									},
+									{
+										profile: 'mobile',
+										status: 'failed',
+									},
+								],
+								id: 'default',
+								status: 'failed',
+							},
+						],
+					},
+				],
+				profiles: [
+					{
+						id: 'desktop',
+					},
+					{
+						id: 'mobile',
+					},
+				],
+				stateCount: 1,
+			},
+			null,
+			2,
+		),
+	);
+
+	const result = validateReportsSite({ rootDir });
+
+	assert.equal(result.pages, 1);
+	assert.equal(result.states, 1);
+	assert.equal(result.captures, 2);
+	assert.equal(result.screenshots, 1);
 });

--- a/tests/reports-site-validation.test.js
+++ b/tests/reports-site-validation.test.js
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateReportsSite } from "../scripts/validate-reports-site.mjs";
+
+test("committed reporting site manifest and screenshots are coherent", () => {
+	const result = validateReportsSite();
+
+	assert.equal(result.pages, 22);
+	assert.equal(result.states, 39);
+	assert.equal(result.captures, 78);
+	assert.deepEqual(result.profiles.sort(), ["desktop", "mobile"]);
+	assert.equal(result.screenshots, 78);
+});


### PR DESCRIPTION
## Summary

Adds a repository validation gate for the committed reporting site artefacts under:

```text
reports-site/
```

This addresses the review gap that the reporting site is generated and committed, but did not have a dedicated integrity check proving that `index.html`, `manifest.json` and screenshots remain coherent.

## Branch

```text
test/reports-site-validation-gate
```

## Current head

```text
df18efbedc359dc3a743e558c609c6da8994c41d
```

## Changes

Adds:

```text
scripts/validate-reports-site.mjs
tests/reports-site-validation.test.js
```

Updates:

```text
package.json
```

with:

```text
reports:validate
```

## What the validator checks

The validator checks that:

- `reports-site/index.html` exists
- `reports-site/manifest.json` exists and is valid JSON
- `manifest.pageCount` matches the number of pages
- `manifest.stateCount` matches the number of states
- `manifest.captureCount` matches the number of captures
- `manifest.failureCount` matches the generator failure model
- `manifest.failures.length` is treated as the source of truth where present
- failed captures without screenshots are allowed
- successful captures must reference screenshot files
- screenshot paths are relative and do not include `..`
- every screenshot file under `reports-site/screenshots/` is referenced by the manifest
- every manifest screenshot is referenced by `index.html`
- profile capture counts are balanced when `failureCount` is 0

## Review feedback addressed

Codex identified that failed visual-walkthrough captures can be represented by both:

```text
state.status = failed
capture.status = failed
```

while the generated manifest still records the failed capture once through `failureCount: failures.length`.

This PR now aligns the validator with the generator semantics. It uses `manifest.failures.length` when present and avoids double-counting the failed state marker and failed capture marker.

It also adds a regression test for a generated report shape with:

```text
1 failed state
1 failed capture
failureCount: 1
no screenshot on the failed capture
```

## CI integration

The validation is enforced through the existing Node test gate:

```text
npm test
```

The new tests import the validator and assert:

```text
22 pages
39 states
78 captures
78 screenshots
profiles: desktop, mobile
```

They also assert that failed-capture report semantics validate correctly.

## Validation observed for current head

For current head `df18efbedc359dc3a743e558c609c6da8994c41d`, the following workflows completed successfully:

- Format pull request
- Validate ResearchOps
- qa-bdd
- QA — Broken links (Lychee)
- Accessibility audit (pa11y-ci)
- CI
- Worker CI
- Release Gate

## Review focus

Please review:

1. Whether the validator checks are strict enough for committed reporting-site evidence.
2. Whether the fixed page/state/capture count assertions should stay, or whether they should be loosened in future as the reporting site grows.
3. Whether `reports:validate` should also be called directly from `scripts/validate.sh` in a later PR.

## Boundaries

This PR does not regenerate the reporting site.

This PR does not add a separate reporting-site deployment workflow.

This PR does not modify screenshots, manifest content or page HTML.