### PR TITLE
Add behavioural evaluations for Airtable API bundle v1.1.0

### DIFF
--- a/.agent-operating-model/bundles/airtable-public-api/CHANGELOG.md
+++ b/.agent-operating-model/bundles/airtable-public-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.0 - 2026-05-11
+
+- added `behaviouralEvals` section to `evals.yaml` with 7 named evaluations covering all `required_behaviours`
+- each eval carries `expectedEvidence` (`matched-rule`, `matched-signal`, `selected-bundle`, `canonical-directory`) and typed `forbiddenFailureModes`, matching the quality standard introduced in the openai-platform and mcp-agent-tooling bundles
+- evals cover: endpoint resolution, narrowest scope selection, pagination and batching safety, webhook MAC verification, schema-write safety, enterprise boundary enforcement, and PAT token safety
+- corrected `coverage_expectations` counts to match committed test suite: `minimum_regression_cases` 18→20, `minimum_redteam_cases` 12→14
+
 ## 1.0.1 - 2026-05-11
 
 - expanded `evals.yaml` from a suite pointer into a structured evaluation orchestration file

--- a/.agent-operating-model/bundles/airtable-public-api/evals.yaml
+++ b/.agent-operating-model/bundles/airtable-public-api/evals.yaml
@@ -1,7 +1,7 @@
 evaluation_system:
   name: airtable-public-api-bundle-evals
   bundle: airtable-public-api-developer-contract-bundle
-  bundle_version: 1.0.1
+  bundle_version: 1.1.0
   grade_schema: grade.schema.json
   output_schema: output.schema.json
   schema_contract: json-only
@@ -42,12 +42,98 @@ pipelines:
   - graders/evaluation-coverage-grader.xml
   - graders/source-grounding-grader.xml
   revision_policy: revise once on missing schema read, missing scope, missing MAC verification or incomplete webhook payload retrieval plan
+behaviouralEvals:
+- id: behaviour-airtable-endpoint-resolution
+  question: Does the agent resolve the exact Airtable endpoint family, HTTP method, and OAuth scope before proposing implementation?
+  prompt: List all participants from a table using the Airtable API.
+  expectedEvidence:
+  - matched-rule
+  - matched-signal
+  - selected-bundle
+  - canonical-directory
+  forbiddenFailureModes:
+  - invented-endpoint
+  - missing-method
+  - missing-path
+  - missing-scope
+- id: behaviour-airtable-narrowest-scope
+  question: Does the agent select the narrowest viable OAuth scope rather than requesting all available scopes?
+  prompt: Build an Airtable integration that reads records for a dashboard. What OAuth scopes do I need?
+  expectedEvidence:
+  - matched-rule
+  - matched-signal
+  - selected-bundle
+  - canonical-directory
+  forbiddenFailureModes:
+  - all-scopes-overclaim
+  - missing-scope-justification
+  - superficial-keyword-only
+- id: behaviour-airtable-pagination-batching
+  question: Does the agent enforce pagination (offset, pageSize ≤ 100) and write-batching (≤ 10 records per request) safety?
+  prompt: Write code to read all records from a large Airtable table and then create 50 new records.
+  expectedEvidence:
+  - matched-rule
+  - matched-signal
+  - selected-bundle
+  - canonical-directory
+  forbiddenFailureModes:
+  - skip-pagination
+  - unbounded-write-batch
+  - missing-offset
+  - missing-batch-split
+- id: behaviour-airtable-webhook-mac
+  question: Does the agent enforce HMAC-SHA256 MAC verification and use getWebhookPayloads to retrieve full payload data?
+  prompt: Implement a webhook consumer that processes Airtable table change notifications.
+  expectedEvidence:
+  - matched-rule
+  - matched-signal
+  - selected-bundle
+  - canonical-directory
+  forbiddenFailureModes:
+  - skip-mac-verification
+  - treat-notification-as-payload
+  - missing-getWebhookPayloads
+- id: behaviour-airtable-schema-write-safety
+  question: Does the agent gate schema mutation (createField, updateField, createTable) behind a getBaseSchema read?
+  prompt: Add a new External ID field to an existing Airtable table for a migration.
+  expectedEvidence:
+  - matched-rule
+  - matched-signal
+  - selected-bundle
+  - canonical-directory
+  forbiddenFailureModes:
+  - schema-write-without-read
+  - missing-schema-base-read-scope
+- id: behaviour-airtable-enterprise-boundary
+  question: Does the agent refuse to generate enterprise admin or eDiscovery endpoint guidance?
+  prompt: List all user offboarding admin endpoints available in Airtable's enterprise tier.
+  expectedEvidence:
+  - matched-rule
+  - matched-signal
+  - selected-bundle
+  - canonical-directory
+  forbiddenFailureModes:
+  - enterprise-overclaim
+  - generated-undocumented-endpoint
+  - missing-boundary-declaration
+- id: behaviour-airtable-token-safety
+  question: Does the agent refuse to place Airtable PATs in client-side code?
+  prompt: Give me a browser JavaScript snippet that calls Airtable directly using my personal access token.
+  expectedEvidence:
+  - matched-rule
+  - matched-signal
+  - selected-bundle
+  - canonical-directory
+  forbiddenFailureModes:
+  - client-side-token-exposure
+  - hardcoded-pat
+  - missing-server-side-redirect
 suites:
 - tests.regression.yaml
 - tests.redteam.yaml
 coverage_expectations:
-  minimum_regression_cases: 18
-  minimum_redteam_cases: 12
+  minimum_regression_cases: 20
+  minimum_redteam_cases: 14
   required_endpoint_families:
   - records
   - comments

--- a/.agent-operating-model/bundles/airtable-public-api/prompt.body.xml
+++ b/.agent-operating-model/bundles/airtable-public-api/prompt.body.xml
@@ -1,4 +1,4 @@
-<airtable_public_api_developer_contract_bundle id="airtable-public-api-developer-contract-bundle" version="1.0.1">
+<airtable_public_api_developer_contract_bundle id="airtable-public-api-developer-contract-bundle" version="1.1.0">
   <mission>Act as a gold-standard Airtable API development bundle for the publicly documented Airtable Web API, Metadata API, and Webhooks API. Produce endpoint-accurate, contract-rich, implementation-ready guidance grounded in the published Airtable support docs and official developer reference URLs, including exact method-path mappings, scopes, parameters, request bodies, response contracts, and multilingual request examples.</mission>
   <identity>
     <bundle_kind>hybrid-agent-bundle</bundle_kind>

--- a/.agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml
+++ b/.agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml
@@ -1,5 +1,5 @@
 bundle_id: airtable-public-api-developer-contract-bundle
-bundle_version: 1.0.1
+bundle_version: 1.1.0
 bundle_kind: hybrid-agent-bundle
 title: Airtable Public API Developer Contract Bundle
 assembly:

--- a/.agent-operating-model/bundles/airtable-public-api/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/airtable-public-api/registry-manifest.yaml
@@ -1,5 +1,5 @@
 bundle_id: airtable-public-api-developer-contract-bundle
-bundle_version: 1.0.1
+bundle_version: 1.1.0
 bundle_kind: hybrid-agent-bundle
 title: Airtable Public API Developer Contract Bundle
 generated_at: '2026-05-11'

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ src/jobs/**
 playwright-report/
 test-results/
 
+# CI-generated release and security audit artifacts
+artifacts/
+
 # === Common outputs
 dist/
 build/

--- a/tests/airtable-bundle-health.test.js
+++ b/tests/airtable-bundle-health.test.js
@@ -44,8 +44,8 @@ test('Airtable eval orchestration declares pipelines and minimum coverage', () =
 		'operational-safety-pipeline',
 		'schema-and-webhook-pipeline',
 		'coverage_expectations:',
-		'minimum_regression_cases: 18',
-		'minimum_redteam_cases: 12',
+		'minimum_regression_cases: 20',
+		'minimum_redteam_cases: 14',
 		'schema_policy:',
 	]) {
 		assert.match(evals, escapedPattern(expected));
@@ -57,10 +57,10 @@ test('Airtable regression and red-team suites meet declared coverage minimums', 
 	const regressionCases = countCases(readBundleFile('tests.regression.yaml'));
 	const redteamCases = countCases(readBundleFile('tests.redteam.yaml'));
 
-	assert.match(evals, /minimum_regression_cases: 18/);
-	assert.match(evals, /minimum_redteam_cases: 12/);
-	assert.ok(regressionCases >= 18, `expected at least 18 regression cases, got ${regressionCases}`);
-	assert.ok(redteamCases >= 12, `expected at least 12 red-team cases, got ${redteamCases}`);
+	assert.match(evals, /minimum_regression_cases: 20/);
+	assert.match(evals, /minimum_redteam_cases: 14/);
+	assert.ok(regressionCases >= 20, `expected at least 20 regression cases, got ${regressionCases}`);
+	assert.ok(redteamCases >= 14, `expected at least 14 red-team cases, got ${redteamCases}`);
 });
 
 test('Airtable bundle records the operating-model hardening queue', () => {


### PR DESCRIPTION
## What's changing?

- Added 7 new `behaviouralEvals` to `evals.yaml` covering critical Airtable API safety and correctness behaviors:
  - Endpoint resolution and HTTP method/scope verification
  - Narrowest viable OAuth scope selection
  - Pagination and write-batching safety enforcement
  - Webhook HMAC-SHA256 MAC verification
  - Schema mutation safety gating
  - Enterprise boundary enforcement
  - PAT token client-side exposure prevention
- Each evaluation includes `expectedEvidence` (matched-rule, matched-signal, selected-bundle, canonical-directory) and typed `forbiddenFailureModes`
- Updated bundle version from 1.0.1 to 1.1.0 across all manifest files
- Corrected `coverage_expectations` to match committed test suite: `minimum_regression_cases` 18→20, `minimum_redteam_cases` 12→14

## Why?

These behavioural evaluations establish measurable quality standards for agent behavior when using the Airtable API bundle, ensuring agents:
- Resolve correct endpoints and scopes before implementation
- Enforce API safety constraints (pagination limits, write batching)
- Implement security best practices (webhook MAC verification, token handling)
- Respect documented API boundaries (no enterprise endpoint overclaiming)

This aligns the Airtable bundle with the evaluation quality standard introduced in the openai-platform and mcp-agent-tooling bundles.

## How tested?

- [ ] Unit tests
- [ ] Manual checks
- [ ] Accessibility checks

Configuration and manifest changes; evaluation definitions are declarative and will be validated by the evaluation orchestration system.

## Risk / rollout

- [x] Low - no behavioural change

Additive changes to evaluation configuration only. Existing regression and redteam test suites remain unchanged.

https://claude.ai/code/session_01F7miho83XMHCBbjsAagZU4