### PR TITLE
Airtable evals v1.1.0, May 11 traces, reports:validate wiring

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/11/airtable-bundle-evals-expansion-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/11/airtable-bundle-evals-expansion-trace.json
@@ -1,0 +1,101 @@
+{
+	"trace_id": "atrace-20260511-airtable-bundle-evals-expansion",
+	"trace_layer": "operational",
+	"trace_source": "live-session",
+	"date": "2026-05-11",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "claude/fetch-parallel-updates-ZbDQQ",
+	"pull_request": {
+		"number": 236,
+		"state": "merged",
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/236"
+	},
+	"trigger": "agent-task",
+	"request_interpreted": [
+		"Expand the sparse airtable-public-api/evals.yaml from a pipeline-and-coverage structure into a full evaluation file with named behaviour evaluations.",
+		"Each behaviour eval must carry expectedEvidence and forbiddenFailureModes, matching the quality standard introduced in the openai-platform and mcp-agent-tooling bundles.",
+		"Fix stale coverage_expectations counts to match the committed test suite.",
+		"Address CI failures and Codex review comments on the resulting PR."
+	],
+	"operating_model_files_loaded": [
+		".agent-operating-model/bundles/airtable-public-api/evals.yaml",
+		".agent-operating-model/bundles/airtable-public-api/tests.regression.yaml",
+		".agent-operating-model/bundles/airtable-public-api/tests.redteam.yaml",
+		".agent-operating-model/bundles/airtable-public-api/registry-manifest.yaml",
+		".agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml",
+		".agent-operating-model/bundles/airtable-public-api/prompt.body.xml",
+		".agent-operating-model/bundles/airtable-public-api/CHANGELOG.md",
+		".agent-operating-model/bundles/airtable-public-api/grade.schema.json",
+		".agent-operating-model/bundles/mcp-agent-tooling/evals.yaml",
+		".agent-operating-model/behavioural-evals.json",
+		"tests/airtable-bundle-health.test.js"
+	],
+	"bundles_selected": [
+		"airtable-public-api",
+		"researchops-developer-control",
+		"github-diamond",
+		"multi-functional-team"
+	],
+	"files_modified": [
+		".agent-operating-model/bundles/airtable-public-api/evals.yaml",
+		".agent-operating-model/bundles/airtable-public-api/CHANGELOG.md",
+		".agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml",
+		".agent-operating-model/bundles/airtable-public-api/registry-manifest.yaml",
+		".agent-operating-model/bundles/airtable-public-api/prompt.body.xml",
+		"tests/airtable-bundle-health.test.js",
+		".gitignore"
+	],
+	"commits_recorded": [
+		"344cfa4",
+		"3a31def",
+		"6541c35"
+	],
+	"key_decisions": [
+		"Seven named behaviouralEvals added, one per required_behaviour in coverage_expectations: endpoint-resolution, narrowest-scope, pagination-batching, webhook-mac, schema-write-safety, enterprise-boundary, token-safety.",
+		"Each eval carries expectedEvidence [matched-rule, matched-signal, selected-bundle, canonical-directory] and typed forbiddenFailureModes.",
+		"Bundle version bumped from 1.0.1 to 1.1.0 across evals.yaml, prompt.spec.yaml, registry-manifest.yaml, and prompt.body.xml root element.",
+		"coverage_expectations corrected: minimum_regression_cases 18 to 20, minimum_redteam_cases 12 to 14.",
+		"tests/airtable-bundle-health.test.js assertions updated to match corrected minimums — fixing Node 20, Node 22 and Release gate CI failures.",
+		"artifacts/ added to .gitignore: CI-generated security audit outputs were untracked but should never be committed."
+	],
+	"ci_failures_resolved": [
+		{
+			"check": "Node 20",
+			"root_cause": "airtable-bundle-health.test.js asserted old minimums (18/12) after evals.yaml was bumped to 20/14",
+			"fix_commit": "3a31def"
+		},
+		{
+			"check": "Node 22",
+			"root_cause": "Same as Node 20",
+			"fix_commit": "3a31def"
+		},
+		{
+			"check": "Release gate",
+			"root_cause": "Downstream of Node test failures",
+			"fix_commit": "3a31def"
+		}
+	],
+	"codex_reviews_addressed": [
+		{
+			"priority": "P1",
+			"comment": "Keep Airtable bundle health tests aligned",
+			"action": "Updated all four assertions in tests/airtable-bundle-health.test.js",
+			"commit": "3a31def"
+		},
+		{
+			"priority": "P2",
+			"comment": "Bump the root prompt version too",
+			"action": "Updated prompt.body.xml root element from version=1.0.1 to version=1.1.0",
+			"commit": "3a31def"
+		}
+	],
+	"validation_recorded": [
+		"All 4 airtable-bundle-health tests pass locally after fix.",
+		"Cloudflare Pages deploy succeeded for PR #236.",
+		"PR merged with all CI checks green."
+	],
+	"status_at_trace_write": {
+		"pr_merged": true,
+		"merge_commit": "6541c35"
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/11/airtable-bundle-evals-expansion-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/11/airtable-bundle-evals-expansion-trace.md
@@ -1,0 +1,106 @@
+# Agent trace: Airtable bundle evals expansion
+
+Date: 2026-05-11
+
+Branch: `claude/fetch-parallel-updates-ZbDQQ`
+
+Pull request: #236
+
+## Trigger
+
+Agent task from live session. This trace records the implementation audit for PR #236.
+
+## Request interpreted
+
+Expand the `airtable-public-api/evals.yaml` file from its current pipeline-and-coverage structure into a full evaluation file with named behaviour evaluations, matching the quality standard introduced in the openai-platform and mcp-agent-tooling bundles.
+
+Required outcomes:
+
+- add a `behaviouralEvals` section with named evaluations, one per `required_behaviour` in `coverage_expectations`
+- each eval carries `expectedEvidence` (`matched-rule`, `matched-signal`, `selected-bundle`, `canonical-directory`) and typed `forbiddenFailureModes`
+- correct stale `coverage_expectations` counts (18/12 to 20/14) to match the committed test suite
+- bump bundle version from 1.0.1 to 1.1.0 across all bundle metadata files
+
+## Evidence checked
+
+Repository files read:
+
+- `.agent-operating-model/bundles/airtable-public-api/evals.yaml`
+- `.agent-operating-model/bundles/airtable-public-api/tests.regression.yaml` (20 cases confirmed)
+- `.agent-operating-model/bundles/airtable-public-api/tests.redteam.yaml` (14 cases confirmed)
+- `.agent-operating-model/bundles/airtable-public-api/registry-manifest.yaml`
+- `.agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml`
+- `.agent-operating-model/bundles/airtable-public-api/prompt.body.xml`
+- `.agent-operating-model/bundles/airtable-public-api/CHANGELOG.md`
+- `.agent-operating-model/bundles/airtable-public-api/grade.schema.json`
+- `.agent-operating-model/bundles/mcp-agent-tooling/evals.yaml` (reference for mature pattern)
+- `.agent-operating-model/behavioural-evals.json` (confirmed `behaviour-structured-rule-application` already references airtable bundle)
+- `tests/airtable-bundle-health.test.js`
+
+The CHANGELOG confirmed v1.0.1 was set earlier the same day when evals.yaml was first expanded from a bare suite pointer to its pipeline structure.
+
+## Findings
+
+The `evals.yaml` file had three evaluation pipelines, a `coverage_expectations` block, and a `schema_policy` block — but no named `behaviouralEvals` section.
+
+The `behavioural-evals.json` `behaviour-structured-rule-application` eval already cited `airtable-public-api` as an expected bundle, creating an inbound reference with no corresponding outbound declaration in the airtable bundle itself.
+
+`coverage_expectations` counts were stale: `minimum_regression_cases: 18` but the committed regression suite had 20 cases; `minimum_redteam_cases: 12` but the committed redteam suite had 14 cases.
+
+The `prompt.body.xml` root element still declared `version="1.0.1"` after `prompt.spec.yaml` and `registry-manifest.yaml` were bumped by the day's earlier work, creating a version skew.
+
+## Implementation applied
+
+**behaviouralEvals section added** with 7 named evaluations:
+
+| Eval ID | Behaviour | Key forbidden failure modes |
+|---|---|---|
+| `behaviour-airtable-endpoint-resolution` | Exact endpoint family, method, scope before implementation | `invented-endpoint`, `missing-scope` |
+| `behaviour-airtable-narrowest-scope` | Narrowest viable OAuth scopes only | `all-scopes-overclaim`, `superficial-keyword-only` |
+| `behaviour-airtable-pagination-batching` | offset/pageSize ≤ 100, write batches ≤ 10 | `skip-pagination`, `unbounded-write-batch` |
+| `behaviour-airtable-webhook-mac` | HMAC-SHA256 MAC + `getWebhookPayloads` required | `skip-mac-verification`, `treat-notification-as-payload` |
+| `behaviour-airtable-schema-write-safety` | `getBaseSchema` read gates schema mutation | `schema-write-without-read` |
+| `behaviour-airtable-enterprise-boundary` | Refuses Enterprise/eDiscovery endpoint invention | `enterprise-overclaim`, `generated-undocumented-endpoint` |
+| `behaviour-airtable-token-safety` | Refuses client-side PAT exposure | `client-side-token-exposure`, `hardcoded-pat` |
+
+**Coverage counts corrected:** `minimum_regression_cases: 18 → 20`, `minimum_redteam_cases: 12 → 14`.
+
+**Version bumped to 1.1.0** across `evals.yaml`, `prompt.spec.yaml`, `registry-manifest.yaml`, and `prompt.body.xml` root element.
+
+**`.gitignore` updated:** `artifacts/` added so CI-generated security audit outputs do not appear as untracked files.
+
+## CI failures resolved
+
+After the initial commit, three CI checks failed on PR #236:
+
+- **Node 20 / Node 22:** `tests/airtable-bundle-health.test.js` was asserting the old minimum counts (18/12) against the evals.yaml that now declared 20/14. Four assertions updated. All 4 health tests pass locally.
+- **Release gate:** downstream of the Node test failures; cleared after fix.
+
+This was identified and fixed in the same session before merge.
+
+## Codex reviews addressed
+
+Two Codex review comments were left on PR #236:
+
+- **P1** — Keep Airtable bundle health tests aligned. Valid. Fixed in commit `3a31def`.
+- **P2** — Bump the root prompt version too. Valid. Fixed in commit `3a31def`.
+
+Replies with 👍 posted to both review threads confirming the fix.
+
+## Commits recorded
+
+```text
+344cfa4 Expand airtable-public-api evals to v1.1.0 with named behaviour evaluations
+3a31def Fix airtable bundle test assertions and prompt.body.xml version for v1.1.0
+6541c35 Add artifacts/ to .gitignore
+```
+
+## Validation recorded
+
+- All 4 `airtable-bundle-health` tests pass locally
+- Cloudflare Pages deploy succeeded
+- PR #236 merged with all CI checks green
+
+## Current status at trace write
+
+PR #236 merged. Merge commit: `6541c35`.

--- a/docs/agent-audit/reasoning/2026/05/11/mcp-agent-tooling-bundle-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/11/mcp-agent-tooling-bundle-trace.json
@@ -1,0 +1,115 @@
+{
+	"trace_id": "atrace-20260511-mcp-agent-tooling-bundle",
+	"trace_layer": "operational",
+	"trace_source": "retrospective-commit-evidence",
+	"date": "2026-05-11",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "perf/include-mcp-agent-tooling-bundle",
+	"pull_request": {
+		"number": 233,
+		"state": "merged",
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/233"
+	},
+	"trigger": "agent-task",
+	"note": "Retrospective trace created from commit evidence. No live [reasoning] session was captured for this PR.",
+	"request_interpreted": [
+		"Add the MCP Agent Tooling bundle as a new canonical bundle directory.",
+		"Register selection rules and signal phrases for MCP protocol, servers, clients, tools, sampling, roots, elicitation, and tool consent.",
+		"Wire the bundle into the operating model: README, bundle-registry.json, orchestration docs, agent instructions.",
+		"Add a behavioural eval (behaviour-mcp-tool-consent) with expectedEvidence and forbiddenFailureModes.",
+		"Qualify trigger phrases to prevent OpenAI tool keywords from selecting the MCP bundle.",
+		"Add roles, modes, templates, and reference modules for MCP developer, agent-safety, and tool-qa."
+	],
+	"operating_model_files_loaded": [
+		".agent-operating-model/README.md",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/task-signal-catalog.json"
+	],
+	"bundles_selected": [
+		"researchops-developer-control",
+		"github-diamond",
+		"multi-functional-team"
+	],
+	"bundles_created": [
+		"mcp-agent-tooling"
+	],
+	"files_created": [
+		".agent-operating-model/bundles/mcp-agent-tooling/prompt.body.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/prompt.spec.yaml",
+		".agent-operating-model/bundles/mcp-agent-tooling/registry-manifest.yaml",
+		".agent-operating-model/bundles/mcp-agent-tooling/CHANGELOG.md",
+		".agent-operating-model/bundles/mcp-agent-tooling/README.md",
+		".agent-operating-model/bundles/mcp-agent-tooling/evals.yaml",
+		".agent-operating-model/bundles/mcp-agent-tooling/grade.schema.json",
+		".agent-operating-model/bundles/mcp-agent-tooling/output.schema.json",
+		".agent-operating-model/bundles/mcp-agent-tooling/variables.schema.json",
+		".agent-operating-model/bundles/mcp-agent-tooling/tests.redteam.yaml",
+		".agent-operating-model/bundles/mcp-agent-tooling/tests.regression.yaml",
+		".agent-operating-model/bundles/mcp-agent-tooling/roles/agent-safety.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/roles/mcp-developer.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/roles/tool-qa.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/modes/mcp-build.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/modes/mcp-release.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/modes/mcp-review.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/templates/consent-checkpoint.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/templates/resource-contract.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/templates/tool-contract.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/graders/mcp-behaviour.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/contracts/agent-tooling-validation-evidence.schema.json",
+		".agent-operating-model/bundles/mcp-agent-tooling/contracts/resource-exposure-review.schema.json",
+		".agent-operating-model/bundles/mcp-agent-tooling/contracts/tool-invocation-review.schema.json",
+		".agent-operating-model/bundles/mcp-agent-tooling/references/architecture-lifecycle.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/references/authorization-security.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/references/client-features.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/references/mcp-platform-context.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/references/resources-prompts-tools.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/references/source-catalog.yaml",
+		".agent-operating-model/bundles/mcp-agent-tooling/references/utilities-and-errors.xml",
+		".agent-operating-model/bundles/mcp-agent-tooling/scripts/validate-source-catalog.py",
+		".agent-operating-model/bundles/mcp-agent-tooling/examples/resource-contract.example.yaml",
+		".agent-operating-model/bundles/mcp-agent-tooling/examples/tool-contract.example.json"
+	],
+	"files_modified": [
+		".agent-operating-model/README.md",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/task-signal-catalog.json"
+	],
+	"commits_recorded": [
+		"e95dd01",
+		"2530356",
+		"fda2e61",
+		"afcdc0d",
+		"2485d66",
+		"3e3df2f",
+		"9938a9d",
+		"9f6ab5b",
+		"14bf155",
+		"e71be87",
+		"1798278",
+		"371ae23",
+		"7d0a34e",
+		"ffdac67",
+		"16a38db"
+	],
+	"key_decisions": [
+		"MCP trigger phrases qualified to prevent selection by OpenAI tool-use keywords.",
+		"Test added confirming OpenAI tool wording does not select MCP bundle.",
+		"forbiddenFailureModes on behaviour-mcp-tool-consent includes superficial-keyword-only.",
+		"expectedEvidence array: matched-rule, matched-signal, selected-bundle, canonical-directory.",
+		"MCP bundle assigned precedence 64, one below openai-platform (65)."
+	],
+	"validation_recorded": [
+		"Operating model selection test added for MCP bundle.",
+		"Negative test added: OpenAI tool wording must not select MCP bundle.",
+		"Behavioural eval behaviour-mcp-tool-consent added to behavioural-evals.json.",
+		"Source catalog validation script added."
+	],
+	"status_at_trace_write": {
+		"pr_merged": true,
+		"merge_commit": "16a38db"
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/11/mcp-agent-tooling-bundle-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/11/mcp-agent-tooling-bundle-trace.md
@@ -1,0 +1,94 @@
+# Agent trace: MCP Agent Tooling bundle
+
+Date: 2026-05-11
+
+Branch: `perf/include-mcp-agent-tooling-bundle`
+
+Pull request: #233
+
+## Note
+
+Retrospective trace created from commit evidence after merge. No live `[reasoning]` session was captured for this PR.
+
+## Request interpreted
+
+Add the MCP Agent Tooling bundle as a new canonical bundle directory and wire it fully into the operating model.
+
+Required outcomes:
+
+- add `mcp-agent-tooling` as a canonical bundle directory with core files, reference modules, roles, modes, templates, graders, contracts, and examples
+- register selection rules and signal phrases covering MCP protocol, servers, clients, tools, sampling, roots, elicitation, and tool consent
+- wire the bundle into `bundle-registry.json`, `selection-rules.json`, `task-signal-catalog.json`, operating model README, and agent instructions
+- add behavioural eval `behaviour-mcp-tool-consent` with `expectedEvidence` and `forbiddenFailureModes`
+- qualify trigger phrases to prevent OpenAI tool keywords from selecting the MCP bundle
+
+## Evidence checked
+
+Repository files checked from commit evidence:
+
+- `.agent-operating-model/README.md`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/bundles/openai-platform/` (for cross-bundle boundary)
+
+## Implementation applied
+
+Full bundle directory created under `.agent-operating-model/bundles/mcp-agent-tooling/` including `prompt.body.xml`, `prompt.spec.yaml`, `registry-manifest.yaml`, `CHANGELOG.md`, `README.md`, `evals.yaml`, schemas, test suites, three roles (`agent-safety`, `mcp-developer`, `tool-qa`), three modes (`mcp-build`, `mcp-release`, `mcp-review`), three templates (`consent-checkpoint`, `resource-contract`, `tool-contract`), a behaviour grader, contracts, reference modules, a source catalog, and a source catalog validation script.
+
+Operating model wiring commits in order:
+
+1. Add MCP agent tooling bundle core files
+2. Add MCP agent tooling reference modules
+3. Add MCP agent tooling operational modules
+4. Register MCP agent tooling bundle selection rules
+5. Document MCP bundle in orchestration
+6. Document MCP canonical bundle directory
+7. Document MCP bundle precedence
+8. Reference MCP canonical bundle in agent instructions
+9. Validate MCP bundle operating model selection
+10. Add MCP behavioural operating model eval
+11. Test MCP bundle operating model selection
+12. Qualify MCP tool selector phrases
+13. Qualify MCP registry keywords
+14. Test OpenAI tool wording does not select MCP
+
+## Key decisions
+
+MCP trigger phrases qualified after testing showed overlap with OpenAI tool-use vocabulary. A dedicated negative test (`ffdac67`) confirms OpenAI tool wording does not select the MCP bundle.
+
+`behaviour-mcp-tool-consent` eval carries `expectedEvidence` and `forbiddenFailureModes: [superficial-keyword-only]`, consistent with the standard set by `behaviour-openai-structured-output` in PR #232.
+
+MCP bundle assigned precedence 64, one below openai-platform (65).
+
+## Commits recorded
+
+```text
+e95dd01 Add MCP agent tooling bundle core files
+2530356 Add MCP agent tooling reference modules
+fda2e61 Add MCP agent tooling operational modules
+afcdc0d Register MCP agent tooling bundle selection rules
+2485d66 Document MCP bundle in orchestration
+3e3df2f Document MCP canonical bundle directory
+9938a9d Document MCP bundle precedence
+9f6ab5b Reference MCP canonical bundle in agent instructions
+14bf155 Validate MCP bundle operating model selection
+e71be87 Add MCP behavioural operating model eval
+1798278 Test MCP bundle operating model selection
+371ae23 Qualify MCP tool selector phrases
+7d0a34e Qualify MCP registry keywords
+ffdac67 Test OpenAI tool wording does not select MCP
+16a38db Merge pull request #233
+```
+
+## Validation recorded
+
+- Operating model selection test added for MCP bundle
+- Negative test: OpenAI tool wording must not select MCP bundle
+- Behavioural eval `behaviour-mcp-tool-consent` added to `behavioural-evals.json`
+- Source catalog validation script added
+
+## Current status at trace write
+
+PR #233 merged. Merge commit: `16a38db`.

--- a/docs/agent-audit/reasoning/2026/05/11/openai-platform-bundle-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/11/openai-platform-bundle-trace.json
@@ -1,0 +1,89 @@
+{
+	"trace_id": "atrace-20260511-openai-platform-bundle",
+	"trace_layer": "operational",
+	"trace_source": "retrospective-commit-evidence",
+	"date": "2026-05-11",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "perf/include-openai-platform-bundle",
+	"pull_request": {
+		"number": 232,
+		"state": "merged",
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/232"
+	},
+	"trigger": "agent-task",
+	"note": "Retrospective trace created from commit evidence. No live [reasoning] session was captured for this PR.",
+	"request_interpreted": [
+		"Add the OpenAI Platform bundle as a new canonical bundle directory.",
+		"Register selection rules and signal phrases for OpenAI API, Responses API, Structured Outputs, embeddings, Batch, Realtime, and Evals.",
+		"Wire the bundle into the operating model: README, bundle-registry.json, orchestration docs, agent instructions.",
+		"Add a behavioural eval (behaviour-openai-structured-output) with expectedEvidence and forbiddenFailureModes.",
+		"Qualify trigger phrases to prevent superficial-keyword-only selection.",
+		"Validate operating model selection and require bundle files in repository validation."
+	],
+	"operating_model_files_loaded": [
+		".agent-operating-model/README.md",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/task-signal-catalog.json"
+	],
+	"bundles_selected": [
+		"researchops-developer-control",
+		"github-diamond",
+		"multi-functional-team"
+	],
+	"bundles_created": [
+		"openai-platform"
+	],
+	"files_created": [
+		".agent-operating-model/bundles/openai-platform/prompt.body.xml",
+		".agent-operating-model/bundles/openai-platform/prompt.spec.yaml",
+		".agent-operating-model/bundles/openai-platform/registry-manifest.yaml",
+		".agent-operating-model/bundles/openai-platform/CHANGELOG.md",
+		".agent-operating-model/bundles/openai-platform/README.md",
+		".agent-operating-model/bundles/openai-platform/evals.yaml",
+		".agent-operating-model/bundles/openai-platform/grade.schema.json",
+		".agent-operating-model/bundles/openai-platform/output.schema.json",
+		".agent-operating-model/bundles/openai-platform/variables.schema.json",
+		".agent-operating-model/bundles/openai-platform/tests.redteam.yaml",
+		".agent-operating-model/bundles/openai-platform/tests.regression.yaml"
+	],
+	"files_modified": [
+		".agent-operating-model/README.md",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/task-signal-catalog.json"
+	],
+	"commits_recorded": [
+		"f773122",
+		"fc54842",
+		"40374c7",
+		"35a79bd",
+		"f9f56f8",
+		"3fa856a",
+		"8a62612",
+		"548a1a0",
+		"0db7551",
+		"b823329",
+		"57a0a44",
+		"a60516d",
+		"56e8910",
+		"c8f85c2"
+	],
+	"key_decisions": [
+		"Trigger phrases qualified to prevent superficial-keyword-only bundle selection.",
+		"forbiddenFailureModes on behaviour-openai-structured-output includes superficial-keyword-only.",
+		"expectedEvidence array introduced: matched-rule, matched-signal, selected-bundle, canonical-directory.",
+		"OpenAI bundle assigned precedence 65, below cloudflare (70) and above airtable-public-api (60)."
+	],
+	"validation_recorded": [
+		"Operating model selection test added for OpenAI bundle.",
+		"Behavioural eval behaviour-openai-structured-output added to behavioural-evals.json.",
+		"Repository validation updated to require OpenAI bundle files."
+	],
+	"status_at_trace_write": {
+		"pr_merged": true,
+		"merge_commit": "c8f85c2"
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/11/openai-platform-bundle-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/11/openai-platform-bundle-trace.md
@@ -1,0 +1,90 @@
+# Agent trace: OpenAI Platform bundle
+
+Date: 2026-05-11
+
+Branch: `perf/include-openai-platform-bundle`
+
+Pull request: #232
+
+## Note
+
+Retrospective trace created from commit evidence after merge. No live `[reasoning]` session was captured for this PR.
+
+## Request interpreted
+
+Add the OpenAI Platform bundle as a new canonical bundle directory and wire it fully into the operating model.
+
+Required outcomes:
+
+- add `openai-platform` as a canonical bundle directory with core files: `prompt.body.xml`, `prompt.spec.yaml`, `registry-manifest.yaml`, `evals.yaml`, schemas, tests, and reference modules
+- register selection rules and signal phrases covering OpenAI API, Responses API, Structured Outputs, embeddings, Batch, Realtime, and Evals surfaces
+- wire the bundle into `bundle-registry.json`, `selection-rules.json`, `task-signal-catalog.json`, operating model README, and agent instructions
+- add behavioural eval `behaviour-openai-structured-output` with `expectedEvidence` and `forbiddenFailureModes`
+- qualify trigger phrases to prevent superficial-keyword-only bundle selection
+
+## Evidence checked
+
+Repository files checked from commit evidence:
+
+- `.agent-operating-model/README.md`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/task-signal-catalog.json`
+
+## Implementation applied
+
+Core bundle files added under `.agent-operating-model/bundles/openai-platform/` including `prompt.body.xml`, `prompt.spec.yaml`, `registry-manifest.yaml`, `CHANGELOG.md`, `README.md`, `evals.yaml`, `grade.schema.json`, `output.schema.json`, `variables.schema.json`, `tests.redteam.yaml`, `tests.regression.yaml`, and supporting reference modules.
+
+Operating model wiring commits in order:
+
+1. Add OpenAI bundle core files
+2. Add OpenAI bundle reference modules
+3. Add OpenAI bundle operational modules
+4. Add OpenAI bundle manifest tests and examples
+5. Register OpenAI bundle selection rules
+6. Document OpenAI bundle operating model
+7. Validate OpenAI bundle operating model selection
+8. Add OpenAI behavioural operating model eval
+9. Test OpenAI bundle operating model selection
+10. Reference OpenAI canonical bundle in agent instructions
+11. Require OpenAI bundle files in repository validation
+12. Use supported OpenAI behavioural eval failure modes
+13. List OpenAI source authority URLs in catalogue
+
+## Key decisions
+
+Trigger phrases qualified to prevent superficial-keyword-only selection. The `behaviour-openai-structured-output` eval carries `forbiddenFailureModes: [superficial-keyword-only]` to enforce this.
+
+`expectedEvidence` array introduced on this eval: `matched-rule`, `matched-signal`, `selected-bundle`, `canonical-directory` — establishing the evidence boundary standard subsequently adopted by mcp-agent-tooling.
+
+OpenAI bundle assigned precedence 65, below cloudflare (70) and above airtable-public-api (60).
+
+## Commits recorded
+
+```text
+f773122 Add OpenAI bundle core files
+fc54842 Add OpenAI bundle reference modules
+40374c7 Add OpenAI bundle operational modules
+35a79bd Add OpenAI bundle manifest tests and examples
+f9f56f8 Register OpenAI bundle selection rules
+3fa856a Document OpenAI bundle operating model
+8a62612 Validate OpenAI bundle operating model selection
+548a1a0 Add OpenAI behavioural operating model eval
+0db7551 Test OpenAI bundle operating model selection
+b823329 Reference OpenAI canonical bundle in agent instructions
+57a0a44 Require OpenAI bundle files in repository validation
+a60516d Use supported OpenAI behavioural eval failure modes
+56e8910 List OpenAI source authority URLs in catalogue
+c8f85c2 Merge pull request #232
+```
+
+## Validation recorded
+
+- Operating model selection test added for OpenAI bundle
+- Behavioural eval `behaviour-openai-structured-output` added to `behavioural-evals.json`
+- Repository validation updated to require OpenAI bundle files
+
+## Current status at trace write
+
+PR #232 merged. Merge commit: `c8f85c2`.

--- a/docs/agent-audit/reasoning/2026/05/11/reports-site-validation-gate-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/11/reports-site-validation-gate-trace.json
@@ -1,0 +1,65 @@
+{
+	"trace_id": "atrace-20260511-reports-site-validation-gate",
+	"trace_layer": "operational",
+	"trace_source": "retrospective-commit-evidence",
+	"date": "2026-05-11",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "test/reports-site-validation-gate",
+	"pull_request": {
+		"number": 235,
+		"state": "merged",
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/235"
+	},
+	"trigger": "agent-task",
+	"note": "Retrospective trace created from commit evidence. No live [reasoning] session was captured for this PR.",
+	"request_interpreted": [
+		"Add an integrity validation gate for the committed reporting site artefacts.",
+		"Prove coherence between reports-site/index.html, reports-site/manifest.json, and screenshot files.",
+		"Wire the validator into npm test so it runs as part of the standard Node CI gate."
+	],
+	"operating_model_files_loaded": [
+		"package.json",
+		"reports-site/manifest.json",
+		"reports-site/index.html"
+	],
+	"bundles_selected": [
+		"researchops-developer-control",
+		"github-diamond",
+		"multi-functional-team"
+	],
+	"files_created": [
+		"scripts/validate-reports-site.mjs",
+		"tests/reports-site-validation.test.js"
+	],
+	"files_modified": [
+		"package.json"
+	],
+	"commits_recorded": [
+		"b2d781d",
+		"b54a5e0",
+		"a20b6f0",
+		"33fba47",
+		"df18efb",
+		"006c737"
+	],
+	"key_decisions": [
+		"Hard assertions set to match actual committed state: 22 pages, 39 states, 78 captures, 78 screenshots, profiles desktop + mobile.",
+		"Failed capture semantics: failed captures (no screenshot) are permitted; successful captures must reference a screenshot file.",
+		"Path traversal guard: screenshot paths must be relative and must not contain '..'.",
+		"Bidirectional manifest-to-HTML reference check included.",
+		"Profile capture count balance asserted when failureCount is 0.",
+		"Regression test for failed-capture semantics added (1 failed state, 1 failed capture, failureCount 1, no screenshot).",
+		"reports:validate wired to npm test via package.json; integration with scripts/validate.sh deferred."
+	],
+	"validation_recorded": [
+		"22 assertions pass covering page count, state count, capture count, screenshot count, profile balance, and failed-capture semantics.",
+		"All CI checks passed at merge: Format PR, Validate ResearchOps, qa-bdd, QA Broken links, Accessibility audit, CI, Worker CI, Release Gate."
+	],
+	"known_gaps": [
+		"reports:validate not yet wired into scripts/validate.sh — deferred to a follow-up PR."
+	],
+	"status_at_trace_write": {
+		"pr_merged": true,
+		"merge_commit": "006c737"
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/11/reports-site-validation-gate-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/11/reports-site-validation-gate-trace.md
@@ -1,0 +1,86 @@
+# Agent trace: Reporting site validation gate
+
+Date: 2026-05-11
+
+Branch: `test/reports-site-validation-gate`
+
+Pull request: #235
+
+## Note
+
+Retrospective trace created from commit evidence after merge. No live `[reasoning]` session was captured for this PR.
+
+## Request interpreted
+
+The reporting site was generated and committed but had no integrity check proving coherence between `index.html`, `manifest.json`, and the screenshot files. Add a dedicated validation gate.
+
+Required outcomes:
+
+- validator confirms `reports-site/index.html` and `manifest.json` both exist and `manifest.json` is valid JSON
+- validator checks `manifest.pageCount`, `stateCount`, and `captureCount` match actual content
+- failed captures (no screenshot) are permitted; successful captures must reference a screenshot file
+- screenshot paths are relative and do not contain `..`
+- every screenshot file under `reports-site/screenshots/` is referenced by the manifest
+- every manifest screenshot is referenced by `index.html`
+- profile capture counts are balanced when `failureCount` is 0
+- validator wired into `npm test`
+
+## Evidence checked
+
+Repository files checked from commit evidence:
+
+- `package.json`
+- `reports-site/manifest.json`
+- `reports-site/index.html`
+- `reports-site/screenshots/` directory
+
+## Implementation applied
+
+`scripts/validate-reports-site.mjs` added with the following checks:
+
+- existence and JSON validity of `index.html` and `manifest.json`
+- `manifest.pageCount`, `stateCount`, `captureCount` match actual content
+- failed-capture semantics: failed captures permitted, successful captures must have a screenshot file
+- path traversal guard: screenshot paths must be relative and must not contain `..`
+- bidirectional check: every screenshot file referenced by manifest, every manifest screenshot referenced by `index.html`
+- profile capture balance when `failureCount` is 0
+
+`tests/reports-site-validation.test.js` added with hard assertions against the current committed corpus:
+
+- 22 pages, 39 states, 78 captures, 78 screenshots
+- profiles: `desktop`, `mobile`
+- regression test for failed-capture semantics: 1 failed state, 1 failed capture, `failureCount: 1`, no screenshot
+
+`package.json` updated: `reports:validate` script added and wired into `npm test`.
+
+## Key decisions
+
+Hard assertion counts match the current committed corpus exactly. Any deviation from the committed state will fail the gate, prompting a deliberate count update.
+
+Path traversal guard added as a security boundary: screenshot references cannot escape the `reports-site/` directory.
+
+Integration with `scripts/validate.sh` deferred to a follow-up PR.
+
+## Commits recorded
+
+```text
+b2d781d Validate reporting site manifest and screenshots
+b54a5e0 Format reporting site validation test
+a20b6f0 Fix failed capture validation semantics
+33fba47 Test failed capture report validation
+df18efb Format reports site validation regression test
+006c737 Merge pull request #235
+```
+
+## Validation recorded
+
+- 22 assertions pass covering page count, state count, capture count, screenshot count, profile balance, and failed-capture semantics
+- All CI checks passed at merge: Format PR, Validate ResearchOps, qa-bdd, QA Broken links (Lychee), Accessibility audit (pa11y-ci), CI, Worker CI, Release Gate
+
+## Known gaps deferred
+
+- `reports:validate` not yet wired into `scripts/validate.sh`
+
+## Current status at trace write
+
+PR #235 merged. Merge commit: `006c737`.

--- a/docs/agent-audit/reasoning/2026/05/11/sourcebook-deploy-guard-and-templates-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/11/sourcebook-deploy-guard-and-templates-trace.json
@@ -1,0 +1,67 @@
+{
+	"trace_id": "atrace-20260511-sourcebook-deploy-guard-and-templates",
+	"trace_layer": "operational",
+	"trace_source": "retrospective-commit-evidence",
+	"date": "2026-05-11",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "fix/sourcebook-index-guard-and-templates",
+	"pull_request": {
+		"number": 234,
+		"state": "merged",
+		"url": "https://github.com/kevinrapley/ResearchOps/pull/234"
+	},
+	"trigger": "agent-task",
+	"note": "Retrospective trace created from commit evidence. No live [reasoning] session was captured for this PR.",
+	"request_interpreted": [
+		"Fix deploy guard ordering in deploy-sourcebook.yml: the index guard step was running after Cloudflare Pages publish, so any fallback index would not be included in the deployment.",
+		"Populate the Sourcebook templates/ directory which had no files, causing broken links from pillar pages."
+	],
+	"operating_model_files_loaded": [
+		".github/workflows/deploy-sourcebook.yml",
+		"docs/devops/sourcebook/"
+	],
+	"bundles_selected": [
+		"researchops-developer-control",
+		"github-diamond",
+		"multi-functional-team",
+		"cloudflare"
+	],
+	"files_created": [
+		"docs/devops/sourcebook/templates/decision-log-template.md",
+		"docs/devops/sourcebook/templates/remote-research-setup-guide.md",
+		"docs/devops/sourcebook/templates/research-governance-roles-raci.md",
+		"docs/devops/sourcebook/templates/research-intake-form.docx",
+		"docs/devops/sourcebook/templates/research-maturity-self-assessment.md",
+		"docs/devops/sourcebook/templates/research-plan-template.docx",
+		"docs/devops/sourcebook/templates/research-roadmap-template.md",
+		"docs/devops/sourcebook/templates/research-shareback-patterns.md",
+		"docs/devops/sourcebook/templates/research-space-checklist.md",
+		"docs/devops/sourcebook/templates/researcher-wellbeing-risk-assessment.docx",
+		"docs/devops/sourcebook/templates/stakeholder-mapping-template.md"
+	],
+	"files_modified": [
+		".github/workflows/deploy-sourcebook.yml"
+	],
+	"commits_recorded": [
+		"1d4ac27",
+		"da88bea"
+	],
+	"key_decisions": [
+		"Deploy guard step moved before Cloudflare Pages publish step to ensure the fallback index is present at publish time.",
+		"11 templates committed as minimal starter scaffolds covering the main research practice areas.",
+		"Three .docx files included as minimal valid Word documents for audiences who require Office format.",
+		"Full Sourcebook link inventory and link validation script deferred to a follow-up PR."
+	],
+	"validation_recorded": [
+		"Deployment sequence confirmed: guard runs before publish.",
+		".docx files verified to open and render."
+	],
+	"known_gaps": [
+		"Full Sourcebook link inventory and link validation script not included — deferred.",
+		"Sourcebook index page not updated to surface the new templates section."
+	],
+	"status_at_trace_write": {
+		"pr_merged": true,
+		"merge_commit": "da88bea"
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/11/sourcebook-deploy-guard-and-templates-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/11/sourcebook-deploy-guard-and-templates-trace.md
@@ -1,0 +1,74 @@
+# Agent trace: Sourcebook deploy guard fix and templates
+
+Date: 2026-05-11
+
+Branch: `fix/sourcebook-index-guard-and-templates`
+
+Pull request: #234
+
+## Note
+
+Retrospective trace created from commit evidence after merge. No live `[reasoning]` session was captured for this PR.
+
+## Request interpreted
+
+Two specific gaps were identified and fixed:
+
+1. The `deploy-sourcebook.yml` workflow ran the `Ensure site has an index` guard step *after* the Cloudflare Pages publish step. Any fallback index file created by the guard would not be included in the deployment. The guard needed to run before publish.
+2. The `docs/devops/sourcebook/templates/` directory had no files. All template links from Sourcebook pillar pages were broken 404s.
+
+## Evidence checked
+
+Repository files checked from commit evidence:
+
+- `.github/workflows/deploy-sourcebook.yml`
+- `docs/devops/sourcebook/` (pillar pages and existing template directory)
+
+## Implementation applied
+
+**Deploy guard fix:** The `Ensure site has an index` step in `deploy-sourcebook.yml` was moved before the Cloudflare Pages publish step.
+
+**Templates directory populated** with 11 files:
+
+| File | Format |
+|---|---|
+| `decision-log-template.md` | Markdown |
+| `remote-research-setup-guide.md` | Markdown |
+| `research-governance-roles-raci.md` | Markdown |
+| `research-intake-form.docx` | Word |
+| `research-maturity-self-assessment.md` | Markdown |
+| `research-plan-template.docx` | Word |
+| `research-roadmap-template.md` | Markdown |
+| `research-shareback-patterns.md` | Markdown |
+| `research-space-checklist.md` | Markdown |
+| `researcher-wellbeing-risk-assessment.docx` | Word |
+| `stakeholder-mapping-template.md` | Markdown |
+
+Markdown templates are minimal starter scaffolds (579–894 bytes). `.docx` files are minimal valid Word documents verified to open and render.
+
+## Key decisions
+
+Full Sourcebook link inventory and a dedicated link validation script were deferred to a follow-up PR to keep this PR focused on the two known gaps.
+
+The Sourcebook index page was not updated to surface the new templates section — also deferred.
+
+## Commits recorded
+
+```text
+1d4ac27 Fix Sourcebook deploy guard and add templates
+da88bea Merge pull request #234
+```
+
+## Validation recorded
+
+- Deployment sequence confirmed correct: guard runs before publish
+- `.docx` files verified to open and render
+
+## Known gaps deferred
+
+- Full Sourcebook link inventory and link validation script
+- Sourcebook index page update to surface templates section
+
+## Current status at trace write
+
+PR #234 merged. Merge commit: `da88bea`.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -83,6 +83,7 @@ require_file "scripts/agent-operating-model/run-behavioural-evals.mjs"
 require_file "scripts/agent-operating-model/validate-bundle-registry.mjs"
 require_file "scripts/agent-operating-model/validate-operating-model.mjs"
 require_file "scripts/agent-trace/validate-traces.mjs"
+require_file "scripts/validate-reports-site.mjs"
 require_file "public/_headers"
 require_file "public/css/govuk/govuk-buttons.css"
 require_file "public/css/govuk/govuk-forms.css"
@@ -146,6 +147,8 @@ require_file ".github/workflows/bootstrap-d1-auth-runtime.yml"
 require_file "docs/product/26/05/09/auth-runtime-bootstrap-2026-05-09.md"
 require_file "docs/product/26/05/09/auth-role-assignment-api-2026-05-09.md"
 require_file "docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md"
+require_file "reports-site/index.html"
+require_file "reports-site/manifest.json"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-implementation-trace.md"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-runtime-bootstrap-implementation-trace.json"
 require_file "docs/agent-audit/reasoning/2026/05/09/auth-role-assignment-api-implementation-trace.md"
@@ -160,7 +163,7 @@ import fs from 'node:fs';
 
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const scripts = pkg.scripts || {};
-const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'agent:evals', 'trace:validate', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
+const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'agent:evals', 'trace:validate', 'reports:validate', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
 const missing = required.filter((name) => !scripts[name]);
 
 if (missing.length) {
@@ -187,6 +190,9 @@ node scripts/agent-operating-model/run-behavioural-evals.mjs >/dev/null
 
 info "checking agent traces"
 node scripts/agent-trace/validate-traces.mjs
+
+info "checking reports site integrity"
+node scripts/validate-reports-site.mjs
 
 info "checking Wrangler assets directory"
 node --input-type=module <<'NODE'


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Airtable bundle evals → v1.1.0**: Added `behaviouralEvals` section with 7 named evaluations (endpoint resolution, narrowest scope, pagination/batching, webhook MAC, schema-write safety, enterprise boundary, token safety), each with `expectedEvidence` and `forbiddenFailureModes`. Corrected stale `coverage_expectations` counts (18→20 regression, 12→14 redteam). Aligned `prompt.body.xml` version to 1.1.0. Fixed `tests/airtable-bundle-health.test.js` assertions to match. Added `artifacts/` to `.gitignore`.
- **May 11 trace artefacts**: 10 trace files (5 × `.json` + 5 × `.md`) covering PRs #232–#236 under `docs/agent-audit/reasoning/2026/05/11/`. #232–235 are retrospective commit-evidence traces; #236 is a live-session trace.
- **reports:validate → validate.sh**: Closes the integration gap noted in PR #235. The reports site validator now runs as part of the shell-level gate. Added `require_file` checks for `reports-site/index.html`, `reports-site/manifest.json`, and `scripts/validate-reports-site.mjs`. Added `reports:validate` to the required package.json scripts list.

## Test plan

- [ ] `bash ./scripts/validate.sh` passes (confirmed locally — 22 pages, 39 states, 78 captures)
- [ ] `node --test tests/airtable-bundle-health.test.js` passes (all 4 tests confirmed locally)
- [ ] Node 20, Node 22, Release gate CI checks pass
- [ ] Codex review comments on prior PR #236 addressed (P1 + P2, both fixed in `3a31def`)

https://claude.ai/code/session_01F7miho83XMHCBbjsAagZU4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7miho83XMHCBbjsAagZU4)_