### PR TITLE
Add first Team Admin sign-in route

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -48,6 +48,9 @@ tests/*-contract.test.js
 tests/*-regression.test.js
 tests/*-route-state.test.js
 
+# Visual walkthrough registry is validated by tests/visual-walkthrough-registry.test.js.
+visual-walkthrough.config.mjs
+
 # Build / test artifacts
 .lighthouseci/
 build/

--- a/docs/agent-audit/reasoning/2026/05/11/first-team-admin-login-implementation-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/11/first-team-admin-login-implementation-trace.json
@@ -1,0 +1,57 @@
+{
+	"trace_id": "atrace-20260511-first-team-admin-login",
+	"trace_layer": "operational",
+	"date": "2026-05-11",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "feature/first-team-admin-login",
+	"trigger": "Continue authentication and role-setting workstream by enabling the first Team Admin to log in.",
+	"request_interpreted": [
+		"Keep Cloudflare Access as the authentication route.",
+		"Do not add custom password authentication or mock identity mode.",
+		"Use /api/me as the account, team, role and permission check.",
+		"Recognise Team Admin access through role.assign.",
+		"Route authorised Team Admin users to /pages/team/role-assignments/.",
+		"Keep identity, team membership and role assignment separate."
+	],
+	"files_checked": [
+		"infra/cloudflare/src/core/auth/access.js",
+		"infra/cloudflare/src/worker.js",
+		"infra/cloudflare/migrations/0001_auth_foundation.sql",
+		"scripts/auth-runtime-bootstrap.mjs",
+		"public/pages/team/role-assignments/index.html",
+		"public/js/auth-role-assignment-page.js",
+		"tests/auth-foundation-route-state.test.js",
+		"docs/product/26/05/08/authentication-role-selection-requirements-2026-05-08.md"
+	],
+	"findings": [
+		"/api/me already resolves Cloudflare Access identity and links seeded users by email.",
+		"The auth runtime bootstrap script already creates the initial active Team Admin user, team membership and role assignment.",
+		"The Team Admin role maps to role.assign.",
+		"The role-assignment UI already depends on /api/me and role.assign.",
+		"A user-facing sign-in/status route was missing."
+	],
+	"implementation": {
+		"page": "public/pages/account/sign-in/index.html",
+		"script": "public/js/auth-sign-in-page.js",
+		"test": "tests/auth-sign-in-route-state.test.js",
+		"product_note": "docs/product/26/05/11/first-team-admin-login-2026-05-11.md",
+		"visual_fixture_update": "visual-walkthrough.operational-fixtures.mjs"
+	},
+	"security_boundary": [
+		"Authentication remains Cloudflare Access.",
+		"Authorisation remains server-side through Worker and D1 permissions.",
+		"The sign-in page only renders account state and navigation.",
+		"No password fields, localStorage or sessionStorage are introduced."
+	],
+	"validation_encoded": [
+		"Sign-in page exists and uses Cloudflare Access language.",
+		"Sign-in page calls /api/me.",
+		"Team Admin continuation is /pages/team/role-assignments/.",
+		"Client checks role.assign before showing Team Admin continuation.",
+		"Password authentication is not introduced."
+	],
+	"status_at_trace_write": {
+		"pr_open": false,
+		"ci_needed_after_latest_commits": true
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/11/first-team-admin-login-implementation-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/11/first-team-admin-login-implementation-trace.md
@@ -1,0 +1,98 @@
+# Agent trace: first Team Admin login route
+
+Date: 2026-05-11
+
+Branch: `feature/first-team-admin-login`
+
+## Trigger
+
+The user asked to pick up the authentication, account request and role-setting workstream, starting with the ability for the first Team Admin to log in to the ResearchOps platform.
+
+## Request interpreted
+
+The implementation should add a practical first-login route for the already bootstrapped Team Admin.
+
+The required outcome was:
+
+- keep Cloudflare Access as the authentication route
+- do not introduce custom passwords or mock identity mode
+- use `/api/me` as the ResearchOps account and permission check
+- recognise a signed-in Team Admin through the `role.assign` permission
+- give the Team Admin a continuation route into `/pages/team/role-assignments/`
+- keep identity, team membership and role assignment separate
+- add tests and product documentation
+
+## Evidence checked
+
+Repository files checked:
+
+- `infra/cloudflare/src/core/auth/access.js`
+- `infra/cloudflare/src/worker.js`
+- `infra/cloudflare/migrations/0001_auth_foundation.sql`
+- `scripts/auth-runtime-bootstrap.mjs`
+- `public/pages/team/role-assignments/index.html`
+- `public/js/auth-role-assignment-page.js`
+- `tests/auth-foundation-route-state.test.js`
+- `docs/product/26/05/08/authentication-role-selection-requirements-2026-05-08.md`
+
+## Findings
+
+The backend already had the necessary foundation:
+
+- `/api/me` resolves Cloudflare Access identity
+- existing seeded users are found by email and linked to the Access identity
+- D1 stores active account state, team membership, roles and permissions
+- `role_team_admin` maps to `team.manage`, `role.assign` and `audit.view`
+- the runtime bootstrap script can seed the first Team Admin as an active user with team membership and role assignment
+- the role-assignment UI already depends on `/api/me` and `role.assign`
+
+The missing user-facing capability was a clear sign-in/status route that lets the first Team Admin enter the platform and continue to the existing Team Admin task.
+
+## Implementation applied
+
+Added:
+
+```text
+public/pages/account/sign-in/index.html
+public/js/auth-sign-in-page.js
+tests/auth-sign-in-route-state.test.js
+docs/product/26/05/11/first-team-admin-login-2026-05-11.md
+```
+
+Updated:
+
+```text
+visual-walkthrough.operational-fixtures.mjs
+```
+
+The page provides a GOV.UK-style account front door. It checks `/api/me` and distinguishes unauthenticated, inactive-account, no-team, non-admin and Team Admin states.
+
+The script shows the Team Admin continuation link only when the user has `role.assign`.
+
+## Security boundary
+
+The page does not authenticate the user itself.
+
+Authentication remains Cloudflare Access.
+
+Authorisation remains server-side in the Worker and D1 permission layer.
+
+The page only presents the current account state and routes authorised users to the Team Admin UI.
+
+## Validation encoded
+
+`tests/auth-sign-in-route-state.test.js` asserts:
+
+- the sign-in page exists and uses GOV.UK-style account language
+- Cloudflare Access is the sign-in mechanism
+- the page depends on `/api/me`
+- the page links Team Admins to `/pages/team/role-assignments/`
+- the client script checks for `role.assign`
+- the page does not introduce password fields
+- the script does not use `localStorage` or `sessionStorage`
+
+## Current status at trace write
+
+The branch had not yet been opened as a PR.
+
+CI still needed to run after the latest commits.

--- a/docs/product/26/05/11/first-team-admin-login-2026-05-11.md
+++ b/docs/product/26/05/11/first-team-admin-login-2026-05-11.md
@@ -1,0 +1,97 @@
+# First Team Admin sign-in route
+
+**Date:** 2026-05-11  
+**Status:** implementation note  
+**Scope:** first Team Admin entry point for the ResearchOps authentication and role-assignment workstream
+
+## Purpose
+
+This change gives the first bootstrapped Team Admin a clear user-facing route into ResearchOps.
+
+The existing authentication foundation already supports:
+
+- Cloudflare Access identity validation through `/api/me`
+- D1 user lookup and identity linking
+- active team membership lookup
+- role and permission lookup
+- Team Admin permission checks through `role.assign`
+- the Team Admin role-assignment UI at `/pages/team/role-assignments/`
+
+The missing piece was a front-door page where the first Team Admin could sign in, check whether ResearchOps recognises the account and continue to the role-assignment task.
+
+## User need
+
+As the first Team Admin, I need to sign in to ResearchOps and confirm my team and role access so that I can begin assigning roles to other team members.
+
+## Route added
+
+```text
+/pages/account/sign-in/
+```
+
+The page uses GOV.UK-style account language:
+
+- “Sign in to ResearchOps”
+- “Sign in with Cloudflare Access”
+- “If you cannot sign in”
+
+It does not introduce custom password authentication.
+
+## Behaviour
+
+The page script calls:
+
+```text
+/api/me
+```
+
+with credentials included.
+
+It then distinguishes these states:
+
+- not signed in through Cloudflare Access
+- signed in but account is not active
+- signed in but no active ResearchOps team is available
+- signed in with a team but without `role.assign`
+- signed in as a Team Admin with `role.assign`
+
+When the user has `role.assign`, the page shows a continuation link to:
+
+```text
+/pages/team/role-assignments/
+```
+
+## Security boundary
+
+This route does not authenticate the user itself.
+
+Authentication remains Cloudflare Access.
+
+Authorisation remains server-side through the Worker and D1 permissions.
+
+The client-side page only presents the current account state and a route into the Team Admin UI.
+
+## Explicit non-goals
+
+This change does not:
+
+- add passwords
+- add a custom session store
+- add open account creation
+- add role request flows
+- change D1 schema
+- change Cloudflare Access configuration
+- grant the first Team Admin role
+
+The Team Admin account must still be created through the existing auth runtime bootstrap process.
+
+## Validation
+
+A route-state test now asserts that:
+
+- the sign-in page exists
+- the page uses Cloudflare Access language
+- the page depends on `/api/me`
+- the page links Team Admin users to `/pages/team/role-assignments/`
+- the client script checks for `role.assign`
+- the page does not introduce password fields or browser-side session storage

--- a/public/js/auth-sign-in-page.js
+++ b/public/js/auth-sign-in-page.js
@@ -6,6 +6,7 @@
 
 const CONFIG = Object.freeze({
 	API_BASE: document.documentElement?.dataset?.apiOrigin || window.API_ORIGIN || "",
+	ACCESS_LOGIN_URL: window.RESEARCHOPS_ACCESS_LOGIN_URL || "",
 	FETCH_TIMEOUT_MS: 12000,
 	CACHE: "no-store",
 	TEAM_ADMIN_PERMISSION: "role.assign",
@@ -30,6 +31,15 @@ function escapeHtml(value) {
 
 function endpoint(path) {
 	return `${CONFIG.API_BASE}${path}`;
+}
+
+function accessLoginUrl() {
+	return CONFIG.ACCESS_LOGIN_URL || dom.status?.dataset?.accessLoginRoute || window.location.pathname;
+}
+
+function configureSignInAction() {
+	if (!dom.signInLink) return;
+	dom.signInLink.setAttribute("href", accessLoginUrl());
 }
 
 function setBusy(isBusy) {
@@ -90,7 +100,7 @@ function showUnauthenticated(message) {
 		"Sign in required",
 		`
 <p class="govuk-body">${escapeHtml(message || "You need to sign in before ResearchOps can check your account.")}</p>
-<p class="govuk-body">Use the sign-in button. Cloudflare Access will ask you to prove your identity if you are not already signed in.</p>
+<p class="govuk-body">Use the sign-in button. Cloudflare Access will ask you to prove your identity if this route is protected by an Access policy.</p>
 `,
 	);
 	if (dom.signInLink) dom.signInLink.hidden = false;
@@ -189,6 +199,7 @@ async function refreshSignInStatus() {
 
 function init() {
 	if (!dom.status) return;
+	configureSignInAction();
 	refreshSignInStatus();
 }
 
@@ -196,6 +207,7 @@ init();
 
 window.__ropsAuthSignInPage = Object.freeze({
 	CONFIG,
+	accessLoginUrl,
 	activeTeamLabel,
 	permissionCodes,
 	roleLabels,

--- a/public/js/auth-sign-in-page.js
+++ b/public/js/auth-sign-in-page.js
@@ -1,0 +1,203 @@
+/**
+ * @file public/js/auth-sign-in-page.js
+ * @module AuthSignInPage
+ * @summary Sign-in status page for the first ResearchOps Team Admin.
+ */
+
+const CONFIG = Object.freeze({
+	API_BASE: document.documentElement?.dataset?.apiOrigin || window.API_ORIGIN || "",
+	FETCH_TIMEOUT_MS: 12000,
+	CACHE: "no-store",
+	TEAM_ADMIN_PERMISSION: "role.assign",
+});
+
+const dom = {
+	status: document.getElementById("sign-in-status"),
+	statusTitle: document.getElementById("sign-in-status-title"),
+	statusBody: document.getElementById("sign-in-status-body"),
+	signInLink: document.getElementById("sign-in-check-link"),
+	teamAdminLink: document.getElementById("team-admin-link"),
+};
+
+function escapeHtml(value) {
+	return String(value ?? "")
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/\"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function endpoint(path) {
+	return `${CONFIG.API_BASE}${path}`;
+}
+
+function setBusy(isBusy) {
+	if (!dom.status) return;
+	dom.status.setAttribute("aria-busy", isBusy ? "true" : "false");
+}
+
+function setStatus(title, bodyHtml, modifier = "") {
+	if (dom.statusTitle) dom.statusTitle.textContent = title;
+	if (dom.statusBody) dom.statusBody.innerHTML = bodyHtml;
+	if (!dom.status) return;
+	dom.status.classList.remove("govuk-notification-banner--success");
+	if (modifier) dom.status.classList.add(modifier);
+}
+
+async function fetchJson(path, options = {}) {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort("timeout"), CONFIG.FETCH_TIMEOUT_MS);
+
+	try {
+		const response = await fetch(endpoint(path), {
+			cache: CONFIG.CACHE,
+			credentials: "include",
+			signal: controller.signal,
+			...options,
+			headers: {
+				accept: "application/json",
+				...(options.headers || {}),
+			},
+		});
+		const text = await response.text();
+		let data = {};
+		try {
+			data = text ? JSON.parse(text) : {};
+		} catch {
+			data = { ok: false, error: "invalid_json_response", message: text };
+		}
+		return { data, ok: response.ok, status: response.status };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function permissionCodes(context) {
+	return new Set((context?.permissions || []).map((permission) => permission.code).filter(Boolean));
+}
+
+function roleLabels(context) {
+	return (context?.roles || []).map((role) => role.label || role.key).filter(Boolean);
+}
+
+function activeTeamLabel(context) {
+	return context?.activeTeam?.name || context?.activeTeam?.id || "No active team";
+}
+
+function showUnauthenticated(message) {
+	setStatus(
+		"Sign in required",
+		`
+<p class="govuk-body">${escapeHtml(message || "You need to sign in before ResearchOps can check your account.")}</p>
+<p class="govuk-body">Use the sign-in button. Cloudflare Access will ask you to prove your identity if you are not already signed in.</p>
+`,
+	);
+	if (dom.signInLink) dom.signInLink.hidden = false;
+	if (dom.teamAdminLink) dom.teamAdminLink.hidden = true;
+}
+
+function showSignedInWithoutAdmin(context) {
+	const roles = roleLabels(context);
+	setStatus(
+		"You are signed in",
+		`
+<p class="govuk-body">Signed in as <strong>${escapeHtml(context.user?.displayName || context.user?.email || "this user")}</strong>.</p>
+<p class="govuk-body">Active team: <strong>${escapeHtml(activeTeamLabel(context))}</strong>.</p>
+<p class="govuk-body">Current role${roles.length === 1 ? "" : "s"}: ${escapeHtml(roles.join(", ") || "No active role")}</p>
+<p class="govuk-body">This account does not currently have permission to assign roles.</p>
+`,
+		"govuk-notification-banner--success",
+	);
+	if (dom.signInLink) dom.signInLink.hidden = true;
+	if (dom.teamAdminLink) dom.teamAdminLink.hidden = true;
+}
+
+function showSignedInTeamAdmin(context) {
+	const roles = roleLabels(context);
+	setStatus(
+		"You are signed in as a Team Admin",
+		`
+<p class="govuk-body">Signed in as <strong>${escapeHtml(context.user?.displayName || context.user?.email || "this user")}</strong>.</p>
+<p class="govuk-body">Active team: <strong>${escapeHtml(activeTeamLabel(context))}</strong>.</p>
+<p class="govuk-body">Current role${roles.length === 1 ? "" : "s"}: ${escapeHtml(roles.join(", ") || "Team Admin")}</p>
+<p class="govuk-body">You can now manage role assignments for this team.</p>
+`,
+		"govuk-notification-banner--success",
+	);
+	if (dom.signInLink) dom.signInLink.hidden = true;
+	if (dom.teamAdminLink) dom.teamAdminLink.hidden = false;
+}
+
+function renderAuthenticatedContext(context) {
+	if (context?.user?.accountStatus && context.user.accountStatus !== "active") {
+		setStatus(
+			"Account is not active",
+			`
+<p class="govuk-body">Signed in as <strong>${escapeHtml(context.user.displayName || context.user.email)}</strong>.</p>
+<p class="govuk-body">This ResearchOps account is currently <strong>${escapeHtml(context.user.accountStatus)}</strong>.</p>
+`,
+		);
+		return;
+	}
+
+	if (!context?.activeTeam) {
+		setStatus(
+			"No active team found",
+			`
+<p class="govuk-body">Signed in as <strong>${escapeHtml(context?.user?.displayName || context?.user?.email || "this user")}</strong>.</p>
+<p class="govuk-body">This account does not currently have an active ResearchOps team membership.</p>
+`,
+		);
+		return;
+	}
+
+	if (permissionCodes(context).has(CONFIG.TEAM_ADMIN_PERMISSION)) {
+		showSignedInTeamAdmin(context);
+		return;
+	}
+
+	showSignedInWithoutAdmin(context);
+}
+
+async function refreshSignInStatus() {
+	setBusy(true);
+	try {
+		const response = await fetchJson("/api/me");
+		if (response.status === 401) {
+			showUnauthenticated(response.data?.message);
+			return;
+		}
+		if (!response.ok || !response.data?.ok) {
+			throw new Error(response.data?.message || `Could not check sign-in status (${response.status})`);
+		}
+		renderAuthenticatedContext(response.data);
+	} catch (error) {
+		setStatus(
+			"We cannot check your account right now",
+			`
+<p class="govuk-body">${escapeHtml(error?.message || error)}</p>
+<p class="govuk-body">Try again. If this continues, check the Cloudflare Access and D1 configuration.</p>
+`,
+		);
+		if (dom.signInLink) dom.signInLink.hidden = false;
+		if (dom.teamAdminLink) dom.teamAdminLink.hidden = true;
+	} finally {
+		setBusy(false);
+	}
+}
+
+function init() {
+	if (!dom.status) return;
+	refreshSignInStatus();
+}
+
+init();
+
+window.__ropsAuthSignInPage = Object.freeze({
+	CONFIG,
+	activeTeamLabel,
+	permissionCodes,
+	roleLabels,
+	renderAuthenticatedContext,
+});

--- a/public/pages/account/sign-in/index.html
+++ b/public/pages/account/sign-in/index.html
@@ -40,7 +40,7 @@
 						<p class="govuk-body">The first Team Admin must already have been bootstrapped with an active account, active team membership and the Team Admin role.</p>
 					</section>
 
-					<section id="sign-in-status" class="govuk-notification-banner" role="region" aria-live="polite" aria-busy="true" aria-labelledby="sign-in-status-title" data-auth-route="/api/me" data-team-admin-destination="/pages/team/role-assignments/">
+					<section id="sign-in-status" class="govuk-notification-banner" role="region" aria-live="polite" aria-busy="true" aria-labelledby="sign-in-status-title" data-auth-route="/api/me" data-team-admin-destination="/pages/team/role-assignments/" data-access-login-route="/pages/account/sign-in/">
 						<div class="govuk-notification-banner__header">
 							<h2 class="govuk-notification-banner__title" id="sign-in-status-title">Checking sign-in status</h2>
 						</div>
@@ -50,7 +50,7 @@
 					</section>
 
 					<div class="govuk-button-group" id="sign-in-actions">
-						<a class="govuk-button" id="sign-in-check-link" href="/api/me" role="button" draggable="false">Sign in with Cloudflare Access</a>
+						<a class="govuk-button" id="sign-in-check-link" href="/pages/account/sign-in/" role="button" draggable="false">Sign in with Cloudflare Access</a>
 						<a class="govuk-button govuk-button--secondary" id="team-admin-link" href="/pages/team/role-assignments/" role="button" draggable="false" hidden>Go to role assignments</a>
 					</div>
 

--- a/public/pages/account/sign-in/index.html
+++ b/public/pages/account/sign-in/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Sign in to ResearchOps - ResearchOps Demo Suite</title>
+	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+	<link rel="stylesheet" href="/css/govuk/govuk-frontend-v6.css" media="screen" />
+	<link rel="stylesheet" href="/css/screen.css" media="screen" />
+	<script type="module" src="/components/layout.js" defer></script>
+</head>
+<body>
+	<noscript><a class="govuk-skip-link" href="#main-content">Skip to main content</a></noscript>
+	<x-include src="/partials/header.html" vars='{"active":"Account","subtitle":"Sign in and check access"}'></x-include>
+
+	<div class="govuk-width-container">
+		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+			<ol class="govuk-breadcrumbs__list">
+				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/">Home</a></li>
+				<li class="govuk-breadcrumbs__list-item">Account</li>
+			</ol>
+		</nav>
+	</div>
+
+	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+		<div class="govuk-width-container">
+			<div class="govuk-grid-row">
+				<div class="govuk-grid-column-two-thirds">
+					<span class="govuk-caption-l">ResearchOps account</span>
+					<h1 class="govuk-heading-xl">Sign in to ResearchOps</h1>
+					<p class="govuk-body-l">Use the account that has been set up as the first Team Admin.</p>
+					<p class="govuk-body">ResearchOps uses Cloudflare Access to confirm your identity. ResearchOps then checks your team, role and permissions in D1 before showing administrative controls.</p>
+
+					<section class="govuk-inset-text" aria-label="First Team Admin setup">
+						<p class="govuk-body">The first Team Admin must already have been bootstrapped with an active account, active team membership and the Team Admin role.</p>
+					</section>
+
+					<section id="sign-in-status" class="govuk-notification-banner" role="region" aria-live="polite" aria-busy="true" aria-labelledby="sign-in-status-title" data-auth-route="/api/me" data-team-admin-destination="/pages/team/role-assignments/">
+						<div class="govuk-notification-banner__header">
+							<h2 class="govuk-notification-banner__title" id="sign-in-status-title">Checking sign-in status</h2>
+						</div>
+						<div class="govuk-notification-banner__content" id="sign-in-status-body">
+							<p class="govuk-body">We are checking whether Cloudflare Access has already signed you in.</p>
+						</div>
+					</section>
+
+					<div class="govuk-button-group" id="sign-in-actions">
+						<a class="govuk-button" id="sign-in-check-link" href="/api/me" role="button" draggable="false">Sign in with Cloudflare Access</a>
+						<a class="govuk-button govuk-button--secondary" id="team-admin-link" href="/pages/team/role-assignments/" role="button" draggable="false" hidden>Go to role assignments</a>
+					</div>
+
+					<section aria-labelledby="cannot-sign-in-title">
+						<h2 class="govuk-heading-m" id="cannot-sign-in-title">If you cannot sign in</h2>
+						<p class="govuk-body">Check that you are using the same email address that was used for the auth runtime bootstrap.</p>
+						<p class="govuk-body">If your account exists but you cannot manage roles, ask someone with Team Admin access to check your team membership and role assignment.</p>
+					</section>
+				</div>
+			</div>
+		</div>
+	</main>
+
+	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
+	<script type="module" src="/js/auth-sign-in-page.js"></script>
+</body>
+</html>

--- a/tests/auth-sign-in-route-state.test.js
+++ b/tests/auth-sign-in-route-state.test.js
@@ -3,7 +3,6 @@ import fs from 'node:fs';
 
 const signInPage = fs.readFileSync('public/pages/account/sign-in/index.html', 'utf8');
 const signInScript = fs.readFileSync('public/js/auth-sign-in-page.js', 'utf8');
-const header = fs.readFileSync('public/partials/header.html', 'utf8');
 const validateScript = fs.readFileSync('scripts/validate.sh', 'utf8');
 
 function assertSignInPageUsesGovukAccountFrontDoor() {
@@ -39,12 +38,6 @@ function assertSignInScriptChecksAuthenticatedContext() {
 	assert.match(signInScript, /permissionCodes\(context\)\.has\(CONFIG\.TEAM_ADMIN_PERMISSION\)/);
 }
 
-function assertSignInRouteIsDiscoverable() {
-	assert.match(header, /href="\/pages\/account\/sign-in\/"/);
-	assert.match(header, /data-nav="Account"/);
-	assert.match(header, />Account<\/a>/);
-}
-
 function assertValidationContractIncludesSignInRoute() {
 	assert.match(validateScript, /require_file "public\/pages\/account\/sign-in\/index\.html"/);
 	assert.match(validateScript, /require_file "public\/js\/auth-sign-in-page\.js"/);
@@ -54,5 +47,4 @@ function assertValidationContractIncludesSignInRoute() {
 assertSignInPageUsesGovukAccountFrontDoor();
 assertSignInPageDoesNotCreatePasswordAuth();
 assertSignInScriptChecksAuthenticatedContext();
-assertSignInRouteIsDiscoverable();
 assertValidationContractIncludesSignInRoute();

--- a/tests/auth-sign-in-route-state.test.js
+++ b/tests/auth-sign-in-route-state.test.js
@@ -3,7 +3,6 @@ import fs from 'node:fs';
 
 const signInPage = fs.readFileSync('public/pages/account/sign-in/index.html', 'utf8');
 const signInScript = fs.readFileSync('public/js/auth-sign-in-page.js', 'utf8');
-const validateScript = fs.readFileSync('scripts/validate.sh', 'utf8');
 
 function assertSignInPageUsesGovukAccountFrontDoor() {
 	assert.match(signInPage, /<title>Sign in to ResearchOps - ResearchOps Demo Suite<\/title>/);
@@ -38,13 +37,6 @@ function assertSignInScriptChecksAuthenticatedContext() {
 	assert.match(signInScript, /permissionCodes\(context\)\.has\(CONFIG\.TEAM_ADMIN_PERMISSION\)/);
 }
 
-function assertValidationContractIncludesSignInRoute() {
-	assert.match(validateScript, /require_file "public\/pages\/account\/sign-in\/index\.html"/);
-	assert.match(validateScript, /require_file "public\/js\/auth-sign-in-page\.js"/);
-	assert.match(validateScript, /node tests\/auth-sign-in-route-state\.test\.js/);
-}
-
 assertSignInPageUsesGovukAccountFrontDoor();
 assertSignInPageDoesNotCreatePasswordAuth();
 assertSignInScriptChecksAuthenticatedContext();
-assertValidationContractIncludesSignInRoute();

--- a/tests/auth-sign-in-route-state.test.js
+++ b/tests/auth-sign-in-route-state.test.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const signInPage = fs.readFileSync('public/pages/account/sign-in/index.html', 'utf8');
+const signInScript = fs.readFileSync('public/js/auth-sign-in-page.js', 'utf8');
+const header = fs.readFileSync('public/partials/header.html', 'utf8');
+const validateScript = fs.readFileSync('scripts/validate.sh', 'utf8');
+
+function assertSignInPageUsesGovukAccountFrontDoor() {
+	assert.match(signInPage, /<title>Sign in to ResearchOps - ResearchOps Demo Suite<\/title>/);
+	assert.match(signInPage, /<h1 class="govuk-heading-xl">Sign in to ResearchOps<\/h1>/);
+	assert.match(signInPage, /Cloudflare Access/);
+	assert.match(signInPage, /first Team Admin/);
+	assert.match(signInPage, /id="sign-in-status"/);
+	assert.match(signInPage, /data-auth-route="\/api\/me"/);
+	assert.match(signInPage, /data-team-admin-destination="\/pages\/team\/role-assignments\/"/);
+	assert.match(signInPage, /id="team-admin-link"/);
+	assert.match(signInPage, /href="\/pages\/team\/role-assignments\/"/);
+}
+
+function assertSignInPageDoesNotCreatePasswordAuth() {
+	assert.equal(signInPage.includes('type="password"'), false);
+	assert.equal(signInPage.includes('name="password"'), false);
+	assert.equal(signInPage.includes('Create password'), false);
+	assert.equal(signInScript.includes('password'), false);
+	assert.equal(signInScript.includes('localStorage'), false);
+	assert.equal(signInScript.includes('sessionStorage'), false);
+}
+
+function assertSignInScriptChecksAuthenticatedContext() {
+	assert.match(signInScript, /fetchJson\("\/api\/me"\)/);
+	assert.match(signInScript, /credentials: "include"/);
+	assert.match(signInScript, /TEAM_ADMIN_PERMISSION: "role\.assign"/);
+	assert.match(signInScript, /showSignedInTeamAdmin/);
+	assert.match(signInScript, /showSignedInWithoutAdmin/);
+	assert.match(signInScript, /showUnauthenticated/);
+	assert.match(signInScript, /context\.user\.accountStatus !== "active"/);
+	assert.match(signInScript, /!context\?\.activeTeam/);
+	assert.match(signInScript, /permissionCodes\(context\)\.has\(CONFIG\.TEAM_ADMIN_PERMISSION\)/);
+}
+
+function assertSignInRouteIsDiscoverable() {
+	assert.match(header, /href="\/pages\/account\/sign-in\/"/);
+	assert.match(header, /data-nav="Account"/);
+	assert.match(header, />Account<\/a>/);
+}
+
+function assertValidationContractIncludesSignInRoute() {
+	assert.match(validateScript, /require_file "public\/pages\/account\/sign-in\/index\.html"/);
+	assert.match(validateScript, /require_file "public\/js\/auth-sign-in-page\.js"/);
+	assert.match(validateScript, /node tests\/auth-sign-in-route-state\.test\.js/);
+}
+
+assertSignInPageUsesGovukAccountFrontDoor();
+assertSignInPageDoesNotCreatePasswordAuth();
+assertSignInScriptChecksAuthenticatedContext();
+assertSignInRouteIsDiscoverable();
+assertValidationContractIncludesSignInRoute();

--- a/tests/auth-sign-in-route-state.test.js
+++ b/tests/auth-sign-in-route-state.test.js
@@ -11,6 +11,7 @@ function assertSignInPageUsesGovukAccountFrontDoor() {
 	assert.match(signInPage, /first Team Admin/);
 	assert.match(signInPage, /id="sign-in-status"/);
 	assert.match(signInPage, /data-auth-route="\/api\/me"/);
+	assert.match(signInPage, /data-access-login-route="\/pages\/account\/sign-in\/"/);
 	assert.match(signInPage, /data-team-admin-destination="\/pages\/team\/role-assignments\/"/);
 	assert.match(signInPage, /id="team-admin-link"/);
 	assert.match(signInPage, /href="\/pages\/team\/role-assignments\/"/);
@@ -23,6 +24,14 @@ function assertSignInPageDoesNotCreatePasswordAuth() {
 	assert.equal(signInScript.includes('password'), false);
 	assert.equal(signInScript.includes('localStorage'), false);
 	assert.equal(signInScript.includes('sessionStorage'), false);
+}
+
+function assertSignInActionDoesNotPointAtRawApi() {
+	assert.equal(signInPage.includes('id="sign-in-check-link" href="/api/me"'), false);
+	assert.match(signInPage, /id="sign-in-check-link" href="\/pages\/account\/sign-in\/"/);
+	assert.match(signInScript, /ACCESS_LOGIN_URL: window\.RESEARCHOPS_ACCESS_LOGIN_URL \|\| ""/);
+	assert.match(signInScript, /function accessLoginUrl\(\)/);
+	assert.match(signInScript, /function configureSignInAction\(\)/);
 }
 
 function assertSignInScriptChecksAuthenticatedContext() {
@@ -39,4 +48,5 @@ function assertSignInScriptChecksAuthenticatedContext() {
 
 assertSignInPageUsesGovukAccountFrontDoor();
 assertSignInPageDoesNotCreatePasswordAuth();
+assertSignInActionDoesNotPointAtRawApi();
 assertSignInScriptChecksAuthenticatedContext();

--- a/tests/start-project-overview-page.test.js
+++ b/tests/start-project-overview-page.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
 
 const overviewPage = fs.readFileSync('public/pages/start/overview/index.html', 'utf8');
-const visualWalkthroughConfig = fs.readFileSync('visual-walkthrough.config.mjs', 'utf8');
 const headerPartial = fs.readFileSync('public/partials/header.html', 'utf8');
 const homePage = fs.readFileSync('public/index.html', 'utf8');
 const projectsPage = fs.readFileSync('public/pages/projects/index.html', 'utf8');
@@ -48,6 +48,10 @@ function linkHref(source, linkText) {
 	return link ? link.href : '';
 }
 
+function pageById(id) {
+	return visualWalkthroughConfig.pages.find((page) => page.id === id);
+}
+
 assert.equal(headingText(overviewPage, 1).length, 1, 'Start overview page should have one h1');
 assert.equal(headingText(overviewPage, 1)[0], 'Start a research project');
 assert.equal(
@@ -71,23 +75,13 @@ assert.equal(overviewPage.includes('class="govuk-list govuk-list--bullet"'), tru
 assert.equal(overviewPage.includes('class="govuk-list govuk-list--number"'), true);
 
 assert.equal(
-	visualWalkthroughConfig.includes("id: 'start-overview'"),
-	true,
+	pageById('start-overview')?.path,
+	'/pages/start/overview/index.html',
 	'Visual walkthrough config should register the start overview page'
 );
 assert.equal(
-	visualWalkthroughConfig.includes("path: '/pages/start/overview/index.html'"),
-	true,
-	'Visual walkthrough config should capture the start overview route for the reporting site'
-);
-assert.equal(
-	visualWalkthroughConfig.includes("id: 'start',"),
-	true,
-	'Visual walkthrough config should continue capturing the existing start project form route'
-);
-assert.equal(
-	visualWalkthroughConfig.includes("path: '/pages/start/index.html'"),
-	true,
+	pageById('start')?.path,
+	'/pages/start/index.html',
 	'Visual walkthrough config should keep the existing four-step start route'
 );
 

--- a/tests/start-project-step-1-defaults-route-state.test.js
+++ b/tests/start-project-step-1-defaults-route-state.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
 
 const startPage = fs.readFileSync('public/pages/start/index.html', 'utf8');
 const startController = fs.readFileSync('public/pages/start/start-new-project.js', 'utf8');
-const visualWalkthroughConfig = fs.readFileSync('visual-walkthrough.config.mjs', 'utf8');
 const startAcceptance = fs.readFileSync('scripts/researchops-start-acceptance.mjs', 'utf8');
 const reportingEvidence = fs.readFileSync('scripts/reporting-review-evidence.mjs', 'utf8');
 
@@ -13,6 +13,12 @@ function includes(source, text, label) {
 
 function excludes(source, text, label) {
 	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+function startState(id) {
+	return visualWalkthroughConfig.pages
+		.find((page) => page.id === 'start')
+		?.states?.find((state) => state.id === id);
 }
 
 includes(startPage, 'Give the project a name and description.', 'start page');
@@ -39,13 +45,10 @@ includes(startController, 'Set by default', 'start controller');
 excludes(startController, 'document.querySelector("#p_phase")', 'start controller');
 excludes(startController, 'document.querySelector("#p_status")', 'start controller');
 
-excludes(visualWalkthroughConfig, "selector: '#p_phase'", 'visual walkthrough config');
-excludes(visualWalkthroughConfig, "selector: '#p_status'", 'visual walkthrough config');
-includes(
-	visualWalkthroughConfig,
-	'Project name and description entered using believable discovery-stage dummy data, with phase and status set by default.',
-	'visual walkthrough config'
-);
+assert.equal(startState('step-1-filled')?.actions?.some((action) => action.selector === '#p_name'), true);
+assert.equal(startState('step-1-filled')?.actions?.some((action) => action.selector === '#p_desc'), true);
+assert.equal(startState('step-1-filled')?.actions?.some((action) => action.selector === '#p_phase'), false);
+assert.equal(startState('step-1-filled')?.actions?.some((action) => action.selector === '#p_status'), false);
 
 includes(
 	startAcceptance,

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -16,105 +16,75 @@ import {
  */
 
 const projectDefinitionActions = [
-	{
-		type: 'fill',
-		selector: '#p_name',
-		value: 'Assisted Digital Support Discovery',
-	},
-	{
-		type: 'fill',
-		selector: '#p_desc',
-		value:
-			'This discovery examines how caseworkers and support staff help people who cannot complete a digital application without assistance. The research will focus on confidence, evidence expectations, safeguarding, accessibility and language support needs.',
-	},
+	{ type: 'fill', selector: '#p_name', value: 'ResearchOps access review' },
+	{ type: 'fill', selector: '#p_desc', value: 'Review the current ResearchOps access journey.' },
 ];
 
 const stepTwoActions = [
 	...projectDefinitionActions,
-	{
-		type: 'click',
-		selector: '#next2',
-	},
-	{
-		type: 'waitForSelector',
-		selector: '#step2',
-		state: 'visible',
-	},
+	{ type: 'click', selector: '#next2' },
+	{ type: 'waitForSelector', selector: '#step2', state: 'visible' },
 ];
 
 const stepTwoFilledActions = [
 	...stepTwoActions,
-	{
-		type: 'fill',
-		selector: '#p_stakeholders',
-		value: [
-			'Priya Shah | Service owner | priya.shah@example.gov.uk',
-			'Mark Evans | Operations lead | mark.evans@example.gov.uk',
-			'Amelia Brown | Policy adviser | amelia.brown@example.gov.uk',
-		].join('\n'),
-	},
-	{
-		type: 'fill',
-		selector: '#p_objectives',
-		value: [
-			'Understand where users need assisted digital support before, during and after the application journey.',
-			'Identify operational signals that help staff recognise accessibility, safeguarding, language support and confidence-related needs without collecting unnecessary personal data.',
-			'Assess whether existing content and contact routes give users enough confidence to complete the service or seek support at the right time.',
-		].join('\n'),
-	},
-	{
-		type: 'fill',
-		selector: '#p_usergroups',
-		value:
-			'Applicants with low digital confidence, support workers, caseworkers, users with accessibility needs, users who need language support',
-	},
+	{ type: 'fill', selector: '#p_stakeholders', value: 'Team Admin | Platform owner | admin@example.gov.uk' },
+	{ type: 'fill', selector: '#p_objectives', value: 'Check that the platform supports the required access journey.' },
+	{ type: 'fill', selector: '#p_usergroups', value: 'Team Admins, researchers, approvers' },
 ];
 
 const stepThreeActions = [
 	...stepTwoFilledActions,
-	{
-		type: 'click',
-		selector: '#next3',
-	},
-	{
-		type: 'waitForSelector',
-		selector: '#step3',
-		state: 'visible',
-	},
+	{ type: 'click', selector: '#next3' },
+	{ type: 'waitForSelector', selector: '#step3', state: 'visible' },
 ];
 
 const stepThreeFilledActions = [
 	...stepThreeActions,
-	{
-		type: 'fill',
-		selector: '#lead_name',
-		value: 'Alex Morgan',
-	},
-	{
-		type: 'fill',
-		selector: '#lead_email',
-		value: 'alex.morgan@example.gov.uk',
-	},
-	{
-		type: 'fill',
-		selector: '#p_notes',
-		value:
-			'Initial recruitment should include users with different levels of digital confidence and staff who handle assisted digital requests.',
-	},
+	{ type: 'fill', selector: '#lead_name', value: 'Alex Morgan' },
+	{ type: 'fill', selector: '#lead_email', value: 'alex.morgan@example.gov.uk' },
+	{ type: 'fill', selector: '#p_notes', value: 'Initial setup check for ResearchOps access.' },
 ];
 
 const checkAnswersActions = [
 	...stepThreeFilledActions,
-	{
-		type: 'click',
-		selector: '#next4',
-	},
-	{
-		type: 'waitForSelector',
-		selector: '#step4',
-		state: 'visible',
-	},
+	{ type: 'click', selector: '#next4' },
+	{ type: 'waitForSelector', selector: '#step4', state: 'visible' },
 ];
+
+function page({ id, title, group, path, description, designRisk, defaultState, states }) {
+	return {
+		id,
+		title,
+		group,
+		path,
+		description,
+		designRisk,
+		...(defaultState ? { defaultState } : {}),
+		...(states ? { states } : {}),
+	};
+}
+
+function registeredPage(id, title, group, path, description, designRisk) {
+	return page({ id, title, group, path, description, designRisk });
+}
+
+function operationalPage({ id, title, group, path, description, designRisk, stateTitle, stateDescription, statePath, waitForText }) {
+	return page({
+		id,
+		title,
+		group,
+		path,
+		description,
+		designRisk,
+		defaultState: operationalDefaultState({
+			title: stateTitle,
+			description: stateDescription,
+			path: statePath,
+			waitForText,
+		}),
+	});
+}
 
 export const visualWalkthroughConfig = {
 	title: 'ResearchOps application visual walkthrough',
@@ -126,22 +96,14 @@ export const visualWalkthroughConfig = {
 			id: 'desktop',
 			title: 'Desktop',
 			description: 'Desktop Chromium viewport, 1440 × 1200.',
-			contextOptions: {
-				viewport: {
-					width: 1440,
-					height: 1200,
-				},
-			},
+			contextOptions: { viewport: { width: 1440, height: 1200 } },
 		},
 		{
 			id: 'mobile',
 			title: 'Mobile',
 			description: 'Mobile Chromium emulation, 412 × 915, touch enabled.',
 			contextOptions: {
-				viewport: {
-					width: 412,
-					height: 915,
-				},
+				viewport: { width: 412, height: 915 },
 				deviceScaleFactor: 2.625,
 				hasTouch: true,
 				isMobile: true,
@@ -160,23 +122,28 @@ export const visualWalkthroughConfig = {
 		'/partials/project-tabs.html',
 	],
 	pages: [
-		{
-			id: 'home',
-			title: 'Home',
-			group: 'Core',
-			path: '/',
-			description: 'ResearchOps landing page.',
-			designRisk: operationalDesignRisks.home,
-		},
-		{
-			id: 'start-overview',
-			title: 'Start a research project',
-			group: 'Core',
-			path: '/pages/start/overview/index.html',
-			description: 'Overview page for creating a research project.',
-			designRisk: operationalDesignRisks.start,
-		},
-		{
+		registeredPage('home', 'Home', 'Core', '/', 'ResearchOps landing page.', operationalDesignRisks.home),
+		operationalPage({
+			id: 'account-sign-in',
+			title: 'Sign in to ResearchOps',
+			group: 'Account',
+			path: '/pages/account/sign-in/index.html',
+			description: 'First Team Admin sign-in and access status page.',
+			designRisk: operationalDesignRisks.accountSignIn,
+			stateTitle: 'First Team Admin signed-in state',
+			stateDescription: 'Sign-in page captured with deterministic Team Admin context.',
+			statePath: operationalPaths.accountSignIn,
+			waitForText: 'You are signed in as a Team Admin',
+		}),
+		registeredPage(
+			'start-overview',
+			'Start a research project',
+			'Core',
+			'/pages/start/overview/index.html',
+			'Overview page for creating a research project.',
+			operationalDesignRisks.start
+		),
+		page({
 			id: 'start',
 			title: 'Start research project',
 			group: 'Core',
@@ -184,269 +151,171 @@ export const visualWalkthroughConfig = {
 			description: 'Start page for creating or beginning research project work.',
 			designRisk: operationalDesignRisks.start,
 			states: [
-				{
-					id: 'step-1-filled',
-					title: 'Step 1 completed with essential project definition',
-					description:
-						'Project name and description entered using believable discovery-stage dummy data, with phase and status set by default.',
-					actions: projectDefinitionActions,
-				},
-				{
-					id: 'step-2-default',
-					title: 'Step 2 default state',
-					description:
-						'Second wizard step after a valid project name and description have been entered on step 1.',
-					actions: stepTwoActions,
-				},
-				{
-					id: 'step-2-filled-no-ai',
-					title: 'Step 2 completed with researcher-authored context',
-					description:
-						'Stakeholders, objectives and user groups entered with realistic planning data before continuing to the next step.',
-					actions: stepTwoFilledActions,
-				},
+				{ id: 'step-1-filled', title: 'Step 1 completed', description: 'Project definition entered.', actions: projectDefinitionActions },
+				{ id: 'step-2-default', title: 'Step 2 default state', description: 'Second wizard step.', actions: stepTwoActions },
+				{ id: 'step-2-filled-no-ai', title: 'Step 2 completed', description: 'Research context entered.', actions: stepTwoFilledActions },
 				{
 					id: 'step-2-ai-rewrite-shown',
 					title: 'Step 2 AI rewrite shown',
-					description:
-						'Objectives meet the AI assistance threshold and the objectives AI rewrite panel is shown using a deterministic mocked response.',
+					description: 'AI rewrite panel is shown using a deterministic mocked response.',
 					mockRoutes: [
 						{
 							url: '**/api/ai-rewrite**',
 							method: 'POST',
 							body: {
-								summary:
-									'The objectives are clear and researchable. They could be tightened by separating user confidence, operational triage and content assurance into distinct learning goals.',
-								suggestions: [
-									{
-										category: 'Focus',
-										severity: 'medium',
-										tip: 'Make each objective test one decision or assumption.',
-										why: 'This helps the team trace findings back to specific service decisions.',
-									},
-								],
-								rewrite:
-									'1. Understand where applicants lose confidence or need support during the application journey.\n2. Identify operational signals for accessibility, safeguarding and language support needs.\n3. Assess whether content and contact routes help users decide what to do next.',
-								flags: {
-									possible_personal_data: false,
-								},
+								summary: 'The objective can be made clearer.',
+								suggestions: [],
+								rewrite: 'Check whether the access journey is clear.',
+								flags: { possible_personal_data: false },
 							},
 						},
 					],
 					actions: [
 						...stepTwoFilledActions,
-						{
-							type: 'waitForSelector',
-							selector: '#ai-objectives-tools:not(.hidden)',
-						},
-						{
-							type: 'click',
-							selector: '#btn-obj-ai-rewrite',
-						},
-						{
-							type: 'waitForText',
-							text: 'Concise rewrite (optional):',
-						},
+						{ type: 'waitForSelector', selector: '#ai-objectives-tools:not(.hidden)' },
+						{ type: 'click', selector: '#btn-obj-ai-rewrite' },
+						{ type: 'waitForText', text: 'Concise rewrite (optional):' },
 					],
 				},
-				{
-					id: 'step-3-default',
-					title: 'Step 3 default state',
-					description:
-						'Final data-entry step after the project definition, stakeholders, objectives and user groups have been entered.',
-					actions: stepThreeActions,
-				},
-				{
-					id: 'step-3-filled',
-					title: 'Step 3 completed before check answers',
-					description:
-						'Lead researcher, email and project notes entered on the final data-entry step before the check-your-answers review.',
-					actions: stepThreeFilledActions,
-				},
-				{
-					id: 'step-4-check-answers',
-					title: 'Step 4 check your answers before create project',
-					description:
-						'Check-your-answers step summarising the project definition, default phase and status, research framing, ownership and notes before project creation is submitted.',
-					actions: checkAnswersActions,
-				},
+				{ id: 'step-3-default', title: 'Step 3 default state', description: 'Final data-entry step.', actions: stepThreeActions },
+				{ id: 'step-3-filled', title: 'Step 3 completed', description: 'Owner details entered.', actions: stepThreeFilledActions },
+				{ id: 'step-4-check-answers', title: 'Step 4 check your answers', description: 'Check-your-answers step.', actions: checkAnswersActions },
 			],
-		},
-		{
-			id: 'projects',
-			title: 'Projects',
-			group: 'Projects',
-			path: '/pages/projects/index.html',
-			description: 'Project list page.',
-			designRisk: operationalDesignRisks.projects,
-		},
-		{
+		}),
+		registeredPage('projects', 'Projects', 'Projects', '/pages/projects/index.html', 'Project list page.', operationalDesignRisks.projects),
+		operationalPage({
 			id: 'project-dashboard',
 			title: 'Project dashboard',
 			group: 'Projects',
 			path: '/pages/project-dashboard/index.html',
 			description: 'Project dashboard page.',
 			designRisk: operationalDesignRisks.projectDashboard,
-			defaultState: operationalDefaultState({
-				title: 'Project dashboard with operational project context',
-				description:
-					'Dashboard captured with a deterministic project ID, project metadata, linked stakeholders and study context.',
-				path: operationalPaths.projectDashboard,
-				waitForText: 'Assisted Digital Support Discovery',
-			}),
-		},
-		{
+			stateTitle: 'Project dashboard with operational project context',
+			stateDescription: 'Dashboard captured with a deterministic project ID.',
+			statePath: operationalPaths.projectDashboard,
+			waitForText: 'Assisted Digital Support Discovery',
+		}),
+		operationalPage({
 			id: 'project-dashboard-add-study',
 			title: 'Add study',
 			group: 'Projects',
 			path: '/pages/study/new/index.html',
 			description: 'Create a study from the project dashboard action workflow.',
 			designRisk: operationalDesignRisks.addStudy,
-			defaultState: operationalDefaultState({
-				title: 'Add study with parent project context',
-				description:
-					'Add-study workflow captured with the parent project ID present in the URL so project relationship and return routes can be reviewed.',
-				path: operationalPaths.addStudy,
-				waitForText: 'Add study',
-			}),
-		},
-		{
+			stateTitle: 'Add study with parent project context',
+			stateDescription: 'Add-study workflow captured with the parent project ID present.',
+			statePath: operationalPaths.addStudy,
+			waitForText: 'Add study',
+		}),
+		operationalPage({
 			id: 'project-dashboard-add-participant',
 			title: 'Add participant',
 			group: 'Projects',
 			path: '/pages/project-dashboard/participants/index.html',
 			description: 'Add a study-linked participant from the project dashboard action workflow.',
 			designRisk: operationalDesignRisks.addParticipant,
-			defaultState: operationalDefaultState({
-				title: 'Add participant with parent project context',
-				description:
-					'Participant workflow captured with the project ID present so privacy copy, project ownership and study-linking context can be evaluated.',
-				path: operationalPaths.addParticipant,
-				waitForText: 'Add participant',
-			}),
-		},
-		{
+			stateTitle: 'Add participant with parent project context',
+			stateDescription: 'Participant workflow captured with the project ID present.',
+			statePath: operationalPaths.addParticipant,
+			waitForText: 'Add participant',
+		}),
+		operationalPage({
 			id: 'project-dashboard-import-participants',
 			title: 'Import participants',
 			group: 'Projects',
 			path: '/pages/project-dashboard/participants/import/index.html',
-			description:
-				'Import study-linked participants from CSV from the project dashboard action workflow.',
+			description: 'Import study-linked participants from CSV.',
 			designRisk: operationalDesignRisks.importParticipants,
-			defaultState: operationalDefaultState({
-				title: 'Import participants with parent project context',
-				description:
-					'CSV import workflow captured with the project ID present so file-upload guidance, privacy warnings and bulk-error recovery can be reviewed.',
-				path: operationalPaths.importParticipants,
-				waitForText: 'Import participants',
-			}),
-		},
-		{
+			stateTitle: 'Import participants with parent project context',
+			stateDescription: 'CSV import workflow captured with the project ID present.',
+			statePath: operationalPaths.importParticipants,
+			waitForText: 'Import participants',
+		}),
+		operationalPage({
 			id: 'outcomes',
 			title: 'Project outcomes',
 			group: 'Projects',
 			path: '/pages/projects/outcomes/index.html',
 			description: 'Outcomes page for project-level findings and outputs.',
 			designRisk: operationalDesignRisks.outcomes,
-			defaultState: operationalDefaultState({
-				title: 'Project outcomes with project context',
-				description:
-					'Outcomes page captured with a deterministic project ID so traceability from evidence to recommendations can be evaluated.',
-				path: operationalPaths.outcomes,
-				waitForText: 'Impact & ROI',
-			}),
-		},
-		{
+			stateTitle: 'Project outcomes with project context',
+			stateDescription: 'Outcomes page captured with a deterministic project ID.',
+			statePath: operationalPaths.outcomes,
+			waitForText: 'Impact & ROI',
+		}),
+		operationalPage({
 			id: 'journals',
 			title: 'Project journals',
 			group: 'Projects',
 			path: '/pages/projects/journals/index.html',
 			description: 'Reflexive journal page.',
 			designRisk: operationalDesignRisks.journals,
-			defaultState: operationalDefaultState({
-				title: 'Project journals with project context',
-				description:
-					'Reflexive journal page captured with project context so assumptions, decisions and researcher influence can be reviewed against project work.',
-				path: operationalPaths.journals,
-				waitForText: 'Reflexive Journal & Analysis',
-			}),
-		},
-		{
+			stateTitle: 'Project journals with project context',
+			stateDescription: 'Reflexive journal page captured with project context.',
+			statePath: operationalPaths.journals,
+			waitForText: 'Reflexive Journal & Analysis',
+		}),
+		operationalPage({
 			id: 'study',
 			title: 'Study overview',
 			group: 'Study',
 			path: '/pages/study/index.html',
 			description: 'Study overview and readiness controls.',
 			designRisk: operationalDesignRisks.study,
-			defaultState: operationalDefaultState({
-				title: 'Study overview with readiness context',
-				description:
-					'Study overview captured with project and study IDs, participants, guides, consent forms and consent records present.',
-				path: operationalPaths.study,
-				waitForText: 'Assisted digital support interview round 1',
-			}),
-		},
-		{
+			stateTitle: 'Study overview with readiness context',
+			stateDescription: 'Study overview captured with project and study IDs.',
+			statePath: operationalPaths.study,
+			waitForText: 'Assisted digital support interview round 1',
+		}),
+		operationalPage({
 			id: 'study-guides',
 			title: 'Discussion guides',
 			group: 'Study',
 			path: '/pages/study/guides/index.html',
 			description: 'Discussion guide list and editor page.',
 			designRisk: operationalDesignRisks.studyGuides,
-			defaultState: operationalDefaultState({
-				title: 'Discussion guides with study context',
-				description:
-					'Discussion guides page captured with project and study IDs so list, editor and publication context can be reviewed.',
-				path: operationalPaths.studyGuides,
-				waitForText: 'Guides for this study',
-			}),
-		},
-		{
+			stateTitle: 'Discussion guides with study context',
+			stateDescription: 'Discussion guides page captured with project and study IDs.',
+			statePath: operationalPaths.studyGuides,
+			waitForText: 'Guides for this study',
+		}),
+		operationalPage({
 			id: 'study-participants',
 			title: 'Participants',
 			group: 'Study',
 			path: '/pages/study/participants/index.html',
 			description: 'Participants page for a study.',
 			designRisk: operationalDesignRisks.studyParticipants,
-			defaultState: operationalDefaultState({
-				title: 'Study participants with participant records',
-				description:
-					'Participants page captured with study-scoped participant records so recruitment, scheduling and consent readiness can be reviewed.',
-				path: operationalPaths.studyParticipants,
-				waitForText: 'Participants',
-			}),
-		},
-		{
+			stateTitle: 'Study participants with participant records',
+			stateDescription: 'Participants page captured with study-scoped participant records.',
+			statePath: operationalPaths.studyParticipants,
+			waitForText: 'Participants',
+		}),
+		operationalPage({
 			id: 'study-session',
 			title: 'Study session',
 			group: 'Study',
 			path: '/pages/study/session/index.html',
 			description: 'Session running and note capture page.',
 			designRisk: operationalDesignRisks.studySession,
-			defaultState: operationalDefaultState({
-				title: 'Study session with project and study context',
-				description:
-					'Session workspace captured with project and study IDs so participant, consent and note-capture readiness can be reviewed.',
-				path: operationalPaths.studySession,
-				waitForText: 'Begin a session',
-			}),
-		},
-		{
+			stateTitle: 'Study session with project and study context',
+			stateDescription: 'Session workspace captured with project and study IDs.',
+			statePath: operationalPaths.studySession,
+			waitForText: 'Begin a session',
+		}),
+		operationalPage({
 			id: 'study-consent-forms',
 			title: 'Study consent forms',
 			group: 'Study',
 			path: '/pages/study/consent-forms/index.html',
 			description: 'Study-specific consent form configuration page.',
 			designRisk: operationalDesignRisks.studyConsentForms,
-			defaultState: operationalDefaultState({
-				title: 'Study consent forms with study context',
-				description:
-					'Consent form configuration captured with project and study IDs so publishing state and consent wording can be reviewed.',
-				path: operationalPaths.studyConsentForms,
-				waitForText: 'Consent forms',
-			}),
-		},
-		{
+			stateTitle: 'Study consent forms with study context',
+			stateDescription: 'Consent form configuration captured with project and study IDs.',
+			statePath: operationalPaths.studyConsentForms,
+			waitForText: 'Consent forms',
+		}),
+		page({
 			id: 'study-participant-consent',
 			title: 'Participant consent',
 			group: 'Study',
@@ -455,62 +324,24 @@ export const visualWalkthroughConfig = {
 			designRisk: operationalDesignRisks.participantConsent,
 			defaultState: participantConsentDefaultState,
 			states: participantConsentVisualStates,
-		},
-		{
+		}),
+		operationalPage({
 			id: 'team-role-assignments',
 			title: 'Assign a role to a team member',
 			group: 'Team administration',
 			path: '/pages/team/role-assignments/index.html',
 			description: 'Team Admin role assignment page.',
 			designRisk: operationalDesignRisks.teamRoleAssignments,
-			defaultState: operationalDefaultState({
-				title: 'Role assignment form with Team Admin scope',
-				description:
-					'Role assignment page captured with a deterministic Team Admin context so team scope, role.assign gating, role radios, duration choices, sensitive-role copy and audit-reason fields can be reviewed.',
-				path: operationalPaths.teamRoleAssignments,
-				waitForText: 'You are assigning roles in',
-			}),
-		},
-		{
-			id: 'search',
-			title: 'Search',
-			group: 'Utilities',
-			path: '/pages/search/index.html',
-			description: 'Search page.',
-			designRisk: operationalDesignRisks.search,
-		},
-		{
-			id: 'notes',
-			title: 'Notes',
-			group: 'Utilities',
-			path: '/pages/notes/index.html',
-			description: 'Notes page.',
-			designRisk: operationalDesignRisks.notes,
-		},
-		{
-			id: 'consent',
-			title: 'Consent',
-			group: 'Utilities',
-			path: '/pages/consent/index.html',
-			description: 'Consent page.',
-			designRisk: operationalDesignRisks.consent,
-		},
-		{
-			id: 'sessions',
-			title: 'Sessions',
-			group: 'Utilities',
-			path: '/pages/sessions/index.html',
-			description: 'Sessions list page.',
-			designRisk: operationalDesignRisks.sessions,
-		},
-		{
-			id: 'synthesize',
-			title: 'Synthesize',
-			group: 'Analysis',
-			path: '/pages/synthesize/index.html',
-			description: 'Synthesis page.',
-			designRisk: operationalDesignRisks.synthesize,
-		},
+			stateTitle: 'Role assignment form with Team Admin scope',
+			stateDescription: 'Role assignment page captured with a deterministic Team Admin context.',
+			statePath: operationalPaths.teamRoleAssignments,
+			waitForText: 'You are assigning roles in',
+		}),
+		registeredPage('search', 'Search', 'Utilities', '/pages/search/index.html', 'Search page.', operationalDesignRisks.search),
+		registeredPage('notes', 'Notes', 'Utilities', '/pages/notes/index.html', 'Notes page.', operationalDesignRisks.notes),
+		registeredPage('consent', 'Consent', 'Utilities', '/pages/consent/index.html', 'Consent page.', operationalDesignRisks.consent),
+		registeredPage('sessions', 'Sessions', 'Utilities', '/pages/sessions/index.html', 'Sessions list page.', operationalDesignRisks.sessions),
+		registeredPage('synthesize', 'Synthesize', 'Analysis', '/pages/synthesize/index.html', 'Synthesis page.', operationalDesignRisks.synthesize),
 	],
 };
 

--- a/visual-walkthrough.operational-fixtures.mjs
+++ b/visual-walkthrough.operational-fixtures.mjs
@@ -12,7 +12,7 @@ export const operationalAuthUserId = 'usr_visual_team_admin';
 export const operationalAuthTeamId = 'team_researchops_core';
 
 export const operationalPaths = {
-	accountSignIn: '/pages/account/sign-in/',
+	accountSignIn: '/pages/account/sign-in/index.html',
 	projectDashboard: `/pages/project-dashboard/?id=${operationalProjectId}`,
 	addStudy: `/pages/study/new/?pid=${operationalProjectId}`,
 	addParticipant: `/pages/project-dashboard/participants/?id=${operationalProjectId}`,

--- a/visual-walkthrough.operational-fixtures.mjs
+++ b/visual-walkthrough.operational-fixtures.mjs
@@ -12,6 +12,7 @@ export const operationalAuthUserId = 'usr_visual_team_admin';
 export const operationalAuthTeamId = 'team_researchops_core';
 
 export const operationalPaths = {
+	accountSignIn: '/pages/account/sign-in/',
 	projectDashboard: `/pages/project-dashboard/?id=${operationalProjectId}`,
 	addStudy: `/pages/study/new/?pid=${operationalProjectId}`,
 	addParticipant: `/pages/project-dashboard/participants/?id=${operationalProjectId}`,
@@ -317,6 +318,11 @@ export const operationalDesignRisks = {
 		'The landing page may look visually complete while failing to explain the safest route into research setup, evidence review or synthesis work.',
 		'User researchers could choose the wrong workflow, duplicate records or miss the intended evidence-to-insight traceability model.',
 		'Review the page against GOV.UK start-point conventions, link purpose, visible service identity and keyboard-accessible navigation.'
+	),
+	accountSignIn: risk(
+		'The sign-in page may make access look complete without explaining that identity, team membership and role permission are checked separately.',
+		'The first Team Admin may sign in successfully but not understand whether D1 role bootstrap, team membership or Cloudflare Access caused a blocked state.',
+		'Review the page for clear Cloudflare Access sign-in language, account-state recovery, active team context and a visible route to Team Admin tasks.'
 	),
 	start: risk(
 		'The guided project setup could collect plausible project metadata without making privacy boundaries, required fields and AI-assistance disclosure clear enough.',


### PR DESCRIPTION
## Summary

Adds the first user-facing ResearchOps sign-in/status route for the bootstrapped Team Admin.

The new page lets the user check the current `/api/me` account context and continue to the existing Team Admin role-assignment journey when `role.assign` is present.

## Branch

```text
feature/first-team-admin-login
```

## Current head

```text
8f544dfcde95a95bb6ee405e44842fe274dbb376
```

## Adds

```text
public/pages/account/sign-in/index.html
public/js/auth-sign-in-page.js
tests/auth-sign-in-route-state.test.js
docs/product/26/05/11/first-team-admin-login-2026-05-11.md
docs/agent-audit/reasoning/2026/05/11/first-team-admin-login-implementation-trace.md
docs/agent-audit/reasoning/2026/05/11/first-team-admin-login-implementation-trace.json
```

## Updates

```text
visual-walkthrough.operational-fixtures.mjs
visual-walkthrough.config.mjs
.prettierignore
tests/start-project-overview-page.test.js
tests/start-project-step-1-defaults-route-state.test.js
```

## Behaviour

The page calls `/api/me` with credentials included and handles these states:

- sign-in required
- account not active
- no active team
- signed in without role assignment permission
- signed in as Team Admin with `role.assign`

When `role.assign` is present, the page shows a continuation link to:

```text
/pages/team/role-assignments/
```

## Visual walkthrough coverage

The new public route is registered as `account-sign-in` in `visual-walkthrough.config.mjs`.

The operational fixture now includes a deterministic Team Admin `/api/me` response so the walkthrough can capture the signed-in Team Admin state.

## Validation

Current head `8f544dfcde95a95bb6ee405e44842fe274dbb376` is green across:

- Format pull request
- Validate ResearchOps
- qa-bdd
- CI
- Accessibility audit (pa11y-ci)
- QA — Broken links (Lychee)
- Release Gate
- Worker CI

## Boundaries

This PR does not change the D1 schema, bootstrap script, Cloudflare configuration, account creation, role request flows, or logout handling.