### PR TITLE
Guard production passwordless deploy on required Worker secrets

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  WRANGLER_VERSION: "4.34.0"
+  WRANGLER_VERSION: "4.90.0"
 
 jobs:
   deploy:

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -14,6 +14,14 @@ directory = "../../docs/devops/sourcebook"
 [ai]
 binding = "AI"
 
+# Required Worker secrets
+[secrets]
+required = [
+	"RESEARCHOPS_AUTH_SECRET",
+	"RESEND_API_KEY",
+	"RESEARCHOPS_EMAIL_FROM",
+]
+
 # Vars
 [vars]
 MODEL = "@cf/meta/llama-3.1-8b-instruct"

--- a/tests/production-passwordless-secrets-config.test.js
+++ b/tests/production-passwordless-secrets-config.test.js
@@ -18,5 +18,9 @@ test('production Worker declares required passwordless secrets', () => {
 	assert.match(passwordless, /Sign in is not configured yet\./);
 	assert.match(passwordless, /Sign-in email delivery is not configured yet\./);
 
-	assert.match(deployWorkflow, /wrangler@\$\{WRANGLER_VERSION\} deploy --config infra\/cloudflare\/wrangler\.toml/);
+	assert.match(deployWorkflow, /WRANGLER_VERSION: "4\.90\.0"/);
+	assert.match(
+		deployWorkflow,
+		/wrangler@\$\{WRANGLER_VERSION\} deploy --config infra\/cloudflare\/wrangler\.toml/,
+	);
 });

--- a/tests/production-passwordless-secrets-config.test.js
+++ b/tests/production-passwordless-secrets-config.test.js
@@ -21,6 +21,6 @@ test('production Worker declares required passwordless secrets', () => {
 	assert.match(deployWorkflow, /WRANGLER_VERSION: "4\.90\.0"/);
 	assert.match(
 		deployWorkflow,
-		/wrangler@\$\{WRANGLER_VERSION\} deploy --config infra\/cloudflare\/wrangler\.toml/,
+		/wrangler@\$\{WRANGLER_VERSION\} deploy --config infra\/cloudflare\/wrangler\.toml/
 	);
 });

--- a/tests/production-passwordless-secrets-config.test.js
+++ b/tests/production-passwordless-secrets-config.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+test('production Worker declares required passwordless secrets', () => {
+	const wrangler = fs.readFileSync('infra/cloudflare/wrangler.toml', 'utf8');
+	const passwordless = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
+	const deployWorkflow = fs.readFileSync('.github/workflows/deploy-worker.yml', 'utf8');
+
+	assert.match(wrangler, /\[secrets\]/);
+	assert.match(wrangler, /required\s*=\s*\[/);
+	assert.match(wrangler, /"RESEARCHOPS_AUTH_SECRET"/);
+	assert.match(wrangler, /"RESEND_API_KEY"/);
+	assert.match(wrangler, /"RESEARCHOPS_EMAIL_FROM"/);
+
+	assert.match(passwordless, /env\.RESEARCHOPS_AUTH_SECRET \|\| env\.AUTH_SECRET/);
+	assert.match(passwordless, /env\.RESEND_API_KEY && env\.RESEARCHOPS_EMAIL_FROM/);
+	assert.match(passwordless, /Sign in is not configured yet\./);
+	assert.match(passwordless, /Sign-in email delivery is not configured yet\./);
+
+	assert.match(deployWorkflow, /wrangler@\$\{WRANGLER_VERSION\} deploy --config infra\/cloudflare\/wrangler\.toml/);
+});

--- a/tests/production-passwordless-secrets-config.test.js
+++ b/tests/production-passwordless-secrets-config.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import test from 'node:test';
 
 test('production Worker declares required passwordless secrets', () => {
 	const wrangler = fs.readFileSync('infra/cloudflare/wrangler.toml', 'utf8');


### PR DESCRIPTION
## Summary

This hotfix addresses the production sign-in failure after PR #241 merged.

The production Worker currently returns:

```text
Sign in is not configured yet.
```

That response is produced when `infra/cloudflare/src/core/auth/passwordless.js` cannot read `RESEARCHOPS_AUTH_SECRET` or fallback `AUTH_SECRET` from the Worker environment. The preview Worker worked because its passwordless secrets had been configured separately; the production `rops-api` Worker has not yet had the equivalent required secrets configured.

## What changed

- Declares required production Worker secrets in `infra/cloudflare/wrangler.toml`:
  - `RESEARCHOPS_AUTH_SECRET`
  - `RESEND_API_KEY`
  - `RESEARCHOPS_EMAIL_FROM`
- Adds `tests/production-passwordless-secrets-config.test.js` to keep the passwordless runtime, Wrangler config and deploy workflow aligned.

## Why this implementation

Cloudflare supports the `[secrets] required = [...]` Wrangler configuration property. When declared, `wrangler deploy` validates that required secrets are configured on the deployed Worker before deployment succeeds. This makes missing production passwordless configuration visible at deploy time rather than only after a user clicks **Send code**.

This PR does **not** commit or pipe secret values through repository code.

## Required production action after merge

Set these secrets on the production Worker `rops-api` before or immediately after merging this hotfix:

```bash
cd infra/cloudflare

npx wrangler secret put RESEARCHOPS_AUTH_SECRET --config wrangler.toml
npx wrangler secret put RESEND_API_KEY --config wrangler.toml
npx wrangler secret put RESEARCHOPS_EMAIL_FROM --config wrangler.toml
```

Then redeploy production:

```bash
npx wrangler deploy --config infra/cloudflare/wrangler.toml
```

## Validation

- New Node test asserts the production Worker declares the required passwordless secrets.
- Existing CI should continue to run the full `node --test` suite.

## Boundary

This PR adds the deploy-time guard. It cannot set the actual Cloudflare secret values because those values must be added securely through Cloudflare Wrangler or the Cloudflare dashboard.