### PR TITLE
Apply production passwordless workflow fix

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -22,6 +22,7 @@ env:
   WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
   D1_DATABASE_NAME: "researchops-d1"
   PASSWORDLESS_MIGRATION: "infra/cloudflare/migrations/0003_auth_passwordless_sessions.sql"
+  PASSWORDLESS_LOCKED_MIGRATION: "infra/cloudflare/migrations/0004_auth_login_challenges_locked_status.sql"
 
 jobs:
   deploy:
@@ -47,24 +48,22 @@ jobs:
       - name: Check production passwordless secrets are available
         env:
           RESEARCHOPS_AUTH_SECRET: ${{ secrets.RESEARCHOPS_AUTH_SECRET }}
-          RESEARCHOPS_EMAIL_WEBHOOK_URL: ${{ secrets.RESEARCHOPS_EMAIL_WEBHOOK_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}
         run: |
-          if [ -z "${RESEARCHOPS_AUTH_SECRET}" ]; then
-            echo "Missing required secret: RESEARCHOPS_AUTH_SECRET"
-            exit 1
-          fi
-
-          if [ -z "${RESEARCHOPS_EMAIL_WEBHOOK_URL}" ] && { [ -z "${RESEND_API_KEY}" ] || [ -z "${RESEARCHOPS_EMAIL_FROM}" ]; }; then
-            echo "Configure either RESEARCHOPS_EMAIL_WEBHOOK_URL or both RESEND_API_KEY and RESEARCHOPS_EMAIL_FROM"
+          missing=""
+          if [ -z "${RESEARCHOPS_AUTH_SECRET}" ]; then missing="${missing} RESEARCHOPS_AUTH_SECRET"; fi
+          if [ -z "${RESEND_API_KEY}" ]; then missing="${missing} RESEND_API_KEY"; fi
+          if [ -z "${RESEARCHOPS_EMAIL_FROM}" ]; then missing="${missing} RESEARCHOPS_EMAIL_FROM"; fi
+          if [ -n "${missing}" ]; then
+            echo "Missing required production passwordless secrets:${missing}"
             exit 1
           fi
 
       - name: Record Wrangler toolchain version
         run: npx --yes wrangler@${WRANGLER_VERSION} --version
 
-      - name: Apply passwordless migration to production D1
+      - name: Apply passwordless migrations to production D1
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -73,6 +72,10 @@ jobs:
             --remote \
             --config "${WRANGLER_CONFIG}" \
             --file "${PASSWORDLESS_MIGRATION}"
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${PASSWORDLESS_LOCKED_MIGRATION}"
 
       - name: Deploy Worker with production passwordless secrets
         uses: cloudflare/wrangler-action@v3
@@ -83,13 +86,9 @@ jobs:
           command: deploy --config infra/cloudflare/wrangler.toml
           secrets: |
             RESEARCHOPS_AUTH_SECRET
-            RESEARCHOPS_EMAIL_WEBHOOK_URL
-            RESEARCHOPS_EMAIL_WEBHOOK_TOKEN
             RESEND_API_KEY
             RESEARCHOPS_EMAIL_FROM
         env:
           RESEARCHOPS_AUTH_SECRET: ${{ secrets.RESEARCHOPS_AUTH_SECRET }}
-          RESEARCHOPS_EMAIL_WEBHOOK_URL: ${{ secrets.RESEARCHOPS_EMAIL_WEBHOOK_URL }}
-          RESEARCHOPS_EMAIL_WEBHOOK_TOKEN: ${{ secrets.RESEARCHOPS_EMAIL_WEBHOOK_TOKEN }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}


### PR DESCRIPTION
## Summary

This hotfix applies the production deploy workflow changes that were requested after PR #243 merged.

The main branch still had the unresolved production deploy risks identified in Codex review:

1. optional webhook secrets were still listed in the production deploy upload list, even though the preflight allowed them to be absent
2. the new `0004_auth_login_challenges_locked_status.sql` forward migration existed, but the production deploy workflow only executed `0003`

## What changed

- Makes the production passwordless deploy Resend-only for now.
- Removes webhook bindings from the production preflight check, Wrangler action `secrets:` list, and deploy step environment.
- Adds `PASSWORDLESS_LOCKED_MIGRATION` for `0004_auth_login_challenges_locked_status.sql`.
- Runs both passwordless migrations during production Worker deployment:
  - `0003_auth_passwordless_sessions.sql`
  - `0004_auth_login_challenges_locked_status.sql`
- Keeps `WRANGLER_VERSION` at `4.90.0`.

## Why this is needed

The production Worker must receive only the required passwordless secret bindings that are guaranteed by preflight. Uploading unset optional webhook bindings can fail production deploy.

The production D1 database also needs the forward migration for the `locked` login challenge status. Running `0003` again is not sufficient if `0003` has already created the table with the older CHECK constraint.

## After merge

Run the `Deploy ResearchOps Worker` workflow on `main`. That deploy should apply both D1 migrations, bind the production passwordless Resend secrets, and redeploy `rops-api`.
