### PR TITLE
Use Node 22 for production Worker deploy

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

This hotfix fixes the failing `Deploy ResearchOps Worker` run on `main` after PR #244 merged.

The workflow now pins Wrangler to `4.90.0`, but the job still used Node.js 20. Wrangler `4.90.0` requires Node.js 22 or later, so the production deploy failed during the `Record Wrangler toolchain version` step before it could apply D1 migrations or deploy `rops-api`.

## Evidence from logs

The failing log shows:

```text
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

## Change

- Updates `.github/workflows/deploy-worker.yml` from `Use Node.js 20` to `Use Node.js 22`.
- Sets `node-version: 22` for the production Worker deploy workflow.

## After merge

Run the `Deploy ResearchOps Worker` workflow on `main` again. It should now proceed past the Wrangler version step and reach the D1 migration and Worker deployment steps.
