### PR TITLE
Run Wrangler action from Worker config directory

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -83,7 +83,8 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: ${{ env.WRANGLER_VERSION }}
-          command: deploy --config infra/cloudflare/wrangler.toml
+          workingDirectory: infra/cloudflare
+          command: deploy --config wrangler.toml
           secrets: |
             RESEARCHOPS_AUTH_SECRET
             RESEND_API_KEY


### PR DESCRIPTION
## Summary

This hotfix fixes the latest failing `Deploy ResearchOps Worker` run after the Node 22 update.

The deploy now reaches the passwordless D1 migrations successfully, but fails when `cloudflare/wrangler-action@v3` uploads Worker secrets.

## Evidence from uploaded logs

The D1 migration step now succeeds:

```text
Executed 7 queries
success: true
```

The failure occurs in the Wrangler action secret upload step:

```text
Required Worker name missing. Please specify the Worker name in your Wrangler configuration file, or pass it as an argument with `--name <worker-name>`
Failed to upload secrets.
```

## Cause

The Wrangler action runs its secret upload before the configured deploy command. The deploy command has `--config infra/cloudflare/wrangler.toml`, but the action's secret-upload phase calls Wrangler without that config path. From the repository root, Wrangler cannot see the Worker config and therefore cannot resolve the Worker name.

## Change

- Adds `workingDirectory: infra/cloudflare` to the Wrangler action.
- Changes the action deploy command to `deploy --config wrangler.toml`.

This lets the action's internal secret upload run from the directory that contains `wrangler.toml`, so it can resolve the production Worker name `rops-api`.

## After merge

Run `Deploy ResearchOps Worker` on `main` again. The workflow should now proceed through:

1. validation
2. production passwordless secret preflight
3. Wrangler version check
4. passwordless D1 migrations
5. Worker secret upload
6. Worker deploy
