### PR TITLE
Fix account sign-in visual walkthrough state

### DIFF
--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -52,6 +52,32 @@ const checkAnswersActions = [
 	{ type: 'waitForSelector', selector: '#step4', state: 'visible' },
 ];
 
+const accountSignInDefaultState = {
+	id: 'default',
+	title: 'Passwordless sign-in code request',
+	description: 'Sign-in page captured before a one-time code is requested.',
+	path: operationalPaths.accountSignIn,
+	mockRoutes: [
+		{
+			url: /\/api\/me(?:\?.*)?$/,
+			method: 'GET',
+			status: 401,
+			body: {
+				ok: false,
+				authenticated: false,
+				error: 'not_authenticated',
+				message: 'Sign in required.',
+			},
+		},
+	],
+	actions: [
+		{
+			type: 'waitForText',
+			text: 'Use your work email address to continue',
+		},
+	],
+};
+
 function page({ id, title, group, path, description, designRisk, defaultState, states }) {
 	return {
 		id,
@@ -123,17 +149,14 @@ export const visualWalkthroughConfig = {
 	],
 	pages: [
 		registeredPage('home', 'Home', 'Core', '/', 'ResearchOps landing page.', operationalDesignRisks.home),
-		operationalPage({
+		page({
 			id: 'account-sign-in',
 			title: 'Sign in to ResearchOps',
 			group: 'Account',
 			path: '/pages/account/sign-in/index.html',
 			description: 'First Team Admin sign-in and one-time code request page.',
 			designRisk: operationalDesignRisks.accountSignIn,
-			stateTitle: 'Passwordless sign-in code request',
-			stateDescription: 'Sign-in page captured before a one-time code is requested.',
-			statePath: operationalPaths.accountSignIn,
-			waitForText: 'Use your work email address to continue',
+			defaultState: accountSignInDefaultState,
 		}),
 		operationalPage({
 			id: 'account-dashboard',


### PR DESCRIPTION
## Summary

This hotfix fixes the remaining failing BDD visual walkthrough job on `main`.

The Cucumber smoke test passes. The failing job is the visual walkthrough capture, specifically:

```text
account-sign-in/default/desktop
account-sign-in/default/mobile
```

## Cause

The `account-sign-in` visual walkthrough state expected to see this unauthenticated sign-in copy:

```text
Use your work email address to continue
```

However, the state was using the shared operational mock routes. Those routes mock `/api/me` as an authenticated Team Admin.

That means the sign-in page correctly redirects to `/pages/account/` during the walkthrough, because already-authenticated users should not see the one-time-code sign-in form.

The walkthrough was therefore waiting for unauthenticated sign-in content on a page that had correctly redirected away.

## Change

- Adds a dedicated `accountSignInDefaultState` in `visual-walkthrough.config.mjs`.
- That state mocks `/api/me` as unauthenticated with a 401 response.
- The rest of the operational walkthrough pages continue to use the deterministic Team Admin auth context.

## Validation expectation

The visual walkthrough should now capture:

- `account-sign-in/default/desktop`
- `account-sign-in/default/mobile`

without redirecting to the account dashboard first.

## Boundary

This does not change production authentication behaviour. It only corrects the deterministic mock context used by the visual walkthrough for the unauthenticated sign-in state.