### PR TITLE
Fix role assignment BDD visual walkthrough

### DIFF
--- a/tests/visual-walkthrough-role-assignment-route-state.test.js
+++ b/tests/visual-walkthrough-role-assignment-route-state.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const walkthroughConfigSource = fs.readFileSync('visual-walkthrough.config.mjs', 'utf8');
+const roleAssignmentScriptSource = fs.readFileSync('public/js/auth-role-assignment-page.js', 'utf8');
+const roleAssignmentPageSource = fs.readFileSync('public/pages/team/role-assignments/index.html', 'utf8');
+
+function assertWalkthroughUsesCurrentRoleAssignmentCopy() {
+	assert.match(walkthroughConfigSource, /id: 'team-role-assignments'/);
+	assert.match(walkthroughConfigSource, /waitForText: 'You can assign roles in teams you manage'/);
+	assert.doesNotMatch(walkthroughConfigSource, /waitForText: 'You are assigning roles in'/);
+}
+
+function assertRoleAssignmentPageStillProvidesWalkthroughAnchor() {
+	assert.match(roleAssignmentScriptSource, /You can assign roles in teams you manage/);
+	assert.match(roleAssignmentScriptSource, /Your current team is/);
+	assert.match(roleAssignmentPageSource, /id="auth-context"/);
+	assert.match(roleAssignmentPageSource, /aria-live="polite"/);
+}
+
+assertWalkthroughUsesCurrentRoleAssignmentCopy();
+assertRoleAssignmentPageStillProvidesWalkthroughAnchor();

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -394,7 +394,7 @@ export const visualWalkthroughConfig = {
 			stateTitle: 'Role assignment form with Team Admin scope',
 			stateDescription: 'Role assignment page captured with a deterministic Team Admin context.',
 			statePath: operationalPaths.teamRoleAssignments,
-			waitForText: 'You are assigning roles in',
+			waitForText: 'You can assign roles in teams you manage',
 		}),
 		registeredPage('search', 'Search', 'Utilities', '/pages/search/index.html', 'Search page.', operationalDesignRisks.search),
 		registeredPage('notes', 'Notes', 'Utilities', '/pages/notes/index.html', 'Notes page.', operationalDesignRisks.notes),


### PR DESCRIPTION
## Summary

Fixes the BDD visual walkthrough after the account registration and role-assignment work was merged to main.

The role-assignment visual walkthrough was still waiting for old Team scope copy:

`You are assigning roles in`

The implemented page now renders:

`You can assign roles in teams you manage`

This PR updates the visual walkthrough registry to use the current user-facing copy and adds a route-state guard so the walkthrough wait text does not drift from the role-assignment page again.

## Changes

- Updated `visual-walkthrough.config.mjs` for the `team-role-assignments` state.
- Added `tests/visual-walkthrough-role-assignment-route-state.test.js`.

## Validation

The new test asserts:

- the walkthrough uses the current role-assignment Team Admin scope copy
- the old removed copy is no longer used
- the role-assignment page still exposes the `auth-context` live region used by the walkthrough state

## Notes

This is intentionally narrow. It does not touch the registration request implementation or role-assignment behaviour merged in PR #248.