### PR TITLE
Redirect unauthenticated users from projects page to sign-in

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.json
@@ -1,0 +1,30 @@
+{
+  "traceId": "projects-auth-redirect-trace",
+  "date": "2026-05-19",
+  "branch": "fix/projects-auth-redirect-pr-unified",
+  "task": "Redirect logged out user from /pages/projects/ to /pages/account/sign-in/.",
+  "signals": [
+    "authentication",
+    "route-behaviour",
+    "frontend-page-logic"
+  ],
+  "selectedBundles": [
+    "github",
+    "researchops-developer-control",
+    "cloudflare",
+    "multi-functional-team",
+    "govuk-design-system"
+  ],
+  "changes": [
+    "Added sign-in redirect helper in public/js/projects-page.js.",
+    "Trigger redirect when /api/projects returns HTTP 401.",
+    "Avoid rendering transient error when redirect is in progress.",
+    "Use a named redirect sentinel error constant instead of a hard-coded message string."
+  ],
+  "validation": [
+    {
+      "command": "npm run lint -- public/js/projects-page.js",
+      "result": "pass_with_existing_warnings"
+    }
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.json
+++ b/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.json
@@ -1,7 +1,7 @@
 {
   "traceId": "projects-auth-redirect-trace",
   "date": "2026-05-19",
-  "branch": "fix/projects-auth-redirect-pr-unified",
+  "branch": "fix/projects-auth-redirect-pr254-remediation",
   "task": "Redirect logged out user from /pages/projects/ to /pages/account/sign-in/.",
   "signals": [
     "authentication",

--- a/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.md
@@ -1,0 +1,12 @@
+# Projects auth redirect trace
+
+- Branch: `fix/projects-auth-redirect-pr-unified`
+- Task: Redirect logged out user from `/pages/projects/` to `/pages/account/sign-in/`.
+- Signals: authentication, route-behaviour, frontend-page-logic.
+- Selected bundles: github, researchops-developer-control, cloudflare, multi-functional-team, govuk-design-system.
+- Change summary:
+  - Added sign-in redirect helper in `public/js/projects-page.js`.
+  - Trigger redirect when `/api/projects` returns HTTP 401.
+  - Avoid rendering transient error when redirect is in progress.
+- Validation:
+  - `npm run lint -- public/js/projects-page.js` completed with existing repository warnings only.

--- a/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.md
+++ b/docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.md
@@ -1,6 +1,6 @@
 # Projects auth redirect trace
 
-- Branch: `fix/projects-auth-redirect-pr-unified`
+- Branch: `fix/projects-auth-redirect-pr254-remediation`
 - Task: Redirect logged out user from `/pages/projects/` to `/pages/account/sign-in/`.
 - Signals: authentication, route-behaviour, frontend-page-logic.
 - Selected bundles: github, researchops-developer-control, cloudflare, multi-functional-team, govuk-design-system.

--- a/public/js/projects-page.js
+++ b/public/js/projects-page.js
@@ -25,6 +25,16 @@ const container = document.getElementById("list");
 const startProjectAction = document.querySelector(".projects-page-actions");
 
 const VALID_PROJECT_PHASES = new Set(["pre-discovery", "discovery", "alpha", "beta", "live"]);
+const REDIRECTING_TO_SIGN_IN_ERROR = "redirecting_to_sign_in";
+
+function signInUrl() {
+	const returnTo = `${window.location.pathname}${window.location.search || ""}`;
+	return `/pages/account/sign-in/?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
+function redirectToSignIn() {
+	window.location.assign(signInUrl());
+}
 
 function setListBusy(isBusy) {
 	if (!container) return;
@@ -176,6 +186,10 @@ function normaliseProject(p) {
 
 async function listProjects() {
 	const { ok, status, data } = await fetchWithTimeout(apiUrl("/api/projects"));
+	if (status === 401) {
+		redirectToSignIn();
+		throw new Error(REDIRECTING_TO_SIGN_IN_ERROR);
+	}
 	if (!ok || !data?.ok) throw new Error(`Project list failed (${status})`);
 
 	const rawProjects = Array.isArray(data.projects) ? data.projects : [];
@@ -327,6 +341,7 @@ function render(projects, source, canStartProject = false, malformed = []) {
 		const { source, projects, canStartProject, malformed } = await listProjects();
 		render(projects, source, canStartProject, malformed);
 	} catch (error) {
+		if (error?.message === REDIRECTING_TO_SIGN_IN_ERROR) return;
 		setStartProjectVisible(false);
 		renderErrorState(error);
 	} finally {


### PR DESCRIPTION
### Motivation

- Ensure logged-out users requesting `/pages/projects/` are redirected to the sign-in page instead of showing a transient error, and centralise the redirect sentinel value into a named constant for clearer control flow and rendering logic.

### Description

- Add `REDIRECTING_TO_SIGN_IN_ERROR` constant, `signInUrl()` helper, and `redirectToSignIn()` helper to `public/js/projects-page.js` and use them to build and perform the redirect.
- Detect HTTP `401` from `fetchWithTimeout(apiUrl("/api/projects"))` in `listProjects()` and trigger `redirectToSignIn()` followed by throwing the sentinel error to stop further processing.
- Update the top-level async IIFE to swallow the sentinel error (`REDIRECTING_TO_SIGN_IN_ERROR`) so the transient error UI is not rendered while a redirect is in progress.
- Add agent-audit reasoning trace files `docs/agent-audit/reasoning/2026/05/19/projects-auth-redirect-trace.json` and `.md` documenting the change and rationale.

### Testing

- Ran `npm run lint -- public/js/projects-page.js` which completed with existing repository warnings only (`pass_with_existing_warnings`).
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb685dd10832fb5e1c2739f6e597e)