### PR TITLE
Fix role assignment session origin handling

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/19/role-assignment-session-origin.json
+++ b/docs/agent-audit/reasoning/2026/05/19/role-assignment-session-origin.json
@@ -1,0 +1,37 @@
+{
+  "task": "Fix Team Admin role assignment page session origin handling",
+  "branch": "fix/role-assignment-session-origin-clean",
+  "date": "2026-05-19",
+  "bundles": [
+    "github-diamond",
+    "researchops-developer-control",
+    "multi-functional-team",
+    "govuk-design-system",
+    "cloudflare",
+    "airtable-public-api"
+  ],
+  "rootCause": {
+    "type": "cross-origin-auth-context",
+    "summary": "Role assignment page resolved API requests to external Worker origins instead of same-origin Pages API routes.",
+    "impact": "Authenticated Team Admin users appeared unauthenticated on the role assignment page."
+  },
+  "filesChanged": [
+    {
+      "path": "public/js/auth-role-assignment-page.js",
+      "changes": [
+        "defaultApiOrigin now falls back to location.origin",
+        "fallback API origin routing disabled for this flow",
+        "apiBaseCandidates prioritises same-origin API routing"
+      ]
+    }
+  ],
+  "expectedOutcome": {
+    "authenticatedTeamAdmin": true,
+    "roleAssignmentVisible": true,
+    "sameOriginApi": true
+  },
+  "validation": {
+    "localExecution": false,
+    "ciExpected": true
+  }
+}

--- a/docs/agent-audit/reasoning/2026/05/19/role-assignment-session-origin.md
+++ b/docs/agent-audit/reasoning/2026/05/19/role-assignment-session-origin.md
@@ -1,0 +1,77 @@
+# Role assignment session origin trace
+
+- Branch: `fix/role-assignment-session-origin-clean`
+- Task: Fix Team Admin role assignment page showing sign-in required for an authenticated Team Admin account.
+- Branch trace decision: `fix/` branch, trace required.
+
+## Operating model files loaded
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+
+## Selected bundles
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `govuk-design-system`
+- `cloudflare`
+- `airtable-public-api`
+
+## Skipped bundles
+
+- `openai-platform` — no OpenAI API or model integration change.
+- `mcp-agent-tooling` — no MCP tool consent or server/tool contract change.
+- `mural-public-api` — no Mural API implementation change.
+
+## Files read
+
+- `docs/product/26/05/09/auth-role-assignment-ui-2026-05-09.md`
+- `public/js/auth-role-assignment-page.js`
+- `public/js/auth-account-page.js`
+- `public/js/auth-sign-in-page.js`
+- `public/pages/team/role-assignments/index.html`
+- `infra/cloudflare/src/worker.js`
+- `infra/cloudflare/src/core/auth/access-scoped.js`
+- `infra/cloudflare/src/core/auth/access.js`
+- `infra/cloudflare/src/core/auth/passwordless.js`
+- `tests/auth-role-assignment-ui-route-state.test.js`
+
+## Root cause
+
+The role-assignment page used Worker-origin fallback routing for `/api/me` on Pages hosts when no explicit API origin was configured.
+
+That meant an authenticated browser session on the ResearchOps Pages origin could call the external Worker origin rather than the same-origin `/api/*` route path. The passwordless session cookie is first-party to the active site origin, so the role-assignment page could show `You cannot assign roles` and `Sign in is required to use this part of ResearchOps` even when the user had the Team Admin role in the active team.
+
+## Change summary
+
+- Updated `public/js/auth-role-assignment-page.js` so `defaultApiOrigin()` falls back to `location.origin` when no explicit API origin is configured.
+- Disabled external fallback API origin selection for this authenticated role-assignment flow.
+- Updated `apiBaseCandidates()` to use the resolved same-origin API base and only include fallback origins if fallback routing is explicitly enabled.
+
+## Intended user outcome
+
+A signed-in Team Admin, including `digikev.kevin.rapley@gmail.com` in the ResearchOps Core Team, should load the role-assignment page with their active authenticated `/api/me` context and see the role assignment form rather than the sign-in required error.
+
+## Implementation method
+
+The clean repair branch was created from current `main`, after the earlier PR branch produced an invalid partial-tree diff. This branch intentionally contains only the role assignment script change and the required trace files.
+
+## Validation
+
+Local validation was not executed in this ChatGPT environment. CI should run after the PR is opened.
+
+## Residual risks
+
+- The fix assumes same-origin `/api/*` routing is available for Pages deployments and previews.
+- If an environment deliberately requires a configured external API origin, it must provide `data-api-origin` or `window.API_ORIGIN` explicitly.

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -16,7 +16,7 @@ function configuredApiOrigin() {
 }
 
 function defaultApiOrigin() {
-	return configuredApiOrigin();
+	return configuredApiOrigin() || location.origin.replace(/\/$/, "");
 }
 
 const CONFIG = Object.freeze({
@@ -140,15 +140,13 @@ function isResearchOpsBranchPreviewHost(hostname = location.hostname) {
 }
 
 function shouldUseFallbackApiOrigin() {
-	return !CONFIG.API_BASE && location.hostname.endsWith("pages.dev");
+	return false;
 }
 
 function apiBaseCandidates() {
-	if (CONFIG.API_BASE) return [CONFIG.API_BASE];
-	if (isProductionPagesHost()) return [PRODUCTION_API_ORIGIN];
-	if (isResearchOpsBranchPreviewHost()) return [PREVIEW_API_ORIGIN];
-	if (shouldUseFallbackApiOrigin()) return [PRODUCTION_API_ORIGIN];
-	return [""];
+	const candidates = [CONFIG.API_BASE];
+	if (shouldUseFallbackApiOrigin()) candidates.push(...FALLBACK_API_ORIGINS);
+	return [...new Set(candidates.map((base) => String(base || "").replace(/\/$/, "")))];
 }
 
 function endpoint(path, base = CONFIG.API_BASE) {


### PR DESCRIPTION
## Summary

Fixes Team Admin role assignment authentication context failures caused by cross-origin API resolution.

The role-assignment page was resolving `/api/me` and role-assignment requests against external Worker origins on Pages deployments when no explicit API origin was configured.

This caused authenticated Team Admin users to appear signed out because the active passwordless session cookie remained first-party to the Pages origin.

## Changes

- default role-assignment API origin to the active site origin
- disable external Worker fallback routing for this authenticated flow
- prioritise same-origin API resolution in `apiBaseCandidates()`
- add agent audit reasoning trace files

## Expected outcome

Authenticated Team Admin users should now:

- load role assignment context correctly
- see the role assignment form
- successfully assign roles using their active Pages session

## Trace

- `docs/agent-audit/reasoning/2026/05/19/role-assignment-session-origin.md`
- `docs/agent-audit/reasoning/2026/05/19/role-assignment-session-origin.json`

## Note

This clean branch replaces the earlier broken PR branch that produced an invalid partial-tree diff.