### PR TITLE
Fix intermittent footer include defaults race

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.json
+++ b/docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.json
@@ -1,0 +1,43 @@
+{
+  "traceId": "footer-include-defaults-race",
+  "date": "2026-05-19",
+  "branch": "fix/footer-include-defaults-race",
+  "task": "Fix intermittent footer partial rendering with missing default variables.",
+  "selectedBundles": [
+    "github-diamond",
+    "researchops-developer-control",
+    "multi-functional-team",
+    "govuk-design-system"
+  ],
+  "rootCause": {
+    "type": "custom-element-lifecycle-race",
+    "summary": "Observed attribute changes could trigger x-include rendering before connectedCallback applied footer defaults.",
+    "impact": "A stale footer render could output blank template variables and overwrite the correct footer text."
+  },
+  "filesChanged": [
+    {
+      "path": "public/components/layout.js",
+      "changes": [
+        "Added connected-state guard before rendering from attributeChangedCallback.",
+        "Queued renders so footer defaults are applied before first render.",
+        "Added render IDs and abort handling to stop stale fetches overwriting newer content."
+      ]
+    },
+    {
+      "path": "tests/layout-footer-include-race.test.js",
+      "changes": [
+        "Added regression coverage for footer include lifecycle ordering and stale render protection."
+      ]
+    }
+  ],
+  "expectedOutcome": {
+    "footerAlwaysContainsYear": true,
+    "footerAlwaysContainsOrganisation": true,
+    "footerAlwaysContainsBuild": true,
+    "blankFooterTemplatePrevented": true
+  },
+  "validation": {
+    "localExecution": false,
+    "ciExpected": true
+  }
+}

--- a/docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.md
+++ b/docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.md
@@ -1,0 +1,54 @@
+# Footer include defaults race trace
+
+- Branch: `fix/footer-include-defaults-race`
+- Task: Fix intermittent footer rendering where only `© ·` appears instead of the full footer text.
+- Branch trace decision: `fix/` branch, trace required.
+
+## Operating model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Selected bundles
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `govuk-design-system`
+
+## Files read
+
+- `public/components/layout.js`
+- `public/partials/footer.html`
+- `public/index.html`
+- `package.json`
+
+## Root cause
+
+`<x-include>` renders observed attributes as soon as the custom element upgrades. For existing markup such as `<x-include src="/partials/footer.html"></x-include>`, `attributeChangedCallback()` can run before `connectedCallback()`.
+
+The footer default variables are added in `connectedCallback()` by `_maybeApplyFooterDefaults()`. That meant an early attribute-triggered render could fetch and render `/partials/footer.html` with an empty data object before `year`, `org` and `build` were set.
+
+If that stale render completed after the later connected render, it could overwrite the correct footer with the blank-template output: `© ·`.
+
+## Change summary
+
+- Added a connected-state guard so attribute changes do not render includes before the element has connected.
+- Added render queuing so initial footer defaults and rendering are coalesced into a single microtask.
+- Added render IDs so stale fetches cannot overwrite newer rendered content.
+- Aborted an in-flight include fetch when a newer render supersedes it.
+- Added a regression test that guards the lifecycle and stale-render protections.
+
+## Expected outcome
+
+The footer partial should always render with defaults:
+
+`© 2026 Home Office Biometrics · ResearchOps v1.0.0`
+
+It should no longer intermittently render as `© ·`.
+
+## Validation
+
+Local validation was not executed in this ChatGPT environment. CI should run `node --test` and formatting checks after the PR is opened.

--- a/public/components/layout.js
+++ b/public/components/layout.js
@@ -63,24 +63,29 @@ class XInclude extends HTMLElement {
 		super();
 		this._loading = false;
 		this._abort = null;
-		this._needsRerender = false; // NEW: queue flag
+		this._needsRerender = false;
+		this._renderQueued = false;
+		this._renderId = 0;
+		this._hasConnected = false;
 	}
 
 	connectedCallback() {
-		this._maybeApplyFooterDefaults(); // NEW: ensure footer vars before first render
-		this._render();
+		this._hasConnected = true;
+		this._maybeApplyFooterDefaults();
+		this._queueRender();
 	}
 
 	attributeChangedCallback() {
-		// If a change happens during a fetch, queue one more render
-		if (this._loading) {
-			this._needsRerender = true;
-			return;
-		}
-		this._render();
+		if (!this._hasConnected) return;
+		this._maybeApplyFooterDefaults();
+		this._queueRender();
 	}
 
-	disconnectedCallback() { if (this._abort) this._abort.abort(); }
+	disconnectedCallback() {
+		this._hasConnected = false;
+		this._renderId += 1;
+		if (this._abort) this._abort.abort();
+	}
 
 	// ── utils ───────────────────────────────────────────────────────────
 	normalizeUrl(u) {
@@ -167,8 +172,21 @@ class XInclude extends HTMLElement {
 		return isDebugPartial ? "no-store" : "force-cache";
 	}
 
+	_queueRender() {
+		if (this._renderQueued) return;
+		this._renderQueued = true;
+		Promise.resolve().then(() => {
+			this._renderQueued = false;
+			this._render();
+		});
+	}
+
 	// ── rendering ───────────────────────────────────────────────────────
 	async _render() {
+		const renderId = this._renderId + 1;
+		this._renderId = renderId;
+		if (this._abort) this._abort.abort();
+
 		// Debug gate
 		if (this.hasAttribute("debug-only")) {
 			const url = new URL(location.href);
@@ -186,13 +204,14 @@ class XInclude extends HTMLElement {
 
 		// Begin fetch
 		this._loading = true;
-		this._needsRerender = false; // clear any prior request (we're starting a fresh one)
+		this._needsRerender = false;
 		this._abort = new AbortController();
 
 		try {
 			const res = await fetch(src, { cache: this.fetchCacheMode(src), credentials: "same-origin", signal: this._abort.signal });
 			const text = await res.text();
 			if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+			if (renderId !== this._renderId) return;
 
 			const html = this.renderTemplate(text, data);
 			this.innerHTML = html;
@@ -203,18 +222,18 @@ class XInclude extends HTMLElement {
 
 			this.dispatchEvent(new CustomEvent("x-include:loaded", { detail: { src, ok: true } }));
 		} catch (err) {
+			if (renderId !== this._renderId || err?.name === "AbortError") return;
 			console.error("[x-include] render error:", src, err);
 			this.innerHTML = `<!-- x-include error: ${this.esc(String(err?.message || err))} -->`;
 			this.dispatchEvent(new CustomEvent("x-include:error", { detail: { src, error: String(err) } }));
 		} finally {
+			if (renderId !== this._renderId) return;
 			this._loading = false;
 			this._abort = null;
 
-			// If attributes changed while we were fetching, do exactly one more render
 			if (this._needsRerender) {
 				this._needsRerender = false;
-				// Important: avoid tight recursion; schedule microtask
-				Promise.resolve().then(() => this._render());
+				this._queueRender();
 			}
 		}
 	}

--- a/tests/layout-footer-include-race.test.js
+++ b/tests/layout-footer-include-race.test.js
@@ -1,19 +1,22 @@
-import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import test from "node:test";
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
 
-const layoutSource = readFileSync("public/components/layout.js", "utf8");
+const layoutSource = readFileSync('public/components/layout.js', 'utf8');
 
-test("footer include defaults are applied before connected render is queued", () => {
+test('footer include defaults are applied before connected render is queued', () => {
 	assert.match(layoutSource, /this\._hasConnected = true;/);
 	assert.match(layoutSource, /this\._maybeApplyFooterDefaults\(\);\n\t\tthis\._queueRender\(\);/);
 });
 
-test("attribute changes do not render includes before the element connects", () => {
-	assert.match(layoutSource, /attributeChangedCallback\(\) \{\n\t\tif \(!this\._hasConnected\) return;/);
+test('attribute changes do not render includes before the element connects', () => {
+	assert.match(
+		layoutSource,
+		/attributeChangedCallback\(\) \{\n\t\tif \(!this\._hasConnected\) return;/
+	);
 });
 
-test("stale include fetches cannot overwrite newer rendered footer content", () => {
+test('stale include fetches cannot overwrite newer rendered footer content', () => {
 	assert.match(layoutSource, /const renderId = this\._renderId \+ 1;/);
 	assert.match(layoutSource, /if \(renderId !== this\._renderId\) return;/);
 	assert.match(layoutSource, /if \(this\._abort\) this\._abort\.abort\(\);/);

--- a/tests/layout-footer-include-race.test.js
+++ b/tests/layout-footer-include-race.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const layoutSource = readFileSync("public/components/layout.js", "utf8");
+
+test("footer include defaults are applied before connected render is queued", () => {
+	assert.match(layoutSource, /this\._hasConnected = true;/);
+	assert.match(layoutSource, /this\._maybeApplyFooterDefaults\(\);\n\t\tthis\._queueRender\(\);/);
+});
+
+test("attribute changes do not render includes before the element connects", () => {
+	assert.match(layoutSource, /attributeChangedCallback\(\) \{\n\t\tif \(!this\._hasConnected\) return;/);
+});
+
+test("stale include fetches cannot overwrite newer rendered footer content", () => {
+	assert.match(layoutSource, /const renderId = this\._renderId \+ 1;/);
+	assert.match(layoutSource, /if \(renderId !== this\._renderId\) return;/);
+	assert.match(layoutSource, /if \(this\._abort\) this\._abort\.abort\(\);/);
+});


### PR DESCRIPTION
## Summary

Fixes intermittent footer rendering where the page sometimes shows only `© ·` instead of the full footer text.

The issue was caused by the `<x-include>` custom element rendering from observed attribute changes before `connectedCallback()` had applied default footer variables. A stale fetch/render could then overwrite the correct footer.

## Changes

- prevent `attributeChangedCallback()` from rendering before the element has connected
- apply footer defaults before the first queued render
- queue renders to coalesce lifecycle-triggered changes
- abort superseded include fetches
- use render IDs so stale fetches cannot overwrite newer content
- add regression coverage for the lifecycle ordering and stale-render protections

## Expected outcome

Footer partials without explicit variables should consistently render:

`© 2026 Home Office Biometrics · ResearchOps v1.0.0`

## Trace

- `docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.md`
- `docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.json`

## Validation

Local validation was not executed in this ChatGPT environment. CI should run the node test suite and formatting checks.

## Changed-file verification

Changed files: 4

- `public/components/layout.js`
- `tests/layout-footer-include-race.test.js`
- `docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.md`
- `docs/agent-audit/reasoning/2026/05/19/footer-include-defaults-race.json`