### PR TITLE
Add generated GitHub Diamond bundle documentation site

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.json
+++ b/docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.json
@@ -1,0 +1,53 @@
+{
+  "traceId": "github-diamond-docs-site",
+  "date": "2026-05-20",
+  "branch": "feature/github-diamond-docs-site",
+  "task": "Create a generated multi-file static documentation site for the GitHub Diamond bundle under docs/agent-operating-model/bundles/github/.",
+  "branchTraceDecision": "feature/ branch, trace required.",
+  "selectedBundles": [
+    "github-diamond",
+    "researchops-developer-control",
+    "multi-functional-team"
+  ],
+  "canonicalSourceBoundary": {
+    "generatedDocumentationPath": "docs/agent-operating-model/bundles/github/",
+    "canonicalBundleSourcePath": ".agent-operating-model/bundles/github/",
+    "rule": "Generated documentation must not replace or mutate canonical bundle source files."
+  },
+  "filesChanged": [
+    "docs/agent-operating-model/bundles/github/index.html",
+    "docs/agent-operating-model/bundles/github/assets/styles.css",
+    "docs/agent-operating-model/bundles/github/modes/index.html",
+    "docs/agent-operating-model/bundles/github/roles/index.html",
+    "docs/agent-operating-model/bundles/github/references/index.html",
+    "docs/agent-operating-model/bundles/github/contracts/index.html",
+    "docs/agent-operating-model/bundles/github/graders/index.html",
+    "docs/agent-operating-model/bundles/github/templates/index.html",
+    "docs/agent-operating-model/bundles/github/scripts/index.html",
+    "docs/agent-operating-model/bundles/github/validation/index.html",
+    "docs/agent-operating-model/bundles/github/changelog/index.html",
+    "docs/agent-operating-model/bundles/github/generated-metadata.json",
+    "docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.json",
+    "docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.md"
+  ],
+  "implementationSummary": [
+    "Created a generated static documentation site separate from the canonical bundle source.",
+    "Added a shared stylesheet using ResearchOps/GOV.UK-style documentation conventions.",
+    "Added landing page and section pages for modes, roles, references, contracts, graders, templates, scripts, validation and changelog.",
+    "Added generated metadata to record source boundary and page inventory.",
+    "Added generated-source warnings to pages pointing readers to .agent-operating-model/bundles/github/."
+  ],
+  "validation": {
+    "localExecution": false,
+    "reason": "Changes were created through the GitHub connector in the ChatGPT environment; no local checkout or CI runner was available.",
+    "expectedChecks": [
+      "Review generated HTML in browser.",
+      "Run repository formatting or docs checks if available.",
+      "Confirm no canonical bundle source files changed."
+    ]
+  },
+  "residualRisk": [
+    "The first generated documentation site is explanatory and navigable, not a line-for-line mirror of every bundle source file.",
+    "Full generated source mirroring can be added in a later iteration with a generator script."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.md
+++ b/docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.md
@@ -1,0 +1,65 @@
+# GitHub Diamond docs site trace
+
+- Branch: `feature/github-diamond-docs-site`
+- Date: 2026-05-20
+- Task: Create a generated multi-file static documentation site for the GitHub Diamond bundle.
+- Branch trace decision: `feature/` branch, trace required.
+
+## Selected bundles
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+
+## Source boundary
+
+Generated documentation has been added under:
+
+`docs/agent-operating-model/bundles/github/`
+
+The canonical bundle source remains under:
+
+`.agent-operating-model/bundles/github/`
+
+Generated documentation must not replace, mutate, or outrank the canonical bundle source.
+
+## Implementation summary
+
+- Created a generated static documentation site separate from the canonical bundle source.
+- Added a shared stylesheet using ResearchOps/GOV.UK-style documentation conventions.
+- Added a landing page and section pages for modes, roles, references, contracts, graders, templates, scripts, validation and changelog.
+- Added generated metadata to record the source boundary and page inventory.
+- Added generated-source warning banners to pages pointing readers back to `.agent-operating-model/bundles/github/`.
+
+## Files changed
+
+- `docs/agent-operating-model/bundles/github/index.html`
+- `docs/agent-operating-model/bundles/github/assets/styles.css`
+- `docs/agent-operating-model/bundles/github/modes/index.html`
+- `docs/agent-operating-model/bundles/github/roles/index.html`
+- `docs/agent-operating-model/bundles/github/references/index.html`
+- `docs/agent-operating-model/bundles/github/contracts/index.html`
+- `docs/agent-operating-model/bundles/github/graders/index.html`
+- `docs/agent-operating-model/bundles/github/templates/index.html`
+- `docs/agent-operating-model/bundles/github/scripts/index.html`
+- `docs/agent-operating-model/bundles/github/validation/index.html`
+- `docs/agent-operating-model/bundles/github/changelog/index.html`
+- `docs/agent-operating-model/bundles/github/generated-metadata.json`
+- `docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.json`
+- `docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.md`
+
+## Validation
+
+Local validation was not executed in the ChatGPT environment because the work was created through the GitHub connector without a local checkout or CI runner.
+
+Recommended follow-up checks:
+
+- Review `docs/agent-operating-model/bundles/github/index.html` in a browser.
+- Run repository formatting or documentation checks if available.
+- Confirm that no files under `.agent-operating-model/bundles/github/` changed.
+
+## Residual risk
+
+The first generated documentation site is explanatory and navigable. It is not yet a line-for-line generated source mirror of every bundle file.
+
+A later generator script can add full source extraction pages for each bundle file if required.

--- a/docs/agent-operating-model/bundles/github/assets/styles.css
+++ b/docs/agent-operating-model/bundles/github/assets/styles.css
@@ -1,0 +1,335 @@
+:root {
+	--black: #0b0c0c;
+	--blue: #1d70b8;
+	--dark-blue: #003078;
+	--grey: #505a5f;
+	--mid-grey: #b1b4b6;
+	--light-grey: #f3f2f1;
+	--yellow: #ffdd00;
+	--green: #00703c;
+	--red: #d4351c;
+	--purple: #4c2c92;
+	--white: #ffffff;
+	--max-width: 1180px;
+	}
+
+* {
+	box-sizing: border-box;
+	}
+
+html {
+	scroll-behavior: smooth;
+	}
+
+body {
+	margin: 0;
+	background: var(--white);
+	color: var(--black);
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 18px;
+	line-height: 1.5;
+	}
+
+a {
+	color: var(--blue);
+	text-decoration-thickness: max(1px, 0.08em);
+	text-underline-offset: 0.12em;
+	}
+
+a:focus,
+summary:focus {
+	outline: 3px solid var(--yellow);
+	background: var(--yellow);
+	color: var(--black);
+	}
+
+.skip-link {
+	position: absolute;
+	left: -999em;
+	top: 0;
+	padding: 8px 12px;
+	background: var(--yellow);
+	color: var(--black);
+	z-index: 10;
+	}
+
+.skip-link:focus {
+	left: 0;
+	}
+
+.site-header {
+	background: var(--black);
+	color: var(--white);
+	border-bottom: 10px solid var(--blue);
+	}
+
+.site-header__inner {
+	max-width: var(--max-width);
+	margin: 0 auto;
+	padding: 28px 24px 42px;
+	}
+
+.site-header__product {
+	margin: 0 0 34px;
+	font-weight: 700;
+	}
+
+.site-header h1 {
+	max-width: 940px;
+	margin: 0;
+	font-size: clamp(40px, 7vw, 78px);
+	line-height: 0.95;
+	letter-spacing: -0.04em;
+	}
+
+.site-header__lede {
+	max-width: 860px;
+	margin: 26px 0 0;
+	font-size: 23px;
+	line-height: 1.35;
+	}
+
+.generated-warning {
+	margin: 0;
+	padding: 12px 24px;
+	background: var(--yellow);
+	color: var(--black);
+	font-weight: 700;
+	}
+
+.generated-warning code {
+	background: rgba(255, 255, 255, 0.65);
+	}
+
+.wrapper {
+	max-width: var(--max-width);
+	margin: 0 auto;
+	padding: 32px 24px 72px;
+	}
+
+.breadcrumbs {
+	margin: 0 0 24px;
+	font-size: 16px;
+	}
+
+.breadcrumbs a {
+	margin-right: 8px;
+	}
+
+.breadcrumbs span::before {
+	content: "›";
+	margin: 0 8px 0 0;
+	color: var(--grey);
+	}
+
+.grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 20px;
+	margin: 24px 0;
+	}
+
+.grid-three {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 18px;
+	margin: 24px 0;
+	}
+
+.card {
+	border: 1px solid var(--mid-grey);
+	border-top: 5px solid var(--blue);
+	padding: 18px;
+	background: var(--white);
+	}
+
+.card--green {
+	border-top-color: var(--green);
+	}
+
+.card--purple {
+	border-top-color: var(--purple);
+	}
+
+.card--red {
+	border-top-color: var(--red);
+	}
+
+.card--yellow {
+	border-top-color: var(--yellow);
+	}
+
+.card h2,
+.card h3 {
+	margin-top: 0;
+	}
+
+h2 {
+	margin: 40px 0 16px;
+	font-size: clamp(30px, 4vw, 44px);
+	line-height: 1.05;
+	letter-spacing: -0.025em;
+	}
+
+h3 {
+	margin: 28px 0 12px;
+	font-size: 26px;
+	line-height: 1.16;
+	}
+
+p {
+	max-width: 860px;
+	margin: 0 0 16px;
+	}
+
+.lede {
+	font-size: 23px;
+	line-height: 1.35;
+	max-width: 900px;
+	}
+
+code {
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	font-size: 0.94em;
+	background: var(--light-grey);
+	padding: 1px 4px;
+	}
+
+pre {
+	margin: 16px 0 24px;
+	padding: 16px;
+	background: #1e1e1e;
+	color: #f8f8f8;
+	overflow-x: auto;
+	border-left: 6px solid var(--blue);
+	font-size: 15px;
+	line-height: 1.45;
+	}
+
+pre code {
+	background: transparent;
+	color: inherit;
+	padding: 0;
+	}
+
+.source-panel {
+	border: 1px solid var(--mid-grey);
+	margin: 24px 0;
+	background: var(--white);
+	}
+
+.source-panel__header {
+	border-top: 6px solid var(--blue);
+	border-bottom: 1px solid var(--mid-grey);
+	padding: 16px 18px;
+	background: #fafafa;
+	}
+
+.source-panel--mode .source-panel__header {
+	border-top-color: var(--blue);
+	}
+
+.source-panel--role .source-panel__header {
+	border-top-color: var(--green);
+	}
+
+.source-panel--contract .source-panel__header {
+	border-top-color: var(--yellow);
+	}
+
+.source-panel--grader .source-panel__header {
+	border-top-color: var(--purple);
+	}
+
+.source-panel--reference .source-panel__header {
+	border-top-color: var(--red);
+	}
+
+.source-panel__grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+	}
+
+.source-panel__grid pre {
+	margin: 0;
+	border-left: 0;
+	border-right: 1px solid var(--mid-grey);
+	max-height: 560px;
+	}
+
+.source-panel__notes {
+	padding: 18px;
+	background: var(--light-grey);
+	}
+
+.diagram {
+	margin: 24px 0;
+	padding: 18px;
+	background: var(--light-grey);
+	border: 1px solid var(--mid-grey);
+	overflow-x: auto;
+	}
+
+.diagram svg {
+	display: block;
+	min-width: 760px;
+	max-width: 100%;
+	height: auto;
+	}
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 18px 0 28px;
+	font-size: 16px;
+	}
+
+th,
+td {
+	text-align: left;
+	vertical-align: top;
+	padding: 10px 12px;
+	border-bottom: 1px solid var(--mid-grey);
+	}
+
+th {
+	background: var(--light-grey);
+	border-bottom: 2px solid var(--black);
+	}
+
+.pill {
+	display: inline-block;
+	padding: 2px 8px 3px;
+	margin: 0 6px 6px 0;
+	background: var(--light-grey);
+	border: 1px solid var(--mid-grey);
+	font-size: 14px;
+	font-weight: 700;
+	text-transform: uppercase;
+	}
+
+.site-footer {
+	background: var(--light-grey);
+	border-top: 1px solid var(--mid-grey);
+	}
+
+.site-footer__inner {
+	max-width: var(--max-width);
+	margin: 0 auto;
+	padding: 32px 24px;
+	font-size: 16px;
+	color: var(--grey);
+	}
+
+@media (max-width: 900px) {
+	.grid,
+	.grid-three,
+	.source-panel__grid {
+		grid-template-columns: 1fr;
+		}
+
+	.source-panel__grid pre {
+		border-right: 0;
+		border-bottom: 1px solid var(--mid-grey);
+		}
+	}

--- a/docs/agent-operating-model/bundles/github/changelog/index.html
+++ b/docs/agent-operating-model/bundles/github/changelog/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond changelog</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Changelog</h1><p class="site-header__lede">Release history of the GitHub Diamond bundle.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/CHANGELOG.md</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Changelog</span></nav>
+		<p class="lede">The changelog shows the bundle moving from baseline repository guidance to auditable release assurance with live repository gates, mutation safety and branch-driven trace controls.</p>
+		<table>
+			<thead><tr><th>Version</th><th>Date</th><th>Change theme</th></tr></thead>
+			<tbody>
+				<tr><td><code>2.9.2+researchops.2026-05-19</code></td><td>2026-05-19</td><td>Added GitHub tooling mutation policy, surgical-edit rules, changed-file verification and prevention of repeated failed full-file writes.</td></tr>
+				<tr><td><code>2.9.1+researchops.2026-05-14</code></td><td>2026-05-14</td><td>Added branch-prefix governance, approved prefixes, prohibited prefixes and branch-driven trace posture.</td></tr>
+				<tr><td><code>2.9.1+researchops.2026-05-13</code></td><td>2026-05-13</td><td>Added automated review comment handling: react, reply, fix and resolve only after evidence.</td></tr>
+				<tr><td><code>2.9.1</code></td><td>2026-04-28</td><td>Added release-gate reports, live release policy, trusted attestation evidence and high-assurance live gate fixtures.</td></tr>
+				<tr><td><code>2.9.0</code></td><td>2026-04-28</td><td>Added fast/full release gates, live repository release profiles and trusted attestation verification commands.</td></tr>
+				<tr><td><code>2.8.9</code></td><td>2026-04-28</td><td>Added live repository release gate, workflow action lock validation, trusted SBOM attestation and structured accessibility evidence.</td></tr>
+				<tr><td><code>2.8.8</code></td><td>2026-04-28</td><td>Added subprocess release gate, termination self-test, GitHub API inspection and performance adapter mapping.</td></tr>
+				<tr><td><code>2.8.7</code></td><td>2026-04-28</td><td>Added evidence-against-repo verification, GitHub settings verification, SBOM attestation and performance validation.</td></tr>
+				<tr><td><code>2.8.6</code></td><td>2026-04-28</td><td>Added direct repository-state verification, eval harness tests, richer SBOM output and accessibility evidence validation.</td></tr>
+				<tr><td><code>2.8.5</code></td><td>2026-04-28</td><td>Rebuilt changelog, added changelog/docs consistency validation and improved workflow status-check labels.</td></tr>
+				<tr><td><code>2.8.4</code></td><td>2026-04-27</td><td>Added deterministic Python validation cleanup and generated artefact cleanup.</td></tr>
+				<tr><td><code>2.8.3</code></td><td>2026-04-27</td><td>Added registry-driven CI template selection and direct repository-state verification.</td></tr>
+				<tr><td><code>2.8.2</code></td><td>2026-04-27</td><td>Added selected-template validation, release gate, strict schema validation and positive eval fixtures.</td></tr>
+				<tr><td><code>2.8.1</code></td><td>2026-04-27</td><td>Stabilised 2.8.0 and added mode runbooks, graders, contracts and examples.</td></tr>
+				<tr><td><code>2.8.0</code></td><td>2026-04-27</td><td>Added initial template registry, structured evidence and release gate concept.</td></tr>
+				<tr><td><code>2.7.0</code></td><td>2026-04-27</td><td>Added authoritative template registry, eval runner configuration and validation scripts.</td></tr>
+				<tr><td><code>2.6.0</code></td><td>2026-04-27</td><td>Added runbook-style modes, GitHub settings grader, eval/grade contracts and harm register.</td></tr>
+				<tr><td><code>2.5.0</code></td><td>2026-04-27</td><td>Restored repository-operator responsibilities and strengthened RECENT_LEARNINGS.</td></tr>
+				<tr><td><code>2.4.0</code></td><td>2026-04-27</td><td>Control-system rebuild with modes, contracts, graders, references and CI governance.</td></tr>
+				<tr><td><code>2.3.0</code></td><td>2026-04-27</td><td>Added CI templates, registry manifest, evals, regression and red-team tests.</td></tr>
+				<tr><td><code>2.2.0</code></td><td>2026-04-27</td><td>Added specialist roles, templates, workflows, quality gates and GitHub Settings Pack.</td></tr>
+				<tr><td><code>2.1.0</code></td><td>2026-04-27</td><td>Added learning loop, confidence packs, architecture integrity pack and workflow templates.</td></tr>
+				<tr><td><code>2.0.0</code></td><td>2026-04-27</td><td>Major lifecycle bundle rebuild with modes, contracts, graders, evidence and governance.</td></tr>
+				<tr><td><code>1.1.0</code></td><td>2026-04-27</td><td>Added early templates, CI, branch protection, review and maintenance guidance.</td></tr>
+				<tr><td><code>1.0.0</code></td><td>2026-04-27</td><td>Initial GitHub Diamond Standard Prompt Bundle.</td></tr>
+			</tbody>
+		</table>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/CHANGELOG.md</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/contracts/index.html
+++ b/docs/agent-operating-model/bundles/github/contracts/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond contracts</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Contracts</h1><p class="site-header__lede">Contracts define the shape of evidence and governance artefacts.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/contracts/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Contracts</span></nav>
+		<p class="lede">The bundle uses JSON Schema contracts so repository state can be checked, graded and audited rather than described informally.</p>
+		<section>
+			<h2>Contract families</h2>
+			<table>
+				<thead><tr><th>Family</th><th>Contract files</th><th>Purpose</th></tr></thead>
+				<tbody>
+					<tr><td>Evidence</td><td><code>agent-evidence.schema.json</code>, <code>grade-result.schema.json</code>, <code>eval-result.schema.json</code></td><td>Prove what the agent did, what it checked and how it was graded.</td></tr>
+					<tr><td>Repository governance</td><td><code>repository-contract.schema.json</code>, <code>github-settings.schema.json</code>, <code>conformance-record.schema.json</code>, <code>gap-register.schema.json</code></td><td>Describe repository posture, required settings and incomplete controls.</td></tr>
+					<tr><td>Delivery surfaces</td><td><code>pull-request-contract.schema.json</code>, <code>issue-contract.schema.json</code>, <code>endpoint-catalog.schema.json</code>, <code>workflow-contract.schema.json</code></td><td>Control PRs, issues, API catalogues and GitHub Actions workflows.</td></tr>
+					<tr><td>Release assurance</td><td><code>release-contract.schema.json</code>, <code>release-gate-report.schema.json</code>, <code>live-release-policy.schema.json</code>, <code>sbom-record.schema.json</code>, <code>trusted-attestation-verification.schema.json</code></td><td>Control release readiness, SBOM, attestation and live gate requirements.</td></tr>
+					<tr><td>High-stakes quality</td><td><code>accessibility-evidence.schema.json</code>, <code>harm-register.schema.json</code>, <code>performance-budget.schema.json</code>, <code>provenance-record.schema.json</code></td><td>Structure evidence for accessibility, harms, performance and provenance.</td></tr>
+				</tbody>
+			</table>
+		</section>
+		<section class="source-panel source-panel--contract">
+			<div class="source-panel__header"><h2>Agent evidence schema model</h2><p>This representative shape shows how the bundle makes evidence checkable.</p></div>
+			<div class="source-panel__grid">
+				<pre><code>{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agent evidence",
+  "type": "object",
+  "required": [
+    "task",
+    "repository",
+    "mode",
+    "commands",
+    "changed_files",
+    "validation"
+  ],
+  "properties": {
+    "task": { "type": "string" },
+    "repository": { "type": "string" },
+    "mode": { "type": "string" },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["command", "status"],
+        "properties": {
+          "command": { "type": "string" },
+          "status": { "enum": ["pass", "fail", "not-run"] },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "changed_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}</code></pre>
+				<aside class="source-panel__notes"><h3>How the agent uses this</h3><p>The agent records commands and outcomes. A validation claim without evidence should fail grading.</p><h3>Downstream use</h3><p>Graders and scripts use schema-valid evidence as the input to release readiness, PR readiness and conformance checks.</p></aside>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/contracts/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/generated-metadata.json
+++ b/docs/agent-operating-model/bundles/github/generated-metadata.json
@@ -1,0 +1,34 @@
+{
+  "siteId": "github-diamond-generated-docs",
+  "generatedAt": "2026-05-20",
+  "repository": "kevinrapley/ResearchOps",
+  "branch": "feature/github-diamond-docs-site",
+  "outputPath": "docs/agent-operating-model/bundles/github/",
+  "canonicalSourcePath": ".agent-operating-model/bundles/github/",
+  "bundle": {
+    "id": "github-diamond-standard",
+    "version": "2.9.2",
+    "status": "auditable-release-assurance"
+  },
+  "pages": [
+    "index.html",
+    "modes/index.html",
+    "roles/index.html",
+    "references/index.html",
+    "contracts/index.html",
+    "graders/index.html",
+    "templates/index.html",
+    "scripts/index.html",
+    "validation/index.html",
+    "changelog/index.html"
+  ],
+  "assets": [
+    "assets/styles.css"
+  ],
+  "sourceBoundary": "Generated documentation only. Canonical bundle source remains under .agent-operating-model/bundles/github/.",
+  "notes": [
+    "Generated pages include warning banners that point readers back to the canonical source.",
+    "The static site is intentionally placed outside the canonical bundle directory.",
+    "The first generated version favours navigable explanation over line-for-line source mirroring."
+  ]
+}

--- a/docs/agent-operating-model/bundles/github/graders/index.html
+++ b/docs/agent-operating-model/bundles/github/graders/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond graders</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Graders</h1><p class="site-header__lede">Graders convert evidence into pass, pass-with-gap or fail decisions.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/graders/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Graders</span></nav>
+		<section class="grid-three">
+			<article class="card"><h2>Discovery</h2><p>Checks that repository instructions, manifests, risk and unknowns were genuinely inspected.</p></article>
+			<article class="card"><h2>Code confidence</h2><p>Checks formatting, linting, tests, documentation, gaps and structured evidence.</p></article>
+			<article class="card"><h2>PR readiness</h2><p>Checks summary, validation evidence, risks, rollback, gaps and review requirements.</p></article>
+			<article class="card"><h2>Security</h2><p>Checks secrets, unsafe instructions, repository-local governance and supply-chain posture.</p></article>
+			<article class="card"><h2>Accessibility</h2><p>Blocks automated-only accessibility assurance where manual evidence is needed.</p></article>
+			<article class="card"><h2>Release</h2><p>Checks release evidence, rollback, SBOM, unresolved blockers and gate reports.</p></article>
+		</section>
+		<section class="source-panel source-panel--grader">
+			<div class="source-panel__header"><h2>Grader source pattern</h2><p>Most grader modules use thresholds, evidence, scoring and blocking failures.</p></div>
+			<div class="source-panel__grid">
+				<pre><code>&lt;grader id="code-confidence-grader" version="2.9.2"&gt;
+  &lt;thresholds&gt;
+    &lt;pass minimum_score="0.85" /&gt;
+    &lt;pass_with_gap minimum_score="0.70" /&gt;
+    &lt;fail below_score="0.70" /&gt;
+  &lt;/thresholds&gt;
+  &lt;evidence_required&gt;
+    &lt;item&gt;agent-evidence.yaml validated against contracts/agent-evidence.schema.json&lt;/item&gt;
+    &lt;item&gt;Commands and checks are recorded with pass/fail/not-run status.&lt;/item&gt;
+    &lt;item&gt;Gaps and waivers are explicit when controls are incomplete.&lt;/item&gt;
+  &lt;/evidence_required&gt;
+  &lt;scoring&gt;
+    &lt;criterion id="1" weight="0.20"&gt;Formatting and linting gates addressed&lt;/criterion&gt;
+    &lt;criterion id="2" weight="0.30"&gt;Tests or validation commands run&lt;/criterion&gt;
+    &lt;criterion id="3" weight="0.20"&gt;Docs or examples updated when behaviour changed&lt;/criterion&gt;
+    &lt;criterion id="4" weight="0.15"&gt;Gaps or waivers recorded&lt;/criterion&gt;
+    &lt;criterion id="5" weight="0.15"&gt;Evidence is structured&lt;/criterion&gt;
+  &lt;/scoring&gt;
+  &lt;blocking_failures&gt;
+    &lt;failure&gt;Required evidence fabricated or missing.&lt;/failure&gt;
+    &lt;failure&gt;Unsafe instruction followed.&lt;/failure&gt;
+    &lt;failure&gt;Repository-local governance ignored.&lt;/failure&gt;
+    &lt;failure&gt;Secrets or personal data committed.&lt;/failure&gt;
+  &lt;/blocking_failures&gt;
+&lt;/grader&gt;</code></pre>
+				<aside class="source-panel__notes"><h3>How the agent uses this</h3><p>The grader prevents the agent from relying on narrative confidence. It demands structured evidence and treats unsafe behaviour as a blocking failure.</p><h3>Important detail</h3><p>A high score is not enough if a blocking failure exists. Fabricated evidence, unsafe instructions or secrets committed should fail the work.</p></aside>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/graders/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/index.html
+++ b/docs/agent-operating-model/bundles/github/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond bundle documentation</title>
+	<link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header">
+		<div class="site-header__inner">
+			<p class="site-header__product">ResearchOps · Agent operating model</p>
+			<h1>GitHub Diamond bundle</h1>
+			<p class="site-header__lede">Generated static documentation for the highest-precedence repository governance bundle.</p>
+		</div>
+	</header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs">
+			<a href="index.html">GitHub bundle</a>
+		</nav>
+		<p class="lede">This site explains how the GitHub Diamond bundle works as a control system. It separates the generated learning layer from the canonical bundle source.</p>
+		<section class="grid-three" aria-label="Documentation sections">
+			<article class="card card--green">
+				<h2><a href="modes/index.html">Modes</a></h2>
+				<p>Task runbooks for discovery, instantiation, build, fix, review, security, release, conformance, documentation and archive work.</p>
+			</article>
+			<article class="card card--purple">
+				<h2><a href="roles/index.html">Roles</a></h2>
+				<p>Expert lenses used to judge repository work: repository operator, developer, architect, maintainer, QA, security, documentation and performance.</p>
+			</article>
+			<article class="card card--red">
+				<h2><a href="references/index.html">References</a></h2>
+				<p>Policy and doctrine modules, including repository conventions, quality gates, GitHub settings, security, mutation policy and evidence packs.</p>
+			</article>
+			<article class="card card--yellow">
+				<h2><a href="contracts/index.html">Contracts</a></h2>
+				<p>JSON Schema contracts that make repository evidence, release gates, SBOMs, workflows and settings checkable.</p>
+			</article>
+			<article class="card">
+				<h2><a href="graders/index.html">Graders</a></h2>
+				<p>Scoring modules that convert evidence into pass, pass-with-gap, fail or blocking decisions.</p>
+			</article>
+			<article class="card card--green">
+				<h2><a href="templates/index.html">Templates</a></h2>
+				<p>Repository scaffolds, GitHub workflows, evidence templates, starter trees and release artefact templates.</p>
+			</article>
+			<article class="card card--purple">
+				<h2><a href="scripts/index.html">Scripts</a></h2>
+				<p>Executable validation and generation tools for bundle assurance, release gates, GitHub settings, SBOM, accessibility and workflow hardening.</p>
+			</article>
+			<article class="card card--red">
+				<h2><a href="validation/index.html">Validation</a></h2>
+				<p>How validation evidence proves that the bundle is structurally sound and suitable for repository governance use.</p>
+			</article>
+			<article class="card card--yellow">
+				<h2><a href="changelog/index.html">Changelog</a></h2>
+				<p>Release history from the initial bundle through the current auditable release-assurance model.</p>
+			</article>
+		</section>
+		<section>
+			<h2>Operating model at a glance</h2>
+			<div class="diagram" role="img" aria-label="GitHub bundle operating model flow">
+				<svg viewBox="0 0 980 360" xmlns="http://www.w3.org/2000/svg">
+					<defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#1d70b8"/></marker></defs>
+					<rect x="30" y="40" width="160" height="70" fill="#fff" stroke="#0b0c0c" stroke-width="2"/><text x="110" y="82" text-anchor="middle" font-size="17" font-weight="700">User task</text>
+					<rect x="250" y="40" width="160" height="70" fill="#fff" stroke="#1d70b8" stroke-width="3"/><text x="330" y="74" text-anchor="middle" font-size="17" font-weight="700">Select mode</text><text x="330" y="96" text-anchor="middle" font-size="13">workflow route</text>
+					<rect x="470" y="40" width="160" height="70" fill="#fff" stroke="#00703c" stroke-width="3"/><text x="550" y="74" text-anchor="middle" font-size="17" font-weight="700">Apply roles</text><text x="550" y="96" text-anchor="middle" font-size="13">expert judgement</text>
+					<rect x="690" y="40" width="160" height="70" fill="#fff" stroke="#4c2c92" stroke-width="3"/><text x="770" y="74" text-anchor="middle" font-size="17" font-weight="700">Use contracts</text><text x="770" y="96" text-anchor="middle" font-size="13">evidence shape</text>
+					<rect x="250" y="210" width="160" height="70" fill="#fff" stroke="#d4351c" stroke-width="3"/><text x="330" y="244" text-anchor="middle" font-size="17" font-weight="700">Run scripts</text><text x="330" y="266" text-anchor="middle" font-size="13">validation</text>
+					<rect x="470" y="210" width="160" height="70" fill="#fff" stroke="#ffdd00" stroke-width="3"/><text x="550" y="244" text-anchor="middle" font-size="17" font-weight="700">Grade</text><text x="550" y="266" text-anchor="middle" font-size="13">quality gate</text>
+					<rect x="690" y="210" width="160" height="70" fill="#fff" stroke="#00703c" stroke-width="3"/><text x="770" y="244" text-anchor="middle" font-size="17" font-weight="700">PR evidence</text><text x="770" y="266" text-anchor="middle" font-size="13">ready or revise</text>
+					<line x1="190" y1="75" x2="250" y2="75" stroke="#1d70b8" stroke-width="3" marker-end="url(#arrow)"/><line x1="410" y1="75" x2="470" y2="75" stroke="#1d70b8" stroke-width="3" marker-end="url(#arrow)"/><line x1="630" y1="75" x2="690" y2="75" stroke="#1d70b8" stroke-width="3" marker-end="url(#arrow)"/><line x1="770" y1="110" x2="330" y2="210" stroke="#1d70b8" stroke-width="3" marker-end="url(#arrow)"/><line x1="410" y1="245" x2="470" y2="245" stroke="#1d70b8" stroke-width="3" marker-end="url(#arrow)"/><line x1="630" y1="245" x2="690" y2="245" stroke="#1d70b8" stroke-width="3" marker-end="url(#arrow)"/>
+				</svg>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation for ResearchOps. Canonical bundle source remains under <code>.agent-operating-model/bundles/github/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/modes/index.html
+++ b/docs/agent-operating-model/bundles/github/modes/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond modes</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Modes</h1><p class="site-header__lede">Mode modules are task runbooks. They define the correct workflow before an agent edits, reviews or releases repository work.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/modes/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Modes</span></nav>
+		<p class="lede">Every mode has the same control shape: inputs, actions, outputs, failure states, required contracts and required graders.</p>
+		<section class="grid">
+			<article class="card"><h2>Discovery</h2><p><code>repo-discovery.xml</code> builds verified understanding before changes. It requires root docs, manifests, workflows and governance to be read before implementation.</p></article>
+			<article class="card"><h2>Instantiation</h2><p><code>repo-instantiate.xml</code> creates a governed repository foundation using the template registry, GitHub settings, conformance matrix, gap register and CI selection.</p></article>
+			<article class="card"><h2>Build</h2><p><code>repo-build.xml</code> implements small reviewable changes with tests, docs, fixtures, evidence, conformance updates and PR summary.</p></article>
+			<article class="card"><h2>Fix</h2><p><code>repo-fix.xml</code> diagnoses defects, fixes root causes, adds regression tests and records non-obvious traps in <code>RECENT_LEARNINGS.md</code>.</p></article>
+			<article class="card"><h2>Review</h2><p><code>repo-review.xml</code> reviews PRs, CI evidence, inline comments and Codex comments. It blocks approval without evidence.</p></article>
+			<article class="card"><h2>Security</h2><p><code>repo-security.xml</code> handles vulnerabilities, dependency review, CodeQL, secret scanning and workflow hardening.</p></article>
+			<article class="card"><h2>Release</h2><p><code>repo-release.xml</code> validates version, changelog, release gates, SBOM, provenance, performance budgets and rollback.</p></article>
+			<article class="card"><h2>Conformance</h2><p><code>repo-conformance.xml</code> audits repository files, workflows and settings against bundle controls.</p></article>
+			<article class="card"><h2>Documentation</h2><p><code>repo-docs.xml</code> treats documentation as a tested surface with provenance and validation evidence.</p></article>
+			<article class="card"><h2>Archive</h2><p><code>repo-archive.xml</code> supports safe deprecation, consumer assessment, migration notes and settings updates.</p></article>
+		</section>
+		<section class="source-panel source-panel--mode">
+			<div class="source-panel__header"><h2>Mode source pattern</h2><p>The source is intentionally regular so the agent can treat it as a checklist.</p></div>
+			<div class="source-panel__grid">
+				<pre><code>&lt;mode id="repo-build" version="2.9.2"&gt;
+  &lt;title&gt;Repository Build Mode&lt;/title&gt;
+  &lt;purpose&gt;Implement small reviewable changes.&lt;/purpose&gt;
+  &lt;inputs&gt;
+    &lt;item&gt;Issue/task&lt;/item&gt;
+    &lt;item&gt;Discovery summary&lt;/item&gt;
+  &lt;/inputs&gt;
+  &lt;actions&gt;
+    &lt;item&gt;Plan with developer control contract.&lt;/item&gt;
+    &lt;item&gt;Implement code, tests, docs and fixtures.&lt;/item&gt;
+    &lt;item&gt;Validate contracts and quality gates.&lt;/item&gt;
+    &lt;item&gt;Update conformance, gaps and recent learnings.&lt;/item&gt;
+  &lt;/actions&gt;
+  &lt;outputs&gt;
+    &lt;item&gt;Diff&lt;/item&gt;
+    &lt;item&gt;Tests&lt;/item&gt;
+    &lt;item&gt;Evidence&lt;/item&gt;
+    &lt;item&gt;PR summary&lt;/item&gt;
+  &lt;/outputs&gt;
+  &lt;failure_states&gt;
+    &lt;item&gt;No tests&lt;/item&gt;
+    &lt;item&gt;Docs stale&lt;/item&gt;
+    &lt;item&gt;Fabricated evidence&lt;/item&gt;
+  &lt;/failure_states&gt;
+  &lt;required_contracts&gt;
+    &lt;item&gt;pull-request-contract.schema.json&lt;/item&gt;
+    &lt;item&gt;agent-evidence.schema.json&lt;/item&gt;
+  &lt;/required_contracts&gt;
+  &lt;required_graders&gt;
+    &lt;item&gt;code-confidence-grader.xml&lt;/item&gt;
+    &lt;item&gt;pr-readiness-grader.xml&lt;/item&gt;
+  &lt;/required_graders&gt;
+&lt;/mode&gt;</code></pre>
+				<aside class="source-panel__notes"><h3>How the agent uses this</h3><p>The mode tells the agent what counts as complete. For build work, a code diff alone is insufficient. Tests, evidence, PR summary and governance updates are also part of the mode.</p><h3>Failure states</h3><p>Failure states are blocking conditions. The agent must not call work complete if one remains true.</p></aside>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/modes/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/references/index.html
+++ b/docs/agent-operating-model/bundles/github/references/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond references</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>References</h1><p class="site-header__lede">Reference modules are the policy packs behind the bundle.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/references/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>References</span></nav>
+		<p class="lede">References hold doctrine that would be too large or too specialised for the main prompt body. They are loaded by the prompt spec and used by modes, contracts, graders and scripts.</p>
+		<section class="grid-three">
+			<article class="card"><h2>Repository governance</h2><p><code>repository-charter.xml</code>, <code>repository-conventions.xml</code>, <code>implementation-workflow.xml</code>, <code>developer-control-contract.xml</code>.</p></article>
+			<article class="card card--purple"><h2>Quality and CI</h2><p><code>quality-gates.xml</code>, <code>ci-selection-guidelines.xml</code>, <code>code-confidence-pack.xml</code>, <code>formatter-and-style-policy.xml</code>.</p></article>
+			<article class="card card--red"><h2>Security and supply chain</h2><p><code>github-settings-pack.xml</code>, <code>security-supply-chain-pack.xml</code>, <code>sbom-and-attestation.xml</code>.</p></article>
+			<article class="card card--yellow"><h2>Evidence and risk</h2><p><code>agent-evidence.xml</code>, <code>harm-register.xml</code>, <code>rule-source-traceability.xml</code>.</p></article>
+			<article class="card"><h2>Performance and accessibility</h2><p><code>performance-confidence-pack.xml</code>, <code>performance-budget-control.xml</code>, <code>accessibility-confidence-pack.xml</code>.</p></article>
+			<article class="card card--green"><h2>Mutation policy</h2><p><code>github-tooling-mutation-policy.xml</code> prevents unsafe full-file replacement as the default GitHub edit strategy.</p></article>
+		</section>
+		<section class="source-panel source-panel--reference">
+			<div class="source-panel__header"><h2>Mutation policy excerpt</h2><p>This reference is critical because it governs how agents change files through GitHub tooling.</p></div>
+			<div class="source-panel__grid">
+				<pre><code>&lt;githubToolingMutationPolicy version="1.0.0"&gt;
+  &lt;purpose&gt;
+    Prevent agents from using full-file GitHub contents API replacement
+    as the default for small repository edits.
+  &lt;/purpose&gt;
+  &lt;coreRules&gt;
+    &lt;rule id="mutation-001" priority="must"&gt;
+      When changing an existing file through GitHub tooling, prefer the
+      smallest safe commit mechanism that preserves surrounding content.
+    &lt;/rule&gt;
+    &lt;rule id="mutation-003" priority="must"&gt;
+      A user preference for full rewritten files applies to code shown in
+      chat. It does not require full-file repository replacement.
+    &lt;/rule&gt;
+  &lt;/coreRules&gt;
+  &lt;surgicalEdits&gt;
+    &lt;rule id="surgical-004" priority="must"&gt;
+      If using Git object primitives, create a corrected blob, create a
+      tree based on the current branch head tree, create a commit with
+      the current branch head as parent and update the branch ref with
+      force=false.
+    &lt;/rule&gt;
+  &lt;/surgicalEdits&gt;
+&lt;/githubToolingMutationPolicy&gt;</code></pre>
+				<aside class="source-panel__notes"><h3>How the agent uses this</h3><p>Before repository mutation, the agent must choose the smallest safe edit path. It must verify the diff and changed-file list before reporting readiness.</p><h3>Why it matters</h3><p>This reference reduces the risk of accidental repository-wide deletions, stale full-file writes and misleading PR readiness claims.</p></aside>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/references/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/roles/index.html
+++ b/docs/agent-operating-model/bundles/github/roles/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond roles</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Roles</h1><p class="site-header__lede">Role modules provide expert lenses for repository governance work.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/roles/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Roles</span></nav>
+		<section class="grid">
+			<article class="card card--green"><h2>Repository operator</h2><p>Coordinates discovery, repository mode, governance structures, branch plans, PR descriptions, conformance, gap register and recent learnings.</p></article>
+			<article class="card"><h2>Developer</h2><p>Implements features and fixes while following branch naming, code standards, tests, validation checks and documentation expectations.</p></article>
+			<article class="card"><h2>Architect</h2><p>Reviews frameworks, infrastructure changes, ADRs, layering, domain boundaries and architecture integrity.</p></article>
+			<article class="card"><h2>Maintainer</h2><p>Stewards repository health, branch protection, CODEOWNERS, PR evidence, releases, conformance and gaps.</p></article>
+			<article class="card"><h2>QA</h2><p>Checks completeness, test coverage, accessibility, performance and required artefacts before approval.</p></article>
+			<article class="card card--red"><h2>Security</h2><p>Enforces Dependabot, secret scanning, push protection, disclosure process, dependency review and secure coding.</p></article>
+			<article class="card"><h2>Docs lead</h2><p>Owns repository documentation accuracy, clarity, build health, inclusive language and diagram/documentation updates.</p></article>
+			<article class="card card--yellow"><h2>Performance engineer</h2><p>Defines budgets, selects benchmark tools, reviews results and investigates regressions.</p></article>
+		</section>
+		<section class="source-panel source-panel--role">
+			<div class="source-panel__header"><h2>Role source pattern</h2><p>Roles define responsibilities and escalation. They shape how the agent critiques work.</p></div>
+			<div class="source-panel__grid">
+				<pre><code>&lt;role id="repository-operator" version="2.9.2"&gt;
+  &lt;title&gt;Repository Operator&lt;/title&gt;
+  &lt;description&gt;
+    Coordinates creation, maintenance and governance of GitHub repositories.
+  &lt;/description&gt;
+  &lt;responsibilities&gt;
+    &lt;item&gt;Lead discovery and classify the repository mode.&lt;/item&gt;
+    &lt;item&gt;Draft change plans, branch names and PR descriptions.&lt;/item&gt;
+    &lt;item&gt;Enforce code owners, branch protection and security policies.&lt;/item&gt;
+    &lt;item&gt;Capture project-specific learnings in RECENT_LEARNINGS.md.&lt;/item&gt;
+    &lt;item&gt;Maintain conformance matrix and gap register.&lt;/item&gt;
+  &lt;/responsibilities&gt;
+  &lt;escalation&gt;
+    &lt;item&gt;Escalate architectural, legal, ethical or safety concerns.&lt;/item&gt;
+  &lt;/escalation&gt;
+&lt;/role&gt;</code></pre>
+				<aside class="source-panel__notes"><h3>How the agent uses this</h3><p>The role frames judgement. Repository operator is the default coordinating lens. Other roles are added when a task touches security, performance, documentation, architecture or QA.</p><h3>Relationship to modes</h3><p>Modes decide the route. Roles decide the specialist concerns that must be checked along the route.</p></aside>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/roles/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/scripts/index.html
+++ b/docs/agent-operating-model/bundles/github/scripts/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond scripts</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Scripts</h1><p class="site-header__lede">Scripts are the executable assurance layer of the bundle.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/scripts/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Scripts</span></nav>
+		<p class="lede">The scripts convert bundle doctrine into verifiable checks. They validate evidence, templates, release gates, accessibility, performance, GitHub settings, SBOMs, attestations and workflow hardening.</p>
+		<table>
+			<thead><tr><th>Script group</th><th>Examples</th><th>Purpose</th></tr></thead>
+			<tbody>
+				<tr><td>Bundle validation</td><td><code>validate-bundle.py</code>, <code>validate-changelog.py</code>, <code>validate-docs-consistency.py</code>, <code>validate-evals.py</code></td><td>Check structural integrity, changelog order, docs consistency and eval definitions.</td></tr>
+				<tr><td>Evidence validation</td><td><code>validate-agent-evidence.py</code>, <code>grade-output.py</code>, <code>verify-evidence-against-repo.py</code></td><td>Check that agent claims match structured evidence and repository state.</td></tr>
+				<tr><td>Release assurance</td><td><code>release-gate.py</code>, <code>live-repository-release-gate.py</code>, <code>validate-release-gate-report.py</code>, <code>validate-live-release-policy.py</code></td><td>Run offline and live release readiness gates.</td></tr>
+				<tr><td>Supply chain</td><td><code>generate-sbom.py</code>, <code>validate-sbom.py</code>, <code>validate-sbom-attestation.py</code>, <code>verify-trusted-attestation-commands.py</code></td><td>Generate and validate SBOM and attestation evidence.</td></tr>
+				<tr><td>Workflow hardening</td><td><code>pin-workflow-actions.py</code>, <code>validate-workflow-action-lock.py</code>, <code>validate-workflow-hardening.py</code></td><td>Check GitHub Actions permissions, pins and release-mode workflow hardening.</td></tr>
+				<tr><td>Quality evidence</td><td><code>validate-accessibility-evidence.py</code>, <code>validate-performance-results.py</code>, <code>check-performance-budget.py</code></td><td>Validate accessibility and performance evidence.</td></tr>
+			</tbody>
+		</table>
+		<section class="source-panel">
+			<div class="source-panel__header"><h2>Release gate execution model</h2><p>Release gates must produce schema-valid pass and fail reports.</p></div>
+			<div class="source-panel__grid">
+				<pre><code>def run_release_gate(mode, report_path):
+    checks = select_checks(mode)
+    report = {
+        "mode": mode,
+        "status": "running",
+        "commands": [],
+        "started_at": now_iso(),
+    }
+
+    for check in checks:
+        result = run_check(check)
+        report["commands"].append(result)
+
+        if result["status"] != "pass":
+            report["status"] = "fail"
+            report["failed_command"] = result
+            report["finished_at"] = now_iso()
+            write_json(report_path, report)
+            validate_report(report_path)
+            return 1
+
+    report["status"] = "pass"
+    report["finished_at"] = now_iso()
+    write_json(report_path, report)
+    validate_report(report_path)
+    return 0</code></pre>
+				<aside class="source-panel__notes"><h3>How the agent uses this</h3><p>The agent must run or report the appropriate validation commands. It must not claim a gate passed unless a report exists and validates.</p><h3>Important detail</h3><p>Failure reports are first-class artefacts. A failed release gate should still produce useful, schema-valid diagnostic evidence.</p></aside>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/scripts/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/templates/index.html
+++ b/docs/agent-operating-model/bundles/github/templates/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond templates</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Templates</h1><p class="site-header__lede">Templates make repository scaffolding reproducible.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/templates/</code> and <code>template-registry.yaml</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Templates</span></nav>
+		<section class="grid-three">
+			<article class="card card--green"><h2>Repository baseline</h2><p><code>README.md</code>, <code>CONTRIBUTING.md</code>, <code>SECURITY.md</code>, <code>CODEOWNERS</code>, <code>RECENT_LEARNINGS.md</code>.</p></article>
+			<article class="card"><h2>GitHub workflow templates</h2><p>Node, Python, Go, Java, .NET, Rust, Ruby, PHP, Data/ML, accessibility, performance, conformance, documentation quality, CodeQL and dependency review.</p></article>
+			<article class="card"><h2>Hardened workflows</h2><p>Release-ready workflow variants with stricter permissions, action pinning and lock-file expectations.</p></article>
+			<article class="card card--purple"><h2>Evidence templates</h2><p><code>agent-evidence.yaml</code>, <code>conformance-matrix.yaml</code>, <code>gap-register.yaml</code>, <code>github-settings.yaml</code>, <code>harm-register.yaml</code>.</p></article>
+			<article class="card card--yellow"><h2>Performance templates</h2><p>Budget profiles for Lighthouse, k6, autocannon, JMeter, Gatling, Artillery, Go benchmarks and pytest-benchmark.</p></article>
+			<article class="card"><h2>Starter trees</h2><p>Archetype scaffolds for agent systems, API services, CLIs, data/ML projects, libraries and web apps.</p></article>
+		</section>
+		<section class="source-panel">
+			<div class="source-panel__header"><h2>Template registry entry model</h2><p>The registry links source template, destination, trigger, contract and grader.</p></div>
+			<div class="source-panel__grid">
+				<pre><code>- id: repository-github-settings-template-yaml
+  template_path: templates/repository/github-settings-template.yaml
+  destination_path: github-settings.yaml
+  required_for:
+    - all
+  archetypes:
+    - all
+  trigger_conditions:
+    - instantiate repository or when matching artefact is needed
+  associated_contract: contracts/github-settings.schema.json
+  associated_graders:
+    - graders/github-settings-grader.xml
+  copy_mode: copy
+  required: false</code></pre>
+				<aside class="source-panel__notes"><h3>How the agent uses this</h3><p>The agent should select files from <code>template-registry.yaml</code> rather than inventing scaffold paths. This keeps destination paths, contracts and graders traceable.</p><h3>Why it matters</h3><p>Template selection becomes repeatable and auditable. Required status checks can also be inferred from selected workflow templates.</p></aside>
+			</div>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/templates/</code>.</div></footer>
+</body>
+</html>

--- a/docs/agent-operating-model/bundles/github/validation/index.html
+++ b/docs/agent-operating-model/bundles/github/validation/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>GitHub Diamond validation</title>
+	<link rel="stylesheet" href="../assets/styles.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · GitHub Diamond bundle</p><h1>Validation</h1><p class="site-header__lede">Validation explains whether the bundle is structurally sound and safe to use for repository governance.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>.agent-operating-model/bundles/github/VALIDATION-REPORT.md</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Validation</span></nav>
+		<p class="lede">The current validation report records the GitHub Diamond bundle v2.9.2 as passed, last checked on 2026-05-11. It describes the bundle as the highest-precedence repository governance bundle in the operating model.</p>
+		<section class="grid">
+			<article class="card card--green"><h2>Validation status</h2><p><span class="pill">passed</span> The bundle is suitable for current ResearchOps repository governance use.</p></article>
+			<article class="card"><h2>Scope</h2><p>Repository operation, branch hygiene, pull-request discipline, CI, release gates, evidence handling, attestation, repository settings, workflow hardening and live repository assurance.</p></article>
+		</section>
+		<section>
+			<h2>Entrypoints checked</h2>
+			<table><thead><tr><th>Entrypoint</th><th>What it proves</th></tr></thead><tbody>
+				<tr><td><code>README.md</code></td><td>Human-readable release guidance and non-negotiable behaviours.</td></tr>
+				<tr><td><code>CHANGELOG.md</code></td><td>Version history, release discipline and change trace.</td></tr>
+				<tr><td><code>prompt.spec.yaml</code></td><td>Bundle assembly, role/mode/reference/contract/grader registration.</td></tr>
+				<tr><td><code>prompt.body.xml</code></td><td>Core doctrine, branch governance, mutation policy and refusal rules.</td></tr>
+				<tr><td><code>evals.yaml</code></td><td>Executable behaviour scenarios.</td></tr>
+				<tr><td><code>tests.regression.yaml</code></td><td>Regression behaviour expectations.</td></tr>
+				<tr><td><code>tests.redteam.yaml</code></td><td>Refusal behaviour under unsafe prompts.</td></tr>
+				<tr><td><code>variables.schema.json</code>, <code>output.schema.json</code>, <code>grade.schema.json</code></td><td>Input, output and grading shape.</td></tr>
+				<tr><td><code>registry-manifest.yaml</code></td><td>File coverage and SHA-256 integrity.</td></tr>
+			</tbody></table>
+		</section>
+		<section>
+			<h2>Structural checks</h2>
+			<ul>
+				<li>XML, JSON and YAML parsed successfully.</li>
+				<li>All XML roots declare version <code>2.9.2</code>.</li>
+				<li>Manifest hashes and manifest coverage checked.</li>
+				<li>Changelog order and uniqueness checked.</li>
+				<li>Template registry and eval definition validation checked.</li>
+				<li>Agent evidence validation and evidence-to-repository cross-check checked.</li>
+				<li>Fast and full release gate checked.</li>
+				<li>Pass and fail release-gate report validation checked.</li>
+				<li>SBOM, trusted attestation and external verification evidence checked.</li>
+				<li>Accessibility positive and negative fixtures checked.</li>
+				<li>Workflow hardening and action lock validation checked.</li>
+				<li>High-assurance live gate positive and negative fixtures checked.</li>
+			</ul>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated documentation. Canonical source remains under <code>.agent-operating-model/bundles/github/VALIDATION-REPORT.md</code>.</div></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a generated multi-file static documentation site for the GitHub Diamond bundle under:

`docs/agent-operating-model/bundles/github/`

The generated site provides navigable documentation for:

- modes
- roles
- references
- contracts
- graders
- templates
- scripts
- validation
- changelog

It also adds shared documentation styles and generated metadata.

## Source boundary

This PR does not change the canonical bundle source under:

`.agent-operating-model/bundles/github/`

Every generated page includes a warning banner stating that the canonical source remains under `.agent-operating-model/bundles/github/`.

## Operating model

Selected bundles:

- `github-diamond`
- `researchops-developer-control`
- `multi-functional-team`

Branch trace decision:

- `feature/` branch, trace required.

Trace files added:

- `docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.json`
- `docs/agent-audit/reasoning/2026/05/20/github-diamond-docs-site.md`

## Validation

Local validation was not run because the work was created through the GitHub connector without a local checkout or CI runner.

Recommended review checks:

- Open `docs/agent-operating-model/bundles/github/index.html` in a browser.
- Confirm relative navigation works across section pages.
- Confirm no files under `.agent-operating-model/bundles/github/` changed.
- Run any repository formatting or documentation checks available in CI.

## Residual risk

This first generated documentation site is explanatory and navigable. It is not yet a line-for-line static mirror of every GitHub bundle source file. A later generator script can add full source extraction pages if required.