### PR TITLE
Add generator for GitHub bundle source documentation

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.json
+++ b/docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.json
@@ -1,0 +1,55 @@
+{
+  "traceId": "github-bundle-source-generator",
+  "date": "2026-05-20",
+  "branch": "feature/github-bundle-source-generator",
+  "task": "Add a generator script that creates source extraction pages for each file in the GitHub Diamond bundle documentation site.",
+  "branchTraceDecision": "feature/ branch, trace required.",
+  "selectedBundles": [
+    "github-diamond",
+    "researchops-developer-control",
+    "multi-functional-team"
+  ],
+  "sourceBoundary": {
+    "generatorScript": "scripts/agent-operating-model/generate-bundle-source-docs.mjs",
+    "canonicalBundleSourcePath": ".agent-operating-model/bundles/github/",
+    "generatedDocumentationPath": "docs/agent-operating-model/bundles/github/source/",
+    "rule": "The generator reads canonical bundle source and writes generated documentation. It does not edit canonical bundle source files."
+  },
+  "filesChanged": [
+    "scripts/agent-operating-model/generate-bundle-source-docs.mjs",
+    "package.json",
+    "docs/agent-operating-model/bundles/github/index.html",
+    "docs/agent-operating-model/bundles/github/generated-metadata.json",
+    "docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.json",
+    "docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.md"
+  ],
+  "implementationSummary": [
+    "Added a Node generator that recursively walks .agent-operating-model/bundles/<bundle>/.",
+    "Generated pages are written under docs/agent-operating-model/bundles/<bundle>/source/.",
+    "Each generated source page includes escaped source, line anchors, metadata, purpose notes and canonical source warnings.",
+    "The generator writes a source index grouped by bundle category and a source-metadata.json inventory.",
+    "Added npm scripts for generation and dry-run discovery.",
+    "Linked the GitHub bundle landing page to source/index.html.",
+    "Updated generated-metadata.json to record the generator and source-browser output contract.",
+    "Safe public output paths are used for canonical dot-directories such as .github, emitted as _dot_github in generated docs."
+  ],
+  "validation": {
+    "localRepositoryExecution": false,
+    "reason": "A full repository checkout was not available in this environment.",
+    "mockValidation": [
+      "node --check passed against the generated script in a local mock environment.",
+      "The generator ran against a mock bundle containing prompt.body.xml and templates/github/.github/workflows/ci-node.yml.",
+      "Observed output included source/index.html, source-metadata.json, prompt.body.xml.html and a _dot_github workflow page."
+    ],
+    "recommendedChecks": [
+      "Run npm run agent:docs:source:dry-run in a repository checkout.",
+      "Run npm run agent:docs:source before deployment or as the Cloudflare Pages build command.",
+      "Open /bundles/github/source/index.html after generation.",
+      "Confirm generated pages retain canonical source paths while using safe public output paths."
+    ]
+  },
+  "residualRisk": [
+    "The generator was added but generated source output was not committed from a full repository checkout.",
+    "Cloudflare Pages must run npm run agent:docs:source during build, or generated source files must be committed after running the script locally."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.md
+++ b/docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.md
@@ -1,0 +1,82 @@
+# GitHub bundle source generator trace
+
+- Branch: `feature/github-bundle-source-generator`
+- Date: 2026-05-20
+- Task: Add a generator script that creates source extraction pages for each file in the GitHub Diamond bundle documentation site.
+- Branch trace decision: `feature/` branch, trace required.
+
+## Selected bundles
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+
+## Source boundary
+
+The generator reads canonical bundle files from:
+
+` .agent-operating-model/bundles/github/`
+
+It writes generated documentation to:
+
+`docs/agent-operating-model/bundles/github/source/`
+
+The generator must not edit canonical bundle source files.
+
+## Implementation summary
+
+- Added `scripts/agent-operating-model/generate-bundle-source-docs.mjs`.
+- Added `npm run agent:docs:source` for the GitHub bundle source browser.
+- Added `npm run agent:docs:source:dry-run` for discovery without writing files.
+- Linked the GitHub Diamond bundle landing page to `source/index.html`.
+- Updated `generated-metadata.json` to record the source browser generator.
+- Added safe public path handling for canonical dot-directories such as `.github`, emitted as `_dot_github` in generated docs.
+
+## Generated output contract
+
+When run, the generator writes:
+
+- `docs/agent-operating-model/bundles/github/source/index.html`
+- `docs/agent-operating-model/bundles/github/source/source-metadata.json`
+- `docs/agent-operating-model/bundles/github/source/files/**.html`
+
+Each generated source page includes:
+
+- escaped canonical source content
+- line anchors
+- source file metadata
+- purpose notes
+- agent usage notes
+- a canonical source warning banner
+
+## Files changed
+
+- `scripts/agent-operating-model/generate-bundle-source-docs.mjs`
+- `package.json`
+- `docs/agent-operating-model/bundles/github/index.html`
+- `docs/agent-operating-model/bundles/github/generated-metadata.json`
+- `docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.json`
+- `docs/agent-audit/reasoning/2026/05/20/github-bundle-source-generator.md`
+
+## Validation
+
+A full repository checkout was not available in this environment.
+
+Mock validation completed outside the repository checkout:
+
+- `node --check` passed against the generated script.
+- The generator ran against a mock bundle containing `prompt.body.xml` and `templates/github/.github/workflows/ci-node.yml`.
+- Observed output included `source/index.html`, `source-metadata.json`, `prompt.body.xml.html` and a `_dot_github` workflow page.
+
+Recommended follow-up checks:
+
+- Run `npm run agent:docs:source:dry-run` in a repository checkout.
+- Run `npm run agent:docs:source` before deployment or as the Cloudflare Pages build command.
+- Open `/bundles/github/source/index.html` after generation.
+- Confirm generated pages retain canonical source paths while using safe public output paths.
+
+## Residual risk
+
+The generator has been added, but generated source output was not committed from a full repository checkout.
+
+Cloudflare Pages must run `npm run agent:docs:source` during build, or generated source files must be committed after running the script locally.

--- a/docs/agent-operating-model/bundles/github/generated-metadata.json
+++ b/docs/agent-operating-model/bundles/github/generated-metadata.json
@@ -2,9 +2,10 @@
   "siteId": "github-diamond-generated-docs",
   "generatedAt": "2026-05-20",
   "repository": "kevinrapley/ResearchOps",
-  "branch": "feature/github-diamond-docs-site",
+  "branch": "feature/github-bundle-source-generator",
   "outputPath": "docs/agent-operating-model/bundles/github/",
   "canonicalSourcePath": ".agent-operating-model/bundles/github/",
+  "publicUrl": "https://agents.research-operations.com/bundles/github",
   "bundle": {
     "id": "github-diamond-standard",
     "version": "2.9.2",
@@ -20,15 +21,29 @@
     "templates/index.html",
     "scripts/index.html",
     "validation/index.html",
-    "changelog/index.html"
+    "changelog/index.html",
+    "source/index.html"
   ],
   "assets": [
     "assets/styles.css"
+  ],
+  "generators": [
+    {
+      "id": "bundle-source-browser",
+      "script": "scripts/agent-operating-model/generate-bundle-source-docs.mjs",
+      "defaultCommand": "npm run agent:docs:source",
+      "dryRunCommand": "npm run agent:docs:source:dry-run",
+      "defaultBundle": "github",
+      "sourceDirectory": ".agent-operating-model/bundles/github/",
+      "outputDirectory": "docs/agent-operating-model/bundles/github/source/",
+      "description": "Recursively extracts readable canonical bundle source files into generated source pages, with line anchors, metadata, purpose notes and safe public paths."
+    }
   ],
   "sourceBoundary": "Generated documentation only. Canonical bundle source remains under .agent-operating-model/bundles/github/.",
   "notes": [
     "Generated pages include warning banners that point readers back to the canonical source.",
     "The static site is intentionally placed outside the canonical bundle directory.",
-    "The first generated version favours navigable explanation over line-for-line source mirroring."
+    "The source browser is generated from canonical files and should not be hand-edited.",
+    "Files under canonical dot-directories such as .github are emitted under safe public paths such as _dot_github while retaining the canonical path in page content."
   ]
 }

--- a/docs/agent-operating-model/bundles/github/index.html
+++ b/docs/agent-operating-model/bundles/github/index.html
@@ -58,6 +58,10 @@
 				<h2><a href="changelog/index.html">Changelog</a></h2>
 				<p>Release history from the initial bundle through the current auditable release-assurance model.</p>
 			</article>
+			<article class="card card--green">
+				<h2><a href="source/index.html">Source browser</a></h2>
+				<p>Generated full source extraction pages for every readable file in the canonical GitHub Diamond bundle.</p>
+			</article>
 		</section>
 		<section>
 			<h2>Operating model at a glance</h2>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "agent:model": "node scripts/agent-operating-model/load-operating-model.mjs",
     "agent:model:validate": "node scripts/agent-operating-model/validate-operating-model.mjs",
     "agent:bundles:validate": "node scripts/agent-operating-model/validate-bundle-registry.mjs",
+    "agent:docs:source": "node scripts/agent-operating-model/generate-bundle-source-docs.mjs --bundle github",
+    "agent:docs:source:dry-run": "node scripts/agent-operating-model/generate-bundle-source-docs.mjs --bundle github --dry-run",
     "agent:evals": "node scripts/agent-operating-model/run-behavioural-evals.mjs",
     "trace:promote": "node scripts/agent-trace/promote-trace.mjs",
     "trace:validate": "node scripts/agent-trace/validate-traces.mjs",

--- a/scripts/agent-operating-model/generate-bundle-source-docs.mjs
+++ b/scripts/agent-operating-model/generate-bundle-source-docs.mjs
@@ -91,8 +91,20 @@ function escapeHtml(value) {
 		.replaceAll("'", '&#39;');
 }
 
+function safePathSegment(segment) {
+	const visible = segment.startsWith('.') ? `_dot_${segment.slice(1)}` : segment;
+	return encodeURIComponent(visible).replaceAll('%20', '-');
+}
+
+function safeRelativeHtmlPath(relativePath) {
+	return normalisePath(relativePath)
+		.split('/')
+		.map(safePathSegment)
+		.join('/');
+}
+
 function pagePathForSourceFile(relativePath) {
-	return path.join('source', 'files', `${relativePath}.html`);
+	return path.join('source', 'files', `${safeRelativeHtmlPath(relativePath)}.html`);
 }
 
 function titleForBundle(bundle) {
@@ -349,6 +361,7 @@ async function writeGeneratedMetadata({ bundle, generatedAt, files, outputDirect
 		fileCount: files.length,
 		files: files.map((file) => ({
 			path: file.relativePath,
+			page: normalisePath(path.relative(outputDirectory, pagePathForSourceFile(file.relativePath).replace(/^source\//, ''))),
 			bytes: file.byteLength,
 			category: categoryForFile(file.relativePath),
 			purpose: purposeForFile(file.relativePath)

--- a/scripts/agent-operating-model/generate-bundle-source-docs.mjs
+++ b/scripts/agent-operating-model/generate-bundle-source-docs.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+
+import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_BUNDLE = 'github';
+const DEFAULT_SOURCE_ROOT = '.agent-operating-model/bundles';
+const DEFAULT_DOCS_ROOT = 'docs/agent-operating-model/bundles';
+const DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
+
+const TEXT_EXTENSIONS = new Set([
+	'.css',
+	'.csv',
+	'.html',
+	'.js',
+	'.json',
+	'.jsonc',
+	'.md',
+	'.mjs',
+	'.py',
+	'.txt',
+	'.xml',
+	'.yaml',
+	'.yml'
+]);
+
+const SKIPPED_DIRECTORIES = new Set(['.git', 'node_modules', '.cache', '.wrangler']);
+const SKIPPED_FILES = new Set(['.DS_Store']);
+
+function parseArgs(argv) {
+	const args = {
+		bundle: DEFAULT_BUNDLE,
+		sourceRoot: DEFAULT_SOURCE_ROOT,
+		docsRoot: DEFAULT_DOCS_ROOT,
+		maxFileBytes: DEFAULT_MAX_FILE_BYTES,
+		dryRun: false
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const current = argv[index];
+
+		if (current === '--bundle') {
+			args.bundle = argv[index + 1];
+			index += 1;
+			continue;
+		}
+
+		if (current === '--source-root') {
+			args.sourceRoot = argv[index + 1];
+			index += 1;
+			continue;
+		}
+
+		if (current === '--docs-root') {
+			args.docsRoot = argv[index + 1];
+			index += 1;
+			continue;
+		}
+
+		if (current === '--max-file-bytes') {
+			args.maxFileBytes = Number(argv[index + 1]);
+			index += 1;
+			continue;
+		}
+
+		if (current === '--dry-run') {
+			args.dryRun = true;
+			continue;
+		}
+
+		throw new Error(`Unknown argument: ${current}`);
+	}
+
+	if (!args.bundle) throw new Error('Missing bundle identifier.');
+	if (!Number.isFinite(args.maxFileBytes) || args.maxFileBytes < 1) throw new Error('Invalid --max-file-bytes value.');
+
+	return args;
+}
+
+function normalisePath(value) {
+	return value.split(path.sep).join('/');
+}
+
+function escapeHtml(value) {
+	return String(value)
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;');
+}
+
+function pagePathForSourceFile(relativePath) {
+	return path.join('source', 'files', `${relativePath}.html`);
+}
+
+function titleForBundle(bundle) {
+	if (bundle === 'github') return 'GitHub Diamond bundle';
+	return `${bundle} bundle`;
+}
+
+function categoryForFile(relativePath) {
+	const parts = normalisePath(relativePath).split('/');
+	if (parts.length === 1) return 'bundle root';
+	return parts[0];
+}
+
+function purposeForFile(relativePath) {
+	const category = categoryForFile(relativePath);
+	const name = path.basename(relativePath);
+
+	if (name === 'prompt.body.xml') return 'Core bundle doctrine and behavioural instructions.';
+	if (name === 'prompt.spec.yaml') return 'Bundle assembly manifest and module loading contract.';
+	if (name === 'registry-manifest.yaml') return 'Auditable inventory of bundle files and checksums.';
+	if (name === 'template-registry.yaml') return 'Template selection map linking source templates, destinations, contracts and graders.';
+	if (name === 'VALIDATION-REPORT.md') return 'Human-readable validation status and assurance summary.';
+	if (name === 'CHANGELOG.md') return 'Version history and release trace.';
+	if (name === 'README.md') return 'Human-facing bundle overview and operating instructions.';
+	if (category === 'modes') return 'Mode runbook. Defines task inputs, actions, outputs, failure states, contracts and graders.';
+	if (category === 'roles') return 'Role lens. Defines responsibilities and escalation expectations.';
+	if (category === 'references') return 'Reference module. Supplies policy, doctrine or implementation guidance.';
+	if (category === 'contracts') return 'JSON Schema contract. Defines a checkable artefact shape.';
+	if (category === 'graders') return 'Grader module. Defines thresholds, evidence, scoring and blocking failures.';
+	if (category === 'templates') return 'Template file used when scaffolding or updating repositories.';
+	if (category === 'scripts') return 'Executable utility used for generation, validation or assurance.';
+	if (category === 'examples') return 'Example fixture or demonstration artefact.';
+	if (category === 'fixtures') return 'Validation fixture used by scripts, tests or evals.';
+	return 'Bundle source file.';
+}
+
+function usageForFile(relativePath) {
+	const category = categoryForFile(relativePath);
+	const name = path.basename(relativePath);
+
+	if (name === 'prompt.body.xml') return 'Loaded by the operating model as the primary behavioural contract for this bundle.';
+	if (name === 'prompt.spec.yaml') return 'Read before task execution so the agent knows which module families exist and how they assemble.';
+	if (name === 'registry-manifest.yaml') return 'Used to check bundle file coverage and detect source drift.';
+	if (name === 'template-registry.yaml') return 'Used by repository instantiation and update tasks to select scaffolds without inventing destinations.';
+	if (category === 'modes') return 'Selected by task type. The agent should use it as a completion checklist.';
+	if (category === 'roles') return 'Applied as an expert review lens when judging the task or output.';
+	if (category === 'references') return 'Consulted when the task touches this policy area.';
+	if (category === 'contracts') return 'Validated by scripts or graders before evidence can be trusted.';
+	if (category === 'graders') return 'Used after work is produced to decide whether evidence passes, passes with gaps, or fails.';
+	if (category === 'templates') return 'Copied or adapted through the template registry into target repositories.';
+	if (category === 'scripts') return 'Run locally, in CI, or during release assurance to verify claims.';
+	return 'Included in the generated source browser so reviewers can inspect the canonical bundle source.';
+}
+
+async function collectFiles(directory, root = directory) {
+	const entries = await readdir(directory, { withFileTypes: true });
+	const files = [];
+
+	for (const entry of entries) {
+		if (entry.name.startsWith('.') && entry.name !== '.github') continue;
+		if (SKIPPED_FILES.has(entry.name)) continue;
+
+		const fullPath = path.join(directory, entry.name);
+
+		if (entry.isDirectory()) {
+			if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+			files.push(...await collectFiles(fullPath, root));
+			continue;
+		}
+
+		if (!entry.isFile()) continue;
+
+		files.push({
+			absolutePath: fullPath,
+			relativePath: normalisePath(path.relative(root, fullPath))
+		});
+	}
+
+	return files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+function isTextFile(file, buffer) {
+	const extension = path.extname(file.relativePath).toLowerCase();
+	if (TEXT_EXTENSIONS.has(extension)) return true;
+	return !buffer.includes(0);
+}
+
+function lineRows(content) {
+	const lines = content.split('\n');
+	return lines.map((line, index) => {
+		const lineNumber = index + 1;
+		return `<tr id="L${lineNumber}"><th scope="row"><a href="#L${lineNumber}">${lineNumber}</a></th><td><code>${escapeHtml(line || ' ')}</code></td></tr>`;
+	}).join('\n');
+}
+
+function relativeStylesheetLink(outputFile, bundleDocsDirectory) {
+	const cssPath = path.join(bundleDocsDirectory, 'assets', 'styles.css');
+	return normalisePath(path.relative(path.dirname(outputFile), cssPath));
+}
+
+function relativeIndexLink(outputFile, sourceIndexPath) {
+	return normalisePath(path.relative(path.dirname(outputFile), sourceIndexPath));
+}
+
+function sourcePageHtml({ bundle, file, content, byteLength, outputFile, sourceIndexPath, bundleDocsDirectory }) {
+	const stylesheet = relativeStylesheetLink(outputFile, bundleDocsDirectory);
+	const sourceIndex = relativeIndexLink(outputFile, sourceIndexPath);
+	const canonicalPath = `.agent-operating-model/bundles/${bundle}/${file.relativePath}`;
+	const title = `${file.relativePath} · ${titleForBundle(bundle)}`;
+
+	return `<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>${escapeHtml(title)}</title>
+	<link rel="stylesheet" href="${escapeHtml(stylesheet)}">
+	<style>
+		.source-code-table { width: 100%; border-collapse: collapse; font-size: 15px; }
+		.source-code-table th { width: 4.5rem; text-align: right; user-select: none; background: #f3f2f1; color: #505a5f; }
+		.source-code-table td { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre; overflow-x: auto; }
+		.source-code-table th, .source-code-table td { border-bottom: 1px solid #e5e5e5; padding: 0.25rem 0.5rem; vertical-align: top; }
+		.source-code-table code { background: transparent; padding: 0; }
+		.source-meta { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; margin: 1.5rem 0; }
+		@media (max-width: 800px) { .source-meta { grid-template-columns: 1fr; } }
+	</style>
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header">
+		<div class="site-header__inner">
+			<p class="site-header__product">ResearchOps · ${escapeHtml(titleForBundle(bundle))}</p>
+			<h1>${escapeHtml(file.relativePath)}</h1>
+			<p class="site-header__lede">Generated source extraction page for a canonical bundle file.</p>
+		</div>
+	</header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>${escapeHtml(canonicalPath)}</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs">
+			<a href="${escapeHtml(sourceIndex)}">Source browser</a><span>${escapeHtml(file.relativePath)}</span>
+		</nav>
+		<section class="source-meta" aria-label="Source file metadata">
+			<article class="card"><h2>Purpose</h2><p>${escapeHtml(purposeForFile(file.relativePath))}</p></article>
+			<article class="card"><h2>How the agent uses it</h2><p>${escapeHtml(usageForFile(file.relativePath))}</p></article>
+			<article class="card"><h2>File details</h2><p><code>${escapeHtml(canonicalPath)}</code></p><p>${byteLength.toLocaleString('en-GB')} bytes</p></article>
+		</section>
+		<section>
+			<h2>Extracted source</h2>
+			<table class="source-code-table" aria-label="Source code for ${escapeHtml(file.relativePath)}">
+				<tbody>
+${lineRows(content)}
+				</tbody>
+			</table>
+		</section>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated source page. Canonical source remains under <code>.agent-operating-model/bundles/${escapeHtml(bundle)}/</code>.</div></footer>
+</body>
+</html>
+`;
+}
+
+function binaryPageHtml({ bundle, file, byteLength, outputFile, sourceIndexPath, bundleDocsDirectory }) {
+	const stylesheet = relativeStylesheetLink(outputFile, bundleDocsDirectory);
+	const sourceIndex = relativeIndexLink(outputFile, sourceIndexPath);
+	const canonicalPath = `.agent-operating-model/bundles/${bundle}/${file.relativePath}`;
+
+	return `<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>${escapeHtml(file.relativePath)} · binary source</title>
+	<link rel="stylesheet" href="${escapeHtml(stylesheet)}">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header"><div class="site-header__inner"><p class="site-header__product">ResearchOps · ${escapeHtml(titleForBundle(bundle))}</p><h1>${escapeHtml(file.relativePath)}</h1><p class="site-header__lede">Binary or oversized file detected.</p></div></header>
+	<p class="generated-warning">This page is generated documentation. The canonical source is <code>${escapeHtml(canonicalPath)}</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="${escapeHtml(sourceIndex)}">Source browser</a><span>${escapeHtml(file.relativePath)}</span></nav>
+		<p>This file was not rendered as source because it is binary, not recognised as text, or exceeds the configured source extraction size limit.</p>
+		<p>File size: ${byteLength.toLocaleString('en-GB')} bytes.</p>
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated source page. Canonical source remains under <code>.agent-operating-model/bundles/${escapeHtml(bundle)}/</code>.</div></footer>
+</body>
+</html>
+`;
+}
+
+function sourceIndexHtml({ bundle, generatedAt, files, pages, bundleDocsDirectory, sourceIndexPath }) {
+	const stylesheet = normalisePath(path.relative(path.dirname(sourceIndexPath), path.join(bundleDocsDirectory, 'assets', 'styles.css')));
+	const grouped = new Map();
+
+	for (const file of files) {
+		const category = categoryForFile(file.relativePath);
+		if (!grouped.has(category)) grouped.set(category, []);
+		grouped.get(category).push(file);
+	}
+
+	const categorySections = [...grouped.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([category, categoryFiles]) => {
+		const rows = categoryFiles.map((file) => {
+			const page = pages.get(file.relativePath);
+			const href = normalisePath(path.relative(path.dirname(sourceIndexPath), page));
+			return `<tr><td><a href="${escapeHtml(href)}"><code>${escapeHtml(file.relativePath)}</code></a></td><td>${escapeHtml(purposeForFile(file.relativePath))}</td><td>${file.byteLength.toLocaleString('en-GB')} bytes</td></tr>`;
+		}).join('\n');
+
+		return `<section>
+			<h2>${escapeHtml(category)}</h2>
+			<table>
+				<thead><tr><th>File</th><th>Purpose</th><th>Size</th></tr></thead>
+				<tbody>
+${rows}
+				</tbody>
+			</table>
+		</section>`;
+	}).join('\n');
+
+	return `<!doctype html>
+<html lang="en-GB">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>${escapeHtml(titleForBundle(bundle))} source browser</title>
+	<link rel="stylesheet" href="${escapeHtml(stylesheet)}">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to main content</a>
+	<header class="site-header">
+		<div class="site-header__inner">
+			<p class="site-header__product">ResearchOps · ${escapeHtml(titleForBundle(bundle))}</p>
+			<h1>Source browser</h1>
+			<p class="site-header__lede">Generated source extraction pages for every readable canonical bundle file.</p>
+		</div>
+	</header>
+	<p class="generated-warning">This section is generated documentation. The canonical source is <code>.agent-operating-model/bundles/${escapeHtml(bundle)}/</code>.</p>
+	<main id="main" class="wrapper">
+		<nav class="breadcrumbs" aria-label="Breadcrumbs"><a href="../index.html">GitHub bundle</a><span>Source browser</span></nav>
+		<p class="lede">Generated at ${escapeHtml(generatedAt)}. ${files.length} bundle files were indexed.</p>
+${categorySections}
+	</main>
+	<footer class="site-footer"><div class="site-footer__inner">Generated source browser. Canonical source remains under <code>.agent-operating-model/bundles/${escapeHtml(bundle)}/</code>.</div></footer>
+</body>
+</html>
+`;
+}
+
+async function writeGeneratedMetadata({ bundle, generatedAt, files, outputDirectory, dryRun }) {
+	const metadata = {
+		siteId: `${bundle}-bundle-source-browser`,
+		generatedAt,
+		bundle,
+		canonicalSourcePath: `.agent-operating-model/bundles/${bundle}/`,
+		outputPath: normalisePath(outputDirectory),
+		fileCount: files.length,
+		files: files.map((file) => ({
+			path: file.relativePath,
+			bytes: file.byteLength,
+			category: categoryForFile(file.relativePath),
+			purpose: purposeForFile(file.relativePath)
+		}))
+	};
+
+	const metadataPath = path.join(outputDirectory, 'source-metadata.json');
+	if (dryRun) return metadataPath;
+	await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
+	return metadataPath;
+}
+
+async function generateBundleSourceDocs(options) {
+	const repositoryRoot = process.cwd();
+	const sourceDirectory = path.resolve(repositoryRoot, options.sourceRoot, options.bundle);
+	const bundleDocsDirectory = path.resolve(repositoryRoot, options.docsRoot, options.bundle);
+	const outputDirectory = path.join(bundleDocsDirectory, 'source');
+	const filesDirectory = path.join(outputDirectory, 'files');
+	const sourceIndexPath = path.join(outputDirectory, 'index.html');
+	const sourceStats = await stat(sourceDirectory).catch(() => null);
+
+	if (!sourceStats?.isDirectory()) {
+		throw new Error(`Source bundle directory not found: ${normalisePath(path.relative(repositoryRoot, sourceDirectory))}`);
+	}
+
+	const files = await collectFiles(sourceDirectory);
+	const pages = new Map();
+	const generatedAt = new Date().toISOString();
+
+	if (!options.dryRun) {
+		await rm(outputDirectory, { recursive: true, force: true });
+		await mkdir(filesDirectory, { recursive: true });
+	}
+
+	for (const file of files) {
+		const buffer = await readFile(file.absolutePath);
+		const pagePath = path.join(outputDirectory, pagePathForSourceFile(file.relativePath).replace(/^source\//, ''));
+		file.byteLength = buffer.byteLength;
+		pages.set(file.relativePath, pagePath);
+
+		if (options.dryRun) continue;
+
+		await mkdir(path.dirname(pagePath), { recursive: true });
+
+		const renderAsText = buffer.byteLength <= options.maxFileBytes && isTextFile(file, buffer);
+		const html = renderAsText
+			? sourcePageHtml({
+				bundle: options.bundle,
+				file,
+				content: buffer.toString('utf8'),
+				byteLength: buffer.byteLength,
+				outputFile: pagePath,
+				sourceIndexPath,
+				bundleDocsDirectory
+			})
+			: binaryPageHtml({
+				bundle: options.bundle,
+				file,
+				byteLength: buffer.byteLength,
+				outputFile: pagePath,
+				sourceIndexPath,
+				bundleDocsDirectory
+			});
+
+		await writeFile(pagePath, html, 'utf8');
+	}
+
+	if (!options.dryRun) {
+		const index = sourceIndexHtml({
+			bundle: options.bundle,
+			generatedAt,
+			files,
+			pages,
+			bundleDocsDirectory,
+			sourceIndexPath
+		});
+
+		await writeFile(sourceIndexPath, index, 'utf8');
+		await writeGeneratedMetadata({ bundle: options.bundle, generatedAt, files, outputDirectory, dryRun: options.dryRun });
+	}
+
+	return {
+		bundle: options.bundle,
+		files: files.length,
+		outputDirectory: normalisePath(path.relative(repositoryRoot, outputDirectory)),
+		dryRun: options.dryRun
+	};
+}
+
+async function main() {
+	const options = parseArgs(process.argv.slice(2));
+	const result = await generateBundleSourceDocs(options);
+	console.log(`Generated source documentation for ${result.bundle}: ${result.files} files -> ${result.outputDirectory}`);
+	if (result.dryRun) console.log('Dry run only. No files were written.');
+}
+
+main().catch((error) => {
+	console.error(error.message);
+	process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a Node-based generator for full source extraction pages for the GitHub Diamond bundle documentation site.

The generator reads canonical bundle files from:

`.agent-operating-model/bundles/github/`

and writes generated source documentation to:

`docs/agent-operating-model/bundles/github/source/`

## What changed

- Added `scripts/agent-operating-model/generate-bundle-source-docs.mjs`.
- Added `npm run agent:docs:source`.
- Added `npm run agent:docs:source:dry-run`.
- Linked the GitHub bundle landing page to `source/index.html`.
- Updated `generated-metadata.json` to record the source browser generator and output contract.
- Added trace files for the `feature/` branch.

## Generator behaviour

The generator recursively walks `.agent-operating-model/bundles/<bundle>/` and creates:

- `source/index.html`
- `source/source-metadata.json`
- `source/files/**/*.html`

Each generated source page includes:

- escaped canonical source content
- line anchors
- source file metadata
- purpose notes
- agent usage notes
- a canonical source warning banner

It also handles canonical dot-directories such as `.github` by writing safe public paths such as `_dot_github`, while preserving the original canonical path visibly on the page.

## Source boundary

This PR does not change canonical bundle source under:

`.agent-operating-model/bundles/github/`

The generator reads from that directory only and writes generated documentation under:

`docs/agent-operating-model/bundles/github/source/`

## Validation

A full repository checkout was not available in the ChatGPT environment.

Mock validation completed:

- `node --check` passed against the generated script in a local mock environment.
- The generator was run against a mock bundle containing `prompt.body.xml` and `templates/github/.github/workflows/ci-node.yml`.
- Observed output included `source/index.html`, `source-metadata.json`, `prompt.body.xml.html` and a `_dot_github` workflow page.

Recommended checks before marking ready:

- `npm run agent:docs:source:dry-run`
- `npm run agent:docs:source`
- open `/bundles/github/source/index.html` after generation
- confirm no files under `.agent-operating-model/bundles/github/` changed

## Residual risk

This PR adds the generator but does not commit generated source output from a full repository checkout.

To make the public site immediately serve full source extraction pages, either:

1. run `npm run agent:docs:source` in the Cloudflare Pages build before publishing `docs/agent-operating-model`, or
2. run `npm run agent:docs:source` locally and commit the generated `docs/agent-operating-model/bundles/github/source/` output.

Because of that deployment dependency, this PR is opened as draft.