### PR TITLE
Deploy agent Pages after main builds

### DIFF
--- a/.github/workflows/deploy-agent-pages.yml
+++ b/.github/workflows/deploy-agent-pages.yml
@@ -1,4 +1,4 @@
-name: Build agent documentation Pages
+name: Build and deploy agent documentation Pages
 
 on:
   workflow_dispatch:
@@ -57,7 +57,7 @@ jobs:
         run: bash build.sh
 
       - name: Deploy to Cloudflare Pages
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
## Summary

Restores automatic GitHub Actions deployment for the agent documentation Pages site after a successful `main` build.

## Change

- Pull requests build and verify only.
- Pushes to `main` build and deploy to Cloudflare Pages.
- Manual workflow runs build and deploy to Cloudflare Pages.

## Why

PR #267 was merged with deployment restricted to `workflow_dispatch`, which made the Cloudflare deploy step skip after merge. That stopped the failing authentication step, but it also stopped the intended automatic deployment path.

This PR restores the intended deployment condition while keeping PRs safe.

## Validation

The diff is limited to `.github/workflows/deploy-agent-pages.yml`.

Expected behaviour:

- On this PR, the deploy step is skipped.
- After merge to `main`, the deploy step runs.