### PR TITLE
Scope BDD smoke checks on main pushes

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -15,8 +15,17 @@ on:
   pull_request:
   push:
     branches: [main]
-    paths-ignore:
-      - "reports-site/**"
+    paths:
+      - "pages/**"
+      - "public/**"
+      - "src/**"
+      - "features/**"
+      - "fixtures/**"
+      - "tests/**"
+      - "playwright.config.*"
+      - "cucumber.*"
+      - "package.json"
+      - "package-lock.json"
   workflow_run:
     workflows: ["QA • Playwright E2E"]
     types: [completed]


### PR DESCRIPTION
## Summary

Prevents the public-app BDD smoke suite from running on `main` pushes that only change agent documentation or deployment workflow files.

## Change

- Replaces the broad `push` trigger for `qa-bdd` with path-scoped triggers.
- `qa-bdd` now runs on `main` pushes only when public app or BDD-relevant files change.
- It still runs on manual dispatch and relevant pull requests.

## Why

The previous PR-scope guard prevented workflow-only pull requests from testing the stale public app, but after merge the `push` trigger still ran `qa-bdd` against `https://researchops.pages.dev/`.

That caused unrelated live public-app route failures to block agent Pages deployment workflow changes.

## Validation

Expected behaviour:

- This PR should run `qa-bdd` because the workflow file itself changed.
- Future merges that only change agent Pages deployment files should not trigger `qa-bdd` on `main`.
- Public app changes under `pages/**`, `public/**`, `src/**`, test fixtures, feature files and package changes still trigger the smoke suite.