### PR TITLE
Run agent Pages workflow on every main push

### DIFF
--- a/.github/workflows/deploy-agent-pages.yml
+++ b/.github/workflows/deploy-agent-pages.yml
@@ -5,15 +5,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.agent-operating-model/bundles/github/**'
-      - 'docs/agent-operating-model/**'
-      - 'scripts/agent-operating-model/**'
-      - 'build.sh'
-      - 'wrangler.toml'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/deploy-agent-pages.yml'
   pull_request:
     paths:
       - '.agent-operating-model/bundles/github/**'


### PR DESCRIPTION
Removes the push path filter from the agent Pages workflow so it runs after every merge to main. Pull requests still only run the workflow when relevant files change, and deployment remains limited to push and manual dispatch events.