### PR TITLE
Cap source panel code height

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,10 @@ test -f docs/agent-operating-model/bundles/github/source/scripts/index.html
 test -f docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
 test -f docs/agent-operating-model/bundles/github/assets/source-panel-layout.js
 
+grep -n 'max-height: 1400px' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
+grep -n 'SOURCE_PANEL_CODE_MAX_HEIGHT = 1400' docs/agent-operating-model/bundles/github/assets/source-panel-layout.js
+grep -n 'overflow-y: auto' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
+
 if grep -R '<aside class="notes">[[:space:]]*<ul>' docs/agent-operating-model/bundles/github/source; then
 	printf '%s\n' 'Unexpected list markup found at the start of a source-panel notes column.' >&2
 	exit 1

--- a/scripts/agent-operating-model/normalise-source-panel-layout.mjs
+++ b/scripts/agent-operating-model/normalise-source-panel-layout.mjs
@@ -8,24 +8,33 @@ const DOCS_ROOT = 'docs/agent-operating-model/bundles/github';
 const ASSETS_DIR = path.join(DOCS_ROOT, 'assets');
 const CSS_HREF = '/bundles/github/assets/source-panel-layout.css';
 const JS_SRC = '/bundles/github/assets/source-panel-layout.js';
+const CODE_PANEL_MAX_HEIGHT = 1400;
 
 const CSS = `.source-grid { align-items: stretch; }
-.source-grid pre { height: auto; max-height: none; min-height: 0; }
+.source-grid pre {
+  height: auto;
+  max-height: ${CODE_PANEL_MAX_HEIGHT}px;
+  min-height: 0;
+  overflow-y: auto;
+}
 .source-grid aside.notes p { margin: 0 0 12px; }
 .source-grid aside.notes h4 + p { margin-top: 0; }
 `;
 
-const JS = `function syncSourcePanelHeights() {
+const JS = `var SOURCE_PANEL_CODE_MAX_HEIGHT = ${CODE_PANEL_MAX_HEIGHT};
+
+function syncSourcePanelHeights() {
   document.querySelectorAll('.source-grid').forEach(function (grid) {
     var code = grid.querySelector('pre');
     var notes = grid.querySelector('aside.notes');
     if (!code || !notes) return;
     code.style.height = 'auto';
-    code.style.maxHeight = 'none';
+    code.style.maxHeight = SOURCE_PANEL_CODE_MAX_HEIGHT + 'px';
+    code.style.overflowY = 'auto';
     if (window.matchMedia('(max-width: 1020px)').matches) return;
-    var height = Math.ceil(notes.getBoundingClientRect().height);
+    var height = Math.min(Math.ceil(notes.getBoundingClientRect().height), SOURCE_PANEL_CODE_MAX_HEIGHT);
     code.style.height = height + 'px';
-    code.style.maxHeight = height + 'px';
+    code.style.maxHeight = SOURCE_PANEL_CODE_MAX_HEIGHT + 'px';
   });
 }
 window.addEventListener('load', syncSourcePanelHeights);


### PR DESCRIPTION
## Summary

Caps generated source-panel code blocks at 1400px while preserving the existing height synchronisation with the right-side notes panel.

## Changes

- Adds `CODE_PANEL_MAX_HEIGHT = 1400` to the generated source-panel layout normaliser.
- Writes `max-height: 1400px` and `overflow-y: auto` to the generated source-panel layout CSS.
- Updates the height-sync script so desktop code panels use the lesser of the notes-panel height and 1400px.
- Adds build checks for the generated CSS and JavaScript height-cap markers.

## Expected behaviour

- If the right-side notes panel is under 1400px, the code block matches its height.
- If the right-side notes panel is over 1400px, the code block is capped at 1400px.
- If the code content exceeds the visible code block height, it scrolls on the y-axis.

## Validation

`build.sh` now checks that the generated layout assets include the 1400px max-height, JavaScript cap constant and vertical overflow rule.