### PR TITLE
Cache bust capped source panel layout

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,9 +26,11 @@ test -f docs/agent-operating-model/bundles/github/source/scripts/index.html
 test -f docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
 test -f docs/agent-operating-model/bundles/github/assets/source-panel-layout.js
 
-grep -n 'max-height: 1400px' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
+grep -n 'max-height: 1400px !important' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
 grep -n 'SOURCE_PANEL_CODE_MAX_HEIGHT = 1400' docs/agent-operating-model/bundles/github/assets/source-panel-layout.js
-grep -n 'overflow-y: auto' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
+grep -n 'overflow-y: auto !important' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
+grep -n 'source-panel-layout.css?v=source-panel-height-cap-v2' docs/agent-operating-model/bundles/github/source/modes/index.html
+grep -n 'source-panel-layout.js?v=source-panel-height-cap-v2' docs/agent-operating-model/bundles/github/source/modes/index.html
 
 if grep -R '<aside class="notes">[[:space:]]*<ul>' docs/agent-operating-model/bundles/github/source; then
 	printf '%s\n' 'Unexpected list markup found at the start of a source-panel notes column.' >&2

--- a/scripts/agent-operating-model/normalise-source-panel-layout.mjs
+++ b/scripts/agent-operating-model/normalise-source-panel-layout.mjs
@@ -6,16 +6,21 @@ import process from 'node:process';
 
 const DOCS_ROOT = 'docs/agent-operating-model/bundles/github';
 const ASSETS_DIR = path.join(DOCS_ROOT, 'assets');
-const CSS_HREF = '/bundles/github/assets/source-panel-layout.css';
-const JS_SRC = '/bundles/github/assets/source-panel-layout.js';
+const ASSET_VERSION = 'source-panel-height-cap-v2';
+const CSS_PATH = '/bundles/github/assets/source-panel-layout.css';
+const JS_PATH = '/bundles/github/assets/source-panel-layout.js';
+const CSS_HREF = `${CSS_PATH}?v=${ASSET_VERSION}`;
+const JS_SRC = `${JS_PATH}?v=${ASSET_VERSION}`;
 const CODE_PANEL_MAX_HEIGHT = 1400;
 
-const CSS = `.source-grid { align-items: stretch; }
+const CSS = `.source-grid { align-items: start; }
 .source-grid pre {
+  align-self: start;
+  box-sizing: border-box;
   height: auto;
-  max-height: ${CODE_PANEL_MAX_HEIGHT}px;
+  max-height: ${CODE_PANEL_MAX_HEIGHT}px !important;
   min-height: 0;
-  overflow-y: auto;
+  overflow-y: auto !important;
 }
 .source-grid aside.notes p { margin: 0 0 12px; }
 .source-grid aside.notes h4 + p { margin-top: 0; }
@@ -31,6 +36,7 @@ function syncSourcePanelHeights() {
     code.style.height = 'auto';
     code.style.maxHeight = SOURCE_PANEL_CODE_MAX_HEIGHT + 'px';
     code.style.overflowY = 'auto';
+    code.style.alignSelf = 'start';
     if (window.matchMedia('(max-width: 1020px)').matches) return;
     var height = Math.min(Math.ceil(notes.getBoundingClientRect().height), SOURCE_PANEL_CODE_MAX_HEIGHT);
     code.style.height = height + 'px';
@@ -88,12 +94,10 @@ function normaliseNotes(html) {
 
 function addAssets(html) {
 	let output = html;
-	if (!output.includes(CSS_HREF)) {
-		output = output.replace('</head>', `<link rel="stylesheet" href="${CSS_HREF}">\n</head>`);
-	}
-	if (!output.includes(JS_SRC)) {
-		output = output.replace('</body>', `<script src="${JS_SRC}" defer></script>\n</body>`);
-	}
+	output = output.replace(/<link rel="stylesheet" href="\/bundles\/github\/assets\/source-panel-layout\.css(?:\?[^\"]*)?">\n?/g, '');
+	output = output.replace(/<script src="\/bundles\/github\/assets\/source-panel-layout\.js(?:\?[^\"]*)?" defer><\/script>\n?/g, '');
+	output = output.replace('</head>', `<link rel="stylesheet" href="${CSS_HREF}">\n</head>`);
+	output = output.replace('</body>', `<script src="${JS_SRC}" defer></script>\n</body>`);
 	return output;
 }
 


### PR DESCRIPTION
## Summary

Makes the 1400px source-panel code height cap apply reliably in the deployed documentation.

## Cause

The previous change generated the correct cap rules, but the generated HTML referenced the same CSS and JavaScript asset URLs. Browser or CDN caching could continue serving the earlier uncapped layout assets.

## Changes

- Adds versioned source-panel layout asset URLs.
- Removes any existing unversioned source-panel layout asset references before reinserting the current assets.
- Hardens the CSS with `max-height: 1400px !important` and `overflow-y: auto !important` on the source-panel code block.
- Keeps the JavaScript height sync, but caps the synced height at 1400px.
- Adds build checks for the versioned asset references and hardened cap rules.

## Expected behaviour

- Notes panel under 1400px: code block matches the notes panel height.
- Notes panel over 1400px: code block is capped at 1400px.
- Code content taller than the visible code panel: code block scrolls on the y-axis.