### PR TITLE
Fix GitHub agent docs source refresh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,8 @@ test -f .agent-operating-model/source-annotations/github/source-annotations.yaml
 test -f .agent-operating-model/source-annotations/github/contracts.yaml
 test -f .agent-operating-model/source-annotations/github/graders.yaml
 
+EXPECTED_BUNDLE_VERSION="$(node -e "const fs = require('fs'); const source = fs.readFileSync('.agent-operating-model/bundles/github/prompt.spec.yaml', 'utf8'); const match = source.match(/^\\s*version:\\s*['\"]?([^'\"\\n]+)['\"]?\\s*$/m); if (!match) process.exit(1); process.stdout.write(match[1].trim());")"
+
 if [ -d .agent-operating-model/source-annotations/github/fragments ]; then
 	printf '%s\n' 'Source annotations must live directly in .agent-operating-model/source-annotations/github/.' >&2
 	exit 1
@@ -28,8 +30,8 @@ node scripts/agent-operating-model/verify-github-source-panel-docs.mjs
 printf '%s\n' '--- Verify generated GitHub bundle documentation ---'
 
 grep -n 'Source panels' docs/agent-operating-model/bundles/github/index.html
-grep -n '<strong>Version</strong>2.9.3' docs/agent-operating-model/bundles/github/index.html
-grep -n '"version": "2.9.3"' docs/agent-operating-model/bundles/github/generated-metadata.json
+grep -n "<strong>Version</strong>${EXPECTED_BUNDLE_VERSION}" docs/agent-operating-model/bundles/github/index.html
+grep -n "\"version\": \"${EXPECTED_BUNDLE_VERSION}\"" docs/agent-operating-model/bundles/github/generated-metadata.json
 
 if grep -n 'Source browser' docs/agent-operating-model/bundles/github/index.html; then
 	printf '%s\n' 'Unexpected old Source browser copy found in GitHub bundle overview.' >&2

--- a/build.sh
+++ b/build.sh
@@ -22,11 +22,14 @@ fi
 node scripts/agent-operating-model/generate-bundle-source-docs.mjs --bundle github
 node scripts/agent-operating-model/apply-source-annotations.mjs
 node scripts/agent-operating-model/normalise-source-panel-layout.mjs
+node scripts/agent-operating-model/sync-github-docs-generated-metadata.mjs
 node scripts/agent-operating-model/verify-github-source-panel-docs.mjs
 
 printf '%s\n' '--- Verify generated GitHub bundle documentation ---'
 
 grep -n 'Source panels' docs/agent-operating-model/bundles/github/index.html
+grep -n '<strong>Version</strong>2.9.3' docs/agent-operating-model/bundles/github/index.html
+grep -n '"version": "2.9.3"' docs/agent-operating-model/bundles/github/generated-metadata.json
 
 if grep -n 'Source browser' docs/agent-operating-model/bundles/github/index.html; then
 	printf '%s\n' 'Unexpected old Source browser copy found in GitHub bundle overview.' >&2
@@ -37,14 +40,18 @@ test -f docs/agent-operating-model/bundles/github/source/modes/index.html
 test -f docs/agent-operating-model/bundles/github/source/contracts/index.html
 test -f docs/agent-operating-model/bundles/github/source/templates/index.html
 test -f docs/agent-operating-model/bundles/github/source/scripts/index.html
+test -f docs/agent-operating-model/bundles/github/source/examples/index.html
 test -f docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
 test -f docs/agent-operating-model/bundles/github/assets/source-panel-layout.js
 
 grep -n 'max-height: 1400px !important' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
+grep -n 'source-panel example' docs/agent-operating-model/bundles/github/source/examples/index.html
+grep -n 'max-height: none !important' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
 grep -n 'SOURCE_PANEL_CODE_MAX_HEIGHT = 1400' docs/agent-operating-model/bundles/github/assets/source-panel-layout.js
-grep -n 'overflow-y: auto !important' docs/agent-operating-model/bundles/github/assets/source-panel-layout.css
-grep -n 'source-panel-layout.css?v=source-panel-height-cap-v2' docs/agent-operating-model/bundles/github/source/modes/index.html
-grep -n 'source-panel-layout.js?v=source-panel-height-cap-v2' docs/agent-operating-model/bundles/github/source/modes/index.html
+grep -n 'source-panel-layout.css?v=source-panel-examples-full-source-v1' docs/agent-operating-model/bundles/github/source/modes/index.html
+grep -n 'source-panel-layout.js?v=source-panel-examples-full-source-v1' docs/agent-operating-model/bundles/github/source/modes/index.html
+grep -n 'examples/scenarios/repo-discovery-node-api.yaml' docs/agent-operating-model/bundles/github/source/examples/index.html
+grep -n 'examples/performance-results/python-results.yaml' docs/agent-operating-model/bundles/github/source/examples/index.html
 
 if grep -R '<aside class="notes">[[:space:]]*<ul>' docs/agent-operating-model/bundles/github/source; then
 	printf '%s\n' 'Unexpected list markup found at the start of a source-panel notes column.' >&2

--- a/docs/agent-audit/reasoning/2026/05/22/github-agent-docs-source-refresh.json
+++ b/docs/agent-audit/reasoning/2026/05/22/github-agent-docs-source-refresh.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": "researchops-agent-trace-summary/v1",
+  "traceType": "operational-audit",
+  "date": "2026-05-22",
+  "branch": "fix/github-agent-docs-source-refresh",
+  "scope": [
+    "agent-documentation",
+    "github-diamond-bundle",
+    "generated-source-panels",
+    "examples-source-panels",
+    "bundle-version-metadata",
+    "cloudflare-pages-build"
+  ],
+  "evidenceBoundary": {
+    "summary": "This trace records observable repository work to fix stale generated GitHub bundle documentation. It does not include private chain-of-thought."
+  },
+  "operatingModel": {
+    "selectedBundles": [
+      "github",
+      "researchops-developer-control",
+      "multi-functional-team"
+    ],
+    "branchPolicy": "fix/ branches require audit trace artefacts under docs/agent-audit/reasoning/YYYY/MM/DD."
+  },
+  "problemSummary": [
+    "The public GitHub bundle overview page showed version 2.9.2 after the GitHub bundle was promoted to 2.9.3.",
+    "The public examples source panels did not visibly expose all expanded example source because example code panels inherited the height cap and scroll-box behaviour used for other source families.",
+    "The build script did not explicitly assert that source/examples/index.html existed or contained representative post-2.9.3 example files."
+  ],
+  "workSummary": [
+    "Created fix/github-agent-docs-source-refresh from main after PR #276 was merged.",
+    "Updated the source-panel layout normaliser so example panels show full source code instead of height-capped scroll boxes.",
+    "Changed the source-panel asset version to source-panel-examples-full-source-v1 so Cloudflare Pages receives a cache-busting asset URL.",
+    "Added a metadata sync script that reads the canonical GitHub bundle version from prompt.spec.yaml and updates generated documentation metadata after source pages are generated.",
+    "Updated build.sh to run the metadata sync step and assert that the overview page and generated metadata use version 2.9.3.",
+    "Updated build.sh and the reusable verifier to require the generated examples source page and representative expanded examples."
+  ],
+  "changedAreas": [
+    "scripts/agent-operating-model/normalise-source-panel-layout.mjs",
+    "scripts/agent-operating-model/sync-github-docs-generated-metadata.mjs",
+    "scripts/agent-operating-model/verify-github-source-panel-docs.mjs",
+    "build.sh",
+    "docs/agent-audit/reasoning/2026/05/22"
+  ],
+  "validationEvidence": {
+    "staticChecksAdded": [
+      "build.sh now greps for <strong>Version</strong>2.9.3 in the generated GitHub bundle overview.",
+      "build.sh now greps for version 2.9.3 in generated-metadata.json.",
+      "build.sh now requires docs/agent-operating-model/bundles/github/source/examples/index.html.",
+      "build.sh now checks representative examples including examples/scenarios/repo-discovery-node-api.yaml and examples/performance-results/python-results.yaml.",
+      "verify-github-source-panel-docs.mjs now treats examples as a required source family."
+    ],
+    "notRunLocally": [
+      "No local build command was run in this connector-only environment. CI should run build.sh on the pull request."
+    ]
+  },
+  "risks": [
+    {
+      "risk": "The public site will remain stale until the fix branch is merged and the agent documentation deployment succeeds.",
+      "mitigation": "Open a pull request and rely on the existing Build and deploy agent documentation Pages workflow to verify and deploy."
+    },
+    {
+      "risk": "Long examples pages will become taller because example panels now show full source instead of internal scroll boxes.",
+      "mitigation": "The change is limited to source-panel examples only. Other source families retain the 1400px cap."
+    }
+  ],
+  "status": "ready-for-pr"
+}

--- a/scripts/agent-operating-model/normalise-source-panel-layout.mjs
+++ b/scripts/agent-operating-model/normalise-source-panel-layout.mjs
@@ -6,7 +6,7 @@ import process from 'node:process';
 
 const DOCS_ROOT = 'docs/agent-operating-model/bundles/github';
 const ASSETS_DIR = path.join(DOCS_ROOT, 'assets');
-const ASSET_VERSION = 'source-panel-height-cap-v2';
+const ASSET_VERSION = 'source-panel-examples-full-source-v1';
 const CSS_PATH = '/bundles/github/assets/source-panel-layout.css';
 const JS_PATH = '/bundles/github/assets/source-panel-layout.js';
 const CSS_HREF = `${CSS_PATH}?v=${ASSET_VERSION}`;
@@ -22,6 +22,11 @@ const CSS = `.source-grid { align-items: start; }
   min-height: 0;
   overflow-y: auto !important;
 }
+.source-panel.example .source-grid pre {
+  height: auto !important;
+  max-height: none !important;
+  overflow-y: visible !important;
+}
 .source-grid aside.notes p { margin: 0 0 12px; }
 .source-grid aside.notes h4 + p { margin-top: 0; }
 `;
@@ -32,8 +37,15 @@ function syncSourcePanelHeights() {
   document.querySelectorAll('.source-grid').forEach(function (grid) {
     var code = grid.querySelector('pre');
     var notes = grid.querySelector('aside.notes');
+    var panel = grid.closest('.source-panel');
     if (!code || !notes) return;
     code.style.height = 'auto';
+    if (panel && panel.classList.contains('example')) {
+      code.style.maxHeight = 'none';
+      code.style.overflowY = 'visible';
+      code.style.alignSelf = 'start';
+      return;
+    }
     code.style.maxHeight = SOURCE_PANEL_CODE_MAX_HEIGHT + 'px';
     code.style.overflowY = 'auto';
     code.style.alignSelf = 'start';

--- a/scripts/agent-operating-model/sync-github-docs-generated-metadata.mjs
+++ b/scripts/agent-operating-model/sync-github-docs-generated-metadata.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const BUNDLE_ROOT = '.agent-operating-model/bundles/github';
+const DOCS_ROOT = 'docs/agent-operating-model/bundles/github';
+const PUBLIC_URL = 'https://agents.research-operations.com/bundles/github';
+
+async function fileExists(filePath) {
+	return Boolean((await stat(filePath).catch(() => null))?.isFile());
+}
+
+async function readRequired(filePath) {
+	if (!(await fileExists(filePath))) {
+		throw new Error(`Missing required file: ${filePath}`);
+	}
+
+	return readFile(filePath, 'utf8');
+}
+
+function readBundleVersion(promptSpec) {
+	const match = promptSpec.match(/^\s*version:\s*['"]?([^'"\n]+)['"]?\s*$/m);
+
+	if (!match) {
+		throw new Error('Could not read GitHub bundle version from prompt.spec.yaml');
+	}
+
+	return match[1].trim();
+}
+
+function updateOverviewVersion(html, version) {
+	if (html.includes('<strong>Version</strong>')) {
+		return html.replace(/(<strong>Version<\/strong>)([^<]*)/, `$1${version}`);
+	}
+
+	return html;
+}
+
+function updateMetadataJson(source, version) {
+	const metadata = JSON.parse(source);
+	const now = new Date().toISOString().slice(0, 10);
+
+	metadata.generatedAt = now;
+	metadata.repository = metadata.repository || 'kevinrapley/ResearchOps';
+	metadata.branch = metadata.branch || 'main';
+	metadata.outputPath = metadata.outputPath || `${DOCS_ROOT}/`;
+	metadata.canonicalSourcePath = `${BUNDLE_ROOT}/`;
+	metadata.publicUrl = PUBLIC_URL;
+	metadata.bundle = {
+		...(metadata.bundle || {}),
+		id: 'github-diamond-standard',
+		version
+	};
+
+	if (Array.isArray(metadata.pages) && !metadata.pages.includes('source/examples/index.html')) {
+		metadata.pages.push('source/examples/index.html');
+	}
+
+	return `${JSON.stringify(metadata, null, 2)}\n`;
+}
+
+async function main() {
+	const promptSpec = await readRequired(path.join(BUNDLE_ROOT, 'prompt.spec.yaml'));
+	const version = readBundleVersion(promptSpec);
+	const overviewPath = path.join(DOCS_ROOT, 'index.html');
+	const generatedMetadataPath = path.join(DOCS_ROOT, 'generated-metadata.json');
+	const sourceMetadataPath = path.join(DOCS_ROOT, 'source', 'source-metadata.json');
+
+	if (await fileExists(overviewPath)) {
+		const overviewBefore = await readRequired(overviewPath);
+		const overviewAfter = updateOverviewVersion(overviewBefore, version);
+		if (overviewAfter !== overviewBefore) {
+			await writeFile(overviewPath, overviewAfter, 'utf8');
+		}
+	}
+
+	if (await fileExists(generatedMetadataPath)) {
+		const metadataBefore = await readRequired(generatedMetadataPath);
+		const metadataAfter = updateMetadataJson(metadataBefore, version);
+		if (metadataAfter !== metadataBefore) {
+			await writeFile(generatedMetadataPath, metadataAfter, 'utf8');
+		}
+	}
+
+	if (await fileExists(sourceMetadataPath)) {
+		const sourceMetadataBefore = await readRequired(sourceMetadataPath);
+		const sourceMetadata = JSON.parse(sourceMetadataBefore);
+		sourceMetadata.bundleVersion = version;
+		if (Array.isArray(sourceMetadata.pages) && !sourceMetadata.pages.includes('source/examples/index.html')) {
+			sourceMetadata.pages.push('source/examples/index.html');
+		}
+		const sourceMetadataAfter = `${JSON.stringify(sourceMetadata, null, 2)}\n`;
+		if (sourceMetadataAfter !== sourceMetadataBefore) {
+			await writeFile(sourceMetadataPath, sourceMetadataAfter, 'utf8');
+		}
+	}
+
+	console.log(`Synced GitHub generated documentation metadata to version ${version}.`);
+}
+
+main().catch((error) => {
+	console.error(error.message);
+	process.exitCode = 1;
+});

--- a/scripts/agent-operating-model/verify-github-source-panel-docs.mjs
+++ b/scripts/agent-operating-model/verify-github-source-panel-docs.mjs
@@ -14,6 +14,15 @@ const REQUIRED_FAMILY_PAGES = [
 	['graders', 'grader', ['What this grader scores', 'What causes a fail', 'What evidence it expects']],
 	['templates', 'template', ['When this template is used', 'What must be customised', 'What must not be changed blindly']],
 	['scripts', 'script', ['What this script verifies', 'When it should be run', 'What failure means']],
+	['examples', 'example', ['How the agent uses this file', 'What to look for']],
+];
+const REQUIRED_EXAMPLE_PATHS = [
+	'examples/scenarios/repo-discovery-node-api.yaml',
+	'examples/scenarios/repo-fix-failing-ci.yaml',
+	'examples/expected-outputs/repo-release-readiness.md',
+	'examples/payloads/http-json-success.json',
+	'examples/performance-inputs/k6-summary.json',
+	'examples/performance-results/python-results.yaml',
 ];
 
 async function fileExists(filePath) {
@@ -66,6 +75,7 @@ async function main() {
 	assertContains(overview, 'Source panels', overviewPath);
 	assertContains(overview, 'Worked flow', overviewPath);
 	assertContains(overview, 'Coverage note', overviewPath);
+	assertContains(overview, '<strong>Version</strong>2.9.3', overviewPath);
 
 	for (const forbidden of [
 		'Source browser',
@@ -112,6 +122,13 @@ async function main() {
 			assertNotContains(html, forbidden, pagePath);
 		}
 	}
+
+	const examplesPath = path.join(SOURCE_ROOT, 'examples', 'index.html');
+	const examples = await readRequired(examplesPath);
+	for (const examplePath of REQUIRED_EXAMPLE_PATHS) {
+		assertContains(examples, examplePath, examplesPath);
+	}
+	assertContains(examples, '<span class="pill">example</span>', examplesPath);
 
 	console.log('GitHub source panel docs verified.');
 }

--- a/scripts/agent-operating-model/verify-github-source-panel-docs.mjs
+++ b/scripts/agent-operating-model/verify-github-source-panel-docs.mjs
@@ -6,6 +6,7 @@ import process from 'node:process';
 
 const DOCS_ROOT = 'docs/agent-operating-model/bundles/github';
 const SOURCE_ROOT = path.join(DOCS_ROOT, 'source');
+const PROMPT_SPEC_PATH = '.agent-operating-model/bundles/github/prompt.spec.yaml';
 const REQUIRED_FAMILY_PAGES = [
 	['modes', 'mode', ['How the agent uses this file', 'What to look for', 'Completion evidence']],
 	['roles', 'role', ['How the agent uses this role', 'What judgement it applies', 'Escalation signals']],
@@ -41,6 +42,17 @@ async function readRequired(filePath) {
 	return readFile(filePath, 'utf8');
 }
 
+async function expectedBundleVersion() {
+	const promptSpec = await readRequired(PROMPT_SPEC_PATH);
+	const match = promptSpec.match(/^\s*version:\s*['"]?([^'"\n]+)['"]?\s*$/m);
+
+	if (!match) {
+		throw new Error(`Could not read GitHub bundle version from ${PROMPT_SPEC_PATH}`);
+	}
+
+	return match[1].trim();
+}
+
 function assertContains(value, expected, filePath) {
 	if (!value.includes(expected)) {
 		throw new Error(`${filePath} must contain: ${expected}`);
@@ -62,6 +74,7 @@ function panelId(panelHtml) {
 }
 
 async function main() {
+	const expectedVersion = await expectedBundleVersion();
 	const overviewPath = path.join(DOCS_ROOT, 'index.html');
 	const sourceHubPath = path.join(SOURCE_ROOT, 'index.html');
 	const overview = await readRequired(overviewPath);
@@ -75,7 +88,7 @@ async function main() {
 	assertContains(overview, 'Source panels', overviewPath);
 	assertContains(overview, 'Worked flow', overviewPath);
 	assertContains(overview, 'Coverage note', overviewPath);
-	assertContains(overview, '<strong>Version</strong>2.9.3', overviewPath);
+	assertContains(overview, `<strong>Version</strong>${expectedVersion}`, overviewPath);
 
 	for (const forbidden of [
 		'Source browser',


### PR DESCRIPTION
## Summary

Fixes stale generated GitHub Diamond bundle documentation on the agent documentation site.

The public pages were showing stale generated output after the GitHub bundle examples work was merged:

- `/bundles/github/` still displayed version `2.9.2` even though the canonical bundle version is `2.9.3`.
- `/bundles/github/source/examples/` existed, but long example source panels were height-capped and therefore did not visibly expose the full expanded example source.
- The build did not explicitly assert that the generated examples source page contained representative post-2.9.3 examples.

## Changes

- Adds `scripts/agent-operating-model/sync-github-docs-generated-metadata.mjs`.
  - Reads the canonical GitHub bundle version from `.agent-operating-model/bundles/github/prompt.spec.yaml`.
  - Syncs generated overview metadata to the canonical version.
  - Ensures generated metadata includes the examples source page.
- Updates `scripts/agent-operating-model/normalise-source-panel-layout.mjs`.
  - Keeps the 1400px source-panel cap for normal source families.
  - Allows `example` source panels to display full source without internal vertical clipping.
  - Bumps the source-panel asset cache key to `source-panel-examples-full-source-v1`.
- Updates `scripts/agent-operating-model/verify-github-source-panel-docs.mjs`.
  - Treats `examples` as a required source family.
  - Requires representative 2.9.3 examples to appear in the generated examples page.
  - Requires the generated overview to show version `2.9.3`.
- Updates `build.sh`.
  - Runs the metadata sync step.
  - Fails the build if the overview page still shows the wrong version.
  - Fails the build if generated examples source panels are missing representative expanded examples.
- Adds trace evidence under `docs/agent-audit/reasoning/2026/05/22/`.

## Validation

Not run locally in this connector-only environment.

Expected CI validation:

```bash
bash build.sh
node scripts/agent-operating-model/verify-github-source-panel-docs.mjs
```

## Notes

This is a generated-documentation pipeline fix. It does not alter the canonical GitHub bundle examples themselves. It changes how the documentation build reflects them and how the build verifies that the generated public pages are current.