### PR TITLE
Fix GitHub bundle fast release-gate blockers

### DIFF
--- a/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/README.md
+++ b/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/README.md
@@ -1,0 +1,19 @@
+# API service fixture
+
+This fixture represents a small API service repository used by the `api-contract-change` eval.
+
+It is intentionally compact. Its purpose is to provide enough repository structure for contract-change eval validation, not to implement a production API.
+
+## Fixture contents
+
+- `docs/api/endpoint-catalog.yaml` records API endpoint shape and ownership metadata.
+- `examples/payloads/http-json-success.json` records a representative successful response.
+- `examples/payloads/http-json-error.json` records a representative error response.
+- `tests/contract/README.md` records the expected contract-test location.
+- `agent-evidence.yaml` records safe observable fixture evidence.
+
+## Expected eval behaviour
+
+An agent handling an API contract change should inspect the endpoint catalogue, payload examples and contract-test path before changing API behaviour.
+
+It must not invent undocumented fields or silently change error semantics.

--- a/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/docs/api/endpoint-catalog.yaml
+++ b/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/docs/api/endpoint-catalog.yaml
@@ -1,0 +1,60 @@
+service:
+  id: api-service-fixture
+  name: API service fixture
+  owner: repository-maintainers
+  lifecycle: fixture
+  description: >
+    Compact API service fixture used by the GitHub Diamond api-contract-change eval.
+endpoints:
+  - id: get-health
+    method: GET
+    path: /health
+    status: active
+    owner: repository-maintainers
+    purpose: Report service health for deployment and monitoring checks.
+    request:
+      content_type: null
+      body_schema: null
+    responses:
+      - status: 200
+        content_type: application/json
+        example: ../../examples/payloads/http-json-success.json
+        schema:
+          type: object
+          required:
+            - status
+            - service
+            - checked_at
+          properties:
+            status:
+              type: string
+              enum:
+                - ok
+            service:
+              type: string
+            checked_at:
+              type: string
+              format: date-time
+      - status: 503
+        content_type: application/json
+        example: ../../examples/payloads/http-json-error.json
+        schema:
+          type: object
+          required:
+            - error
+            - message
+            - correlation_id
+          properties:
+            error:
+              type: string
+            message:
+              type: string
+            correlation_id:
+              type: string
+change_control:
+  contract_tests_required: true
+  payload_examples_required: true
+  compatibility_review_required: true
+  notes: >
+    Changes to response fields must update this catalogue, payload examples and
+    tests under tests/contract/.

--- a/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/examples/payloads/http-json-error.json
+++ b/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/examples/payloads/http-json-error.json
@@ -1,0 +1,6 @@
+{
+  "error": "service_unavailable",
+  "message": "The fixture service is temporarily unavailable.",
+  "correlation_id": "fixture-correlation-0001",
+  "retry_after_seconds": 30
+}

--- a/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/examples/payloads/http-json-success.json
+++ b/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/examples/payloads/http-json-success.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "service": "api-service-fixture",
+  "checked_at": "2026-05-23T12:00:00Z",
+  "version": "0.1.0-fixture"
+}

--- a/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/tests/contract/README.md
+++ b/.agent-operating-model/bundles/github/examples/fixtures/repositories/api-service/tests/contract/README.md
@@ -1,0 +1,15 @@
+# Contract tests
+
+This directory is the expected contract-test location for the `api-contract-change` eval.
+
+A real API service should place executable contract tests here.
+
+The fixture keeps this file intentionally small because the eval validates repository shape and evidence paths rather than a production API implementation.
+
+Required contract evidence for API changes:
+
+- endpoint catalogue updated
+- success payload example updated
+- error payload example updated
+- backwards compatibility risks recorded
+- contract tests added or updated

--- a/.agent-operating-model/bundles/github/graders/documentation-grader.xml
+++ b/.agent-operating-model/bundles/github/graders/documentation-grader.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8'?>
+<grader id="documentation-grader" version="2.9.3" xml_profile="native-semantic-xml/v1">
+  <title>Documentation Grader</title>
+  <thresholds>
+    <pass minimum_score="0.85" />
+    <pass_with_gap minimum_score="0.70" />
+    <fail below_score="0.70" />
+  </thresholds>
+  <evidence_required>
+    <item>README.md has been inspected before any rewrite.</item>
+    <item>Repository manifests and CI workflows have been inspected for setup, test and validation commands.</item>
+    <item>RECENT_LEARNINGS.md has been read and updated when documentation behaviour changes.</item>
+    <item>Any unknown deployment, ownership or release detail is recorded as a gap rather than invented.</item>
+  </evidence_required>
+  <scoring>
+    <criterion id="1" weight="0.25">Documentation accurately explains repository purpose, setup and validation commands.</criterion>
+    <criterion id="2" weight="0.25">Documentation reflects observed files, scripts and workflows rather than invented implementation details.</criterion>
+    <criterion id="3" weight="0.25">Documentation supports maintainers and reviewers with clear ownership, risks and release notes.</criterion>
+    <criterion id="4" weight="0.25">Documentation changes preserve existing correct context and record remaining gaps.</criterion>
+  </scoring>
+  <blocking_failures>
+    <failure>README is rewritten without inspecting package scripts or workflow files.</failure>
+    <failure>Deployment, ownership or release claims are invented.</failure>
+    <failure>Existing accurate repository context is removed.</failure>
+    <failure>Validation commands are omitted from the documentation update.</failure>
+  </blocking_failures>
+</grader>

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -570,7 +570,7 @@ artifacts:
 - path: templates/discussion-template.xml
   sha256: fce91a2c126f52d7383fa9c8f59843cdab420bf47f0fb878f7e3490ee647f0c8
 - path: templates/github/.github/CODEOWNERS
-  sha256: 107d6fee7c3ef4fcbc91939cdbb7de3717531d8f46404a953b7f9af51db2e620
+  sha256: 0069336414efd86cce54d1b2b47b704c1327753e0365c5d4cf50d45b262208ec
 - path: templates/github/.github/ISSUE_TEMPLATE/bug_report.yml
   sha256: 7a67b754b86840c937890352bf55858259d25ab301151574190e4f5ce07e3677
 - path: templates/github/.github/ISSUE_TEMPLATE/feature_request.yml

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -251,6 +251,16 @@ artifacts:
   sha256: 1c2ee57374f8f0d72909da44067d173b0f08599fdf35393b4f5d68986e1ea035
 - path: examples/fixtures/release-policy/live-release-policy-pass.yaml
   sha256: 794b8d3cc1ea309007250e7505e07845870bdfacaa67b65672d6bd5cb864997b
+- path: examples/fixtures/repositories/api-service/docs/api/endpoint-catalog.yaml
+  sha256: e75abac85cfba13437f01b7f4971fd32909c2716d742db360b5ede9d0b1a5899
+- path: examples/fixtures/repositories/api-service/examples/payloads/http-json-error.json
+  sha256: eed18d8cfed15462430d49694fc57c2dd6d2adc15c5880c7624fe85dc7a3d3b0
+- path: examples/fixtures/repositories/api-service/examples/payloads/http-json-success.json
+  sha256: 01a9f24c4c25235810f20ffb6584e5555e7304d9d50733b9486483d0e4d55a45
+- path: examples/fixtures/repositories/api-service/README.md
+  sha256: 37d42fa1a90c4ae37ae4b3fde8cc11754c1c8fde16f97494777b14f7f1e084d4
+- path: examples/fixtures/repositories/api-service/tests/contract/README.md
+  sha256: 027aada3a017d9135f4a3318396938168635673e734f51bdc4884a91ea937845
 - path: examples/fixtures/repositories/multilang-empty/package.json
   sha256: 436909968115a2d45beb6d6033224ae41332f97b2bb6214b77f80b0ec8e9923f
 - path: examples/fixtures/repositories/multilang-empty/pyproject.toml
@@ -347,6 +357,8 @@ artifacts:
   sha256: db4c50f17ec5d35ed5d3197047bc9d64c8c6aa30612873051bc70a3b27c6b8c2
 - path: graders/discovery-grader.xml
   sha256: 8198902b6c6ac81c51b0d16189ca3f7ab3364cafc8db849b98af828f0814dcf5
+- path: graders/documentation-grader.xml
+  sha256: 2fb45d32abbd13c52fab978e63f46ee73cad56d8cbe58831429e560144c6f284
 - path: graders/ethics-grader.xml
   sha256: 5e4000a8723130976557dda2ebd86fc8c7c50176ebe64bafbf20c0487d7245e1
 - path: graders/github-settings-grader.xml
@@ -500,9 +512,9 @@ artifacts:
 - path: scripts/validate-bundle.py
   sha256: a085f00149ee800e5267256d3ac062520ddf449c88d07ccf780b82d5503f030d
 - path: scripts/validate-changelog.py
-  sha256: 697806c2e1e718fb1ce35beff7603a8c03a8392dc49d6e94cf4e388007436e1f
+  sha256: cf8a41db446ed9caf179369f24756cc2abc24aaa9453806fa2b412c988bc45e3
 - path: scripts/validate-docs-consistency.py
-  sha256: c4e665ca3d7194c4fc5cef8443d9bf283bfca2c67c680386d8235bf85c6c74b4
+  sha256: 62fb79947860fc46f2242354eef11a9383d39de519770566efe72b3ac650341a
 - path: scripts/validate-evals.py
   sha256: 754f1328ae7f322a8979e10dcf7993507a4bf047c183806a579905b7fd3a8dd9
 - path: scripts/validate-github-api-fixtures.py
@@ -556,7 +568,53 @@ artifacts:
 - path: templates/discussion_template.md
   sha256: e45e9edfca5fae65140fe6b00b7ded3e64a8136250078182aca8adfe90ed203c
 - path: templates/discussion-template.xml
-  sha256: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+  sha256: fce91a2c126f52d7383fa9c8f59843cdab420bf47f0fb878f7e3490ee647f0c8
+- path: templates/github/.github/CODEOWNERS
+  sha256: 107d6fee7c3ef4fcbc91939cdbb7de3717531d8f46404a953b7f9af51db2e620
+- path: templates/github/.github/ISSUE_TEMPLATE/bug_report.yml
+  sha256: 7a67b754b86840c937890352bf55858259d25ab301151574190e4f5ce07e3677
+- path: templates/github/.github/ISSUE_TEMPLATE/feature_request.yml
+  sha256: 3532291630b53a079dcc321365bea55b61920ab02c12481b4f82f239f1083971
+- path: templates/github/.github/PULL_REQUEST_TEMPLATE/default.md
+  sha256: 5981c18ff54edca70c01ff613642a40bd5671ff488bae1e9949c32395aacede3
+- path: templates/github/.github/workflows-hardened/ci-hardened.yml
+  sha256: a93f66962584bc76e1132bfd9bee527a11ceac374b133ae38c85a7ff14b53ef0
+- path: templates/github/.github/workflows/ci-accessibility.yml
+  sha256: 6445259feff5595c5cbf390e63f66e6ed56481d66084ed336c4d94a198384d4f
+- path: templates/github/.github/workflows/ci-conformance.yml
+  sha256: 43897ae06a660f5e4eae6ce808c4e5338da0189c0ff2ae552d6af96168ffac0b
+- path: templates/github/.github/workflows/ci-data-ml.yml
+  sha256: 79570e5362d7c77341eedd543b0d5b121c1b351f29b71183206d4fd851de73dc
+- path: templates/github/.github/workflows/ci-docs-quality.yml
+  sha256: 6092c575383b6468429937c2913da83336f1d494217ed8308765661aabca44a9
+- path: templates/github/.github/workflows/ci-dotnet.yml
+  sha256: f30d2b18c89cb0a97de3ad42c8aae5c107bf198c9a889a82ecaff35b1f7d7d72
+- path: templates/github/.github/workflows/ci-go.yml
+  sha256: d705f33949fba8a7668f19682c856d580ab9d44c2a85de9799203c26cd0b601d
+- path: templates/github/.github/workflows/ci-java.yml
+  sha256: ffe9c9c1563541d818deb742bc9e132e13d90f5f665d9a09599bac98a8cd510a
+- path: templates/github/.github/workflows/ci-node.yml
+  sha256: 09b7ee36e77386cfbb29247d18bdf080393f35a489272ce1478dd803281d4586
+- path: templates/github/.github/workflows/ci-performance.yml
+  sha256: 80a385d8594cbc62001c09cadd5eb14d9c60e673b80b6d494d1b9175b42afdde
+- path: templates/github/.github/workflows/ci-php.yml
+  sha256: b849a430eb860e34cad8c35f6136a768892b6e9c18867ef6c5b823bc512d5a5b
+- path: templates/github/.github/workflows/ci-python.yml
+  sha256: 2e673d57d0d241d9662c6e61b5ff2c2cf800780aa4efe05170008988a4f2f8c1
+- path: templates/github/.github/workflows/ci-ruby.yml
+  sha256: 0e6a4c3c9193bc0246fe5f1173320998d4b26af5b2a7ea8d88286128ea6aaf8e
+- path: templates/github/.github/workflows/ci-rust.yml
+  sha256: e2792814f983ee7cd50f4491600f80695a57f855c5ca7a8739dee7e5670d071c
+- path: templates/github/.github/workflows/codeql.yml
+  sha256: a970aa9fa40a5976a1ec8fb9310f9a62a1b27f7c04b6600eb22e96c091725f5c
+- path: templates/github/.github/workflows/dependency-review.yml
+  sha256: 6ead4d3f17060a81372ff5694da8ddeda29b091b4b9f05b1644ae27de3b038f1
+- path: templates/github/.github/workflows/file-inventory.yml
+  sha256: a0834c1ab19ea85a3b1c20829120bc5649ac037dfc190ebbc6e7330b4822787e
+- path: templates/github/.github/workflows/release-gate.yml
+  sha256: 0dcaa859f3aa38cb5f52c162acaec7a50287bb1fde6f5c0ae4d965574ab417b4
+- path: templates/github/.github/workflows/sbom-cyclonedx.yml
+  sha256: 7e7d6e3d217dedb291eee5c57e9225fa53770e826e0610ca78d799993172285c
 - path: templates/github/workflow-action-lock.example.yaml
   sha256: d2a5d6ca69a4b2dfc0071f8270a6e24b576ed3c1037f719490de152034b22274
 - path: templates/issue_bug_report.yaml

--- a/.agent-operating-model/bundles/github/scripts/validate-changelog.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-changelog.py
@@ -2,30 +2,63 @@
 from pathlib import Path
 import argparse
 import re
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
-REQUIRED_VERSIONS = [
-    "2.9.1", "2.9.0", "2.8.9", "2.8.8", "2.8.7", "2.8.6", "2.8.5", "2.8.4", "2.8.3", "2.8.2", "2.8.1", "2.8.0",
-    "2.7.0", "2.6.0", "2.5.0", "2.4.0", "2.3.0", "2.2.0",
-    "2.1.0", "2.0.0", "1.1.0", "1.0.0",
-]
+VERSION_HEADING = re.compile(r"^## \[([^\]]+)\]", flags=re.MULTILINE)
+SEMVER_PREFIX = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[+-].*)?$")
+
+
+def bundle_version():
+    spec = yaml.safe_load((ROOT / "prompt.spec.yaml").read_text(encoding="utf-8"))
+    version = spec.get("bundle", {}).get("version")
+    if not version:
+        raise SystemExit("Could not read bundle.version from prompt.spec.yaml")
+    return str(version)
+
+
+def version_key(value):
+    match = SEMVER_PREFIX.match(value)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--path", default="CHANGELOG.md")
+    parser.add_argument("--version")
     args = parser.parse_args()
+    expected_version = args.version or bundle_version()
     path = ROOT / args.path
     text = path.read_text(encoding="utf-8")
-    versions = re.findall(r"^## \[([^\]]+)\]", text, flags=re.MULTILINE)
+    versions = VERSION_HEADING.findall(text)
     errors = []
-    duplicates = sorted({v for v in versions if versions.count(v) > 1})
+
+    if not versions:
+        errors.append("No changelog version headings found")
+
+    duplicates = sorted({version for version in versions if versions.count(version) > 1})
     if duplicates:
         errors.append("Duplicate changelog versions: " + ", ".join(duplicates))
-    missing = [v for v in REQUIRED_VERSIONS if v not in versions]
-    if missing:
-        errors.append("Missing changelog versions: " + ", ".join(missing))
-    if versions[:len(REQUIRED_VERSIONS)] != REQUIRED_VERSIONS:
-        errors.append("Changelog versions are not in required newest-to-oldest order")
+
+    if not any(version == expected_version or version.startswith(f"{expected_version}+") for version in versions):
+        errors.append(f"Missing changelog entry for current bundle version: {expected_version}")
+
+    keyed_versions = [(version, version_key(version)) for version in versions]
+    invalid_versions = [version for version, key in keyed_versions if key is None]
+    if invalid_versions:
+        errors.append("Invalid changelog version headings: " + ", ".join(invalid_versions))
+
+    numeric_keys = [key for _version, key in keyed_versions if key is not None]
+    if numeric_keys != sorted(numeric_keys, reverse=True):
+        errors.append("Changelog versions are not in newest-to-oldest semantic version order")
+
+    first_key = numeric_keys[0] if numeric_keys else None
+    expected_key = version_key(expected_version)
+    if first_key and expected_key and first_key != expected_key:
+        errors.append(f"Newest changelog entry {versions[0]} does not match current bundle version {expected_version}")
+
     forbidden = [
         "broken v2.9.1 integration",
         "fixes the broken v2.9.1",
@@ -34,11 +67,13 @@ def main():
     for phrase in forbidden:
         if phrase in text:
             errors.append(f"Forbidden stale phrase found: {phrase}")
+
     if errors:
         for error in errors:
             print(error)
         raise SystemExit(1)
     print("Changelog validation passed.")
+
 
 if __name__ == "__main__":
     main()

--- a/.agent-operating-model/bundles/github/scripts/validate-docs-consistency.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-docs-consistency.py
@@ -1,18 +1,32 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import argparse
+import re
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def bundle_version():
+    spec = yaml.safe_load((ROOT / "prompt.spec.yaml").read_text(encoding="utf-8"))
+    version = spec.get("bundle", {}).get("version")
+    if not version:
+        raise SystemExit("Could not read bundle.version from prompt.spec.yaml")
+    return str(version)
+
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--readme", default="README.md")
-    parser.add_argument("--version", default="2.9.2")
+    parser.add_argument("--version")
     args = parser.parse_args()
+    expected_version = args.version or bundle_version()
     text = (ROOT / args.readme).read_text(encoding="utf-8")
     errors = []
-    if f"Version: {args.version}" not in text:
-        errors.append(f"README missing current Version: {args.version}")
+    if f"Version: {expected_version}" not in text:
+        errors.append(f"README missing current Version: {expected_version}")
+    if not re.search(rf"\bVersion\s+{re.escape(expected_version)}\b", text):
+        errors.append(f"README current release section does not mention Version {expected_version}")
     if "## Current release" not in text:
         errors.append("README missing Current release section")
     if "release-gate report" not in text.lower():
@@ -39,6 +53,7 @@ def main():
             print(error)
         raise SystemExit(1)
     print("Documentation consistency validation passed.")
+
 
 if __name__ == "__main__":
     main()

--- a/.agent-operating-model/bundles/github/templates/discussion-template.xml
+++ b/.agent-operating-model/bundles/github/templates/discussion-template.xml
@@ -1,1 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<discussion-template id="discussion-template" version="2.9.3">
+  <purpose>
+    Provide a structured discussion record for repository decisions, trade-offs,
+    risks, validation evidence and follow-up actions.
+  </purpose>
+  <required-sections>
+    <section id="context" title="Context" />
+    <section id="decision" title="Decision" />
+    <section id="options-considered" title="Options considered" />
+    <section id="evidence" title="Evidence used" />
+    <section id="risks" title="Risks and mitigations" />
+    <section id="validation" title="Validation" />
+    <section id="follow-up" title="Follow-up actions" />
+  </required-sections>
+  <rules>
+    <rule id="no-private-chain-of-thought">
+      Record observable audit evidence. Do not require or expose private chain-of-thought.
+    </rule>
+    <rule id="evidence-before-decision">
+      Decisions must cite inspected files, commands, checks or explicit unavailable evidence.
+    </rule>
+    <rule id="open-gaps-visible">
+      Any unresolved gap or waiver must be recorded with owner, risk and next action.
+    </rule>
+  </rules>
+  <template><![CDATA[
+# Discussion record
 
+## Context
+
+Describe the repository situation, user request and operating mode.
+
+## Decision
+
+State the decision and why it is appropriate.
+
+## Options considered
+
+- Option 1:
+- Option 2:
+- Rejected options:
+
+## Evidence used
+
+- Files inspected:
+- Commands run:
+- Validator results:
+- External or live evidence unavailable:
+
+## Risks and mitigations
+
+| Risk | Mitigation | Owner |
+| --- | --- | --- |
+| | | |
+
+## Validation
+
+Record observed validation results. Do not claim checks that were not run.
+
+## Follow-up actions
+
+- [ ] Action, owner, target date.
+]]></template>
+</discussion-template>

--- a/.agent-operating-model/bundles/github/templates/github/.github/CODEOWNERS
+++ b/.agent-operating-model/bundles/github/templates/github/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* docs-maintainers
+* @kevinrapley

--- a/.agent-operating-model/bundles/github/templates/github/.github/CODEOWNERS
+++ b/.agent-operating-model/bundles/github/templates/github/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* docs-maintainers

--- a/.agent-operating-model/bundles/github/templates/github/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report a reproducible defect with evidence.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for defects that can be reproduced or evidenced.
+        Do not include secrets, personal data, access tokens or production credentials.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: Describe the defect in one or two sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: User or service impact
+      description: Who is affected and how severe is the impact?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reproducible path.
+      placeholder: |
+        1. Go to ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Add logs, screenshots, failing checks or links to CI output. Redact sensitive information.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have removed secrets and personal data.
+          required: true
+        - label: I have included enough evidence for triage.
+          required: true

--- a/.agent-operating-model/bundles/github/templates/github/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose a capability with evidence, constraints and acceptance criteria.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for new or changed capability requests.
+        Include the user need, evidence and acceptance criteria before implementation starts.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or user need
+      description: What need, pain point or service outcome does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: What evidence supports this need?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should change?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Provide testable outcomes.
+      placeholder: |
+        Given ...
+        When ...
+        Then ...
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks, dependencies or trade-offs
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have described the evidence and user/service impact.
+          required: true
+        - label: I have not included secrets or unnecessary personal data.
+          required: true

--- a/.agent-operating-model/bundles/github/templates/github/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.agent-operating-model/bundles/github/templates/github/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,44 @@
+# Pull request
+
+## Summary
+
+Describe the change in plain language.
+
+## Scope
+
+List the files, behaviours or documentation areas changed.
+
+## Evidence read
+
+- [ ] README / repository documentation
+- [ ] Relevant source files
+- [ ] Relevant contracts or schemas
+- [ ] Relevant tests or CI workflows
+- [ ] Recent learnings or audit trace, where applicable
+
+## Validation
+
+Record only checks that were actually run.
+
+```text
+Not run.
+```
+
+## Risk and rollback
+
+Describe release risk, operational risk and rollback or revert path.
+
+## Accessibility, security and data protection
+
+- [ ] Accessibility impact considered
+- [ ] Security impact considered
+- [ ] Personal data and secrets not introduced
+- [ ] Supply-chain or dependency impact considered
+
+## Agent audit trail
+
+For AI-assisted changes, link the safe audit trace. Do not include private chain-of-thought.
+
+## Reviewer notes
+
+Add anything reviewers should inspect first.

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows-hardened/ci-hardened.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows-hardened/ci-hardened.yml
@@ -1,0 +1,33 @@
+name: CI (Hardened Release)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: read
+
+jobs:
+  hardened-release:
+    name: CI (Hardened Release)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Verify hardened release evidence paths
+        run: |
+          test -f README.md
+          test -f SECURITY.md
+          if [ -f workflow-action-lock.yaml ]; then echo "workflow action lock present"; fi
+          if [ -f sbom.json ]; then echo "SBOM evidence present"; fi
+          if [ -f attestation.json ]; then echo "attestation evidence present"; fi
+      - name: Run release gate when configured
+        run: |
+          if [ -f scripts/release-gate.py ]; then
+            python scripts/release-gate.py --mode full --report release-gate-report.json
+          else
+            echo "No repository release gate script configured. Treat this template as scaffold evidence only."
+          fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-accessibility.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-accessibility.yml
@@ -1,0 +1,24 @@
+name: CI (Accessibility)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  accessibility:
+    name: CI (Accessibility)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run accessibility checks when configured
+        run: |
+          if [ -f package.json ] && npm run | grep -q "accessibility"; then
+            npm run accessibility
+          else
+            echo "No accessibility command configured. Add axe, pa11y or equivalent checks for public UI work."
+          fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-conformance.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-conformance.yml
@@ -1,0 +1,24 @@
+name: CI (Conformance)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: CI (Conformance)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate repository evidence files
+        run: |
+          test -f README.md
+          test -f RECENT_LEARNINGS.md
+          if [ -f conformance-matrix.yaml ]; then echo "conformance matrix present"; fi
+          if [ -f gap-register.yaml ]; then echo "gap register present"; fi
+          if [ -f agent-evidence.yaml ]; then echo "agent evidence present"; fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-data-ml.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-data-ml.yml
@@ -1,0 +1,32 @@
+name: CI (Data/ML)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  data-ml:
+    name: CI (Data/ML)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Validate notebooks when present
+        run: |
+          if [ -d notebooks ]; then python -m compileall notebooks; else echo "No notebooks directory present"; fi
+      - name: Test
+        run: |
+          if [ -d tests ]; then python -m pytest; else echo "No tests directory present"; fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-docs-quality.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-docs-quality.yml
@@ -1,0 +1,26 @@
+name: CI (Documentation Quality)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  docs-quality:
+    name: CI (Documentation Quality)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check required documentation
+        run: |
+          test -f README.md
+          test -f CONTRIBUTING.md
+          test -f SECURITY.md
+          test -f RECENT_LEARNINGS.md
+      - name: Check Markdown links when configured
+        run: |
+          if [ -f package.json ] && npm run | grep -q "links"; then npm run links; else echo "No link checker configured"; fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-dotnet.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-dotnet.yml
@@ -1,0 +1,27 @@
+name: CI (.NET)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dotnet:
+    name: CI (.NET)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+      - name: Test
+        run: dotnet test --no-build --configuration Release

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-go.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-go.yml
@@ -1,0 +1,24 @@
+name: CI (Go)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: CI (Go)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Test
+        run: go test ./...

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-java.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-java.yml
@@ -1,0 +1,26 @@
+name: CI (Java)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  java:
+    name: CI (Java)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Test Maven project
+        run: |
+          if [ -f mvnw ]; then ./mvnw test; elif [ -f pom.xml ]; then mvn test; elif [ -f gradlew ]; then ./gradlew test; else gradle test; fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-node.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-node.yml
@@ -1,0 +1,30 @@
+name: CI (Node)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  node:
+    name: CI (Node)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Test
+        run: npm test --if-present
+      - name: Build
+        run: npm run build --if-present

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-performance.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-performance.yml
@@ -1,0 +1,26 @@
+name: CI (Performance)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  performance:
+    name: CI (Performance)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run performance checks when configured
+        run: |
+          if [ -f performance-budget.yaml ] && [ -f performance-results.yaml ]; then
+            echo "Performance budget and result evidence present."
+          elif [ -f package.json ] && npm run | grep -q "performance"; then
+            npm run performance
+          else
+            echo "No performance command configured. Add performance evidence for performance-sensitive services."
+          fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-php.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-php.yml
@@ -1,0 +1,25 @@
+name: CI (PHP)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  php:
+    name: CI (PHP)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+      - name: Test
+        run: if [ -f vendor/bin/phpunit ]; then vendor/bin/phpunit; else composer test; fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-python.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-python.yml
@@ -1,0 +1,30 @@
+name: CI (Python)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: CI (Python)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e .; fi
+      - name: Test
+        run: |
+          if [ -d tests ]; then python -m pytest; else python -m compileall .; fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-ruby.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-ruby.yml
@@ -1,0 +1,23 @@
+name: CI (Ruby)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ruby:
+    name: CI (Ruby)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Test
+        run: if [ -f bin/rails ]; then bundle exec rails test; else bundle exec rake test; fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-rust.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/ci-rust.yml
@@ -1,0 +1,21 @@
+name: CI (Rust)
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: CI (Rust)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        run: rustup show
+      - name: Test
+        run: cargo test --locked

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/codeql.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '21 3 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript, python
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/dependency-review.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+"on":
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/file-inventory.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/file-inventory.yml
@@ -1,0 +1,29 @@
+name: File Inventory
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  file-inventory:
+    name: File Inventory
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate file inventory
+        run: |
+          find . -type file \
+            -not -path './.git/*' \
+            -not -path './node_modules/*' \
+            -not -path './.venv/*' \
+            | sort > file-inventory.txt
+          sed -n '1,200p' file-inventory.txt
+      - name: Check required root files
+        run: |
+          test -f README.md
+          test -f RECENT_LEARNINGS.md

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/release-gate.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/release-gate.yml
@@ -1,0 +1,33 @@
+name: Release Gate
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: read
+
+jobs:
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run release gate when configured
+        run: |
+          if [ -f scripts/release-gate.py ]; then
+            python scripts/release-gate.py --mode fast --report release-gate-report.json
+          elif [ -f .agent-operating-model/bundles/github/scripts/release-gate.py ]; then
+            cd .agent-operating-model/bundles/github
+            python scripts/release-gate.py --mode fast --report release-gate-report.json
+          else
+            echo "No release gate script found. Add a release gate before treating this workflow as blocking."
+          fi

--- a/.agent-operating-model/bundles/github/templates/github/.github/workflows/sbom-cyclonedx.yml
+++ b/.agent-operating-model/bundles/github/templates/github/.github/workflows/sbom-cyclonedx.yml
@@ -1,0 +1,30 @@
+name: CycloneDX SBOM
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: CycloneDX SBOM
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate placeholder SBOM path
+        run: |
+          mkdir -p artifacts
+          if [ -f package-lock.json ]; then
+            echo "Node dependency lockfile present. Configure CycloneDX generation for production use." > artifacts/sbom-note.txt
+          elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+            echo "Python dependency manifest present. Configure CycloneDX generation for production use." > artifacts/sbom-note.txt
+          else
+            echo "No dependency manifest found for SBOM generation." > artifacts/sbom-note.txt
+          fi
+      - name: Verify SBOM evidence path
+        run: test -f artifacts/sbom-note.txt

--- a/docs/agent-audit/reasoning/2026/05/23/github-bundle-release-gate-blockers.json
+++ b/docs/agent-audit/reasoning/2026/05/23/github-bundle-release-gate-blockers.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": "researchops-agent-trace-summary/v1",
+  "traceType": "operational-audit",
+  "date": "2026-05-23",
+  "branch": "fix/github-bundle-release-gate-blockers",
+  "scope": [
+    "github-diamond-bundle",
+    "release-gate",
+    "template-registry",
+    "eval-fixtures",
+    "graders",
+    "version-validators"
+  ],
+  "evidenceBoundary": {
+    "summary": "This trace records observable repository work to repair structural blockers reported by an external GitHub bundle evaluation. It does not include private chain-of-thought."
+  },
+  "operatingModel": {
+    "selectedBundles": [
+      "github",
+      "researchops-developer-control",
+      "multi-functional-team"
+    ],
+    "branchPolicy": "fix/ branches require audit trace artefacts under docs/agent-audit/reasoning/YYYY/MM/DD."
+  },
+  "problemSummary": [
+    "The GitHub Diamond bundle archive failed its own fast release gate.",
+    "The release-gate blockers included an empty XML template, missing template-registry targets, a missing eval fixture repository, a missing documentation grader and stale version validators.",
+    "The user requested the first remediation PR and explicitly asked that missing template registry entries be created rather than removed."
+  ],
+  "workSummary": [
+    "Replaced the empty templates/discussion-template.xml file with valid XML and a structured discussion record template.",
+    "Created GitHub issue, pull request, CODEOWNERS and workflow templates referenced by template-registry.yaml.",
+    "Created the templates/github/.github/workflows-hardened/ci-hardened.yml directory/file needed by release-gate workflow-hardening validation.",
+    "Added graders/documentation-grader.xml because scenario examples reference it.",
+    "Added examples/fixtures/repositories/api-service with endpoint catalogue, payload examples and contract-test path evidence because evals.yaml references it.",
+    "Updated validate-docs-consistency.py to read the current bundle version from prompt.spec.yaml instead of defaulting to 2.9.2.",
+    "Updated validate-changelog.py to read the current bundle version from prompt.spec.yaml and validate changelog order without a stale hard-coded version list."
+  ],
+  "changedAreas": [
+    ".agent-operating-model/bundles/github/templates/discussion-template.xml",
+    ".agent-operating-model/bundles/github/templates/github/.github/ISSUE_TEMPLATE",
+    ".agent-operating-model/bundles/github/templates/github/.github/PULL_REQUEST_TEMPLATE",
+    ".agent-operating-model/bundles/github/templates/github/.github/workflows",
+    ".agent-operating-model/bundles/github/templates/github/.github/workflows-hardened",
+    ".agent-operating-model/bundles/github/templates/github/.github/CODEOWNERS",
+    ".agent-operating-model/bundles/github/graders/documentation-grader.xml",
+    ".agent-operating-model/bundles/github/examples/fixtures/repositories/api-service",
+    ".agent-operating-model/bundles/github/scripts/validate-changelog.py",
+    ".agent-operating-model/bundles/github/scripts/validate-docs-consistency.py"
+  ],
+  "validationEvidence": {
+    "staticCompatibilityChecks": [
+      "discussion-template.xml now has a versioned XML root element.",
+      "GitHub workflow templates include top-level permissions so validate-workflow-hardening.py can evaluate them.",
+      "The hardened workflow directory exists for the release gate hardened-template check.",
+      "The api-service eval fixture path exists and contains the expected endpoint catalogue, payload and contract-test locations.",
+      "The documentation grader exists at the scenario-referenced path."
+    ],
+    "notRunLocally": [
+      "No local release gate was run in this connector-only environment. CI should run the fast release gate and bundle validators on the pull request."
+    ],
+    "recommendedNextChecks": [
+      "cd .agent-operating-model/bundles/github",
+      "PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode fast --report fast-release-gate-report.json",
+      "python scripts/validate-template-registry.py",
+      "python scripts/validate-evals.py",
+      "python scripts/validate-changelog.py",
+      "python scripts/validate-docs-consistency.py"
+    ]
+  },
+  "risks": [
+    {
+      "risk": "Registry manifest checksums may be stale after adding new bundle files.",
+      "mitigation": "The existing GitHub bundle registry-manifest workflow should regenerate registry-manifest.yaml on the pull request branch."
+    },
+    {
+      "risk": "The fast gate may reveal additional blockers after the known structural blockers are removed.",
+      "mitigation": "Inspect CI logs and patch only release-gate blockers in this first remediation PR. Defer eval-harness hardening and schema tightening to later PRs."
+    }
+  ],
+  "status": "ready-for-pr"
+}

--- a/docs/agent-audit/reasoning/2026/05/23/github-bundle-release-gate-blockers.md
+++ b/docs/agent-audit/reasoning/2026/05/23/github-bundle-release-gate-blockers.md
@@ -1,0 +1,135 @@
+# Agent audit trace — GitHub bundle release-gate blockers
+
+Date: 2026-05-23
+
+Branch: `fix/github-bundle-release-gate-blockers`
+
+Trace type: operational audit
+
+Status: ready for PR review
+
+## Evidence boundary
+
+This trace records observable repository work to repair structural blockers reported by an external GitHub bundle evaluation.
+
+It does not include private chain-of-thought.
+
+## Scope
+
+This first remediation branch covers the fast release-gate blockers only:
+
+- `github-diamond-bundle`
+- `release-gate`
+- `template-registry`
+- `eval-fixtures`
+- `graders`
+- `version-validators`
+
+It does not attempt the later hardening work around eval execution, stronger output contracts, broader scenario validation or evidence-state modelling.
+
+## Problem summary
+
+The GitHub Diamond bundle archive failed its own fast release gate.
+
+Known structural blockers included:
+
+- `templates/discussion-template.xml` was empty and invalid XML.
+- `template-registry.yaml` referenced missing GitHub templates.
+- `evals.yaml` referenced a missing `examples/fixtures/repositories/api-service` fixture repository.
+- `examples/scenarios/repo-docs-readme-gap.yaml` referenced a missing `graders/documentation-grader.xml` file.
+- `validate-changelog.py` used a stale hard-coded version list.
+- `validate-docs-consistency.py` defaulted to a stale bundle version.
+
+The user requested the first remediation PR and asked that missing template registry entries be created rather than removed.
+
+## Work completed
+
+Replaced `templates/discussion-template.xml` with valid XML and a structured discussion-record template.
+
+Created GitHub issue templates:
+
+- `templates/github/.github/ISSUE_TEMPLATE/bug_report.yml`
+- `templates/github/.github/ISSUE_TEMPLATE/feature_request.yml`
+
+Created the GitHub pull request template:
+
+- `templates/github/.github/PULL_REQUEST_TEMPLATE/default.md`
+
+Created the GitHub CODEOWNERS template:
+
+- `templates/github/.github/CODEOWNERS`
+
+Created GitHub workflow templates referenced by the registry, including:
+
+- `ci-accessibility.yml`
+- `ci-conformance.yml`
+- `ci-data-ml.yml`
+- `ci-docs-quality.yml`
+- `ci-dotnet.yml`
+- `ci-go.yml`
+- `ci-java.yml`
+- `ci-node.yml`
+- `ci-performance.yml`
+- `ci-php.yml`
+- `ci-python.yml`
+- `ci-ruby.yml`
+- `ci-rust.yml`
+- `codeql.yml`
+- `dependency-review.yml`
+- `file-inventory.yml`
+- `release-gate.yml`
+- `sbom-cyclonedx.yml`
+
+Created the hardened workflow template used by the offline release gate:
+
+- `templates/github/.github/workflows-hardened/ci-hardened.yml`
+
+Added the missing documentation grader:
+
+- `graders/documentation-grader.xml`
+
+Added the missing API service eval fixture:
+
+- `examples/fixtures/repositories/api-service/README.md`
+- `examples/fixtures/repositories/api-service/docs/api/endpoint-catalog.yaml`
+- `examples/fixtures/repositories/api-service/examples/payloads/http-json-success.json`
+- `examples/fixtures/repositories/api-service/examples/payloads/http-json-error.json`
+- `examples/fixtures/repositories/api-service/tests/contract/README.md`
+
+Updated version validators:
+
+- `scripts/validate-changelog.py` now reads `bundle.version` from `prompt.spec.yaml`.
+- `scripts/validate-docs-consistency.py` now reads `bundle.version` from `prompt.spec.yaml` unless an explicit `--version` override is provided.
+
+## Compatibility notes
+
+The workflow templates include top-level `permissions`, because `validate-workflow-hardening.py` requires this.
+
+The generated workflow templates use quoted `"on"` keys to avoid YAML 1.1 parsers interpreting `on` as a boolean.
+
+The version validators no longer require future releases to edit stale hard-coded values before validation can pass.
+
+## Validation status
+
+No local release gate was run in this connector-only environment.
+
+Recommended checks:
+
+```bash
+cd .agent-operating-model/bundles/github
+PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode fast --report fast-release-gate-report.json
+python scripts/validate-template-registry.py
+python scripts/validate-evals.py
+python scripts/validate-changelog.py
+python scripts/validate-docs-consistency.py
+```
+
+## Risks and mitigations
+
+Risk: registry manifest checksums may be stale after adding new bundle files.
+
+Mitigation: the existing GitHub bundle registry-manifest workflow should regenerate `registry-manifest.yaml` on the pull request branch.
+
+Risk: the fast gate may reveal additional blockers after the known structural blockers are removed.
+
+Mitigation: inspect CI logs and patch only release-gate blockers in this first remediation PR. Defer eval-harness hardening and schema tightening to later PRs.


### PR DESCRIPTION
## Summary

Repairs the first set of structural blockers identified by the external evaluation of the zipped GitHub Diamond bundle.

This PR is intentionally scoped to the fast release-gate blockers. It does not attempt the later hardening work around eval execution, stricter output schemas, stronger evidence-state modelling or broader scenario-reference validation.

## Changes

### XML blocker

- Replaces empty `templates/discussion-template.xml` with valid versioned XML and a structured discussion-record template.

### Missing template registry targets

Creates registry-backed GitHub templates instead of removing registry entries:

- GitHub issue templates:
  - `templates/github/.github/ISSUE_TEMPLATE/bug_report.yml`
  - `templates/github/.github/ISSUE_TEMPLATE/feature_request.yml`
- GitHub pull request template:
  - `templates/github/.github/PULL_REQUEST_TEMPLATE/default.md`
- GitHub CODEOWNERS template:
  - `templates/github/.github/CODEOWNERS`
- GitHub workflow templates:
  - `ci-accessibility.yml`
  - `ci-conformance.yml`
  - `ci-data-ml.yml`
  - `ci-docs-quality.yml`
  - `ci-dotnet.yml`
  - `ci-go.yml`
  - `ci-java.yml`
  - `ci-node.yml`
  - `ci-performance.yml`
  - `ci-php.yml`
  - `ci-python.yml`
  - `ci-ruby.yml`
  - `ci-rust.yml`
  - `codeql.yml`
  - `dependency-review.yml`
  - `file-inventory.yml`
  - `release-gate.yml`
  - `sbom-cyclonedx.yml`
- Hardened workflow template required by the release gate:
  - `templates/github/.github/workflows-hardened/ci-hardened.yml`

### Missing eval and grader references

- Adds `graders/documentation-grader.xml` because scenario examples reference it.
- Adds `examples/fixtures/repositories/api-service/` because `evals.yaml` references it.
  - Includes endpoint catalogue, success/error payloads and contract-test location.

### Stale version validators

- Updates `scripts/validate-changelog.py` so the current version comes from `prompt.spec.yaml` instead of a stale hard-coded list.
- Updates `scripts/validate-docs-consistency.py` so the expected version comes from `prompt.spec.yaml` unless explicitly overridden.

### Trace evidence

Adds machine-readable and human-readable audit traces:

- `docs/agent-audit/reasoning/2026/05/23/github-bundle-release-gate-blockers.json`
- `docs/agent-audit/reasoning/2026/05/23/github-bundle-release-gate-blockers.md`

## Validation

Not run locally in this connector-only environment.

Expected validation:

```bash
cd .agent-operating-model/bundles/github
PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode fast --report fast-release-gate-report.json
python scripts/validate-template-registry.py
python scripts/validate-evals.py
python scripts/validate-changelog.py
python scripts/validate-docs-consistency.py
```

## Notes

This PR may trigger the existing GitHub bundle registry-manifest workflow because bundle files were added. Any checksum-only commit should be reviewed as generated metadata.