### PR TITLE
Tighten GitHub contracts and scenario validation

### DIFF
--- a/.agent-operating-model/bundles/github/contracts/agent-evidence.schema.json
+++ b/.agent-operating-model/bundles/github/contracts/agent-evidence.schema.json
@@ -43,6 +43,13 @@
         "minLength": 1
       }
     },
+    "evidence_states": {
+      "type": "array",
+      "description": "Explicit evidence-state records distinguishing claimed, observed, verified, unavailable and waived evidence.",
+      "items": {
+        "$ref": "evidence-state.schema.json#/definitions/evidenceStateRecord"
+      }
+    },
     "commands_run": {
       "type": "array",
       "items": {
@@ -62,8 +69,23 @@
             "enum": [
               "passed",
               "failed",
-              "not-run"
+              "not-run",
+              "timeout",
+              "unavailable",
+              "waived"
             ]
+          },
+          "state": {
+            "$ref": "evidence-state.schema.json#/definitions/evidenceState"
+          },
+          "returncode": {
+            "type": ["integer", "null"]
+          },
+          "stdout": {
+            "type": "string"
+          },
+          "stderr": {
+            "type": "string"
           },
           "evidence": {
             "type": "string"
@@ -97,8 +119,14 @@
             "enum": [
               "passed",
               "failed",
-              "not-run"
+              "not-run",
+              "timeout",
+              "unavailable",
+              "waived"
             ]
+          },
+          "state": {
+            "$ref": "evidence-state.schema.json#/definitions/evidenceState"
           },
           "evidence": {
             "type": "string"
@@ -387,8 +415,14 @@
             "enum": [
               "passed",
               "failed",
-              "not-run"
+              "not-run",
+              "timeout",
+              "unavailable",
+              "waived"
             ]
+          },
+          "state": {
+            "$ref": "evidence-state.schema.json#/definitions/evidenceState"
           },
           "returncode": {
             "type": "integer"
@@ -416,6 +450,12 @@
           "type": "integer"
         },
         "licence_metadata_present": {
+          "type": "boolean"
+        },
+        "purls_present": {
+          "type": "boolean"
+        },
+        "tool_metadata_present": {
           "type": "boolean"
         }
       }
@@ -455,6 +495,18 @@
           "type": "integer"
         },
         "validated": {
+          "type": "boolean"
+        },
+        "dsse_present": {
+          "type": "boolean"
+        },
+        "slsa_present": {
+          "type": "boolean"
+        },
+        "github_artifact_attestation_present": {
+          "type": "boolean"
+        },
+        "sigstore_present": {
           "type": "boolean"
         }
       }

--- a/.agent-operating-model/bundles/github/contracts/evidence-state.schema.json
+++ b/.agent-operating-model/bundles/github/contracts/evidence-state.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evidence State Contract",
+  "description": "Shared evidence-state vocabulary used to distinguish claimed, observed, verified, unavailable and waived evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["state", "rationale"],
+  "properties": {
+    "state": {
+      "$ref": "#/definitions/evidenceState"
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string"
+    },
+    "verified_by": {
+      "type": "string"
+    },
+    "verified_at": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "evidenceState": {
+      "type": "string",
+      "enum": [
+        "claimed",
+        "observed",
+        "verified",
+        "unavailable",
+        "waived"
+      ]
+    },
+    "evidenceStateRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "rationale"],
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/evidenceState"
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "verified_by": {
+          "type": "string"
+        },
+        "verified_at": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.agent-operating-model/bundles/github/contracts/safe-audit-trail.schema.json
+++ b/.agent-operating-model/bundles/github/contracts/safe-audit-trail.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Safe Audit Trail Contract",
+  "description": "A safe operational audit-trail contract for AI-assisted repository work. This explicitly records observable evidence and decisions without requiring private chain-of-thought.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "task_interpretation",
+    "rules_loaded",
+    "files_inspected",
+    "evidence_used",
+    "decisions_made",
+    "commands_run",
+    "changes_made",
+    "errors_encountered",
+    "pivots_made",
+    "validation_results",
+    "remaining_gaps",
+    "chain_of_thought_excluded"
+  ],
+  "properties": {
+    "task_interpretation": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rules_loaded": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "files_inspected": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "state"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "state": { "$ref": "evidence-state.schema.json#/definitions/evidenceState" },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "evidence_used": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["description", "state"],
+        "properties": {
+          "description": { "type": "string", "minLength": 1 },
+          "state": { "$ref": "evidence-state.schema.json#/definitions/evidenceState" },
+          "source": { "type": "string" }
+        }
+      }
+    },
+    "decisions_made": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["decision", "rationale"],
+        "properties": {
+          "decision": { "type": "string", "minLength": 1 },
+          "rationale": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "commands_run": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command", "status", "state"],
+        "properties": {
+          "command": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["passed", "failed", "not-run", "timeout", "unavailable"] },
+          "state": { "$ref": "evidence-state.schema.json#/definitions/evidenceState" },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "changes_made": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "change_type"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "change_type": { "type": "string", "enum": ["created", "modified", "deleted", "renamed", "none"] },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "errors_encountered": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["summary", "resolved"],
+        "properties": {
+          "summary": { "type": "string", "minLength": 1 },
+          "resolved": { "type": "boolean" },
+          "resolution": { "type": "string" }
+        }
+      }
+    },
+    "pivots_made": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to", "reason"],
+        "properties": {
+          "from": { "type": "string", "minLength": 1 },
+          "to": { "type": "string", "minLength": 1 },
+          "reason": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "validation_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status", "state"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["passed", "failed", "not-run", "not-applicable", "unavailable"] },
+          "state": { "$ref": "evidence-state.schema.json#/definitions/evidenceState" },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "remaining_gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["summary", "state"],
+        "properties": {
+          "summary": { "type": "string", "minLength": 1 },
+          "state": { "$ref": "evidence-state.schema.json#/definitions/evidenceState" },
+          "owner": { "type": "string" }
+        }
+      }
+    },
+    "chain_of_thought_excluded": {
+      "type": "boolean",
+      "const": true
+    }
+  }
+}

--- a/.agent-operating-model/bundles/github/grade.schema.json
+++ b/.agent-operating-model/bundles/github/grade.schema.json
@@ -1,11 +1,62 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Grade Output Contract",
+  "description": "Structured grader result contract for GitHub Diamond bundle assurance.",
   "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "grader_id",
+    "score",
+    "decision",
+    "blocking_failures",
+    "evidence",
+    "deductions",
+    "feedback"
+  ],
   "properties": {
-    "score": { "type": "number", "minimum": 0, "maximum": 1 },
-    "feedback": { "type": "string" }
-  },
-  "required": ["score", "feedback"],
-  "additionalProperties": true
+    "grader_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["pass", "pass_with_gap", "fail"]
+    },
+    "blocking_failures": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "deductions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "feedback": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evidence_states": {
+      "type": "array",
+      "items": {
+        "$ref": "contracts/evidence-state.schema.json#/definitions/evidenceStateRecord"
+      }
+    }
+  }
 }

--- a/.agent-operating-model/bundles/github/output.schema.json
+++ b/.agent-operating-model/bundles/github/output.schema.json
@@ -1,10 +1,173 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Agent Output Contract",
+  "description": "Structured final output contract for GitHub Diamond bundle work. This contract requires the assistant to expose safe, observable audit information without requiring private chain-of-thought.",
   "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "response",
+    "mode_selected",
+    "repository_classification",
+    "evidence_read",
+    "branch_decision",
+    "mutation_strategy",
+    "files_changed",
+    "commands_run",
+    "validation_results",
+    "gaps",
+    "waivers",
+    "risk_decision",
+    "pr_readiness",
+    "safe_audit_trail"
+  ],
   "properties": {
-    "response": { "type": "string" }
-  },
-  "required": ["response"],
-  "additionalProperties": true
+    "response": {
+      "type": "string",
+      "minLength": 1,
+      "description": "User-facing summary of the result."
+    },
+    "mode_selected": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Operational mode selected from the bundle, such as repo-discovery, repo-fix or repo-release."
+    },
+    "repository_classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary_stack", "risk_level", "service_surface", "confidence"],
+      "properties": {
+        "primary_stack": { "type": "string", "minLength": 1 },
+        "detected_languages": { "type": "array", "items": { "type": "string" } },
+        "service_surface": { "type": "string", "enum": ["none", "library", "cli", "api", "web", "mobile", "data-ml", "infrastructure", "unknown"] },
+        "risk_level": { "type": "string", "enum": ["low", "standard", "high", "high-assurance", "unknown"] },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "evidence_read": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "state"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "state": { "$ref": "contracts/evidence-state.schema.json#/definitions/evidenceState" },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "branch_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["branch", "prefix", "rationale"],
+      "properties": {
+        "branch": { "type": "string", "minLength": 1 },
+        "prefix": { "type": "string", "enum": ["feature", "chore", "test", "fix", "perf", "hotfix", "none"] },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "mutation_strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strategy", "smallest_safe_change", "rationale"],
+      "properties": {
+        "strategy": { "type": "string", "enum": ["none", "read-only", "patch", "file-update", "new-file", "delete-file", "tree-update"] },
+        "smallest_safe_change": { "type": "boolean" },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "files_changed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "change_type"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "change_type": { "type": "string", "enum": ["created", "modified", "deleted", "renamed", "none"] },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "commands_run": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command", "status", "state"],
+        "properties": {
+          "command": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["passed", "failed", "not-run", "timeout", "unavailable"] },
+          "state": { "$ref": "contracts/evidence-state.schema.json#/definitions/evidenceState" },
+          "returncode": { "type": ["integer", "null"] },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "validation_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status", "state"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["passed", "failed", "not-run", "not-applicable", "unavailable"] },
+          "state": { "$ref": "contracts/evidence-state.schema.json#/definitions/evidenceState" },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "summary", "state"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "summary": { "type": "string", "minLength": 1 },
+          "state": { "$ref": "contracts/evidence-state.schema.json#/definitions/evidenceState" },
+          "release_blocking": { "type": "boolean" }
+        }
+      }
+    },
+    "waivers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "summary", "state", "approved"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "summary": { "type": "string", "minLength": 1 },
+          "state": { "$ref": "contracts/evidence-state.schema.json#/definitions/evidenceState" },
+          "approved": { "type": "boolean" }
+        }
+      }
+    },
+    "risk_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "rationale"],
+      "properties": {
+        "decision": { "type": "string", "enum": ["proceed", "proceed_with_gaps", "block", "escalate", "not_applicable"] },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "pr_readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ready", "reason"],
+      "properties": {
+        "ready": { "type": "boolean" },
+        "reason": { "type": "string", "minLength": 1 },
+        "checks_expected": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "safe_audit_trail": {
+      "$ref": "contracts/safe-audit-trail.schema.json"
+    }
+  }
 }

--- a/.agent-operating-model/bundles/github/prompt.spec.yaml
+++ b/.agent-operating-model/bundles/github/prompt.spec.yaml
@@ -63,6 +63,7 @@ assembly:
   - contracts/endpoint-catalog.schema.json
   - contracts/eval-result.schema.json
   - contracts/eval.schema.json
+  - contracts/evidence-state.schema.json
   - contracts/gap-register.schema.json
   - contracts/github-settings.schema.json
   - contracts/grade-result.schema.json
@@ -73,6 +74,7 @@ assembly:
   - contracts/pull-request-contract.schema.json
   - contracts/release-contract.schema.json
   - contracts/repository-contract.schema.json
+  - contracts/safe-audit-trail.schema.json
   - contracts/sbom-record.schema.json
   - contracts/template-registry.schema.json
   - contracts/workflow-contract.schema.json

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -10,7 +10,7 @@ artifacts:
 - path: contracts/accessibility-evidence.schema.json
   sha256: 6dcfd29a11ce04bb610a9aae7cdd1194c6c4ef190bf61be0b10da3148bc01c08
 - path: contracts/agent-evidence.schema.json
-  sha256: 5b719e726cf9f52b95c589cc5eca87a649ae91003d9d4524865a69a8001d4f5b
+  sha256: aec8c2eaf9da67a383b47815be2195317067bd2de54a5ade313eff86b11c5452
 - path: contracts/conformance-record.schema.json
   sha256: 3e3ebea281fa111150da063d8d56902f5547e991696553c419e3d4353316627a
 - path: contracts/endpoint-catalog.schema.json
@@ -19,6 +19,8 @@ artifacts:
   sha256: bbc13b4003877c2a26d3935f99825215215d79a8687882e13886f9db720a63c7
 - path: contracts/eval.schema.json
   sha256: 528f8dd1bf317b8740b4d067bafa00917f0a60ea766212d85b143300269dd6d5
+- path: contracts/evidence-state.schema.json
+  sha256: 4dec7c729ae8aebcdb65180961b1693ea0c10911640fb3d12fb4c3b9f307c7ff
 - path: contracts/gap-register.schema.json
   sha256: 29e9ce9d38890c19790fc7852b1ea5ea61f3c90a871dd9b301d0498cc1f84c15
 - path: contracts/github-settings.schema.json
@@ -43,6 +45,8 @@ artifacts:
   sha256: 0df72f7e2d983351f7511722d9c5d895f18564fbb79b03eccc323ce5b0036997
 - path: contracts/repository-contract.schema.json
   sha256: 7dd2463202acaa025df5fd0de5a94da5a10a8dd1303230dc915bd3eeac4d1df3
+- path: contracts/safe-audit-trail.schema.json
+  sha256: 48b88eca3a26dc06173c7ea2ad55809d03952108f4906c2cfc13879dd1c5f0d4
 - path: contracts/sbom-record.schema.json
   sha256: ba8035b279ed28ffb86db82ef04d8eacd29c5abfb490a1fbbd16da68ba80d28a
 - path: contracts/template-registry.schema.json
@@ -348,7 +352,7 @@ artifacts:
 - path: examples/scenarios/workflow-node-ci-selection.yaml
   sha256: 7f5510693b1fee8a1b8ae50d1c64e4c5f438a627ebb7cee5e8d8538778f18294
 - path: grade.schema.json
-  sha256: 1042e384faf41b1a3bd58fdb21b51fa58347f2d0df8a446e72aa3fed0f0d2b62
+  sha256: 14bdfe004b4e06484856ffa13c2bec0a2c8097a4de4c3dc7fd9504800c194110
 - path: graders/accessibility-grader.xml
   sha256: f34c3a0986d765316eeb71b881ec6dc2158511b28e549f5f953a45bd5df6ab79
 - path: graders/ci-selection-grader.xml
@@ -402,11 +406,11 @@ artifacts:
 - path: modes/repo-security.xml
   sha256: 7327d1f02ce2c824c5e3dde2a517411b098f91be7cb111b2e470eb29ef73b142
 - path: output.schema.json
-  sha256: b385b0f658ad5c29bf9c0511aa117b0939a6c2e8baccdbca5cd88dddd57495d0
+  sha256: 5b65943fe37561efc0a98625fa80355b74a451f25e0f714edd52b31452bbf7ad
 - path: prompt.body.xml
   sha256: a0bd68a5fe3c3f700ba2d6e6d7d0a7592c2feef3fe986a4c5811435abbcb6ba0
 - path: prompt.spec.yaml
-  sha256: 1bb00446a7a1d1e861cbec1c21250cedaed8f50b3dcb53f47735b6f4968d5115
+  sha256: 70b63bd30bda9970e20acba30c4a75d6ecda0658096d8e7025002d465c177bb4
 - path: README.md
   sha256: 6c34825d920bf11b9a7e7e85d1a43a50e74970c48be147147bb073d426018438
 - path: references/accessibility-confidence-pack.xml
@@ -488,7 +492,7 @@ artifacts:
 - path: scripts/github_settings_verification.py
   sha256: 4bdddd4d29acec55c7999771c2b1826bbf1b8d202180a279ae56074f20ff8834
 - path: scripts/grade-output.py
-  sha256: c114ddffd0b608445ce1aedc9f64af947cfd3cddb717ae05fdc09a454fb02750
+  sha256: 11285ce180cbcfb8432ebf026c264807828c7dfe1514749da62af774b48f76dc
 - path: scripts/live-repository-release-gate.py
   sha256: a707c0871329e9c50c1a9ff90f43d39ba21cce5b9563ea97543f620f6def9e50
 - path: scripts/performance-adapters.py
@@ -498,7 +502,7 @@ artifacts:
 - path: scripts/README.md
   sha256: 77b533dff46947c81a32dea78ea3f66eb59fb635535861c33babeb07c18e9cac
 - path: scripts/release-gate.py
-  sha256: 8d71a23edd4f23beede76a4111fb2b1e66385f7c24f5809b1c9a69939604c4f3
+  sha256: d8c9f4a52f6fe010810806da8ef677cc94e890d34d63093b531f88cff5470f1b
 - path: scripts/repository_conditions.py
   sha256: 80cfb8ab4eea061561e3db42eed0ecec3254d9bff9811dfa6d5240d75be976c6
 - path: scripts/run-eval-harness.py
@@ -512,7 +516,7 @@ artifacts:
 - path: scripts/validate-agent-evidence.py
   sha256: 7ed427d6aae1212500b3a9547dbff9aa57b580ec15d680c33c1b688249fed952
 - path: scripts/validate-bundle.py
-  sha256: a085f00149ee800e5267256d3ac062520ddf449c88d07ccf780b82d5503f030d
+  sha256: 74eb56b495f00b97cba744775bb2b46cd9abd9265797044982c564a14ce7d85d
 - path: scripts/validate-changelog.py
   sha256: cf8a41db446ed9caf179369f24756cc2abc24aaa9453806fa2b412c988bc45e3
 - path: scripts/validate-docs-consistency.py
@@ -537,6 +541,8 @@ artifacts:
   sha256: f8cb55c28c7dbc70e9cd48929ef60c72f9feb741ac020e5a917cbfacbc28a28a
 - path: scripts/validate-sbom.py
   sha256: 62a6b5091b7461a715b3e5ff0954c625de3e7ab06c804f1ca7e1fb928e190bdc
+- path: scripts/validate-scenario-references.py
+  sha256: bc65b1680fd42c94b742f97ff5b442a8609147cfe37fe020f60e05d3701ff1db
 - path: scripts/validate-selected-template-set.py
   sha256: ce72ff192a730d036053100c3398982754044f4042261f6445023ecf2b95acd3
 - path: scripts/validate-template-registry.py

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -542,7 +542,7 @@ artifacts:
 - path: scripts/validate-sbom.py
   sha256: 62a6b5091b7461a715b3e5ff0954c625de3e7ab06c804f1ca7e1fb928e190bdc
 - path: scripts/validate-scenario-references.py
-  sha256: bc65b1680fd42c94b742f97ff5b442a8609147cfe37fe020f60e05d3701ff1db
+  sha256: 3f16d16b9ebf8d31d99b01203c91b7095af42fec862a84c7f8db922569306a62
 - path: scripts/validate-selected-template-set.py
   sha256: ce72ff192a730d036053100c3398982754044f4042261f6445023ecf2b95acd3
 - path: scripts/validate-template-registry.py

--- a/.agent-operating-model/bundles/github/scripts/grade-output.py
+++ b/.agent-operating-model/bundles/github/scripts/grade-output.py
@@ -5,14 +5,17 @@ import argparse, json, yaml, xml.etree.ElementTree as ET
 ROOT = Path(__file__).resolve().parents[1]
 REQUIRED = {"task_id","mode","files_read","files_changed","commands_run","contracts_validated","artifacts_created","gaps_recorded","waivers_recorded"}
 
+
 def load_data(path):
     text = Path(path).read_text(encoding="utf-8")
     return yaml.safe_load(text) if str(path).endswith((".yaml",".yml")) else json.loads(text)
+
 
 def validate_evidence(e):
     missing = REQUIRED - set(e)
     if missing:
         raise ValueError(f"Evidence missing required fields: {sorted(missing)}")
+
 
 def load_grader(grader):
     gp = ROOT / "graders" / (grader if str(grader).endswith(".xml") else f"{grader}.xml")
@@ -23,12 +26,48 @@ def load_grader(grader):
     gap_min = float(root.find(".//pass_with_gap").attrib["minimum_score"])
     return criteria, pass_min, gap_min
 
+
 def any_passed(items):
     return any(isinstance(i, dict) and i.get("status") == "passed" for i in items)
 
+
+def evidence_state_record(state, rationale, source="agent-evidence"):
+    return {
+        "state": state,
+        "rationale": rationale,
+        "source": source,
+    }
+
+
+def emit_grade_result(grader_id, score, decision, blocking_failures, evidence, deductions):
+    feedback_parts = []
+    if decision == "pass":
+        feedback_parts.append("Evidence satisfies the grader threshold.")
+    elif decision == "pass_with_gap":
+        feedback_parts.append("Evidence satisfies the gap threshold but has deductions that need review.")
+    else:
+        feedback_parts.append("Evidence does not satisfy the grader threshold or has blocking failures.")
+    if blocking_failures:
+        feedback_parts.append("Blocking failures: " + "; ".join(blocking_failures))
+    if deductions:
+        feedback_parts.append("Deductions: " + "; ".join(deductions[:3]))
+    result = {
+        "grader_id": grader_id,
+        "score": round(score, 3),
+        "decision": decision,
+        "blocking_failures": blocking_failures,
+        "evidence": evidence,
+        "deductions": deductions,
+        "feedback": " ".join(feedback_parts),
+        "evidence_states": [
+            evidence_state_record("verified" if decision != "fail" else "observed", "Grader result produced from structured agent evidence.")
+        ],
+    }
+    print(yaml.safe_dump(result, sort_keys=False))
+
+
 def github_settings_score(e):
     raw = e.get("github_settings") or {}
-    # Prefer observed state when available; fall back to desired state, then legacy flat shape.
     gs = raw.get("observed_state") or raw.get("desired_state") or raw
     bp = gs.get("branch_protection") or {}
     sf = gs.get("security_features") or {}
@@ -47,6 +86,7 @@ def github_settings_score(e):
     evidence = [f"github_settings_check_{i+1}: {'pass' if ok else 'fail'}" for i, ok in enumerate(checks)]
     evidence.append(f"verification_method: {verification}")
     return score, evidence
+
 
 def criterion_satisfied(text, e):
     t = text.lower()
@@ -92,6 +132,7 @@ def criterion_satisfied(text, e):
         return bool(e.get("harms")) or "harm-register" in artifacts or "harm-register" in contracts
     return False
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--grader", required=True)
@@ -103,7 +144,7 @@ def main():
     if "github-settings" in grader_id:
         score, ev_lines = github_settings_score(e)
         decision = "pass" if score >= 0.85 else "pass_with_gap" if score >= 0.70 else "fail"
-        print(yaml.safe_dump({"grader_id": grader_id, "score": round(score,3), "decision": decision, "blocking_failures": [] if decision != "fail" else ["github_settings_below_threshold"], "evidence": ev_lines, "deductions": []}, sort_keys=False))
+        emit_grade_result(grader_id, score, decision, [] if decision != "fail" else ["github_settings_below_threshold"], ev_lines, [])
         return
     criteria, pass_min, gap_min = load_grader(args.grader)
     score = 0.0
@@ -120,7 +161,8 @@ def main():
     if "tests passed" in claims and not (any_passed(e.get("commands_run", [])) or any_passed(e.get("tests_run", []))):
         blocking.append("Claimed tests passed without passing command/test evidence.")
     decision = "pass" if score >= pass_min and not blocking else "pass_with_gap" if score >= gap_min and not blocking else "fail"
-    print(yaml.safe_dump({"grader_id": grader_id, "score": round(score,3), "decision": decision, "blocking_failures": blocking, "evidence": ev_lines, "deductions": deductions}, sort_keys=False))
+    emit_grade_result(grader_id, score, decision, blocking, ev_lines, deductions)
+
 
 if __name__ == "__main__":
     main()

--- a/.agent-operating-model/bundles/github/scripts/release-gate.py
+++ b/.agent-operating-model/bundles/github/scripts/release-gate.py
@@ -155,6 +155,7 @@ def add_common_checks(report, positive, evidence, timeout):
     run(["scripts/validate-bundle.py", "--strict"], report, timeout)
     run(["scripts/validate-evals.py"], report, timeout)
     run(["scripts/validate-template-registry.py"], report, timeout)
+    run(["scripts/validate-scenario-references.py"], report, timeout)
     run(["scripts/validate-changelog.py"], report, timeout)
     run(["scripts/validate-docs-consistency.py"], report, timeout)
     run(["scripts/validate-agent-evidence.py", "examples/agent-evidence.example.yaml"], report, timeout)

--- a/.agent-operating-model/bundles/github/scripts/validate-bundle.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-bundle.py
@@ -15,6 +15,32 @@ SECRET_PATTERNS = [
 ]
 GENERATED_PARTS = {"__pycache__", ".pytest_cache", "node_modules", "dist", "build", "coverage", "artifacts", "tmp", "temp", "__MACOSX"}
 GENERATED_SUFFIXES = {".pyc", ".pyo", ".log"}
+REQUIRED_OUTPUT_FIELDS = {
+    "response",
+    "mode_selected",
+    "repository_classification",
+    "evidence_read",
+    "branch_decision",
+    "mutation_strategy",
+    "files_changed",
+    "commands_run",
+    "validation_results",
+    "gaps",
+    "waivers",
+    "risk_decision",
+    "pr_readiness",
+    "safe_audit_trail",
+}
+REQUIRED_GRADE_FIELDS = {
+    "grader_id",
+    "score",
+    "decision",
+    "blocking_failures",
+    "evidence",
+    "deductions",
+    "feedback",
+}
+
 
 def is_generated(path: Path) -> bool:
     try:
@@ -23,6 +49,7 @@ def is_generated(path: Path) -> bool:
         parts = set(path.parts)
     return bool(parts & GENERATED_PARTS) or path.suffix in GENERATED_SUFFIXES
 
+
 def files_for_manifest():
     return {
         p.relative_to(ROOT).as_posix()
@@ -30,8 +57,10 @@ def files_for_manifest():
         if p.is_file() and p.name != "registry-manifest.yaml" and not is_generated(p)
     }
 
+
 def load_yaml(path):
     return yaml.safe_load(path.read_text(encoding="utf-8"))
+
 
 def check_schema_shape(path, data, errors):
     if not path.name.endswith(".schema.json"):
@@ -42,6 +71,7 @@ def check_schema_shape(path, data, errors):
         errors.append(f"Schema type must be object: {path.relative_to(ROOT)}")
     if "properties" not in data:
         errors.append(f"Schema missing properties: {path.relative_to(ROOT)}")
+
 
 def strict_schema_checks(schema_docs, errors):
     try:
@@ -54,6 +84,35 @@ def strict_schema_checks(schema_docs, errors):
             Draft7Validator.check_schema(data)
         except Exception as exc:
             errors.append(f"Invalid JSON schema {path.relative_to(ROOT)}: {exc}")
+
+
+def contract_strength_checks(errors):
+    output = json.loads((ROOT / "output.schema.json").read_text(encoding="utf-8"))
+    grade = json.loads((ROOT / "grade.schema.json").read_text(encoding="utf-8"))
+    output_required = set(output.get("required", []))
+    grade_required = set(grade.get("required", []))
+
+    missing_output = sorted(REQUIRED_OUTPUT_FIELDS - output_required)
+    if missing_output:
+        errors.append("output.schema.json missing required contract fields: " + ", ".join(missing_output))
+    if output.get("additionalProperties") is not False:
+        errors.append("output.schema.json must set additionalProperties to false")
+    if "safe_audit_trail" not in output.get("properties", {}):
+        errors.append("output.schema.json must require a safe_audit_trail property")
+
+    missing_grade = sorted(REQUIRED_GRADE_FIELDS - grade_required)
+    if missing_grade:
+        errors.append("grade.schema.json missing required contract fields: " + ", ".join(missing_grade))
+    if grade.get("additionalProperties") is not False:
+        errors.append("grade.schema.json must set additionalProperties to false")
+    decision = grade.get("properties", {}).get("decision", {})
+    if set(decision.get("enum", [])) != {"pass", "pass_with_gap", "fail"}:
+        errors.append("grade.schema.json decision enum must be pass, pass_with_gap, fail")
+
+    for rel in ["contracts/evidence-state.schema.json", "contracts/safe-audit-trail.schema.json"]:
+        if not (ROOT / rel).exists():
+            errors.append(f"Required shared contract missing: {rel}")
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -88,6 +147,7 @@ def main():
 
     if args.strict:
         strict_schema_checks(schema_docs, errors)
+        contract_strength_checks(errors)
 
     for p in ROOT.rglob("*"):
         if p.is_file() and not is_generated(p) and p.suffix.lower() in {".md", ".xml", ".yaml", ".yml", ".json", ".py", ".txt"}:

--- a/.agent-operating-model/bundles/github/scripts/validate-scenario-references.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-scenario-references.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCENARIOS = ROOT / "examples" / "scenarios"
+
+REFERENCE_LISTS = [
+    ("expected_mode.file", lambda data: [data.get("expected_mode", {}).get("file")]),
+    ("roles.primary", lambda data: data.get("roles", {}).get("primary", [])),
+    ("roles.supporting", lambda data: data.get("roles", {}).get("supporting", [])),
+    ("references.must_load", lambda data: data.get("references", {}).get("must_load", [])),
+    ("contracts.must_apply", lambda data: data.get("contracts", {}).get("must_apply", [])),
+    ("graders.must_consider", lambda data: data.get("graders", {}).get("must_consider", [])),
+]
+
+
+def load_yaml(path):
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def path_exists(rel):
+    return bool(rel) and (ROOT / rel).exists()
+
+
+def template_registry():
+    registry = load_yaml(ROOT / "template-registry.yaml")
+    by_id = {}
+    by_path = {}
+    for item in registry.get("templates", []):
+        tid = item.get("id")
+        tpath = item.get("template_path")
+        if tid:
+            by_id[tid] = item
+        if tpath:
+            by_path[tpath] = item
+    return by_id, by_path
+
+
+def check_path_refs(path, data, errors):
+    for label, getter in REFERENCE_LISTS:
+        refs = [item for item in as_list(getter(data)) if item]
+        for ref in refs:
+            if not isinstance(ref, str):
+                errors.append(f"{path.name}: {label} contains non-string reference: {ref!r}")
+                continue
+            if not path_exists(ref):
+                errors.append(f"{path.name}: {label} references missing path: {ref}")
+
+
+def selected_template_items(data):
+    items = []
+    if isinstance(data.get("selected_template"), dict):
+        items.append(data["selected_template"])
+    items.extend(item for item in data.get("selected_templates", []) or [] if isinstance(item, dict))
+    return items
+
+
+def check_selected_templates(path, data, registry_by_id, registry_by_path, errors):
+    for item in selected_template_items(data):
+        tid = item.get("id")
+        tpath = item.get("template_path")
+        destination = item.get("destination_path")
+        if not tid:
+            errors.append(f"{path.name}: selected template is missing id")
+            continue
+        if tid not in registry_by_id:
+            errors.append(f"{path.name}: selected template id not found in template-registry.yaml: {tid}")
+            continue
+        registry_item = registry_by_id[tid]
+        if tpath and registry_item.get("template_path") != tpath:
+            errors.append(f"{path.name}: selected template {tid} path mismatch: scenario={tpath} registry={registry_item.get('template_path')}")
+        if destination and registry_item.get("destination_path") != destination:
+            errors.append(f"{path.name}: selected template {tid} destination mismatch: scenario={destination} registry={registry_item.get('destination_path')}")
+        if not path_exists(registry_item.get("template_path")):
+            errors.append(f"{path.name}: selected template {tid} references missing template path: {registry_item.get('template_path')}")
+        associated_contract = registry_item.get("associated_contract")
+        if associated_contract and not path_exists(associated_contract):
+            errors.append(f"{path.name}: selected template {tid} associated contract missing: {associated_contract}")
+        for grader in registry_item.get("associated_graders", []) or []:
+            if not path_exists(grader):
+                errors.append(f"{path.name}: selected template {tid} associated grader missing: {grader}")
+
+    for item in data.get("rejected_templates", []) or []:
+        if not isinstance(item, dict):
+            errors.append(f"{path.name}: rejected_templates contains non-object entry")
+            continue
+        tid = item.get("id")
+        reason = item.get("reason")
+        if not tid:
+            errors.append(f"{path.name}: rejected template is missing id")
+        if not reason:
+            errors.append(f"{path.name}: rejected template {tid or '<missing>'} is missing reason")
+        if tid and tid not in registry_by_id:
+            errors.append(f"{path.name}: rejected template id not found in template-registry.yaml: {tid}")
+
+
+def check_required_sections(path, data, errors):
+    for field in ["id", "kind", "status", "user_prompt", "repository_context", "expected_mode", "roles", "contracts", "graders", "failure_conditions"]:
+        if field not in data:
+            errors.append(f"{path.name}: missing required scenario field: {field}")
+    if data.get("kind") != "scenario":
+        errors.append(f"{path.name}: kind must be scenario")
+    if data.get("status") not in {"canonical", "draft", "deprecated"}:
+        errors.append(f"{path.name}: status must be canonical, draft, or deprecated")
+    if not data.get("failure_conditions"):
+        errors.append(f"{path.name}: failure_conditions must not be empty")
+
+
+def main():
+    errors = []
+    registry_by_id, registry_by_path = template_registry()
+    scenario_files = sorted(SCENARIOS.glob("*.yaml"))
+    if not scenario_files:
+        errors.append("No scenario files found under examples/scenarios")
+    seen_ids = set()
+    for path in scenario_files:
+        try:
+            data = load_yaml(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: YAML parse error: {exc}")
+            continue
+        sid = data.get("id")
+        if sid in seen_ids:
+            errors.append(f"{path.name}: duplicate scenario id: {sid}")
+        if sid:
+            seen_ids.add(sid)
+        check_required_sections(path, data, errors)
+        check_path_refs(path, data, errors)
+        check_selected_templates(path, data, registry_by_id, registry_by_path, errors)
+
+    if errors:
+        for error in errors:
+            print(error)
+        raise SystemExit(1)
+    print("Scenario reference validation passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent-operating-model/bundles/github/scripts/validate-scenario-references.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-scenario-references.py
@@ -104,15 +104,15 @@ def check_selected_templates(path, data, registry_by_id, registry_by_path, error
 
 
 def check_required_sections(path, data, errors):
-    for field in ["id", "kind", "status", "user_prompt", "repository_context", "expected_mode", "roles", "contracts", "graders", "failure_conditions"]:
+    for field in ["id", "kind", "status", "user_prompt", "repository_context", "expected_mode", "roles", "contracts", "graders"]:
         if field not in data:
             errors.append(f"{path.name}: missing required scenario field: {field}")
     if data.get("kind") != "scenario":
         errors.append(f"{path.name}: kind must be scenario")
     if data.get("status") not in {"canonical", "draft", "deprecated"}:
         errors.append(f"{path.name}: status must be canonical, draft, or deprecated")
-    if not data.get("failure_conditions"):
-        errors.append(f"{path.name}: failure_conditions must not be empty")
+    if "failure_conditions" in data and not data.get("failure_conditions"):
+        errors.append(f"{path.name}: failure_conditions must not be empty when provided")
 
 
 def main():

--- a/docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.json
+++ b/docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": "researchops-agent-trace-summary/v1",
+  "traceType": "operational-audit",
+  "date": "2026-05-23",
+  "branch": "fix/github-contracts-scenario-validation",
+  "scope": [
+    "github-diamond-bundle",
+    "output-contract",
+    "grade-contract",
+    "scenario-reference-validation",
+    "safe-audit-trail",
+    "evidence-state-model"
+  ],
+  "evidenceBoundary": {
+    "summary": "This trace records observable repository work to tighten GitHub Diamond contracts and scenario validation. It does not include private chain-of-thought."
+  },
+  "operatingModel": {
+    "selectedBundles": [
+      "github",
+      "researchops-developer-control",
+      "multi-functional-team"
+    ],
+    "branchPolicy": "fix/ branches require audit trace artefacts under docs/agent-audit/reasoning/YYYY/MM/DD."
+  },
+  "problemSummary": [
+    "The prior bundle evaluation found that output.schema.json only required response and grade.schema.json only required score and feedback.",
+    "Scenario files referenced modes, roles, references, contracts, graders and selected templates, but there was no dedicated scenario-reference validator to fail on drift.",
+    "The bundle used reasoning-trace language, but the safer governance need is an observable audit trail that excludes private chain-of-thought.",
+    "Evidence files implied different evidence states, but there was no shared contract vocabulary for claimed, observed, verified, unavailable and waived evidence."
+  ],
+  "workSummary": [
+    "Strengthened output.schema.json so final outputs must include mode selection, repository classification, evidence read, branch decision, mutation strategy, changed files, commands, validation results, gaps, waivers, risk decision, PR readiness and a safe audit trail.",
+    "Added contracts/evidence-state.schema.json with the shared evidence-state vocabulary: claimed, observed, verified, unavailable and waived.",
+    "Added contracts/safe-audit-trail.schema.json requiring task interpretation, rules loaded, files inspected, evidence used, decisions, commands, changes, errors, pivots, validation, gaps and chain_of_thought_excluded=true.",
+    "Strengthened grade.schema.json so grade outputs must include grader_id, score, decision, blocking failures, evidence, deductions and feedback.",
+    "Updated grade-output.py so emitted grader results match the tightened grade contract and include evidence-state records.",
+    "Registered evidence-state and safe-audit-trail contracts in prompt.spec.yaml.",
+    "Added scripts/validate-scenario-references.py to check scenario references against actual mode, role, reference, contract, grader and template-registry paths.",
+    "Wired scenario-reference validation into scripts/release-gate.py.",
+    "Updated validate-bundle.py strict mode so weak output and grade contracts fail explicit contract-strength checks.",
+    "Updated agent-evidence.schema.json to allow evidence_states records and evidence-state fields on commands, tests and test results."
+  ],
+  "changedAreas": [
+    ".agent-operating-model/bundles/github/output.schema.json",
+    ".agent-operating-model/bundles/github/grade.schema.json",
+    ".agent-operating-model/bundles/github/contracts/evidence-state.schema.json",
+    ".agent-operating-model/bundles/github/contracts/safe-audit-trail.schema.json",
+    ".agent-operating-model/bundles/github/contracts/agent-evidence.schema.json",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/scripts/grade-output.py",
+    ".agent-operating-model/bundles/github/scripts/validate-scenario-references.py",
+    ".agent-operating-model/bundles/github/scripts/validate-bundle.py",
+    ".agent-operating-model/bundles/github/scripts/release-gate.py"
+  ],
+  "validationEvidence": {
+    "staticCompatibilityChecks": [
+      "output.schema.json now has additionalProperties=false and requires safe_audit_trail.",
+      "grade.schema.json now has additionalProperties=false and requires decision, blocking_failures, evidence and deductions.",
+      "validate-bundle.py --strict now enforces strengthened output and grade contract fields.",
+      "validate-scenario-references.py checks selected template IDs against template-registry.yaml.",
+      "release-gate.py now runs validate-scenario-references.py as part of common checks.",
+      "safe-audit-trail.schema.json explicitly excludes private chain-of-thought by requiring chain_of_thought_excluded=true."
+    ],
+    "notRunLocally": [
+      "No local release gate was run in this connector-only environment. CI should run the fast release gate and bundle validators on the pull request."
+    ],
+    "recommendedNextChecks": [
+      "cd .agent-operating-model/bundles/github",
+      "python scripts/validate-scenario-references.py",
+      "python scripts/validate-bundle.py --strict",
+      "PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode fast --report fast-release-gate-report.json"
+    ]
+  },
+  "risks": [
+    {
+      "risk": "Stronger schemas may expose previously tolerated weak outputs or grader results.",
+      "mitigation": "grade-output.py was updated to emit the tightened shape; output.schema.json is a contract for future agent output rather than a validator for existing fixture files."
+    },
+    {
+      "risk": "Scenario-reference validation may reveal existing stale scenario links.",
+      "mitigation": "The validator is intentionally wired into the release gate so CI will expose any residual drift before merge."
+    },
+    {
+      "risk": "Registry manifest checksums may be stale after adding contract and script files.",
+      "mitigation": "The existing GitHub bundle registry-manifest workflow should regenerate registry-manifest.yaml on the pull request branch."
+    }
+  ],
+  "status": "ready-for-pr"
+}

--- a/docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.json
+++ b/docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.json
@@ -9,7 +9,8 @@
     "grade-contract",
     "scenario-reference-validation",
     "safe-audit-trail",
-    "evidence-state-model"
+    "evidence-state-model",
+    "codex-review"
   ],
   "evidenceBoundary": {
     "summary": "This trace records observable repository work to tighten GitHub Diamond contracts and scenario validation. It does not include private chain-of-thought."
@@ -26,7 +27,8 @@
     "The prior bundle evaluation found that output.schema.json only required response and grade.schema.json only required score and feedback.",
     "Scenario files referenced modes, roles, references, contracts, graders and selected templates, but there was no dedicated scenario-reference validator to fail on drift.",
     "The bundle used reasoning-trace language, but the safer governance need is an observable audit trail that excludes private chain-of-thought.",
-    "Evidence files implied different evidence states, but there was no shared contract vocabulary for claimed, observed, verified, unavailable and waived evidence."
+    "Evidence files implied different evidence states, but there was no shared contract vocabulary for claimed, observed, verified, unavailable and waived evidence.",
+    "Codex identified that validate-scenario-references.py introduced an unconditional failure_conditions requirement even though template-selection-node-api.yaml is canonical and does not define that field."
   ],
   "workSummary": [
     "Strengthened output.schema.json so final outputs must include mode selection, repository classification, evidence read, branch decision, mutation strategy, changed files, commands, validation results, gaps, waivers, risk decision, PR readiness and a safe audit trail.",
@@ -38,7 +40,9 @@
     "Added scripts/validate-scenario-references.py to check scenario references against actual mode, role, reference, contract, grader and template-registry paths.",
     "Wired scenario-reference validation into scripts/release-gate.py.",
     "Updated validate-bundle.py strict mode so weak output and grade contracts fail explicit contract-strength checks.",
-    "Updated agent-evidence.schema.json to allow evidence_states records and evidence-state fields on commands, tests and test results."
+    "Updated agent-evidence.schema.json to allow evidence_states records and evidence-state fields on commands, tests and test results.",
+    "Accepted the Codex review comment and removed failure_conditions from the unconditional scenario required-fields list.",
+    "Kept failure_conditions validation conditional: when present it must be non-empty, but absence does not fail reference validation."
   ],
   "changedAreas": [
     ".agent-operating-model/bundles/github/output.schema.json",
@@ -52,6 +56,18 @@
     ".agent-operating-model/bundles/github/scripts/validate-bundle.py",
     ".agent-operating-model/bundles/github/scripts/release-gate.py"
   ],
+  "codexReview": {
+    "commentId": 3292014062,
+    "reviewedCommit": "0c3838dc0c",
+    "severity": "P1",
+    "finding": "The validator required failure_conditions for every scenario, but an existing canonical scenario intentionally lacks that field.",
+    "decision": "accepted",
+    "mitigation": [
+      "Removed failure_conditions from the unconditional required scenario fields.",
+      "Kept non-empty validation when failure_conditions is provided.",
+      "Preserved the validator's focus on reference drift and template-registry integrity."
+    ]
+  },
   "validationEvidence": {
     "staticCompatibilityChecks": [
       "output.schema.json now has additionalProperties=false and requires safe_audit_trail.",
@@ -59,7 +75,8 @@
       "validate-bundle.py --strict now enforces strengthened output and grade contract fields.",
       "validate-scenario-references.py checks selected template IDs against template-registry.yaml.",
       "release-gate.py now runs validate-scenario-references.py as part of common checks.",
-      "safe-audit-trail.schema.json explicitly excludes private chain-of-thought by requiring chain_of_thought_excluded=true."
+      "safe-audit-trail.schema.json explicitly excludes private chain-of-thought by requiring chain_of_thought_excluded=true.",
+      "validate-scenario-references.py no longer blocks canonical scenarios that omit failure_conditions."
     ],
     "notRunLocally": [
       "No local release gate was run in this connector-only environment. CI should run the fast release gate and bundle validators on the pull request."
@@ -85,5 +102,5 @@
       "mitigation": "The existing GitHub bundle registry-manifest workflow should regenerate registry-manifest.yaml on the pull request branch."
     }
   ],
-  "status": "ready-for-pr"
+  "status": "codex-feedback-addressed"
 }

--- a/docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.md
+++ b/docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.md
@@ -1,0 +1,148 @@
+# Agent audit trace — GitHub contracts and scenario validation
+
+Date: 2026-05-23
+
+Branch: `fix/github-contracts-scenario-validation`
+
+Trace type: operational audit
+
+Status: ready for PR review
+
+## Evidence boundary
+
+This trace records observable repository work to tighten GitHub Diamond contracts and scenario validation.
+
+It does not include private chain-of-thought.
+
+## Scope
+
+This third remediation branch covers:
+
+- `output-contract`
+- `grade-contract`
+- `scenario-reference-validation`
+- `safe-audit-trail`
+- `evidence-state-model`
+
+It follows the first two remediation PRs:
+
+1. fast release-gate structural blockers
+2. eval execution trustworthiness
+
+## Problem summary
+
+The prior bundle evaluation found that `output.schema.json` only required `response`.
+
+It also found that `grade.schema.json` only required `score` and `feedback`.
+
+Those contracts were too permissive for a Diamond-standard control bundle.
+
+Scenario files also referenced modes, roles, references, contracts, graders and selected templates, but there was no dedicated validator to fail on stale or missing references.
+
+The bundle used reasoning-trace language, but the safer governance need is an observable audit trail that excludes private chain-of-thought.
+
+The bundle also implied different evidence states, but had no shared contract vocabulary for claimed, observed, verified, unavailable and waived evidence.
+
+## Work completed
+
+Strengthened `output.schema.json` so final outputs must include:
+
+- `response`
+- `mode_selected`
+- `repository_classification`
+- `evidence_read`
+- `branch_decision`
+- `mutation_strategy`
+- `files_changed`
+- `commands_run`
+- `validation_results`
+- `gaps`
+- `waivers`
+- `risk_decision`
+- `pr_readiness`
+- `safe_audit_trail`
+
+Added `contracts/evidence-state.schema.json` with the shared evidence-state vocabulary:
+
+- `claimed`
+- `observed`
+- `verified`
+- `unavailable`
+- `waived`
+
+Added `contracts/safe-audit-trail.schema.json` requiring:
+
+- task interpretation
+- rules loaded
+- files inspected
+- evidence used
+- decisions made
+- commands run
+- changes made
+- errors encountered
+- pivots made
+- validation results
+- remaining gaps
+- `chain_of_thought_excluded: true`
+
+Strengthened `grade.schema.json` so grader results must include:
+
+- `grader_id`
+- `score`
+- `decision`
+- `blocking_failures`
+- `evidence`
+- `deductions`
+- `feedback`
+
+Updated `scripts/grade-output.py` so emitted grader results match the tightened grade contract and include evidence-state records.
+
+Registered the new contracts in `prompt.spec.yaml`.
+
+Added `scripts/validate-scenario-references.py` to check scenario references against actual files and the template registry.
+
+Updated `scripts/release-gate.py` so the release gate runs the scenario-reference validator.
+
+Updated `scripts/validate-bundle.py` strict mode so weak output and grade contracts fail explicit contract-strength checks.
+
+Updated `contracts/agent-evidence.schema.json` to allow evidence-state records and evidence-state fields on commands, tests and test results.
+
+## Files changed
+
+- `.agent-operating-model/bundles/github/output.schema.json`
+- `.agent-operating-model/bundles/github/grade.schema.json`
+- `.agent-operating-model/bundles/github/contracts/evidence-state.schema.json`
+- `.agent-operating-model/bundles/github/contracts/safe-audit-trail.schema.json`
+- `.agent-operating-model/bundles/github/contracts/agent-evidence.schema.json`
+- `.agent-operating-model/bundles/github/prompt.spec.yaml`
+- `.agent-operating-model/bundles/github/scripts/grade-output.py`
+- `.agent-operating-model/bundles/github/scripts/validate-scenario-references.py`
+- `.agent-operating-model/bundles/github/scripts/validate-bundle.py`
+- `.agent-operating-model/bundles/github/scripts/release-gate.py`
+
+## Validation status
+
+No local release gate was run in this connector-only environment.
+
+Recommended checks:
+
+```bash
+cd .agent-operating-model/bundles/github
+python scripts/validate-scenario-references.py
+python scripts/validate-bundle.py --strict
+PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode fast --report fast-release-gate-report.json
+```
+
+## Risks and mitigations
+
+Risk: stronger schemas may expose previously tolerated weak outputs or grader results.
+
+Mitigation: `grade-output.py` was updated to emit the tightened shape. `output.schema.json` is a contract for future agent output rather than a validator for existing fixture files.
+
+Risk: scenario-reference validation may reveal existing stale scenario links.
+
+Mitigation: the validator is intentionally wired into the release gate so CI will expose residual drift before merge.
+
+Risk: registry manifest checksums may be stale after adding contract and script files.
+
+Mitigation: the existing GitHub bundle registry-manifest workflow should regenerate `registry-manifest.yaml` on the pull request branch.


### PR DESCRIPTION
## Summary

Third remediation PR for the GitHub Diamond bundle evaluation.

This PR tightens the bundle contract layer and scenario validation after the first two remediation PRs:

1. fast release-gate structural blockers
2. eval execution trustworthiness

## Changes

### Output contract

Strengthens `output.schema.json` so final outputs must include:

- `response`
- `mode_selected`
- `repository_classification`
- `evidence_read`
- `branch_decision`
- `mutation_strategy`
- `files_changed`
- `commands_run`
- `validation_results`
- `gaps`
- `waivers`
- `risk_decision`
- `pr_readiness`
- `safe_audit_trail`

The schema now uses `additionalProperties: false` so shallow or vague output objects cannot satisfy the contract by accident.

### Grade contract

Strengthens `grade.schema.json` so grader outputs must include:

- `grader_id`
- `score`
- `decision`
- `blocking_failures`
- `evidence`
- `deductions`
- `feedback`

Updates `scripts/grade-output.py` so emitted grader results match the tightened contract and include evidence-state records.

### Evidence-state model

Adds `contracts/evidence-state.schema.json` with shared evidence states:

- `claimed`
- `observed`
- `verified`
- `unavailable`
- `waived`

Updates `contracts/agent-evidence.schema.json` so evidence-state records and state fields can be represented in agent evidence.

### Safe audit trail

Adds `contracts/safe-audit-trail.schema.json`.

This captures a safe operational audit trail without requiring private chain-of-thought. It requires:

- task interpretation
- rules loaded
- files inspected
- evidence used
- decisions made
- commands run
- changes made
- errors encountered
- pivots made
- validation results
- remaining gaps
- `chain_of_thought_excluded: true`

### Scenario-reference validation

Adds `scripts/validate-scenario-references.py`.

This validates scenario files under `examples/scenarios/` and fails if they reference missing:

- modes
- roles
- references
- contracts
- graders
- selected templates
- selected template registry IDs
- associated contracts or graders from the registry

It also verifies rejected templates include reasons and selected template IDs match `template-registry.yaml`.

### Release gate and strict validation

- Wires `validate-scenario-references.py` into `scripts/release-gate.py`.
- Updates `scripts/validate-bundle.py --strict` so weak placeholder contracts fail explicit contract-strength checks.
- Registers `contracts/evidence-state.schema.json` and `contracts/safe-audit-trail.schema.json` in `prompt.spec.yaml`.

### Audit trace

Adds safe audit traces:

- `docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.json`
- `docs/agent-audit/reasoning/2026/05/23/github-contracts-scenario-validation.md`

## Validation

Not run locally in this connector-only environment.

Expected validation:

```bash
cd .agent-operating-model/bundles/github
python scripts/validate-scenario-references.py
python scripts/validate-bundle.py --strict
PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode fast --report fast-release-gate-report.json
```

## Notes

This PR may trigger the existing registry-manifest checksum automation because bundle contracts and scripts changed. Any checksum-only commit should be reviewed as generated metadata.