### PR TITLE
Move GitHub bundle to full release readiness

### DIFF
--- a/.agent-operating-model/bundles/github/VALIDATION-REPORT.md
+++ b/.agent-operating-model/bundles/github/VALIDATION-REPORT.md
@@ -1,16 +1,18 @@
 # Validation Report — GitHub Diamond Bundle v2.9.3
 
-Validation status: pending final manifest regeneration.
+Validation status: full-release-readiness remediation in progress.
 
-Last checked: 2026-05-21.
+Last checked: 2026-05-23.
 
-Version 2.9.3 refreshes the bundle examples layer. It promotes placeholder-style examples into concrete scenarios, expected outputs and behavioural anti-examples while preserving the v2.9.2 assurance model.
+Version 2.9.3 is now a fast-gate clean candidate. The fast release gate passes after the structural release-gate, eval-harness and contract-validation remediation work.
+
+The remaining release-readiness focus is the full release gate. The latest external archive evaluation identified a full-gate performance adapter mismatch where adapter output did not satisfy the canonical metrics expected by pytest-benchmark and Go benchmark performance budgets.
 
 ## Scope
 
-This bundle governs GitHub repository operation, branch hygiene, pull-request discipline, CI, release gates, evidence handling, attestation, repository settings, workflow hardening and live repository assurance.
+This bundle governs GitHub repository operation, branch hygiene, pull-request discipline, CI, release gates, evidence handling, attestation, repository settings, workflow hardening, performance budget assurance and live repository assurance.
 
-The examples refresh is part of the bundle assurance surface because examples teach how agents should apply modes, roles, references, contracts, graders and evidence expectations.
+The examples, fixtures, templates, contracts, graders and validation scripts are part of the bundle assurance surface because they teach and enforce how agents should apply modes, roles, references, contracts, evidence expectations and release-gate checks.
 
 ## Entrypoints checked
 
@@ -33,20 +35,51 @@ Checked entrypoints:
 Expected before release:
 
 - XML, JSON and YAML parse successfully
-- XML roots declare `version="2.9.3"`
+- XML roots declare their module version
 - manifest hashes are regenerated and checked
-- manifest coverage includes the new scenario, expected-output and anti-example files
+- manifest coverage includes scenarios, expected outputs, anti-examples, fixtures, payloads and performance examples
 - transient citation markers are absent
 - changelog order and uniqueness are preserved
 - documentation consistency is preserved
-- template registry validation still passes
-- eval definition validation still passes
-- agent evidence validation still passes
-- direct repository-state verification still passes
-- GitHub settings verification still passes
-- release-gate pass and fail report validation still passes
-- structured accessibility evidence validation still passes
-- high-assurance live gate fixture validation still passes
+- template registry validation passes
+- scenario reference validation passes
+- eval definition validation passes
+- agent evidence validation enforces command, status, evidence-state and execution-detail semantics
+- direct repository-state verification passes
+- GitHub settings verification passes
+- release-gate pass and fail report validation passes
+- structured accessibility evidence validation passes
+- high-assurance live gate fixture validation passes
+- performance adapters emit canonical metrics required by their budget files
+
+## Current gate position
+
+Fast release gate:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode fast --report fast-release-gate-report.json
+```
+
+Current expected status: pass.
+
+Full release gate:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode full --report full-release-gate-report.json
+```
+
+Previous status: failed before this remediation branch.
+
+Previous blocker:
+
+- pytest-benchmark adapter emitted per-test metrics only, while the budget expected `response_time_mean_seconds` and `response_time_max_seconds`
+- Go benchmark adapter emitted per-benchmark metrics only, while the budget expected `handler_ns_per_op`
+
+Remediation in this branch:
+
+- pytest-benchmark now emits canonical roll-up metrics using the maximum mean and maximum max values across benchmark entries
+- Go benchmark now emits `handler_ns_per_op` using the maximum `ns/op` value across benchmark entries
+- detailed per-test and per-benchmark metrics are preserved as diagnostic measurements
 
 ## Evaluation coverage
 
@@ -60,7 +93,7 @@ The v2.9.3 examples are organised into:
 - `examples/performance-inputs/`
 - `examples/performance-results/`
 
-Scenarios define realistic user prompts, repository context, expected mode selection, roles, references, contracts, graders, required evidence and failure conditions.
+Scenarios define realistic user prompts, repository context, expected mode selection, roles, references, contracts, graders, required evidence and failure conditions where relevant.
 
 Expected outputs show acceptable response shape without redundant example title headings.
 
@@ -70,8 +103,14 @@ Fixture, payload and performance examples have been expanded to exercise validat
 
 ## Known gaps
 
-The final blocking requirement for this branch is manifest regeneration after all source edits are complete.
+No manifest-only blocker is currently recorded. Manifest validation should be treated as passed only after the registry-manifest automation has regenerated hashes for this branch.
+
+The full release gate should be re-run after performance adapter roll-up metrics, prompt assembly coverage and agent-evidence validation hardening are applied.
+
+The `references/github-tooling-mutation-policy.xml` module remains at version `1.0.0`. This is treated as module-versioning rather than bundle-version drift, but should remain visible in release review.
 
 ## Result
 
-The GitHub Diamond bundle v2.9.3 is suitable for review once `registry-manifest.yaml` is regenerated and the release metadata is aligned with the final source tree.
+The GitHub Diamond bundle v2.9.3 is suitable for release-candidate review only after the full release gate passes.
+
+The current branch addresses the known full-gate performance adapter blocker and the secondary assurance issues around validation reporting, prompt assembly coverage and agent-evidence validation strength.

--- a/.agent-operating-model/bundles/github/contracts/agent-evidence.schema.json
+++ b/.agent-operating-model/bundles/github/contracts/agent-evidence.schema.json
@@ -57,7 +57,8 @@
         "additionalProperties": false,
         "required": [
           "command",
-          "status"
+          "status",
+          "state"
         ],
         "properties": {
           "command": {
@@ -107,7 +108,8 @@
         "additionalProperties": false,
         "required": [
           "name",
-          "status"
+          "status",
+          "state"
         ],
         "properties": {
           "name": {
@@ -404,7 +406,8 @@
         "additionalProperties": true,
         "required": [
           "command",
-          "status"
+          "status",
+          "state"
         ],
         "properties": {
           "command": {

--- a/.agent-operating-model/bundles/github/examples/agent-evidence.example.yaml
+++ b/.agent-operating-model/bundles/github/examples/agent-evidence.example.yaml
@@ -23,12 +23,24 @@ files_changed:
 - gap-register.yaml
 - docs/README.md
 - templates/README.md
+evidence_states:
+- state: verified
+  rationale: The example records executable command evidence and repository-state evidence paths.
+  source: examples/agent-evidence.example.yaml
 commands_run:
 - command: npm test
   status: passed
+  state: verified
+  returncode: 0
+  stdout: "node fixture tests passed\n"
+  stderr: ""
   evidence: fixture
-- command: pytest
+- command: python -I -m unittest discover -s tests -p 'test_*.py'
   status: passed
+  state: verified
+  returncode: 0
+  stdout: ""
+  stderr: "OK\n"
   evidence: fixture
 contracts_validated:
 - repository-contract.schema.json
@@ -38,7 +50,8 @@ contracts_validated:
 tests_run:
 - name: unit tests
   status: passed
-  evidence: fixture
+  state: verified
+  evidence: fixture test command returned zero
 gaps_recorded: []
 waivers_recorded: []
 artifacts_created:

--- a/.agent-operating-model/bundles/github/examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml
+++ b/.agent-operating-model/bundles/github/examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml
@@ -34,18 +34,42 @@ files_changed:
   - tests/test_python_fixture.py
   - test-commands.yaml
 
+evidence_states:
+  - state: verified
+    rationale: Eval fixture includes executable command evidence, repository-state evidence and settings evidence.
+    source: examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml
+  - state: waived
+    rationale: Live GitHub settings cannot be verified in this portable eval fixture.
+    source: WAIVER-001
+
 commands_run:
   - command: npm test
     status: passed
+    state: verified
+    returncode: 0
+    stdout: "node fixture tests passed\n"
+    stderr: ""
     evidence: tests/example.test.mjs provides the Node fixture validation path
   - command: python -I -m unittest discover -s tests -p 'test_*.py'
     status: passed
+    state: verified
+    returncode: 0
+    stdout: ""
+    stderr: "OK\n"
     evidence: tests/test_python_fixture.py provides the Python fixture validation path
   - command: python -I -S -c "print('fixture tests passed')"
     status: passed
+    state: verified
+    returncode: 0
+    stdout: "fixture tests passed\n"
+    stderr: ""
     evidence: deterministic fixture smoke command
   - command: python -I -S -c "print('generated repository evidence checked')"
     status: passed
+    state: verified
+    returncode: 0
+    stdout: "generated repository evidence checked\n"
+    stderr: ""
     evidence: deterministic repository evidence check command
 
 contracts_validated:
@@ -59,15 +83,19 @@ contracts_validated:
 tests_run:
   - name: Node fixture test
     status: passed
+    state: verified
     evidence: tests/example.test.mjs validates fixture metadata for the Node path
   - name: Python fixture test
     status: passed
+    state: verified
     evidence: tests/test_python_fixture.py validates fixture metadata for the Python path
   - name: Fixture smoke command
     status: passed
+    state: verified
     evidence: python smoke command returned zero
   - name: Repository evidence check
     status: passed
+    state: verified
     evidence: deterministic repository evidence command returned zero
 
 gaps_recorded:
@@ -193,17 +221,27 @@ risks:
 test_results:
   - command: npm test
     status: passed
+    state: verified
+    returncode: 0
+    stdout: "node fixture tests passed\n"
+    stderr: ""
     evidence: tests/example.test.mjs is present as the Node test fixture.
   - command: python -I -m unittest discover -s tests -p 'test_*.py'
     status: passed
+    state: verified
+    returncode: 0
+    stdout: ""
+    stderr: "OK\n"
     evidence: tests/test_python_fixture.py is present as the Python test fixture.
   - command: python -I -S -c "print('fixture tests passed')"
     status: passed
+    state: verified
     returncode: 0
     stdout: "fixture tests passed\n"
     stderr: ""
   - command: python -I -S -c "print('generated repository evidence checked')"
     status: passed
+    state: verified
     returncode: 0
     stdout: "generated repository evidence checked\n"
     stderr: ""

--- a/.agent-operating-model/bundles/github/examples/fixtures/live-gate/high-assurance-pass/repo/agent-evidence.yaml
+++ b/.agent-operating-model/bundles/github/examples/fixtures/live-gate/high-assurance-pass/repo/agent-evidence.yaml
@@ -45,27 +45,38 @@ files_changed:
   - .github/workflows/dependency-review.yml
   - docs/README.md
   - templates/README.md
+evidence_states:
+  - state: verified
+    rationale: High-assurance pass fixture records executable command, test, accessibility, performance, SBOM and attestation evidence.
+    source: examples/fixtures/live-gate/high-assurance-pass/repo/agent-evidence.yaml
 commands_run:
   - command: npm test
     status: passed
+    state: verified
     evidence: test-commands.yaml#node-unit
   - command: npm run lint
     status: passed
+    state: verified
     evidence: test-commands.yaml#node-lint
   - command: npm run build
     status: passed
+    state: verified
     evidence: test-commands.yaml#node-build
   - command: python -I -S -c "print('fixture tests passed')"
     status: passed
+    state: verified
     evidence: test-commands.yaml#python-smoke
   - command: python scripts/validate-sbom-attestation.py --attestation attestation.json --sbom sbom.json
     status: passed
+    state: verified
     evidence: trusted-attestation-verification.json#sbom_attestation_linkage
   - command: gh attestation verify artifact.zip --repo owner/repo
     status: passed
+    state: verified
     evidence: trusted-attestation-verification.json#github_artifact_attestation
   - command: cosign verify-blob artifact.zip --bundle sigstore-bundle.json
     status: passed
+    state: verified
     evidence: trusted-attestation-verification.json#sigstore_bundle_verification
 contracts_validated:
   - repository-contract.schema.json
@@ -80,24 +91,31 @@ contracts_validated:
 tests_run:
   - name: Node unit fixture command
     status: passed
+    state: verified
     evidence: test-commands.yaml#node-unit
   - name: Node lint fixture command
     status: passed
+    state: verified
     evidence: test-commands.yaml#node-lint
   - name: Node build fixture command
     status: passed
+    state: verified
     evidence: test-commands.yaml#node-build
   - name: Python smoke fixture command
     status: passed
+    state: verified
     evidence: test-commands.yaml#python-smoke
   - name: Accessibility evidence review
     status: passed
+    state: verified
     evidence: accessibility-evidence.yaml
   - name: Performance budget/result review
     status: passed
+    state: verified
     evidence: performance-results.yaml
   - name: Trusted attestation verification review
     status: passed
+    state: verified
     evidence: trusted-attestation-verification.json
 gaps_recorded:
   - GAP-HAP-001
@@ -260,31 +278,37 @@ risks:
 test_results:
   - command: npm test
     status: passed
+    state: verified
     returncode: 0
     stdout: live gate node fixture tests passed
     stderr: ''
   - command: npm run lint
     status: passed
+    state: verified
     returncode: 0
     stdout: live gate node fixture lint passed
     stderr: ''
   - command: npm run build
     status: passed
+    state: verified
     returncode: 0
     stdout: live gate node fixture build passed
     stderr: ''
   - command: python -I -S -c "print('fixture tests passed')"
     status: passed
+    state: verified
     returncode: 0
     stdout: fixture tests passed
     stderr: ''
   - command: gh attestation verify artifact.zip --repo owner/repo
     status: passed
+    state: verified
     returncode: 0
     stdout: Verified artifact.zip for owner/repo using GitHub artifact attestation fixture evidence.
     stderr: ''
   - command: cosign verify-blob artifact.zip --bundle sigstore-bundle.json
     status: passed
+    state: verified
     returncode: 0
     stdout: Verified OK. Bundle contains fixture certificate, Rekor entry, message digest and DSSE envelope.
     stderr: ''

--- a/.agent-operating-model/bundles/github/prompt.spec.yaml
+++ b/.agent-operating-model/bundles/github/prompt.spec.yaml
@@ -2,7 +2,7 @@ bundle:
   id: github-diamond-standard
   name: GitHub Diamond Standard Prompt Bundle
   version: 2.9.3
-  status: examples-assurance-refresh
+  status: full-release-readiness
   default_mode: repository-operator
   prompt_body: prompt.body.xml
 design:
@@ -37,6 +37,7 @@ assembly:
   - references/eval-harness.xml
   - references/archetype-control-profiles.xml
   - references/github-tooling-mutation-policy.xml
+  - references/github-best-practices.xml
   mode_modules:
   - modes/repo-discovery.xml
   - modes/repo-instantiate.xml
@@ -58,6 +59,7 @@ assembly:
   - roles/repository-operator.xml
   - roles/security.xml
   contract_modules:
+  - contracts/accessibility-evidence.schema.json
   - contracts/agent-evidence.schema.json
   - contracts/conformance-record.schema.json
   - contracts/endpoint-catalog.schema.json
@@ -69,14 +71,17 @@ assembly:
   - contracts/grade-result.schema.json
   - contracts/harm-register.schema.json
   - contracts/issue-contract.schema.json
+  - contracts/live-release-policy.schema.json
   - contracts/performance-budget.schema.json
   - contracts/provenance-record.schema.json
   - contracts/pull-request-contract.schema.json
   - contracts/release-contract.schema.json
+  - contracts/release-gate-report.schema.json
   - contracts/repository-contract.schema.json
   - contracts/safe-audit-trail.schema.json
   - contracts/sbom-record.schema.json
   - contracts/template-registry.schema.json
+  - contracts/trusted-attestation-verification.schema.json
   - contracts/workflow-contract.schema.json
   grader_modules:
   - graders/accessibility-grader.xml
@@ -84,6 +89,7 @@ assembly:
   - graders/code-confidence-grader.xml
   - graders/conformance-grader.xml
   - graders/discovery-grader.xml
+  - graders/documentation-grader.xml
   - graders/ethics-grader.xml
   - graders/github-settings-grader.xml
   - graders/performance-grader.xml

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -188,7 +188,7 @@ artifacts:
 - path: examples/fixtures/live-gate/high-assurance-pass/repo/accessibility-evidence.yaml
   sha256: b72e2dd08730fd476c08aaa026ff2b316e5e49b0f287cbaa4bfa9d11ced2e960
 - path: examples/fixtures/live-gate/high-assurance-pass/repo/agent-evidence.yaml
-  sha256: f3304855ae289da97ece714dd85032be15f1098ea6978af1b57e882b145a1853
+  sha256: cf3f84e29f73bff16c9b216e79bd11d1ce62c7879b8a5cccbf3fb1132ddce1ba
 - path: examples/fixtures/live-gate/high-assurance-pass/repo/artifact.zip
   sha256: 0fc7c8c357dfa2cc6116cdf1172b5734908a31644d6a807152023dd63d7f151a
 - path: examples/fixtures/live-gate/high-assurance-pass/repo/attestation.json

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -10,7 +10,7 @@ artifacts:
 - path: contracts/accessibility-evidence.schema.json
   sha256: 6dcfd29a11ce04bb610a9aae7cdd1194c6c4ef190bf61be0b10da3148bc01c08
 - path: contracts/agent-evidence.schema.json
-  sha256: aec8c2eaf9da67a383b47815be2195317067bd2de54a5ade313eff86b11c5452
+  sha256: a5413db1d63e25c3eaf98522ac7fdd7c9268ca5696f29518c2153ea34f235f8a
 - path: contracts/conformance-record.schema.json
   sha256: 3e3ebea281fa111150da063d8d56902f5547e991696553c419e3d4353316627a
 - path: contracts/endpoint-catalog.schema.json

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -64,7 +64,7 @@ artifacts:
 - path: examples/accessibility-results/pa11y.json
   sha256: e320b9c1defc0a09e10b71e199e96a115539ab7bfa0676f9faa3cb6aba721133
 - path: examples/agent-evidence.example.yaml
-  sha256: 27991bd62f8c5e917df40553ad126c9971d1691c6c61c323446bd1350647f621
+  sha256: ae88267e634710807f710ed39867e04dbb35166455630c790c7631ad7e746cae
 - path: examples/anti-examples/removes-quality-gates.yaml
   sha256: bad05cfa75a682389475bb69dd7b1fa19720f182b9a45df9bbb62e804be6001a
 - path: examples/anti-examples/unverified-release-recommendation.yaml
@@ -84,7 +84,7 @@ artifacts:
 - path: examples/eval-outputs/instantiate-multi-language-repo-pass/.github/workflows/dependency-review.yml
   sha256: 68aab9b65551476b75343dc1e3e34778e505bd7ddddc0d345273da86474e152a
 - path: examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml
-  sha256: 3ced3f926b93988876c74c33cbdca5f51b6c19eacfaf6cc0b55c8e7ce0a83c66
+  sha256: 2f175e23ffec4c736ca367a3828c4cceaf615f6143fbcbac74751abcc913d2d2
 - path: examples/eval-outputs/instantiate-multi-language-repo-pass/conformance-matrix.yaml
   sha256: adc5e130b4edbefe1153bbd684af61111a559903e77b7c00a96fe85c6bacf902
 - path: examples/eval-outputs/instantiate-multi-language-repo-pass/CONTRIBUTING.md
@@ -410,7 +410,7 @@ artifacts:
 - path: prompt.body.xml
   sha256: a0bd68a5fe3c3f700ba2d6e6d7d0a7592c2feef3fe986a4c5811435abbcb6ba0
 - path: prompt.spec.yaml
-  sha256: 70b63bd30bda9970e20acba30c4a75d6ecda0658096d8e7025002d465c177bb4
+  sha256: 4b2cde0f8186dbece11a46b1378856f7758b25e87fb54b9d6e7e5daef2470fbc
 - path: README.md
   sha256: 6c34825d920bf11b9a7e7e85d1a43a50e74970c48be147147bb073d426018438
 - path: references/accessibility-confidence-pack.xml
@@ -496,7 +496,7 @@ artifacts:
 - path: scripts/live-repository-release-gate.py
   sha256: a707c0871329e9c50c1a9ff90f43d39ba21cce5b9563ea97543f620f6def9e50
 - path: scripts/performance-adapters.py
-  sha256: db80b6e0d5e26d2b63865ffaabd206971e5a484fd8090874987431976cdf043b
+  sha256: ed440bcf0b9254ad6c6a811efd1af990548d56a29641487244a4bd5a191cbf63
 - path: scripts/pin-workflow-actions.py
   sha256: 8855ecbe8c4c17dee2598ab48da6be48be89b96b05fd1c032210b4dd16626287
 - path: scripts/README.md
@@ -514,9 +514,9 @@ artifacts:
 - path: scripts/validate-accessibility-fixtures.py
   sha256: 21de89e7236b79988e52a77b815568b65d08355604c848b00c4bb7a385498c05
 - path: scripts/validate-agent-evidence.py
-  sha256: 7ed427d6aae1212500b3a9547dbff9aa57b580ec15d680c33c1b688249fed952
+  sha256: 21f16f53525db6d2bbe811b269eeea0a64cfbef3025bfc3b8a9b14e821e27e49
 - path: scripts/validate-bundle.py
-  sha256: 74eb56b495f00b97cba744775bb2b46cd9abd9265797044982c564a14ce7d85d
+  sha256: cc7488dcf24b7087ebd9d520805872a35432de472614b996543a8c93d900b993
 - path: scripts/validate-changelog.py
   sha256: cf8a41db446ed9caf179369f24756cc2abc24aaa9453806fa2b412c988bc45e3
 - path: scripts/validate-docs-consistency.py
@@ -702,6 +702,6 @@ artifacts:
 - path: tests.regression.yaml
   sha256: 45350ecffeb5040f7cb61301fc99d6a23436d934280fc48bb7c3f47d8263d6a1
 - path: VALIDATION-REPORT.md
-  sha256: b7305cb5ba1149685f6fe5ab5568e907c5ca43bbfbb29c96f7798c9a233b0d3a
+  sha256: e4daa71b60bdaf7b1e9b29526a12115ad4df588df6a66bc9d528856cb749c46e
 - path: variables.schema.json
   sha256: 98e5a233501da227f3209b48e8729ac9a3b2a45d6de0c471251d1148e7ce0593

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -502,7 +502,7 @@ artifacts:
 - path: scripts/README.md
   sha256: 77b533dff46947c81a32dea78ea3f66eb59fb635535861c33babeb07c18e9cac
 - path: scripts/release-gate.py
-  sha256: d8c9f4a52f6fe010810806da8ef677cc94e890d34d63093b531f88cff5470f1b
+  sha256: 839aa893490825012f5b8888d1a267ac94fac5de3c44e913a3568cf1e411b09e
 - path: scripts/repository_conditions.py
   sha256: 80cfb8ab4eea061561e3db42eed0ecec3254d9bff9811dfa6d5240d75be976c6
 - path: scripts/run-eval-harness.py

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -513,6 +513,8 @@ artifacts:
   sha256: 4929046e1bc58ad41062cd5615fa77838aff8102ed4fcbc9cf3ac01ab09bdd08
 - path: scripts/validate-accessibility-fixtures.py
   sha256: 21de89e7236b79988e52a77b815568b65d08355604c848b00c4bb7a385498c05
+- path: scripts/validate-agent-evidence-fixtures.py
+  sha256: e07a93f2624e63cbd1f64d555b1457b6bbc9b60424892b5c3b578601996d06e8
 - path: scripts/validate-agent-evidence.py
   sha256: 21f16f53525db6d2bbe811b269eeea0a64cfbef3025bfc3b8a9b14e821e27e49
 - path: scripts/validate-bundle.py

--- a/.agent-operating-model/bundles/github/scripts/performance-adapters.py
+++ b/.agent-operating-model/bundles/github/scripts/performance-adapters.py
@@ -33,6 +33,13 @@ def percentile(values, pct):
         return values[int(k)]
     return values[f] * (c - k) + values[c] * (k - f)
 
+def canonical_rollup(metric, value, unit, source, detail_metrics):
+    result = measurement(metric, value, unit, source)
+    result["rollup"] = True
+    result["rollup_strategy"] = "max"
+    result["source_metrics"] = detail_metrics
+    return result
+
 def apply_profile(adapter, measurements, profile_path):
     if not profile_path:
         return measurements
@@ -47,22 +54,48 @@ def apply_profile(adapter, measurements, profile_path):
     return measurements
 
 def adapt_pytest_benchmark(path):
-    data=json.loads(Path(path).read_text(encoding="utf-8"))
+    path = Path(path)
+    data=json.loads(path.read_text(encoding="utf-8"))
     out=[]
+    mean_values=[]
+    max_values=[]
+    mean_metrics=[]
+    max_metrics=[]
     for item in data.get("benchmarks", []):
         name=item.get("name", "benchmark")
         stats=item.get("stats", {})
-        if "mean" in stats: out.append(measurement(f"{name}_mean_seconds", stats["mean"], "seconds", str(path)))
-        if "max" in stats: out.append(measurement(f"{name}_max_seconds", stats["max"], "seconds", str(path)))
+        if "mean" in stats:
+            metric_name = f"{name}_mean_seconds"
+            out.append(measurement(metric_name, stats["mean"], "seconds", str(path)))
+            mean_values.append(float(stats["mean"]))
+            mean_metrics.append(metric_name)
+        if "max" in stats:
+            metric_name = f"{name}_max_seconds"
+            out.append(measurement(metric_name, stats["max"], "seconds", str(path)))
+            max_values.append(float(stats["max"]))
+            max_metrics.append(metric_name)
+    if mean_values:
+        out.append(canonical_rollup("response_time_mean_seconds", max(mean_values), "seconds", str(path), mean_metrics))
+    if max_values:
+        out.append(canonical_rollup("response_time_max_seconds", max(max_values), "seconds", str(path), max_metrics))
     return out
 
 def adapt_go_bench(path):
+    path = Path(path)
     out=[]
-    text=Path(path).read_text(encoding="utf-8", errors="ignore")
+    ns_values=[]
+    ns_metrics=[]
+    text=path.read_text(encoding="utf-8", errors="ignore")
     for line in text.splitlines():
         m=re.match(r"(Benchmark\S+)\s+\d+\s+([0-9.]+)\s+ns/op", line)
         if m:
-            out.append(measurement(f"{m.group(1)}_ns_per_op", float(m.group(2)), "ns/op", str(path)))
+            metric_name = f"{m.group(1)}_ns_per_op"
+            value = float(m.group(2))
+            out.append(measurement(metric_name, value, "ns/op", str(path)))
+            ns_values.append(value)
+            ns_metrics.append(metric_name)
+    if ns_values:
+        out.append(canonical_rollup("handler_ns_per_op", max(ns_values), "ns/op", str(path), ns_metrics))
     return out
 
 def adapt_lighthouse(path):

--- a/.agent-operating-model/bundles/github/scripts/release-gate.py
+++ b/.agent-operating-model/bundles/github/scripts/release-gate.py
@@ -160,6 +160,7 @@ def add_common_checks(report, positive, evidence, timeout):
     run(["scripts/validate-docs-consistency.py"], report, timeout)
     run(["scripts/validate-agent-evidence.py", "examples/agent-evidence.example.yaml"], report, timeout)
     run(["scripts/validate-agent-evidence.py", evidence], report, timeout)
+    run(["scripts/validate-agent-evidence-fixtures.py"], report, timeout)
 
     selection_yaml = run(["scripts/select-ci-templates.py", "--repo", positive], report, timeout)
     with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tmp:

--- a/.agent-operating-model/bundles/github/scripts/validate-agent-evidence-fixtures.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-agent-evidence-fixtures.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate-agent-evidence.py"
+
+
+def collect_evidence_files(scope):
+    paths = []
+    for base in scope:
+        candidate = ROOT / base
+        if candidate.is_file() and candidate.name == "agent-evidence.yaml":
+            paths.append(candidate)
+        elif candidate.is_dir():
+            paths.extend(candidate.rglob("agent-evidence.yaml"))
+    return sorted(set(paths))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--scope",
+        action="append",
+        default=["examples/fixtures", "examples/eval-outputs"],
+        help="Bundle-relative file or directory to scan for agent-evidence.yaml. May be provided more than once.",
+    )
+    args = parser.parse_args()
+
+    evidence_files = collect_evidence_files(args.scope)
+    if not evidence_files:
+        print("No agent-evidence.yaml files found.")
+        raise SystemExit(1)
+
+    failures = []
+    for path in evidence_files:
+        rel = path.relative_to(ROOT).as_posix()
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), rel],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            failures.append((rel, result.stdout, result.stderr))
+            print(f"FAIL {rel}")
+            if result.stdout:
+                print(result.stdout.rstrip())
+            if result.stderr:
+                print(result.stderr.rstrip(), file=sys.stderr)
+        else:
+            print(f"PASS {rel}")
+
+    if failures:
+        print(f"Agent evidence fixture validation failed for {len(failures)} file(s).")
+        raise SystemExit(1)
+
+    print(f"Agent evidence fixture validation passed for {len(evidence_files)} file(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent-operating-model/bundles/github/scripts/validate-agent-evidence.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-agent-evidence.py
@@ -9,14 +9,110 @@ REQUIRED = {
     "task_id", "mode", "files_read", "files_changed", "commands_run",
     "contracts_validated", "artifacts_created", "gaps_recorded", "waivers_recorded"
 }
+LIST_FIELDS = [
+    "files_read", "files_changed", "contracts_validated", "artifacts_created",
+    "gaps_recorded", "waivers_recorded"
+]
+STATUS_VALUES = {"passed", "failed", "not-run", "timeout", "unavailable", "waived"}
+EVIDENCE_STATES = {"claimed", "observed", "verified", "unavailable", "waived"}
+
 
 def resolve(path_text):
     path = Path(path_text)
     return path if path.exists() else ROOT / path_text
 
+
 def load(path):
     text = path.read_text(encoding="utf-8")
     return yaml.safe_load(text) if path.suffix in {".yaml", ".yml"} else json.loads(text)
+
+
+def validate_string_list(data, field, errors):
+    if field not in data:
+        return
+    if not isinstance(data[field], list):
+        errors.append(f"{field} must be a list")
+        return
+    for index, item in enumerate(data[field]):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"{field}[{index}] must be a non-empty string")
+
+
+def has_observed_execution_detail(item):
+    return any(
+        key in item and item.get(key) not in (None, "")
+        for key in ["returncode", "stdout", "stderr", "evidence"]
+    )
+
+
+def validate_state(value, field, errors):
+    if value not in EVIDENCE_STATES:
+        errors.append(f"{field} must be one of {sorted(EVIDENCE_STATES)}")
+
+
+def validate_status(value, field, errors):
+    if value not in STATUS_VALUES:
+        errors.append(f"{field} must be one of {sorted(STATUS_VALUES)}")
+
+
+def validate_command_like_items(data, field, errors):
+    if field not in data:
+        return
+    if not isinstance(data[field], list):
+        errors.append(f"{field} must be a list")
+        return
+    for index, item in enumerate(data[field]):
+        prefix = f"{field}[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        required_label = "command" if field in {"commands_run", "test_results"} else "name"
+        if not isinstance(item.get(required_label), str) or not item.get(required_label, "").strip():
+            errors.append(f"{prefix}.{required_label} is required and must be a non-empty string")
+        if "status" not in item:
+            errors.append(f"{prefix}.status is required")
+        else:
+            validate_status(item.get("status"), f"{prefix}.status", errors)
+        if "state" not in item:
+            errors.append(f"{prefix}.state is required")
+        else:
+            validate_state(item.get("state"), f"{prefix}.state", errors)
+        if item.get("state") in {"observed", "verified"} and not has_observed_execution_detail(item):
+            errors.append(f"{prefix} with state {item.get('state')} must include returncode, stdout, stderr or evidence")
+        if item.get("status") == "passed" and item.get("state") in {"claimed", "unavailable", "waived"}:
+            errors.append(f"{prefix} cannot report status passed with state {item.get('state')}")
+        if "returncode" in item and item["returncode"] is not None and not isinstance(item["returncode"], int):
+            errors.append(f"{prefix}.returncode must be an integer or null")
+
+
+def validate_evidence_states(data, errors):
+    if "evidence_states" not in data:
+        return
+    if not isinstance(data["evidence_states"], list):
+        errors.append("evidence_states must be a list")
+        return
+    for index, item in enumerate(data["evidence_states"]):
+        prefix = f"evidence_states[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        if "state" not in item:
+            errors.append(f"{prefix}.state is required")
+        else:
+            validate_state(item.get("state"), f"{prefix}.state", errors)
+        if not isinstance(item.get("rationale"), str) or not item.get("rationale", "").strip():
+            errors.append(f"{prefix}.rationale is required and must be a non-empty string")
+
+
+def validate_accessibility(data, errors):
+    if "accessibility" not in data or not isinstance(data["accessibility"], dict):
+        return
+    acc = data["accessibility"]
+    if acc.get("required") is True:
+        for field in ["automated_checks", "keyboard_checks", "focus_checks", "screen_reader_smoke_checks", "release_decision"]:
+            if not acc.get(field):
+                errors.append(f"accessibility.{field} is required when accessibility.required is true")
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -24,28 +120,21 @@ def main():
     args = parser.parse_args()
     data = load(resolve(args.evidence))
     errors = []
-    missing = REQUIRED - set(data)
-    if missing:
-        errors.append(f"Evidence missing required fields: {sorted(missing)}")
-    for field in ["files_read", "files_changed", "contracts_validated", "artifacts_created", "gaps_recorded", "waivers_recorded"]:
-        if field in data and not isinstance(data[field], list):
-            errors.append(f"{field} must be a list")
-    for field in ["commands_run", "tests_run"]:
-        if field in data:
-            if not isinstance(data[field], list):
-                errors.append(f"{field} must be a list")
-            else:
-                for index, item in enumerate(data[field]):
-                    if not isinstance(item, dict) or "status" not in item:
-                        errors.append(f"{field}[{index}] must contain status")
-                    elif item["status"] not in {"passed", "failed", "not-run"}:
-                        errors.append(f"{field}[{index}].status must be passed, failed, or not-run")
-    if "accessibility" in data and isinstance(data["accessibility"], dict):
-        acc = data["accessibility"]
-        if acc.get("required") is True:
-            for field in ["automated_checks", "keyboard_checks", "focus_checks", "screen_reader_smoke_checks", "release_decision"]:
-                if not acc.get(field):
-                    errors.append(f"accessibility.{field} is required when accessibility.required is true")
+
+    if not isinstance(data, dict):
+        errors.append("Evidence root must be an object")
+    else:
+        missing = REQUIRED - set(data)
+        if missing:
+            errors.append(f"Evidence missing required fields: {sorted(missing)}")
+        for field in LIST_FIELDS:
+            validate_string_list(data, field, errors)
+        validate_command_like_items(data, "commands_run", errors)
+        validate_command_like_items(data, "tests_run", errors)
+        validate_command_like_items(data, "test_results", errors)
+        validate_evidence_states(data, errors)
+        validate_accessibility(data, errors)
+
     if errors:
         for error in errors:
             print(error)

--- a/.agent-operating-model/bundles/github/scripts/validate-bundle.py
+++ b/.agent-operating-model/bundles/github/scripts/validate-bundle.py
@@ -40,6 +40,11 @@ REQUIRED_GRADE_FIELDS = {
     "deductions",
     "feedback",
 }
+ASSEMBLY_COVERAGE = {
+    "always_load": "references/*.xml",
+    "contract_modules": "contracts/*.schema.json",
+    "grader_modules": "graders/*.xml",
+}
 
 
 def is_generated(path: Path) -> bool:
@@ -114,6 +119,22 @@ def contract_strength_checks(errors):
             errors.append(f"Required shared contract missing: {rel}")
 
 
+def assembly_coverage_checks(assembly, errors):
+    for key, glob_pattern in ASSEMBLY_COVERAGE.items():
+        configured = set(assembly.get(key, []) or [])
+        actual = {
+            path.relative_to(ROOT).as_posix()
+            for path in ROOT.glob(glob_pattern)
+            if path.is_file() and not is_generated(path)
+        }
+        missing = sorted(actual - configured)
+        extra = sorted(configured - actual)
+        if missing:
+            errors.append(f"prompt.spec.yaml {key} missing module coverage: " + ", ".join(missing))
+        if extra:
+            errors.append(f"prompt.spec.yaml {key} references non-module paths: " + ", ".join(extra))
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--strict", action="store_true")
@@ -145,9 +166,13 @@ def main():
             except Exception as exc:
                 errors.append(f"YAML parse error: {p.relative_to(ROOT)}: {exc}")
 
+    spec = load_yaml(ROOT / "prompt.spec.yaml")
+    assembly = spec.get("assembly", {})
+
     if args.strict:
         strict_schema_checks(schema_docs, errors)
         contract_strength_checks(errors)
+        assembly_coverage_checks(assembly, errors)
 
     for p in ROOT.rglob("*"):
         if p.is_file() and not is_generated(p) and p.suffix.lower() in {".md", ".xml", ".yaml", ".yml", ".json", ".py", ".txt"}:
@@ -180,8 +205,6 @@ def main():
     if extra:
         errors.append("Manifest contains extra/generated files: " + ", ".join(extra[:20]))
 
-    spec = load_yaml(ROOT / "prompt.spec.yaml")
-    assembly = spec.get("assembly", {})
     for key in ["always_load", "mode_modules", "role_modules", "contract_modules", "grader_modules"]:
         for rel in assembly.get(key, []) or []:
             if not (ROOT / rel).exists():

--- a/.prettierignore
+++ b/.prettierignore
@@ -47,6 +47,7 @@ eslint.config.js
 tests/*-contract.test.js
 tests/*-regression.test.js
 tests/*-route-state.test.js
+tests/*-release-gate.test.js
 
 # Visual walkthrough registry is validated by tests/visual-walkthrough-registry.test.js.
 visual-walkthrough.config.mjs

--- a/docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.json
+++ b/docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.json
@@ -9,7 +9,8 @@
     "performance-adapters",
     "validation-report",
     "prompt-spec-assembly",
-    "agent-evidence-validation"
+    "agent-evidence-validation",
+    "registry-manifest"
   ],
   "evidenceBoundary": {
     "summary": "This trace records observable repository work to address the revised github.zip evaluation and move the GitHub Diamond bundle from fast-gate clean to full-release ready. It does not include private chain-of-thought."
@@ -34,7 +35,9 @@
     "Updated prompt.spec.yaml to include github-best-practices.xml in always_load, documentation-grader.xml in grader_modules, and live assurance contracts in contract_modules.",
     "Updated validate-bundle.py strict mode so prompt.spec assembly coverage is checked against references/*.xml, contracts/*.schema.json and graders/*.xml.",
     "Updated validate-agent-evidence.py to require command/name, status, state and execution detail for command-like evidence items.",
-    "Updated agent evidence examples to include verified and waived evidence states plus returncode/stdout/stderr/evidence details for verified passed command evidence."
+    "Updated agent evidence examples to include verified and waived evidence states plus returncode/stdout/stderr/evidence details for verified passed command evidence.",
+    "Observed that the registry-manifest automation refreshed the manifest and moved the PR head to a generated checksum commit.",
+    "Added this follow-up trace update to create a normal branch commit after the generated manifest update so PR checks can run on the latest head."
   ],
   "changedAreas": [
     ".agent-operating-model/bundles/github/scripts/performance-adapters.py",
@@ -43,7 +46,8 @@
     ".agent-operating-model/bundles/github/scripts/validate-bundle.py",
     ".agent-operating-model/bundles/github/scripts/validate-agent-evidence.py",
     ".agent-operating-model/bundles/github/examples/agent-evidence.example.yaml",
-    ".agent-operating-model/bundles/github/examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml"
+    ".agent-operating-model/bundles/github/examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml",
+    ".agent-operating-model/bundles/github/registry-manifest.yaml"
   ],
   "validationEvidence": {
     "staticCompatibilityChecks": [
@@ -51,7 +55,8 @@
       "Go benchmark adapter now emits handler_ns_per_op while preserving detailed per-benchmark metrics.",
       "validate-bundle.py --strict now checks complete assembly coverage for references, contracts and graders.",
       "validate-agent-evidence.py now rejects passed command evidence unless it has an observed or verified state and execution detail.",
-      "The validation report no longer states that manifest regeneration is the only blocker."
+      "The validation report no longer states that manifest regeneration is the only blocker.",
+      "registry-manifest.yaml has been refreshed by the existing checksum automation."
     ],
     "notRunLocally": [
       "No local full release gate was run in this connector-only environment. CI should run release-gate.py on the pull request."
@@ -74,9 +79,9 @@
       "mitigation": "The release-gate evidence fixtures have been updated with explicit state and execution details."
     },
     {
-      "risk": "Registry manifest checksums may be stale after script and evidence edits.",
-      "mitigation": "The existing GitHub bundle registry-manifest workflow should regenerate registry-manifest.yaml on the pull request branch."
+      "risk": "Commits pushed by the default GITHUB_TOKEN may not trigger the full downstream workflow cascade.",
+      "mitigation": "This trace update creates a normal branch commit after the generated manifest update so PR checks can run on the latest head."
     }
   ],
-  "status": "ready-for-pr"
+  "status": "ci-rerun-triggered"
 }

--- a/docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.json
+++ b/docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": "researchops-agent-trace-summary/v1",
+  "traceType": "operational-audit",
+  "date": "2026-05-23",
+  "branch": "fix/github-full-release-readiness",
+  "scope": [
+    "github-diamond-bundle",
+    "full-release-gate",
+    "performance-adapters",
+    "validation-report",
+    "prompt-spec-assembly",
+    "agent-evidence-validation"
+  ],
+  "evidenceBoundary": {
+    "summary": "This trace records observable repository work to address the revised github.zip evaluation and move the GitHub Diamond bundle from fast-gate clean to full-release ready. It does not include private chain-of-thought."
+  },
+  "operatingModel": {
+    "selectedBundles": [
+      "github",
+      "researchops-developer-control",
+      "multi-functional-team"
+    ],
+    "branchPolicy": "fix/ branches require audit trace artefacts under docs/agent-audit/reasoning/YYYY/MM/DD."
+  },
+  "problemSummary": [
+    "The revised github.zip evaluation found that the fast release gate passes but the full release gate fails.",
+    "The primary full-gate blocker was a performance adapter metric mismatch: pytest-benchmark and Go benchmark adapters emitted only per-test/per-benchmark metrics while their budgets expected canonical aggregate metrics.",
+    "Secondary blockers were a stale validation report, incomplete prompt.spec assembly coverage and a weak agent-evidence validator that did not enforce command, state or execution-evidence semantics."
+  ],
+  "workSummary": [
+    "Updated scripts/performance-adapters.py so pytest-benchmark preserves detailed per-test metrics and also emits response_time_mean_seconds and response_time_max_seconds canonical roll-up metrics using max aggregation.",
+    "Updated scripts/performance-adapters.py so Go benchmark preserves detailed per-benchmark ns/op metrics and also emits handler_ns_per_op as a max roll-up metric.",
+    "Updated VALIDATION-REPORT.md to remove the stale manifest-only blocker and record the current fast-gate/full-gate release position.",
+    "Updated prompt.spec.yaml to include github-best-practices.xml in always_load, documentation-grader.xml in grader_modules, and live assurance contracts in contract_modules.",
+    "Updated validate-bundle.py strict mode so prompt.spec assembly coverage is checked against references/*.xml, contracts/*.schema.json and graders/*.xml.",
+    "Updated validate-agent-evidence.py to require command/name, status, state and execution detail for command-like evidence items.",
+    "Updated agent evidence examples to include verified and waived evidence states plus returncode/stdout/stderr/evidence details for verified passed command evidence."
+  ],
+  "changedAreas": [
+    ".agent-operating-model/bundles/github/scripts/performance-adapters.py",
+    ".agent-operating-model/bundles/github/VALIDATION-REPORT.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/scripts/validate-bundle.py",
+    ".agent-operating-model/bundles/github/scripts/validate-agent-evidence.py",
+    ".agent-operating-model/bundles/github/examples/agent-evidence.example.yaml",
+    ".agent-operating-model/bundles/github/examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml"
+  ],
+  "validationEvidence": {
+    "staticCompatibilityChecks": [
+      "pytest-benchmark adapter now emits response_time_mean_seconds and response_time_max_seconds while preserving detailed per-test metrics.",
+      "Go benchmark adapter now emits handler_ns_per_op while preserving detailed per-benchmark metrics.",
+      "validate-bundle.py --strict now checks complete assembly coverage for references, contracts and graders.",
+      "validate-agent-evidence.py now rejects passed command evidence unless it has an observed or verified state and execution detail.",
+      "The validation report no longer states that manifest regeneration is the only blocker."
+    ],
+    "notRunLocally": [
+      "No local full release gate was run in this connector-only environment. CI should run release-gate.py on the pull request."
+    ],
+    "recommendedNextChecks": [
+      "cd .agent-operating-model/bundles/github",
+      "python scripts/validate-agent-evidence.py examples/agent-evidence.example.yaml",
+      "python scripts/validate-agent-evidence.py examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml",
+      "python scripts/validate-bundle.py --strict",
+      "PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode full --report full-release-gate-report.json"
+    ]
+  },
+  "risks": [
+    {
+      "risk": "The full gate may reveal a later adapter mismatch after pytest-benchmark and Go benchmark roll-ups are fixed.",
+      "mitigation": "The full gate exercises all performance adapters. Any further mismatch should be handled as a concrete adapter/budget alignment defect."
+    },
+    {
+      "risk": "Stronger agent-evidence validation may expose weak fixture records.",
+      "mitigation": "The release-gate evidence fixtures have been updated with explicit state and execution details."
+    },
+    {
+      "risk": "Registry manifest checksums may be stale after script and evidence edits.",
+      "mitigation": "The existing GitHub bundle registry-manifest workflow should regenerate registry-manifest.yaml on the pull request branch."
+    }
+  ],
+  "status": "ready-for-pr"
+}

--- a/docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.md
+++ b/docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.md
@@ -1,0 +1,156 @@
+# Agent audit trace — GitHub full release readiness
+
+Date: 2026-05-23
+
+Branch: `fix/github-full-release-readiness`
+
+Trace type: operational audit
+
+Status: ready for PR review
+
+## Evidence boundary
+
+This trace records observable repository work to address the revised `github.zip` evaluation and move the GitHub Diamond bundle from fast-gate clean to full-release ready.
+
+It does not include private chain-of-thought.
+
+## Scope
+
+This remediation branch covers:
+
+- full release-gate performance adapter blockers
+- validation report accuracy
+- prompt specification assembly coverage
+- agent-evidence validation strength
+
+It follows the earlier remediation PRs that repaired structural fast-gate blockers, eval execution trustworthiness, and contract/scenario validation.
+
+## Problem summary
+
+The revised bundle evaluation found that the fast release gate passes, but the full release gate fails.
+
+The primary blocker was a performance adapter metric mismatch.
+
+The pytest-benchmark adapter emitted per-test metrics such as:
+
+- `test_repository_conformance_endpoint_mean_seconds`
+- `test_repository_conformance_endpoint_max_seconds`
+- `test_release_gate_summary_build_mean_seconds`
+- `test_release_gate_summary_build_max_seconds`
+
+The pytest-benchmark budget expected canonical metrics:
+
+- `response_time_mean_seconds`
+- `response_time_max_seconds`
+
+The Go benchmark adapter emitted per-benchmark metrics such as:
+
+- `BenchmarkRepositoryConformanceHandler-8_ns_per_op`
+- `BenchmarkReleaseGateSummaryHandler-8_ns_per_op`
+- `BenchmarkEvidenceIndexLookup-8_ns_per_op`
+
+The Go benchmark budget expected:
+
+- `handler_ns_per_op`
+
+Secondary blockers were:
+
+- stale `VALIDATION-REPORT.md`
+- incomplete `prompt.spec.yaml` assembly coverage
+- weak `validate-agent-evidence.py` semantics
+
+## Work completed
+
+Updated `scripts/performance-adapters.py` so pytest-benchmark preserves detailed per-test metrics and also emits canonical roll-up metrics:
+
+- `response_time_mean_seconds`
+- `response_time_max_seconds`
+
+The roll-up strategy uses the maximum value across benchmark entries. This is conservative for a release gate.
+
+Updated `scripts/performance-adapters.py` so Go benchmark preserves detailed per-benchmark `ns/op` metrics and also emits the canonical budget metric:
+
+- `handler_ns_per_op`
+
+The roll-up strategy uses the maximum `ns/op` value across benchmark entries.
+
+Updated `VALIDATION-REPORT.md` so it no longer states that manifest regeneration is the only blocker. It now records the fast-gate/full-gate position and the performance adapter remediation.
+
+Updated `prompt.spec.yaml` so bundle assembly coverage includes:
+
+- `references/github-best-practices.xml`
+- `graders/documentation-grader.xml`
+- `contracts/accessibility-evidence.schema.json`
+- `contracts/live-release-policy.schema.json`
+- `contracts/release-gate-report.schema.json`
+- `contracts/trusted-attestation-verification.schema.json`
+
+Updated `scripts/validate-bundle.py --strict` so prompt specification assembly coverage is checked against actual files in:
+
+- `references/*.xml`
+- `contracts/*.schema.json`
+- `graders/*.xml`
+
+Updated `scripts/validate-agent-evidence.py` so command-like evidence must include:
+
+- command or name
+- status
+- state
+- execution detail where the state is `observed` or `verified`
+
+The validator now recognises the schema vocabulary:
+
+- `passed`
+- `failed`
+- `not-run`
+- `timeout`
+- `unavailable`
+- `waived`
+
+It also recognises the evidence-state vocabulary:
+
+- `claimed`
+- `observed`
+- `verified`
+- `unavailable`
+- `waived`
+
+Updated the agent evidence fixtures so verified passed commands include explicit state and execution detail.
+
+## Files changed
+
+- `.agent-operating-model/bundles/github/scripts/performance-adapters.py`
+- `.agent-operating-model/bundles/github/VALIDATION-REPORT.md`
+- `.agent-operating-model/bundles/github/prompt.spec.yaml`
+- `.agent-operating-model/bundles/github/scripts/validate-bundle.py`
+- `.agent-operating-model/bundles/github/scripts/validate-agent-evidence.py`
+- `.agent-operating-model/bundles/github/examples/agent-evidence.example.yaml`
+- `.agent-operating-model/bundles/github/examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml`
+
+## Validation status
+
+No local full release gate was run in this connector-only environment.
+
+Recommended checks:
+
+```bash
+cd .agent-operating-model/bundles/github
+python scripts/validate-agent-evidence.py examples/agent-evidence.example.yaml
+python scripts/validate-agent-evidence.py examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml
+python scripts/validate-bundle.py --strict
+PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode full --report full-release-gate-report.json
+```
+
+## Risks and mitigations
+
+Risk: the full gate may reveal a later adapter mismatch after pytest-benchmark and Go benchmark roll-ups are fixed.
+
+Mitigation: the full gate exercises all performance adapters. Any further mismatch should be handled as a concrete adapter/budget alignment defect.
+
+Risk: stronger agent-evidence validation may expose weak fixture records.
+
+Mitigation: the release-gate evidence fixtures have been updated with explicit state and execution details.
+
+Risk: registry manifest checksums may be stale after script and evidence edits.
+
+Mitigation: the existing GitHub bundle registry-manifest workflow should regenerate `registry-manifest.yaml` on the pull request branch.

--- a/scripts/agent-operating-model/tests/github-bundle-full-release-gate.test.mjs
+++ b/scripts/agent-operating-model/tests/github-bundle-full-release-gate.test.mjs
@@ -24,7 +24,7 @@ test('GitHub bundle full release gate passes', { timeout: 180_000 }, () => {
 			encoding: 'utf8',
 			env: {
 				...process.env,
-				PYTHONDONTVERITEBYTECODE: '1',
+				PYTHONDONTWRITEBYTECODE: '1',
 			},
 		}
 	);
@@ -34,7 +34,7 @@ test('GitHub bundle full release gate passes', { timeout: 180_000 }, () => {
 		0,
 		[
 			'Expected GitHub bundle full release gate to pass.',
-			`stdout:\nT{result.stdout}`,
+			`stdout:\n${result.stdout}`,
 			`stderr:\n${result.stderr}`,
 		].join('\n\n')
 	);

--- a/scripts/agent-operating-model/tests/github-bundle-full-release-gate.test.mjs
+++ b/scripts/agent-operating-model/tests/github-bundle-full-release-gate.test.mjs
@@ -24,9 +24,9 @@ test('GitHub bundle full release gate passes', { timeout: 180_000 }, () => {
 			encoding: 'utf8',
 			env: {
 				...process.env,
-				PYTHONDONTWRITEBYTECODE: '1',
+				PYTHONDONTVERITEBYTECODE: '1',
 			},
-		},
+		}
 	);
 
 	assert.equal(
@@ -34,15 +34,15 @@ test('GitHub bundle full release gate passes', { timeout: 180_000 }, () => {
 		0,
 		[
 			'Expected GitHub bundle full release gate to pass.',
-			`stdout:\n${result.stdout}`,
+			`stdout:\nT{result.stdout}`,
 			`stderr:\n${result.stderr}`,
-		].join('\n\n'),
+		].join('\n\n')
 	);
 
 	assert.equal(
 		existsSync(reportPath),
 		true,
-		'Expected full-release-gate-report.json to be written.',
+		'Expected full-release-gate-report.json to be written.'
 	);
 	const report = JSON.parse(readFileSync(reportPath, 'utf8'));
 	assert.equal(report.status, 'passed');

--- a/tests/github-bundle-full-release-gate.test.js
+++ b/tests/github-bundle-full-release-gate.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const bundleDir = '.agent-operating-model/bundles/github';
+const reportPath = join(bundleDir, 'full-release-gate-report.json');
+
+test('GitHub bundle full release gate passes', { timeout: 180_000 }, () => {
+	const result = spawnSync(
+		'python3',
+		['scripts/release-gate.py', '--mode', 'full', '--timeout', '120', '--report', 'full-release-gate-report.json'],
+		{
+			cwd: bundleDir,
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				PYTHONDONTWRITEBYTECODE: '1'
+			}
+		}
+	);
+
+	assert.equal(
+		result.status,
+		0,
+		[
+			'Expected GitHub bundle full release gate to pass.',
+			`stdout:\n${result.stdout}`,
+			`stderr:\n${result.stderr}`
+		].join('\n\n')
+	);
+
+	assert.equal(existsSync(reportPath), true, 'Expected full-release-gate-report.json to be written.');
+	const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+	assert.equal(report.status, 'passed');
+	assert.equal(report.mode, 'full');
+});

--- a/tests/github-bundle-full-release-gate.test.js
+++ b/tests/github-bundle-full-release-gate.test.js
@@ -10,15 +10,23 @@ const reportPath = join(bundleDir, 'full-release-gate-report.json');
 test('GitHub bundle full release gate passes', { timeout: 180_000 }, () => {
 	const result = spawnSync(
 		'python3',
-		['scripts/release-gate.py', '--mode', 'full', '--timeout', '120', '--report', 'full-release-gate-report.json'],
+		[
+			'scripts/release-gate.py',
+			'--mode',
+			'full',
+			'--timeout',
+			'120',
+			'--report',
+			'full-release-gate-report.json',
+		],
 		{
 			cwd: bundleDir,
 			encoding: 'utf8',
 			env: {
 				...process.env,
-				PYTHONDONTWRITEBYTECODE: '1'
-			}
-		}
+				PYTHONDONTWRITEBYTECODE: '1',
+			},
+		},
 	);
 
 	assert.equal(
@@ -27,11 +35,15 @@ test('GitHub bundle full release gate passes', { timeout: 180_000 }, () => {
 		[
 			'Expected GitHub bundle full release gate to pass.',
 			`stdout:\n${result.stdout}`,
-			`stderr:\n${result.stderr}`
-		].join('\n\n')
+			`stderr:\n${result.stderr}`,
+		].join('\n\n'),
 	);
 
-	assert.equal(existsSync(reportPath), true, 'Expected full-release-gate-report.json to be written.');
+	assert.equal(
+		existsSync(reportPath),
+		true,
+		'Expected full-release-gate-report.json to be written.',
+	);
 	const report = JSON.parse(readFileSync(reportPath, 'utf8'));
 	assert.equal(report.status, 'passed');
 	assert.equal(report.mode, 'full');


### PR DESCRIPTION
## Summary

Follow-up remediation PR after the revised `github.zip` evaluation.

The revised evaluation found that the bundle is now fast-gate clean, but not full release-ready because `release-gate.py --mode full` fails on performance adapter metric mismatch. It also identified secondary assurance issues around `VALIDATION-REPORT.md`, `prompt.spec.yaml` assembly coverage and agent-evidence validation semantics.

## Changes

### Full release-gate performance adapter fix

Updates `scripts/performance-adapters.py` so adapters emit canonical roll-up metrics required by their budget files while preserving detailed diagnostic metrics.

For `pytest-benchmark`:

- preserves per-test metrics such as `*_mean_seconds` and `*_max_seconds`
- emits `response_time_mean_seconds` using the maximum mean value across benchmark entries
- emits `response_time_max_seconds` using the maximum max value across benchmark entries

For `go-bench`:

- preserves per-benchmark `*_ns_per_op` metrics
- emits `handler_ns_per_op` using the maximum `ns/op` value across benchmark entries

### Validation report accuracy

Updates `VALIDATION-REPORT.md` so it no longer says manifest regeneration is the only blocker.

The report now records:

- fast gate: expected pass
- previous full gate: failed before this remediation branch
- previous full-gate blocker: performance adapter canonical metric mismatch
- current remediation: canonical performance roll-up metrics

### Prompt spec assembly coverage

Updates `prompt.spec.yaml` so assembly coverage includes:

- `references/github-best-practices.xml`
- `graders/documentation-grader.xml`
- `contracts/accessibility-evidence.schema.json`
- `contracts/live-release-policy.schema.json`
- `contracts/release-gate-report.schema.json`
- `contracts/trusted-attestation-verification.schema.json`

Updates `scripts/validate-bundle.py --strict` so assembly coverage is checked against actual files in:

- `references/*.xml`
- `contracts/*.schema.json`
- `graders/*.xml`

### Agent evidence validation hardening

Updates `scripts/validate-agent-evidence.py` so command-like evidence must include:

- command or name
- status
- state
- execution detail when state is `observed` or `verified`

It now recognises the full status vocabulary:

- `passed`
- `failed`
- `not-run`
- `timeout`
- `unavailable`
- `waived`

And the evidence-state vocabulary:

- `claimed`
- `observed`
- `verified`
- `unavailable`
- `waived`

Updates both release-gate evidence fixtures with explicit evidence states and execution details.

### Audit trace

Adds safe audit traces:

- `docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.json`
- `docs/agent-audit/reasoning/2026/05/23/github-full-release-readiness.md`

## Validation

Not run locally in this connector-only environment.

Expected validation:

```bash
cd .agent-operating-model/bundles/github
python scripts/validate-agent-evidence.py examples/agent-evidence.example.yaml
python scripts/validate-agent-evidence.py examples/eval-outputs/instantiate-multi-language-repo-pass/agent-evidence.yaml
python scripts/validate-bundle.py --strict
PYTHONDONTWRITEBYTECODE=1 python scripts/release-gate.py --mode full --report full-release-gate-report.json
```

## Notes

This PR may trigger the existing registry-manifest checksum automation. Any checksum-only commit should be reviewed as generated metadata.