### PR TITLE
Fix Mural D1-first board resolution

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.json
+++ b/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.json
@@ -1,0 +1,40 @@
+{
+	"date": "2026-05-27",
+	"branch": "fix/mural-d1-first-resolution",
+	"trace_stub": "mural-d1-first-resolution",
+	"trigger": "Test Project 1 still resolved as having no Reflexive Journal Mural board after PR 287, even though Airtable contained a valid matching Mural Boards row.",
+	"operating_model_files_loaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selected_bundles": [
+		"github-diamond",
+		"researchops-developer-control",
+		"multi-functional-team",
+		"cloudflare",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"decision": {
+		"primary_registry": "D1",
+		"fallback_registry": "Airtable",
+		"seed_file_added": false,
+		"reason_seed_file_not_added": "The runtime path should discover the existing Airtable row and mirror it into D1 automatically. Manual seed data would only mask the ordering bug."
+	},
+	"changes": [
+		"Kept D1 as the first Mural board lookup path.",
+		"Added exact Airtable fallback by Project ID when a project ID is known.",
+		"Kept broad Airtable fallback for legacy linked Project or Projects fields.",
+		"Mirrored Airtable fallback matches into D1.",
+		"Ensured the D1 mural_boards table exists before mirroring.",
+		"Updated unit tests for D1-first lookup, exact fallback, legacy fallback and D1 mirroring."
+	],
+	"validation": {
+		"local": "not run",
+		"github_actions": "pending after PR creation"
+	}
+}

--- a/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.md
+++ b/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.md
@@ -1,0 +1,72 @@
+# Mural D1-first board resolution fix
+
+## Run metadata
+
+- Date: 2026-05-27
+- Branch: `fix/mural-d1-first-resolution`
+- Trigger: after PR #287 merged, `Test Project 1` still resolved as having no Reflexive Journal Mural board even though Airtable contained a matching Mural Boards record.
+
+## User evidence
+
+The user confirmed the Airtable Mural Boards row exists and includes:
+
+- `Project ID`: `recgdpwEI5hFO7bUZ`
+- `UID`: `anon`
+- `Mural ID`: `pppt6786.1763312037559`
+- `Purpose`: `reflexive_journal`
+- `Active`: `true`
+- `Primary?`: `true`
+- `Workspace ID`: `pppt6786`
+
+The user also clarified that manual D1 seeding should not be required for normal operation. D1 should be the primary runtime registry, with Airtable as fallback.
+
+## Operating-model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Selected bundles
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `cloudflare`
+- `airtable-public-api`
+- `mural-public-api`
+
+## Files read
+
+- `infra/cloudflare/src/service/internals/airtable.js`
+- `infra/cloudflare/src/service/internals/mural.js`
+- `infra/cloudflare/src/service/internals/researchops-d1.js`
+- `tests/mural-airtable-board-registry.test.js`
+- `RECENT_LEARNINGS.md`
+
+## Diagnosis
+
+PR #287 made D1 available in the helper, but the Airtable fallback was still too broad after D1 missed. When a project ID was known, the helper queried Airtable by `Purpose` and `Active`, then locally filtered the returned page for `Project ID`, `Project`, or `Projects`.
+
+That means a valid Airtable row can be missed if it is outside the returned page, even when it has an exact `Project ID` match.
+
+Manual D1 seeding would mask the problem for one project. It would not fix the runtime ordering or self-healing path.
+
+## Changes made
+
+- Kept D1 as the first board lookup path.
+- Added exact Airtable fallback using `{Project ID}` when a project ID is known.
+- Kept the broad Airtable legacy fallback for rows that use linked `Project` or `Projects` fields instead of `Project ID`.
+- Mirrored Airtable fallback matches into D1 so the next request resolves from D1.
+- Ensured the D1 `mural_boards` table exists before mirroring a mapping.
+- Updated unit tests for D1-first lookup, exact Airtable fallback, legacy Airtable fallback, and D1 mirroring.
+
+## Seed-file decision
+
+No seed file was added. The normal runtime path should not require manual seed data. The corrected fallback should discover the existing Airtable row and mirror it into D1 automatically.
+
+## Validation
+
+Validation is delegated to GitHub Actions after the PR is opened. The focused unit tests cover the corrected order and fallback behaviour.

--- a/infra/cloudflare/src/service/internals/airtable.js
+++ b/infra/cloudflare/src/service/internals/airtable.js
@@ -10,10 +10,7 @@ import {
 	airtableTryWrite,
 } from "../../core/utils.js";
 import { DEFAULTS } from "../../core/constants.js";
-import {
-	d1GetMuralBoardForProject,
-	d1Run,
-} from "./researchops-d1.js";
+import { d1GetMuralBoardForProject, d1Run } from "./researchops-d1.js";
 
 export function makeTableUrl(env, tableName) {
 	const base = env.AIRTABLE_BASE_ID || env.AIRTABLE_BASE;
@@ -47,6 +44,10 @@ export function escFormula(v) {
 
 export function looksLikeAirtableId(v) {
 	return typeof v === "string" && /^rec[a-z0-9]{14}$/i.test(v.trim());
+}
+
+function cleanString(value) {
+	return typeof value === "string" && value.trim() ? value.trim() : "";
 }
 
 function parseAirtableJson(text, fallback = {}) {
@@ -145,9 +146,7 @@ export async function getRecord(
 	const listUrl = `${base}?${params.toString()}`;
 	const res2 = await fetchWithTimeout(listUrl, { headers }, timeoutMs);
 	const txt2 = await res2.text();
-	if (!res2.ok) {
-		throw new Error(`Airtable ${res2.status}: ${safeText(txt2)}`);
-	}
+	if (!res2.ok) throw new Error(`Airtable ${res2.status}: ${safeText(txt2)}`);
 
 	const js2 = parseAirtableJson(txt2, { records: [] });
 	const rec = (js2.records || [])[0];
@@ -349,11 +348,35 @@ function d1BoardRecord(row, { projectId, uid, purpose }) {
 	};
 }
 
+async function ensureMuralBoardsTable(env, log = null) {
+	if (!env?.RESEARCHOPS_D1) return null;
+	try {
+		await d1Run(
+			env,
+			`CREATE TABLE IF NOT EXISTS mural_boards (
+				mural_id TEXT PRIMARY KEY,
+				project TEXT,
+				purpose TEXT,
+				board_url TEXT,
+				workspace_id TEXT
+			)`,
+		);
+		return { ok: true };
+	} catch (err) {
+		log?.warn?.("d1.mural_boards.ensure_failed", {
+			err: String(err?.message || err),
+		});
+		return { ok: false, error: String(err?.message || err) };
+	}
+}
+
 async function mirrorBoardToD1(env, fields, log = null) {
 	if (!env?.RESEARCHOPS_D1) return null;
 	const muralId = String(fields["Mural ID"] || "").trim();
 	const projectId = String(fields["Project ID"] || "").trim();
 	if (!muralId || !projectId) return null;
+	const ensured = await ensureMuralBoardsTable(env, log);
+	if (ensured && ensured.ok === false) return ensured;
 	try {
 		await d1Run(
 			env,
@@ -375,6 +398,88 @@ async function mirrorBoardToD1(env, fields, log = null) {
 		});
 		return { ok: false, error: String(err?.message || err) };
 	}
+}
+
+function airtableBoardFields(record) {
+	return record?.fields || {};
+}
+
+function boardMatchesProject(fields, pidRaw) {
+	if (String(fields["Project ID"] || "").trim() === pidRaw) return true;
+	const pidRec = looksLikeAirtableId(pidRaw) ? pidRaw : null;
+	const candidates = [];
+	if (Array.isArray(fields.Project)) candidates.push(fields.Project);
+	if (Array.isArray(fields.Projects)) candidates.push(fields.Projects);
+	for (const arr of candidates) {
+		if (!Array.isArray(arr)) continue;
+		if (pidRec) {
+			const hasRecordId = arr.some((v) => {
+				return typeof v === "string" && String(v).trim() === pidRec;
+			});
+			const hasObjectRecordId = arr.some((v) => {
+				return (
+					v &&
+					typeof v === "object" &&
+					String(v.id || "").trim() === pidRec
+				);
+			});
+			if (hasRecordId || hasObjectRecordId) return true;
+		}
+		const hasRawProjectId = arr.some((v) => {
+			return typeof v === "string" && String(v).trim() === pidRaw;
+		});
+		if (hasRawProjectId) return true;
+	}
+	const textVal = String(fields.Project || fields.Projects || "").trim();
+	return textVal && textVal === pidRaw;
+}
+
+async function fetchBoardRows(env, formulaParts, max, log, timeoutMs) {
+	const url = new URL(makeTableUrl(env, boardsTableName(env)));
+	if (formulaParts.length) {
+		url.searchParams.set(
+			"filterByFormula",
+			formulaParts.length === 1
+				? formulaParts[0]
+				: `AND(${formulaParts.join(",")})`,
+		);
+	}
+	url.searchParams.set("maxRecords", String(max));
+	url.searchParams.append("sort[0][field]", "Primary?");
+	url.searchParams.append("sort[0][direction]", "desc");
+	url.searchParams.append("sort[1][field]", "Created At");
+	url.searchParams.append("sort[1][direction]", "desc");
+	log?.debug?.("airtable.boards.list.request", { url: url.toString() });
+	const res = await fetchWithTimeout(
+		url.toString(),
+		{ headers: authHeaders(env) },
+		timeoutMs,
+	);
+	const txt = await res.text().catch(() => "");
+	log?.[res.ok ? "debug" : "warn"]?.("airtable.boards.list.response", {
+		status: res.status,
+		ok: res.ok,
+		bodyPreview: txt.slice(0, 500),
+	});
+	if (!res.ok) {
+		const err = new Error("airtable_list_failed");
+		err.status = res.status;
+		try {
+			err.body = JSON.parse(txt);
+		} catch {}
+		throw err;
+	}
+	const js = parseAirtableJson(txt, {});
+	return Array.isArray(js.records) ? js.records : [];
+}
+
+async function mirrorRowsToD1(env, rows, log = null) {
+	await Promise.all(
+		rows.map(async (row) => {
+			const fields = airtableBoardFields(row);
+			await mirrorBoardToD1(env, fields, log);
+		}),
+	);
 }
 
 export async function listBoards(
@@ -401,80 +506,35 @@ export async function listBoards(
 		}
 	}
 
-	const url = new URL(makeTableUrl(env, boardsTableName(env)));
-	const ands = [];
-	if (!pidRaw && uid) ands.push(`{UID} = "${escFormula(uid)}"`);
-	if (purpose) ands.push(`{Purpose} = "${escFormula(purpose)}"`);
-	if (typeof active === "boolean") ands.push(`{Active} = ${active ? "1" : "0"}`);
-	if (ands.length) {
-		url.searchParams.set(
-			"filterByFormula",
-			ands.length === 1 ? ands[0] : `AND(${ands.join(",")})`,
+	const commonParts = [];
+	if (purpose) commonParts.push(`{Purpose} = "${escFormula(purpose)}"`);
+	if (typeof active === "boolean") {
+		commonParts.push(`{Active} = ${active ? "1" : "0"}`);
+	}
+
+	if (pidRaw) {
+		const exactRows = await fetchBoardRows(
+			env,
+			[`{Project ID} = "${escFormula(pidRaw)}"`, ...commonParts],
+			max,
+			log,
+			timeoutMs,
 		);
-	}
-	url.searchParams.set("maxRecords", String(max));
-	url.searchParams.append("sort[0][field]", "Primary?");
-	url.searchParams.append("sort[0][direction]", "desc");
-	url.searchParams.append("sort[1][field]", "Created At");
-	url.searchParams.append("sort[1][direction]", "desc");
-	log?.debug?.("airtable.boards.list.request", {
-		url: url.toString(),
-		projectId,
-		fallback: "airtable",
-	});
-	const res = await fetchWithTimeout(
-		url.toString(),
-		{ headers: authHeaders(env) },
-		timeoutMs,
-	);
-	const txt = await res.text().catch(() => "");
-	log?.[res.ok ? "debug" : "warn"]?.("airtable.boards.list.response", {
-		status: res.status,
-		ok: res.ok,
-		bodyPreview: txt.slice(0, 500),
-	});
-	if (!res.ok) {
-		const err = new Error("airtable_list_failed");
-		err.status = res.status;
-		try {
-			err.body = JSON.parse(txt);
-		} catch {}
-		throw err;
-	}
-	const js = parseAirtableJson(txt, {});
-	const records = Array.isArray(js.records) ? js.records : [];
-	if (!projectId) return records;
-	const pidRec = looksLikeAirtableId(pidRaw) ? pidRaw : null;
-	return records.filter((r) => {
-		const f = r?.fields || {};
-		if (String(f["Project ID"] || "").trim() === pidRaw) return true;
-		const candidates = [];
-		if (Array.isArray(f.Project)) candidates.push(f.Project);
-		if (Array.isArray(f.Projects)) candidates.push(f.Projects);
-		for (const arr of candidates) {
-			if (!Array.isArray(arr)) continue;
-			if (pidRec) {
-				if (arr.some((v) => typeof v === "string" && String(v).trim() === pidRec)) {
-					return true;
-				}
-				if (
-					arr.some(
-						(v) =>
-							v &&
-							typeof v === "object" &&
-							String(v.id || "").trim() === pidRec,
-					)
-				) {
-					return true;
-				}
-			}
-			if (arr.some((v) => typeof v === "string" && String(v).trim() === pidRaw)) {
-				return true;
-			}
+		if (exactRows.length) {
+			await mirrorRowsToD1(env, exactRows, log);
+			return exactRows;
 		}
-		const textVal = String(f.Project || f.Projects || "").trim();
-		return textVal && textVal === pidRaw;
+	}
+
+	const broadParts = [...commonParts];
+	if (!pidRaw && uid) broadParts.push(`{UID} = "${escFormula(uid)}"`);
+	const broadRows = await fetchBoardRows(env, broadParts, max, log, timeoutMs);
+	if (!projectId) return broadRows;
+	const matchedRows = broadRows.filter((row) => {
+		return boardMatchesProject(airtableBoardFields(row), pidRaw);
 	});
+	if (matchedRows.length) await mirrorRowsToD1(env, matchedRows, log);
+	return matchedRows;
 }
 
 export async function createBoard(
@@ -499,12 +559,12 @@ export async function createBoard(
 		UID: String(uid ?? ""),
 		Purpose: String(purpose ?? ""),
 		"Mural ID": String(muralId ?? ""),
-		"Board URL": typeof boardUrl === "string" && boardUrl.trim() ? boardUrl.trim() : "",
+		"Board URL": cleanString(boardUrl),
 		"Primary?": !!primary,
 		Active: !!active,
 	};
-	if (typeof workspaceId === "string" && workspaceId.trim()) {
-		baseFields["Workspace ID"] = workspaceId.trim();
+	if (cleanString(workspaceId)) {
+		baseFields["Workspace ID"] = cleanString(workspaceId);
 	}
 	const d1Write = await mirrorBoardToD1(env, baseFields, log);
 	const body = { typecast: true, records: [{ fields: baseFields }] };
@@ -543,7 +603,9 @@ export async function createBoard(
 		}
 		const err = new Error("airtable_create_failed");
 		err.status = res.status;
-		err.body = Object.keys(parsed || {}).length ? parsed : { raw: txt.slice(0, 800) };
+		err.body = Object.keys(parsed || {}).length
+			? parsed
+			: { raw: txt.slice(0, 800) };
 		throw err;
 	}
 	return parsed;
@@ -557,7 +619,9 @@ export async function updateBoard(
 	timeoutMs = DEFAULTS.TIMEOUT_MS,
 ) {
 	await mirrorBoardToD1(env, fields, log);
-	if (String(recordId || "").startsWith("d1-")) return { ok: true, source: "d1" };
+	if (String(recordId || "").startsWith("d1-")) {
+		return { ok: true, source: "d1" };
+	}
 	const url = `${makeTableUrl(env, boardsTableName(env))}/${recordId}`;
 	log?.info?.("airtable.boards.update.request", { url, recordId });
 	const res = await fetchWithTimeout(

--- a/tests/mural-airtable-board-registry.test.js
+++ b/tests/mural-airtable-board-registry.test.js
@@ -69,12 +69,76 @@ test('listBoards returns D1 board mappings before external fallback', async () =
 	}
 });
 
-test('listBoards preserves legacy fallback rows without Project ID text', async () => {
-	let formula = '';
+test('listBoards uses exact Project ID Airtable fallback before broad scan', async () => {
+	const formulas = [];
+	const d1Writes = [];
 	const originalFetch = globalThis.fetch;
 	globalThis.fetch = async (resource) => {
 		const url = new URL(String(resource));
-		formula = url.searchParams.get('filterByFormula') || '';
+		const formula = url.searchParams.get('filterByFormula') || '';
+		formulas.push(formula);
+		return new Response(
+			JSON.stringify({
+				records: [
+					{
+						id: 'recBoardExact',
+						fields: {
+							'Project ID': 'recgdpwEI5hFO7bUZ',
+							UID: 'anon',
+							Purpose: 'reflexive_journal',
+							Active: true,
+							'Mural ID': 'exact-board',
+							'Workspace ID': 'workspace-fixture',
+						},
+					},
+				],
+			}),
+			{ status: 200, headers: { 'content-type': 'application/json' } }
+		);
+	};
+
+	try {
+		const rows = await listBoards(
+			{
+				...env,
+				RESEARCHOPS_D1: makeD1({
+					onRun(sql, params) {
+						d1Writes.push({ sql, params });
+					},
+				}),
+			},
+			{
+				projectId: 'recgdpwEI5hFO7bUZ',
+				uid: 'anon',
+				purpose: 'reflexive_journal',
+			}
+		);
+
+		assert.equal(rows.length, 1);
+		assert.equal(rows[0].fields['Mural ID'], 'exact-board');
+		assert.match(formulas[0], /\{Project ID\} = "recgdpwEI5hFO7bUZ"/);
+		assert.equal(formulas.length, 1);
+		assert.equal(d1Writes.length, 1);
+		assert.equal(d1Writes[0].params[0], 'exact-board');
+		assert.equal(d1Writes[0].params[1], 'recgdpwEI5hFO7bUZ');
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test('listBoards preserves legacy fallback rows without Project ID text', async () => {
+	const formulas = [];
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async (resource) => {
+		const url = new URL(String(resource));
+		const formula = url.searchParams.get('filterByFormula') || '';
+		formulas.push(formula);
+		if (formula.includes('{Project ID}')) {
+			return new Response(JSON.stringify({ records: [] }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			});
+		}
 		return new Response(
 			JSON.stringify({
 				records: [
@@ -109,9 +173,10 @@ test('listBoards preserves legacy fallback rows without Project ID text', async 
 
 		assert.equal(rows.length, 1);
 		assert.equal(rows[0].fields['Mural ID'], 'legacy-board');
-		assert.doesNotMatch(formula, /\{Project ID\}/);
-		assert.doesNotMatch(formula, /\{UID\}/);
-		assert.match(formula, /\{Purpose\} = "reflexive_journal"/);
+		assert.match(formulas[0], /\{Project ID\}/);
+		assert.doesNotMatch(formulas[1], /\{Project ID\}/);
+		assert.doesNotMatch(formulas[1], /\{UID\}/);
+		assert.match(formulas[1], /\{Purpose\} = "reflexive_journal"/);
 	} finally {
 		globalThis.fetch = originalFetch;
 	}

--- a/tests/mural-airtable-board-registry.test.js
+++ b/tests/mural-airtable-board-registry.test.js
@@ -29,6 +29,10 @@ function makeD1({ rows = [], onRun = () => {} } = {}) {
 	};
 }
 
+function mappingInsert(writes, muralId) {
+	return writes.find((write) => write.params[0] === muralId) || null;
+}
+
 test('listBoards returns D1 board mappings before external fallback', async () => {
 	let fetched = false;
 	const originalFetch = globalThis.fetch;
@@ -114,13 +118,13 @@ test('listBoards uses exact Project ID Airtable fallback before broad scan', asy
 			}
 		);
 
+		const insert = mappingInsert(d1Writes, 'exact-board');
 		assert.equal(rows.length, 1);
 		assert.equal(rows[0].fields['Mural ID'], 'exact-board');
 		assert.match(formulas[0], /\{Project ID\} = "recgdpwEI5hFO7bUZ"/);
 		assert.equal(formulas.length, 1);
-		assert.equal(d1Writes.length, 1);
-		assert.equal(d1Writes[0].params[0], 'exact-board');
-		assert.equal(d1Writes[0].params[1], 'recgdpwEI5hFO7bUZ');
+		assert.ok(insert);
+		assert.equal(insert.params[1], 'recgdpwEI5hFO7bUZ');
 	} finally {
 		globalThis.fetch = originalFetch;
 	}
@@ -214,11 +218,11 @@ test('createBoard mirrors board mappings to D1 before external registration', as
 			}
 		);
 
+		const insert = mappingInsert(d1Writes, 'new-board');
 		assert.equal(result.deferred, true);
 		assert.equal(result.d1Write.ok, true);
-		assert.equal(d1Writes.length, 1);
-		assert.equal(d1Writes[0].params[0], 'new-board');
-		assert.equal(d1Writes[0].params[1], 'recgdpwEI5hFO7bUZ');
+		assert.ok(insert);
+		assert.equal(insert.params[1], 'recgdpwEI5hFO7bUZ');
 	} finally {
 		globalThis.fetch = originalFetch;
 	}


### PR DESCRIPTION
## Summary

Fixes the remaining Mural board resolution issue after PR #287.

`Test Project 1` still resolved as having no Reflexive Journal Mural board even though Airtable contained a valid `Mural Boards` row with:

- `Project ID: recgdpwEI5hFO7bUZ`
- `UID: anon`
- `Mural ID: pppt6786.1763312037559`
- `Purpose: reflexive_journal`
- `Active: true`
- `Primary?: true`
- `Workspace ID: pppt6786`

## Root cause

Manual D1 seeding should not be required for normal operation.

After D1 missed, the Airtable fallback queried by `Purpose` and `Active`, then filtered a returned page locally for `Project ID`, `Project`, or `Projects`.

That can miss a valid Airtable row if the row is outside the returned page, even when it has an exact `Project ID` match.

## Changes

- Keeps D1 as the first Mural board lookup path.
- Adds an exact Airtable fallback query by `{Project ID}` when a project ID is known.
- Keeps the broad Airtable fallback for legacy rows that only have linked `Project` or `Projects` fields.
- Mirrors any Airtable fallback match into D1 so the next resolve can succeed from D1.
- Ensures the D1 `mural_boards` table exists before mirroring a mapping.
- Updates the Mural board registry unit tests for:
  - D1-first lookup
  - exact Airtable Project ID fallback
  - legacy Airtable linked-project fallback
  - D1 mirroring before external registration

## Seed-file decision

No seed file was added.

The correct behaviour is runtime self-healing: D1 first, Airtable fallback, mirror Airtable match into D1. Adding seed data for one project would hide the ordering bug rather than fix it.

## Trace

- `docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.md`
- `docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.json`

## Validation

Expected validation is via GitHub Actions.

The branch changes only:

- `infra/cloudflare/src/service/internals/airtable.js`
- `tests/mural-airtable-board-registry.test.js`
- the paired trace files under `docs/agent-audit/reasoning/2026/05/27/`