### PR TITLE
Fix linked Mural board dashboard action

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.json
+++ b/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.json
@@ -3,6 +3,7 @@
 	"branch": "fix/mural-d1-first-resolution",
 	"trace_stub": "mural-d1-first-resolution",
 	"trigger": "Test Project 1 still resolved as having no Reflexive Journal Mural board after PR 287, even though Airtable contained a valid matching Mural Boards row.",
+	"follow_up_trigger": "After a linked board was created, the dashboard showed two Mural open actions: Open Reflexive Journal and Open Mural board.",
 	"operating_model_files_loaded": [
 		"AGENTS.md",
 		".agent-operating-model/orchestration.xml",
@@ -15,6 +16,7 @@
 		"github-diamond",
 		"researchops-developer-control",
 		"multi-functional-team",
+		"govuk-design-system",
 		"cloudflare",
 		"airtable-public-api",
 		"mural-public-api"
@@ -23,7 +25,8 @@
 		"primary_registry": "D1",
 		"fallback_registry": "Airtable",
 		"seed_file_added": false,
-		"reason_seed_file_not_added": "The runtime path should discover the existing Airtable row and mirror it into D1 automatically. Manual seed data would only mask the ordering bug."
+		"reason_seed_file_not_added": "The runtime path should discover the existing Airtable row and mirror it into D1 automatically. Manual seed data would only mask the ordering bug.",
+		"mural_action_contract": "When a board is linked, show one visible Mural board action named Open Mural board. Hide the legacy mural-open action."
 	},
 	"changes": [
 		"Kept D1 as the first Mural board lookup path.",
@@ -31,10 +34,14 @@
 		"Kept broad Airtable fallback for legacy linked Project or Projects fields.",
 		"Mirrored Airtable fallback matches into D1.",
 		"Ensured the D1 mural_boards table exists before mirroring.",
-		"Updated unit tests for D1-first lookup, exact fallback, legacy fallback and D1 mirroring."
+		"Updated unit tests for D1-first lookup, exact fallback, legacy fallback and D1 mirroring.",
+		"Converted project-dashboard-mural-state.js into a small Mural action normaliser.",
+		"Hid the legacy mural-open action and removed it from tab order.",
+		"Normalised the linked-state setup action label to Open Mural board.",
+		"Updated route-state tests for the single linked Mural board action contract."
 	],
 	"validation": {
 		"local": "not run",
-		"github_actions": "pending after PR creation"
+		"github_actions": "pending after latest PR update"
 	}
 }

--- a/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.md
+++ b/docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.md
@@ -5,6 +5,7 @@
 - Date: 2026-05-27
 - Branch: `fix/mural-d1-first-resolution`
 - Trigger: after PR #287 merged, `Test Project 1` still resolved as having no Reflexive Journal Mural board even though Airtable contained a matching Mural Boards record.
+- Follow-up trigger: after a linked board was created, the dashboard showed two Mural open actions: `Open "Reflexive Journal"` and `Open Mural board`.
 
 ## User evidence
 
@@ -20,6 +21,8 @@ The user confirmed the Airtable Mural Boards row exists and includes:
 
 The user also clarified that manual D1 seeding should not be required for normal operation. D1 should be the primary runtime registry, with Airtable as fallback.
 
+The user later confirmed the linked-board state worked, but the action labels were wrong. The second visible action should be named `Open Mural board`, and the third visible `Open Mural board` action was erroneous.
+
 ## Operating-model files loaded
 
 - `AGENTS.md`
@@ -34,6 +37,7 @@ The user also clarified that manual D1 seeding should not be required for normal
 - `github-diamond`
 - `researchops-developer-control`
 - `multi-functional-team`
+- `govuk-design-system`
 - `cloudflare`
 - `airtable-public-api`
 - `mural-public-api`
@@ -43,7 +47,13 @@ The user also clarified that manual D1 seeding should not be required for normal
 - `infra/cloudflare/src/service/internals/airtable.js`
 - `infra/cloudflare/src/service/internals/mural.js`
 - `infra/cloudflare/src/service/internals/researchops-d1.js`
+- `public/components/mural-integration.js`
+- `public/components/project-dashboard-mural-state.js`
+- `src/govuk/templates/pages/project-dashboard.njk`
+- `public/pages/project-dashboard/index.html`
 - `tests/mural-airtable-board-registry.test.js`
+- `tests/project-dashboard-route-state.test.js`
+- `tests/mural-ui-route-state.test.js`
 - `RECENT_LEARNINGS.md`
 
 ## Diagnosis
@@ -54,6 +64,8 @@ That means a valid Airtable row can be missed if it is outside the returned page
 
 Manual D1 seeding would mask the problem for one project. It would not fix the runtime ordering or self-healing path.
 
+The follow-up UI defect came from two dashboard controls. `mural-integration.js` changes `#mural-setup` into an open action when a board is linked, while the static `#mural-open` action remains visible as a second open control.
+
 ## Changes made
 
 - Kept D1 as the first board lookup path.
@@ -62,6 +74,10 @@ Manual D1 seeding would mask the problem for one project. It would not fix the r
 - Mirrored Airtable fallback matches into D1 so the next request resolves from D1.
 - Ensured the D1 `mural_boards` table exists before mirroring a mapping.
 - Updated unit tests for D1-first lookup, exact Airtable fallback, legacy Airtable fallback, and D1 mirroring.
+- Converted `project-dashboard-mural-state.js` from an inert bridge into a small action normaliser.
+- Hid the legacy `#mural-open` action and removed it from keyboard focus.
+- Normalised the linked-state setup action label from `Open "Reflexive Journal"` to `Open Mural board`.
+- Updated route-state tests for the new action normaliser contract.
 
 ## Seed-file decision
 
@@ -69,4 +85,4 @@ No seed file was added. The normal runtime path should not require manual seed d
 
 ## Validation
 
-Validation is delegated to GitHub Actions after the PR is opened. The focused unit tests cover the corrected order and fallback behaviour.
+Validation is delegated to GitHub Actions. The focused unit tests cover the corrected order and fallback behaviour. Route-state tests cover the single linked Mural board action behaviour.

--- a/public/components/project-dashboard-mural-state.js
+++ b/public/components/project-dashboard-mural-state.js
@@ -1,10 +1,56 @@
 /**
  * @file project-dashboard-mural-state.js
- * @summary Optional Project Dashboard presentation bridge.
+ * @summary Normalises Project Dashboard Mural action presentation.
  *
- * This module is intentionally inert during the GOV.UK Frontend migration spike.
- * The Project Dashboard must render and settle without this optional bridge.
- * Mural account and board actions are handled by mural-integration.js.
+ * Mural account and board state are handled by mural-integration.js. This bridge
+ * keeps the GOV.UK dashboard action set to one visible Mural board action when a
+ * board is linked.
  */
+
+function hideLegacyOpenAction() {
+	const legacyOpen = document.getElementById("mural-open");
+	if (!legacyOpen) return;
+	if (!legacyOpen.hidden) legacyOpen.hidden = true;
+	if (legacyOpen.getAttribute("aria-hidden") !== "true") {
+		legacyOpen.setAttribute("aria-hidden", "true");
+	}
+	if (legacyOpen.getAttribute("aria-disabled") !== "true") {
+		legacyOpen.setAttribute("aria-disabled", "true");
+	}
+	if (legacyOpen.tabIndex !== -1) legacyOpen.tabIndex = -1;
+}
+
+function normaliseSetupActionLabel() {
+	const setup = document.getElementById("mural-setup");
+	if (!setup) return;
+	if (setup.textContent.trim() === 'Open "Reflexive Journal"') {
+		setup.textContent = "Open Mural board";
+	}
+}
+
+function normaliseMuralActions() {
+	hideLegacyOpenAction();
+	normaliseSetupActionLabel();
+}
+
+function startMuralActionNormaliser() {
+	normaliseMuralActions();
+	const section = document.getElementById("mural-integration");
+	if (!section) return;
+	const observer = new MutationObserver(() => normaliseMuralActions());
+	observer.observe(section, {
+		attributes: true,
+		attributeFilter: ["aria-disabled", "disabled", "hidden", "href"],
+		characterData: true,
+		childList: true,
+		subtree: true,
+	});
+}
+
+if (document.readyState === "loading") {
+	document.addEventListener("DOMContentLoaded", startMuralActionNormaliser, { once: true });
+} else {
+	startMuralActionNormaliser();
+}
 
 export {};

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -112,10 +112,13 @@ excludes(muralIntegrationSource, "const backAbs = absolutePagesUrl", "Mural inte
 excludes(muralIntegrationSource, "return=${encodeURIComponent(backAbs)}", "Mural integration component");
 excludes(muralIntegrationSource, "function absolutePagesUrl(pathAndQuery)", "Mural integration component");
 
-includes(muralStateSource, "intentionally inert", "Project Dashboard Mural state bridge");
-includes(muralStateSource, "export {};", "Project Dashboard Mural state bridge");
-excludes(muralStateSource, "MutationObserver", "Project Dashboard Mural state bridge");
-excludes(muralStateSource, "requestAnimationFrame", "Project Dashboard Mural state bridge");
+includes(muralStateSource, "Normalises Project Dashboard Mural action presentation", "Project Dashboard Mural state bridge");
+includes(muralStateSource, "function hideLegacyOpenAction()", "Project Dashboard Mural state bridge");
+includes(muralStateSource, "legacyOpen.hidden = true", "Project Dashboard Mural state bridge");
+includes(muralStateSource, "function normaliseSetupActionLabel()", "Project Dashboard Mural state bridge");
+includes(muralStateSource, 'setup.textContent = "Open Mural board";', "Project Dashboard Mural state bridge");
+includes(muralStateSource, "new MutationObserver", "Project Dashboard Mural state bridge");
+excludes(muralStateSource, "intentionally inert", "Project Dashboard Mural state bridge");
 excludes(muralStateSource, "syncDashboardPresentation", "Project Dashboard Mural state bridge");
 
 includes(dashboardSassSource, ".rops-dashboard-header", "project dashboard Sass source");


### PR DESCRIPTION
## Summary

Fixes the linked Mural board action state on the project dashboard.

When a board is linked, the dashboard currently shows two visible open actions:

- `Open "Reflexive Journal"`
- `Open Mural board`

The desired state is one visible Mural action named `Open Mural board`.

## Changes

- Converts `project-dashboard-mural-state.js` from an inert bridge into a small presentation normaliser.
- Hides the legacy `#mural-open` action and removes it from keyboard focus.
- Normalises the linked-state `#mural-setup` label from `Open "Reflexive Journal"` to `Open Mural board`.
- Leaves `mural-integration.js` untouched so the working Mural resolver and API flow are not disturbed.
- Updates route-state tests for the single linked Mural board action contract.
- Updates the paired trace files.

## Trace

- `docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.md`
- `docs/agent-audit/reasoning/2026/05/27/mural-d1-first-resolution.json`

## Validation

Expected validation is via GitHub Actions.

Changed files are limited to:

- `public/components/project-dashboard-mural-state.js`
- `tests/project-dashboard-route-state.test.js`
- the paired trace files