### PR TITLE
Fix project dashboard template copy and Mural actions

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json
+++ b/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json
@@ -1,0 +1,53 @@
+{
+  "traceLayer": "operational",
+  "date": "2026-05-27",
+  "repository": "kevinrapley/ResearchOps",
+  "branch": "fix/project-dashboard-template",
+  "pullRequest": 291,
+  "traceRequired": true,
+  "taskSummary": "Create a PR for the project dashboard template copy and Mural action cleanup.",
+  "operatingModelFilesLoaded": [
+    "README.md",
+    "AGENTS.md",
+    "RECENT_LEARNINGS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "bundlesSelected": [
+    ".agent-operating-model/bundles/github/",
+    ".agent-operating-model/bundles/researchops-developer-control/",
+    ".agent-operating-model/bundles/multi-functional-team/",
+    ".agent-operating-model/bundles/govuk-design-system/"
+  ],
+  "filesRead": [
+    "README.md",
+    "AGENTS.md",
+    "RECENT_LEARNINGS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/github-mutation-policy.md",
+    "src/govuk/templates/pages/project-dashboard.njk"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md",
+    "docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json"
+  ],
+  "filesModifiedBeforeTrace": [
+    "src/govuk/templates/pages/project-dashboard.njk"
+  ],
+  "validationAttempted": [
+    "Compared fix/project-dashboard-template against main.",
+    "Confirmed implementation diff was scoped to src/govuk/templates/pages/project-dashboard.njk.",
+    "Confirmed there was no pre-existing open PR for the branch.",
+    "Opened PR #291 into main."
+  ],
+  "validationNotRun": [
+    "No local npm, browser or template-render validation was run through the connector path."
+  ],
+  "residualRisks": [
+    "Final readiness depends on GitHub Actions completing successfully for PR #291."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json
+++ b/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json
@@ -5,7 +5,7 @@
   "branch": "fix/project-dashboard-template",
   "pullRequest": 291,
   "traceRequired": true,
-  "taskSummary": "Create a PR for the project dashboard template copy and Mural action cleanup.",
+  "taskSummary": "Create a PR for project dashboard template copy and Mural action cleanup.",
   "operatingModelFilesLoaded": [
     "README.md",
     "AGENTS.md",
@@ -29,25 +29,36 @@
     ".agent-operating-model/bundle-registry.json",
     ".agent-operating-model/trace-policy.md",
     ".agent-operating-model/github-mutation-policy.md",
-    "src/govuk/templates/pages/project-dashboard.njk"
+    "src/govuk/templates/pages/project-dashboard.njk",
+    "tests/project-dashboard-route-state.test.js"
   ],
   "filesCreated": [
     "docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md",
     "docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json"
   ],
-  "filesModifiedBeforeTrace": [
-    "src/govuk/templates/pages/project-dashboard.njk"
+  "filesModified": [
+    "src/govuk/templates/pages/project-dashboard.njk",
+    "tests/project-dashboard-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md",
+    "docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json"
   ],
   "validationAttempted": [
     "Compared fix/project-dashboard-template against main.",
-    "Confirmed implementation diff was scoped to src/govuk/templates/pages/project-dashboard.njk.",
-    "Confirmed there was no pre-existing open PR for the branch.",
-    "Opened PR #291 into main."
+    "Confirmed no pre-existing open PR for the branch.",
+    "Opened PR #291 into main.",
+    "Updated route-state contract after the first CI failure expected the removed Mural action."
   ],
-  "validationNotRun": [
-    "No local npm, browser or template-render validation was run through the connector path."
+  "validationPassed": [
+    "Format pull request",
+    "Accessibility audit (pa11y-ci)",
+    "CI",
+    "Validate ResearchOps",
+    "QA — Broken links (Lychee)",
+    "qa-bdd",
+    "Release Gate",
+    "Worker CI"
   ],
   "residualRisks": [
-    "Final readiness depends on GitHub Actions completing successfully for PR #291."
+    "No local browser check was run through the connector path."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md
+++ b/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md
@@ -30,21 +30,6 @@ Create a pull request for the existing branch `fix/project-dashboard-template`, 
 - `.agent-operating-model/bundles/multi-functional-team/`
 - `.agent-operating-model/bundles/govuk-design-system/`
 
-## Bundles skipped
-
-- `.agent-operating-model/bundles/cloudflare/` — no Worker, Pages routing, deployment or binding change was part of the user edit.
-- `.agent-operating-model/bundles/mural-public-api/` — the change affected dashboard template copy and visible action count only; no Mural API behaviour changed.
-- `.agent-operating-model/bundles/airtable-public-api/` — no Airtable schema, records or API calls changed.
-- `.agent-operating-model/bundles/openai/` — no OpenAI API or model behaviour changed.
-- `.agent-operating-model/bundles/mcp-agent-tooling/` — no MCP tooling change was in scope.
-
-## Precedence decisions
-
-- GitHub repository governance controlled branch, PR and trace handling.
-- ResearchOps Developer Control governed the platform template context.
-- GOV.UK Design System governed page-template content and action clarity.
-- The GitHub mutation policy required checking the changed-file list before reporting readiness.
-
 ## Files read
 
 - `README.md`
@@ -55,6 +40,7 @@ Create a pull request for the existing branch `fix/project-dashboard-template`, 
 - `.agent-operating-model/trace-policy.md`
 - `.agent-operating-model/github-mutation-policy.md`
 - `src/govuk/templates/pages/project-dashboard.njk`
+- `tests/project-dashboard-route-state.test.js`
 
 ## Files created or modified
 
@@ -63,24 +49,39 @@ Created:
 - `docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md`
 - `docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json`
 
-Already modified before this trace was added:
+Modified:
 
 - `src/govuk/templates/pages/project-dashboard.njk`
+- `tests/project-dashboard-route-state.test.js`
 
 ## Validation attempted
 
 - Compared `fix/project-dashboard-template` against `main` before opening the PR.
 - Confirmed the implementation branch was one commit ahead of `main` before trace files were added.
-- Confirmed the implementation diff was scoped to `src/govuk/templates/pages/project-dashboard.njk`.
 - Confirmed there was no pre-existing open PR for `fix/project-dashboard-template`.
 - Opened PR #291 into `main`.
+- Investigated the initial failing route-state contract.
+- Updated `tests/project-dashboard-route-state.test.js` so the rendered page contract matches the intended removal of the third Mural action.
+
+## Validation results
+
+On commit `b075e7ca20d40961df7f0b768796d8b53664b151`, these GitHub Actions passed:
+
+- Format pull request
+- Accessibility audit (pa11y-ci)
+- CI
+- Validate ResearchOps
+- QA — Broken links (Lychee)
+- qa-bdd
+- Release Gate
+- Worker CI
 
 ## Validation not run
 
-No local npm, browser or template-render validation was run through the connector path. GitHub Actions are the expected validation path after the PR is opened.
+No local npm, browser or template-render validation was run through the connector path. GitHub Actions were used as the validation source.
 
 ## Issues, pivots and residual risks
 
 - The PR was opened before the required trace files were added. This trace corrects that branch-policy gap in the same PR.
-- The change is expected to be low risk because it is limited to one GOV.UK template and does not change JavaScript, API routes or data contracts.
-- Final readiness depends on GitHub Actions completing successfully for PR #291.
+- The first validation run failed because the route-state contract still expected the removed third Mural action. The test now requires the rendered page to match the intended two-action panel.
+- The change is expected to be low risk because it is limited to one GOV.UK template and one matching route-state contract. It does not change JavaScript, API routes or data contracts.

--- a/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md
+++ b/docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md
@@ -1,0 +1,86 @@
+# Project dashboard template trace
+
+## Run metadata
+
+- Date: 2026-05-27
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `fix/project-dashboard-template`
+- Pull request: #291
+- Trace requirement: required by `fix/` branch policy
+- Trace layer: operational
+
+## Original task summary
+
+Create a pull request for the existing branch `fix/project-dashboard-template`, where the project dashboard GOV.UK template was edited to include descriptive dashboard copy and remove an unnecessary third button from the Mural panel.
+
+## Operating-model files loaded
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Canonical bundle directories selected
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+## Bundles skipped
+
+- `.agent-operating-model/bundles/cloudflare/` — no Worker, Pages routing, deployment or binding change was part of the user edit.
+- `.agent-operating-model/bundles/mural-public-api/` — the change affected dashboard template copy and visible action count only; no Mural API behaviour changed.
+- `.agent-operating-model/bundles/airtable-public-api/` — no Airtable schema, records or API calls changed.
+- `.agent-operating-model/bundles/openai/` — no OpenAI API or model behaviour changed.
+- `.agent-operating-model/bundles/mcp-agent-tooling/` — no MCP tooling change was in scope.
+
+## Precedence decisions
+
+- GitHub repository governance controlled branch, PR and trace handling.
+- ResearchOps Developer Control governed the platform template context.
+- GOV.UK Design System governed page-template content and action clarity.
+- The GitHub mutation policy required checking the changed-file list before reporting readiness.
+
+## Files read
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+- `src/govuk/templates/pages/project-dashboard.njk`
+
+## Files created or modified
+
+Created:
+
+- `docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md`
+- `docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json`
+
+Already modified before this trace was added:
+
+- `src/govuk/templates/pages/project-dashboard.njk`
+
+## Validation attempted
+
+- Compared `fix/project-dashboard-template` against `main` before opening the PR.
+- Confirmed the implementation branch was one commit ahead of `main` before trace files were added.
+- Confirmed the implementation diff was scoped to `src/govuk/templates/pages/project-dashboard.njk`.
+- Confirmed there was no pre-existing open PR for `fix/project-dashboard-template`.
+- Opened PR #291 into `main`.
+
+## Validation not run
+
+No local npm, browser or template-render validation was run through the connector path. GitHub Actions are the expected validation path after the PR is opened.
+
+## Issues, pivots and residual risks
+
+- The PR was opened before the required trace files were added. This trace corrects that branch-policy gap in the same PR.
+- The change is expected to be low risk because it is limited to one GOV.UK template and does not change JavaScript, API routes or data contracts.
+- Final readiness depends on GitHub Actions completing successfully for PR #291.

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -34,7 +34,7 @@
 	<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
 		<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
 		<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
-		<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description"></p>
+		<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">Use this dashboard to manage project context, research planning, reflexive journaling and research outcomes.</p>
 		<div class="rops-status-strip" aria-label="Project status">
 			<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
 			<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
@@ -127,15 +127,6 @@
 							disabled: true,
 							attributes: {
 								id: "mural-setup"
-							}
-						}) }}
-						{{ govukButton({
-							text: "Open Mural board",
-							href: "#",
-							classes: "govuk-button--secondary",
-							attributes: {
-								id: "mural-open",
-								"aria-disabled": "true"
 							}
 						}) }}
 					</div>

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -35,6 +35,7 @@ includes(templateSource, "id=\"kv-project-stage\"", "project dashboard template"
 includes(templateSource, "Loading service stage", "project dashboard template");
 includes(templateSource, "Loading project stage", "project dashboard template");
 includes(templateSource, "Mural optional", "project dashboard template");
+excludes(templateSource, "id=\"mural-open\"", "project dashboard template");
 excludes(templateSource, "Service stage not recorded", "project dashboard template");
 excludes(templateSource, "Project stage not recorded", "project dashboard template");
 excludes(templateSource, "Mural not checked", "project dashboard template");
@@ -52,7 +53,7 @@ includes(pageSource, "class=\"govuk-summary-list\"", "project dashboard page");
 includes(pageSource, "id=\"project-title\"", "project dashboard page");
 includes(pageSource, "id=\"mural-connect\"", "project dashboard page");
 includes(pageSource, "id=\"mural-setup\"", "project dashboard page");
-includes(pageSource, "id=\"mural-open\"", "project dashboard page");
+excludes(pageSource, "id=\"mural-open\"", "project dashboard page");
 includes(pageSource, "id=\"studies-list\"", "project dashboard page");
 excludes(pageSource, "href=\"/css/screen.css\"", "project dashboard page");
 excludes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "project dashboard page");


### PR DESCRIPTION
## Summary

Updates the GOV.UK project dashboard template to clarify the dashboard description and simplify the Mural panel actions.

## Changes

- Adds/keeps descriptive project dashboard copy in `src/govuk/templates/pages/project-dashboard.njk` so the page explains the dashboard purpose.
- Removes the unnecessary third Mural panel button, keeping the Mural action area focused on connection and board creation.
- Updates the project dashboard route-state contract so it matches the intended removal of `id="mural-open"` from the rendered page.

## Trace

Trace required because this is a `fix/` branch:

- `docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.md`
- `docs/agent-audit/reasoning/2026/05/27/project-dashboard-template.json`

## Validation

GitHub Actions passed on `add3ce36f4b9dbba87fa4b1dc45f9f95c814e917`:

- Format pull request
- Accessibility audit (pa11y-ci)
- CI
- Validate ResearchOps
- QA — Broken links (Lychee)
- qa-bdd
- Release Gate
- Worker CI

Pre-flight repository checks performed:

- Confirmed there was no pre-existing open PR for `fix/project-dashboard-template`.
- Read repository operating guidance and trace policy before opening the PR.
- Confirmed the changed-file list is plausible for this task.