### PR TITLE
Align journals error summary link policy

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/28/journals-error-summary-link-policy.json
+++ b/docs/agent-audit/reasoning/2026/05/28/journals-error-summary-link-policy.json
@@ -1,0 +1,42 @@
+{
+  "traceLayer": "operational",
+  "date": "2026-05-28",
+  "repository": "kevinrapley/ResearchOps",
+  "branch": "fix/journals-error-summary-link-policy",
+  "traceRequired": true,
+  "taskSummary": "Bring main into line with preview deployment behaviour for the journals page feedback model by removing the default linked page-level journal error.",
+  "problem": {
+    "summary": "The journals Nunjucks source still rendered the default page-level journal error summary with href: '#content'.",
+    "impact": "General page-level journal errors could be rendered as links when only the retrieval field-validation error should be linked."
+  },
+  "intendedBehaviour": [
+    "General journals page errors are plain text in the page-level GOV.UK error summary.",
+    "Enter a term to search. is the only linked error summary item.",
+    "The linked retrieval validation error targets #retrieval-q and is paired with an inline field-level GOV.UK error state.",
+    "Rendered static HTML must match the Nunjucks source so Cloudflare Pages targets converge."
+  ],
+  "filesRead": [
+    "src/govuk/templates/pages/projects-journals.njk",
+    "public/js/project-context.js",
+    "public/js/caqdas-interface.js",
+    "tests/journals-route-state.test.js"
+  ],
+  "filesModified": [
+    "src/govuk/templates/pages/projects-journals.njk",
+    "tests/journals-route-state.test.js"
+  ],
+  "filesExpectedFromRenderWorkflow": [
+    "public/pages/projects/journals/index.html"
+  ],
+  "implementationDecisions": [
+    "Removed href: '#content' from the default page-level journal error-summary macro item.",
+    "Preserved the targeted retrieval validation runtime path: flashError('Enter a term to search.', 'retrieval-q').",
+    "Updated route-state coverage so the source template and rendered static page reject the default href=\"#content\" error-summary link.",
+    "Kept the retrieval error as the sole targeted link exception."
+  ],
+  "validationPlan": [
+    "Open a PR to main.",
+    "Let the Render GOV.UK pages workflow regenerate the static journals page.",
+    "Verify all GitHub Actions pass before reporting readiness."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/05/28/journals-error-summary-link-policy.md
+++ b/docs/agent-audit/reasoning/2026/05/28/journals-error-summary-link-policy.md
@@ -1,0 +1,37 @@
+# Journals error summary link policy trace
+
+## Run metadata
+
+- Date: 2026-05-28
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `fix/journals-error-summary-link-policy`
+- Trace requirement: required by `fix/` branch policy
+- Trace layer: operational
+
+## Task summary
+
+Bring `main` into line with the preview deployment behaviour for the journals page feedback model.
+
+## Problem
+
+After PR #293 was merged, `main` contains newer feedback runtime behaviour, but the journals Nunjucks source still renders the default page-level journal error summary with `href: '#content'`. That causes page-level journal errors to be anchor-rendered when only the retrieval field validation error should be linked.
+
+## Intended behaviour
+
+- General journals page errors are plain text in the page-level GOV.UK error summary.
+- `Enter a term to search.` is the only linked error summary item.
+- The linked retrieval validation error targets `#retrieval-q` and is paired with the inline field-level GOV.UK error state.
+- Rendered static HTML must match the Nunjucks source so Cloudflare Pages targets converge.
+
+## Files expected to change
+
+- `src/govuk/templates/pages/projects-journals.njk`
+- `public/pages/projects/journals/index.html`
+- `tests/journals-route-state.test.js`
+- trace files for this branch
+
+## Validation plan
+
+- Open a PR to `main`.
+- Let Render GOV.UK pages regenerate static HTML.
+- Verify all GitHub Actions pass before reporting readiness.

--- a/src/govuk/templates/pages/projects-journals.njk
+++ b/src/govuk/templates/pages/projects-journals.njk
@@ -186,8 +186,7 @@
 			titleText: 'There is a problem',
 			errorList: [
 				{
-					text: 'Could not refresh journal entries.',
-					href: '#content'
+					text: 'Could not refresh journal entries.'
 				}
 			],
 			classes: 'journal-feedback__error',

--- a/tests/journals-route-state.test.js
+++ b/tests/journals-route-state.test.js
@@ -6,6 +6,7 @@ const templateSource = fs.readFileSync("src/govuk/templates/pages/projects-journ
 const layoutSource = fs.readFileSync("src/govuk/templates/layouts/researchops.njk", "utf8");
 const renderGovukPagesSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 const projectContextSource = fs.readFileSync("public/js/project-context.js", "utf8");
+const caqdasSource = fs.readFileSync("public/js/caqdas-interface.js", "utf8");
 const tabsSource = fs.readFileSync("public/js/journal-tabs.js", "utf8");
 const muralSyncSource = fs.readFileSync("public/js/journal-mural-sync-compact.js", "utf8");
 const excerptsSource = fs.readFileSync("public/components/journal-excerpts.js", "utf8");
@@ -37,7 +38,7 @@ includes(templateSource, "{{ govukNotificationBanner({", "journals GOV.UK templa
 includes(templateSource, "id: 'journals-tabs'", "journals GOV.UK template");
 includes(templateSource, "id: 'journal-error-summary'", "journals GOV.UK template");
 includes(templateSource, "id: 'journal-notification-banner'", "journals GOV.UK template");
-includes(templateSource, "href: '#content'", "journals GOV.UK template");
+excludes(templateSource, "href: '#content'", "journals GOV.UK template");
 excludes(templateSource, "id=\"back-to-project\"", "journals GOV.UK template");
 excludes(templateSource, "<nav class=\"govuk-breadcrumbs\"", "journals GOV.UK template");
 excludes(templateSource, "class=\"govuk-tabs\"", "journals GOV.UK template");
@@ -49,7 +50,7 @@ includes(pageSource, "<x-include src=\"/partials/header.html\"", "journals page"
 includes(pageSource, "<x-include src=\"/partials/footer.html\"", "journals page");
 includes(pageSource, "id=\"journal-error-summary\"", "journals page");
 includes(pageSource, "class=\"govuk-error-summary", "journals page");
-includes(pageSource, "href=\"#content\"", "journals page");
+excludes(pageSource, "href=\"#content\"", "journals page");
 includes(pageSource, "id=\"journal-notification-banner\"", "journals page");
 includes(pageSource, "class=\"govuk-notification-banner", "journals page");
 includes(pageSource, "id=\"journals-tabs\"", "journals page");
@@ -70,6 +71,8 @@ includes(projectContextSource, "journal-notification-banner", "project context m
 includes(projectContextSource, "setProjectAnchor(findProjectBreadcrumb(), project)", "project context module");
 includes(projectContextSource, "function ensureProjectActionBar", "project context module");
 includes(projectContextSource, "function setProjectParentLink", "project context module");
+includes(caqdasSource, "flashError('Enter a term to search.', 'retrieval-q')", "CAQDAS analysis module");
+includes(caqdasSource, "setRetrievalError('Enter a term to search.')", "CAQDAS analysis module");
 includes(tabsSource, "tab:shown", "journal tabs module");
 includes(muralSyncSource, "mural", "journal mural sync module");
 includes(excerptsSource, "function renderEntries", "journal excerpts module");


### PR DESCRIPTION
## Summary

Brings `main` into line with the preview journals feedback behaviour.

## Changes

- Removes the default `href: '#content'` from the page-level journal `govukErrorSummary` item.
- Keeps the retrieval search validation as the only targeted error-summary link path via `#retrieval-q`.
- Updates `tests/journals-route-state.test.js` so the source template and rendered page reject the default `href="#content"` link.

## Trace

Trace required because this is a `fix/` branch:

- `docs/agent-audit/reasoning/2026/05/28/journals-error-summary-link-policy.md`
- `docs/agent-audit/reasoning/2026/05/28/journals-error-summary-link-policy.json`

## Validation

The Render GOV.UK pages workflow should regenerate `public/pages/projects/journals/index.html` so the committed static page matches the Nunjucks source. GitHub Actions are the validation source.