### PR TITLE
Add review thread state gate

### DIFF
--- a/.agent-operating-model/behavioural-evals.json
+++ b/.agent-operating-model/behavioural-evals.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"traceLayer": "behavioural",
 	"purpose": "Evaluate whether agent operating-model behaviour follows repository orchestration and canonical bundle-directory precedence rules.",
 	"evals": [
@@ -231,6 +231,30 @@
 				"claims-without-evidence",
 				"no-test-or-check",
 				"vague-make-it-work-plan"
+			]
+		},
+		{
+			"id": "behaviour-review-thread-state-gate",
+			"question": "Does the agent act only on unresolved, non-outdated review threads and avoid redoing resolved work?",
+			"prompt": "See the Codex comment and fix the failing tests.",
+			"expectedBundles": [
+				"github-diamond",
+				"researchops-developer-control",
+				"multi-functional-team"
+			],
+			"expectedSafeguards": [
+				"inspect-review-thread-state",
+				"ignore-resolved-review-threads",
+				"ignore-outdated-review-threads",
+				"preserve-current-pr-head",
+				"avoid-duplicating-completed-work"
+			],
+			"forbiddenFailureModes": [
+				"acts-on-resolved-review-thread",
+				"acts-on-outdated-review-thread",
+				"duplicates-completed-work",
+				"rewinds-pr-head-without-instruction",
+				"treats-comment-text-as-current-state"
 			]
 		}
 	]

--- a/.agent-operating-model/behavioural-evals.json
+++ b/.agent-operating-model/behavioural-evals.json
@@ -236,11 +236,19 @@
 		{
 			"id": "behaviour-review-thread-state-gate",
 			"question": "Does the agent act only on unresolved, non-outdated review threads and avoid redoing resolved work?",
-			"prompt": "See the Codex comment and fix the failing tests.",
+			"prompt": "See the Codex thread and fix the failing tests.",
 			"expectedBundles": [
 				"github-diamond",
 				"researchops-developer-control",
 				"multi-functional-team"
+			],
+			"forbiddenBundles": [
+				"airtable-public-api",
+				"mural-public-api",
+				"cloudflare",
+				"openai-platform",
+				"mcp-agent-tooling",
+				"govuk-design-system"
 			],
 			"expectedSafeguards": [
 				"inspect-review-thread-state",

--- a/.agent-operating-model/bundles/github/README.md
+++ b/.agent-operating-model/bundles/github/README.md
@@ -30,12 +30,18 @@ Use `examples/anti-examples/` for genuine unsafe or incorrect agent behaviours. 
 
 Codex and other automated review comments must be treated as review work items, not as background noise.
 
+Before acting on review feedback, inspect the current review-thread state. Comment text alone is not enough. Only unresolved, non-outdated and still-relevant review threads are active work items.
+
 When an automated review comment is legitimate, the agent must:
 
-1. Fix the issue or provide evidence that the implementation already satisfies the concern.
+1. Fix the issue or provide evidence that the existing implementation already satisfies the concern.
 2. Add a thumbs-up reaction to the original comment.
 3. Reply directly to the comment or thread explaining how the issue was overcome.
 4. Mark the thread resolved with the Resolve conversation action only after the fix and validation evidence are complete.
+
+Resolved review threads are complete unless the user explicitly asks to reopen, re-check or revisit them. Outdated review threads must not be acted on unless the underlying issue still exists on the current pull request head.
+
+When a user refers to a singular Codex comment or review comment, identify the single unresolved relevant thread before making changes. Do not redo work already completed by the user, Codex, GitHub Actions or another agent. Do not move a pull request branch ref to an earlier commit while handling review feedback unless explicitly instructed or recovering from a documented broken branch state.
 
 False positives or superseded comments must still be answered with a clear disposition. Legitimate comments must not be silently ignored, even when status checks are green.
 
@@ -130,4 +136,5 @@ Validate them with `scripts/validate-live-gate-fixtures.py`.
 - Do not release with unresolved release-blocking gaps.
 - Do not publish a bundle if the release gate fails.
 - Do not silently ignore legitimate Codex or automated review comments.
+- Do not act on resolved or outdated automated review threads unless the user explicitly asks to revisit them or the issue still exists on the current pull request head.
 - Do not resolve a legitimate automated review thread until the issue has been overcome, the original comment has a thumbs-up reaction and the thread has an explanatory reply.

--- a/.agent-operating-model/bundles/github/prompt.body.xml
+++ b/.agent-operating-model/bundles/github/prompt.body.xml
@@ -102,6 +102,16 @@
     <rule>Resolve the review thread using the Resolve conversation action only after the code, documentation, tests or workflow evidence is complete.</rule>
     <rule>Do not resolve a legitimate thread before the fix is present on the branch and validation evidence has been checked.</rule>
     <rule>Do not silently ignore legitimate Codex comments, even when all status checks pass.</rule>
+    <review_thread_state_gate>
+      <rule>Before acting on review feedback, inspect the current review-thread state, not only the comment text.</rule>
+      <rule>Only unresolved, non-outdated and still-relevant review threads are active work items.</rule>
+      <rule>Resolved review threads are complete unless the user explicitly asks to reopen, re-check or revisit them.</rule>
+      <rule>Outdated review threads must not be acted on unless the underlying issue still exists on the current pull request head.</rule>
+      <rule>When the user refers to a singular review comment, identify the single unresolved relevant thread before making changes.</rule>
+      <rule>Do not redo work already completed by the user, Codex, GitHub Actions or another agent.</rule>
+      <rule>Before changing files, compare the pull request head, changed-file list and review-thread state so action is based on current branch state.</rule>
+      <rule>Do not move a pull request branch ref to an earlier commit while handling review feedback unless explicitly instructed or recovering from a documented broken branch state.</rule>
+    </review_thread_state_gate>
   </automated_review_comment_handling>
 
   <refusal_rules>
@@ -112,6 +122,7 @@
     <rule>Do not fabricate validation evidence.</rule>
     <rule>Do not create or continue repository work on branches that do not use an approved prefix.</rule>
     <rule>Do not mark a legitimate Codex or automated review thread resolved unless the issue has been overcome and the comment has been acknowledged with a thumbs-up reaction and explanatory reply.</rule>
+    <rule>Do not act on resolved or outdated review threads unless the user explicitly asks to revisit them or the issue still exists on the current pull request head.</rule>
     <rule>Do not use placeholders, omissions or summary tokens inside committed code, configuration or documentation.</rule>
     <rule>Do not repeatedly retry a blocked or failed full-file repository write when another safe mutation strategy exists.</rule>
   </refusal_rules>
@@ -127,6 +138,7 @@
     <item>Agent evidence and grading result when requested.</item>
     <item>PR-ready summary with changed-file verification, risks, rollback and unresolved gaps.</item>
     <item>Automated review comment disposition when Codex or automated reviewer comments were present.</item>
+    <item>Review-thread state summary showing which threads are unresolved, resolved, outdated, ignored or selected for action.</item>
   </required_outputs>
 
   <v2_8_3_repository_state_verification>

--- a/.agent-operating-model/bundles/github/registry-manifest.yaml
+++ b/.agent-operating-model/bundles/github/registry-manifest.yaml
@@ -408,11 +408,11 @@ artifacts:
 - path: output.schema.json
   sha256: 5b65943fe37561efc0a98625fa80355b74a451f25e0f714edd52b31452bbf7ad
 - path: prompt.body.xml
-  sha256: 218dbabe5b371c4ef4ebf9ed234a0bd1c6620c1fc4172e9c9c6b3918e82ead87
+  sha256: 5bc94a526410bce5ab6ac978f4c20668291b5e633e9c360c1358a174a60b727e
 - path: prompt.spec.yaml
   sha256: ee12b3635a0f1620069b04bfa8ac8ed1757ebc514b0964ff3cfc1c0b7db8805a
 - path: README.md
-  sha256: b32ee6cc766363e495d3cb6635afc6a3edd37e3ef69a8cbecf54c58279ca0070
+  sha256: 6bbbb385cecd42b6c0f4ef3151f1dc844d9dc7cd5b7a3b6c71005656b114fe2a
 - path: references/accessibility-confidence-pack.xml
   sha256: 2fc68d05f251363527d279b7cd75bd3608c13d7e5848b94790d182b480ec6421
 - path: references/agent-evidence.xml

--- a/docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.json
+++ b/docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.json
@@ -1,0 +1,32 @@
+{
+	"traceLayer": "behavioural",
+	"date": "2026-05-29",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "chore/review-thread-state-gate",
+	"traceRequired": true,
+	"taskSummary": "Add a GitHub bundle operating procedure for review-thread state gating.",
+	"selectedBundles": [
+		"github-diamond",
+		"researchops-developer-control",
+		"multi-functional-team"
+	],
+	"filesModified": [
+		".agent-operating-model/bundles/github/prompt.body.xml",
+		".agent-operating-model/behavioural-evals.json",
+		"scripts/agent-operating-model/load-operating-model.mjs",
+		"scripts/agent-operating-model/run-behavioural-evals.mjs",
+		".agent-operating-model/bundles/github/README.md",
+		"docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.md",
+		"docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.json"
+	],
+	"implementationDecisions": [
+		"Added the rule to GitHub Diamond automated review comment handling.",
+		"Added executable safeguards rather than prose-only guidance.",
+		"Preserved the current pull request head unless explicit recovery is needed."
+	],
+	"validationPlan": [
+		"Open a pull request to main.",
+		"Use GitHub Actions for CI and release-gate validation.",
+		"Confirm changed files remain limited to GitHub bundle procedure, evals, loader support and trace artefacts."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.md
+++ b/docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.md
@@ -1,0 +1,80 @@
+# Review thread state gate trace
+
+## Run metadata
+
+- Date: 2026-05-29
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `chore/review-thread-state-gate`
+- Trace requirement: required by `chore/` branch policy
+- Trace layer: behavioural
+
+## Task summary
+
+Add a GitHub bundle operating procedure that prevents agents from acting on resolved or outdated Codex review threads and from duplicating work already completed by the user, Codex, GitHub Actions or another agent.
+
+## Operating-model sources loaded
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/README.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/bundles/github/prompt.body.xml`
+- `.agent-operating-model/bundles/github/README.md`
+- `scripts/agent-operating-model/load-operating-model.mjs`
+- `scripts/agent-operating-model/run-behavioural-evals.mjs`
+
+## Selected bundles
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+
+## Conditional bundles skipped
+
+- `govuk-design-system`: no UI, content pattern or accessibility implementation change.
+- `cloudflare`: no Cloudflare runtime, deployment or binding change.
+- `openai-platform`: no OpenAI API implementation change.
+- `mcp-agent-tooling`: no MCP protocol or tooling implementation change.
+- `airtable-public-api`: no Airtable API implementation change.
+- `mural-public-api`: no Mural API implementation change.
+
+## Assumptions and decisions
+
+- The correct home is the GitHub Diamond bundle because the issue is pull-request review governance, not a domain-specific implementation concern.
+- The rule should extend automated review comment handling rather than create a new specialist bundle.
+- The procedure should preserve the current pull request head and avoid branch-ref movement unless explicitly requested or documented as recovery from a broken branch state.
+- The rule should be backed by behavioural eval safeguards so it is testable.
+
+## Files modified
+
+- `.agent-operating-model/bundles/github/prompt.body.xml`
+- `.agent-operating-model/behavioural-evals.json`
+- `scripts/agent-operating-model/load-operating-model.mjs`
+- `scripts/agent-operating-model/run-behavioural-evals.mjs`
+- `.agent-operating-model/bundles/github/README.md`
+- `docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.md`
+- `docs/agent-audit/reasoning/2026/05/29/review-thread-state-gate.json`
+
+## Implementation summary
+
+1. Added a `review_thread_state_gate` section to GitHub Diamond automated review comment handling.
+2. Added a required output for review-thread state summaries.
+3. Added refusal language for acting on resolved or outdated review threads.
+4. Added a behavioural eval for review-thread state gating.
+5. Added loader safeguards for review-thread state handling.
+6. Added eval-runner mappings for review-thread failure modes.
+7. Updated the GitHub bundle README automated review handling section.
+
+## Validation plan
+
+- Open a pull request to `main` from `chore/review-thread-state-gate`.
+- Let CI, Release Gate, Validate ResearchOps and the GitHub bundle manifest workflow validate the change.
+- Confirm the changed-file set is plausible for a GitHub bundle procedure change.

--- a/scripts/agent-operating-model/load-operating-model.mjs
+++ b/scripts/agent-operating-model/load-operating-model.mjs
@@ -36,6 +36,13 @@ const LLM_CODING_BEHAVIOUR_SAFEGUARDS = Object.freeze([
 	"validation-command-or-observable-check",
 	"residual-risk-report",
 ]);
+const REVIEW_THREAD_STATE_SAFEGUARDS = Object.freeze([
+	"inspect-review-thread-state",
+	"ignore-resolved-review-threads",
+	"ignore-outdated-review-threads",
+	"preserve-current-pr-head",
+	"avoid-duplicating-completed-work",
+]);
 const REASONING_TRACE_OUTPUTS = Object.freeze([
 	"raw-jsonl-trace",
 	"user-readable-trace",
@@ -107,6 +114,7 @@ function inferOperatingModelSafeguards(taskText) {
 	const safeguards = new Set([
 		...BASE_OPERATING_MODEL_SAFEGUARDS,
 		...LLM_CODING_BEHAVIOUR_SAFEGUARDS,
+		...REVIEW_THREAD_STATE_SAFEGUARDS,
 	]);
 	const conflicts = inferInstructionConflicts(taskText);
 

--- a/scripts/agent-operating-model/run-behavioural-evals.mjs
+++ b/scripts/agent-operating-model/run-behavioural-evals.mjs
@@ -11,17 +11,28 @@ import { loadOperatingModel } from "./load-operating-model.mjs";
 const ROOT_DIR = process.cwd();
 const EVALS_PATH = ".agent-operating-model/behavioural-evals.json";
 const FORBIDDEN_FAILURE_MODE_REQUIRED_SAFEGUARDS = Object.freeze({
+	"acts-on-outdated-review-thread": [
+		"inspect-review-thread-state",
+		"ignore-outdated-review-threads",
+	],
+	"acts-on-resolved-review-thread": [
+		"inspect-review-thread-state",
+		"ignore-resolved-review-threads",
+	],
 	"broad-refactor": ["single-purpose-change", "bounded-file-scope"],
 	"claims-without-evidence": ["validation-command-or-observable-check"],
+	"duplicates-completed-work": ["avoid-duplicating-completed-work"],
 	"formatting-drive-by": ["single-purpose-change", "no-adjacent-refactor"],
 	"goal-validation-mismatch": ["validation-matches-goal"],
 	"insufficient-validation-evidence": ["reports-validation-limits"],
 	overengineering: ["minimal-change", "no-new-framework"],
 	"no-test-or-check": ["validation-command-or-observable-check", "reproduction-check"],
+	"rewinds-pr-head-without-instruction": ["preserve-current-pr-head"],
 	"scope-creep": ["no-unrequested-configuration", "bounded-file-scope"],
 	"silent-interpretation": ["states-assumptions"],
 	"speculative-implementation": ["asks-or-bounds-before-implementation"],
 	"touches-unrelated-files": ["surgical-edit", "bounded-file-scope"],
+	"treats-comment-text-as-current-state": ["inspect-review-thread-state"],
 	"unrelated-cleanup": ["preserve-unrelated-code", "changed-file-list-plausible"],
 	"unreported-validation-gap": ["reports-validation-limits"],
 	"unrequested-abstraction": ["minimal-change", "no-new-framework"],
@@ -223,7 +234,7 @@ function validateForbiddenFailureModes(evaluation, model) {
 	};
 
 	validateForbiddenFailureModeSafeguards(evaluation, model);
-	
+
 	for (const mode of evaluation.forbiddenFailureModes || []) {
 		const check = modeChecks[mode];
 
@@ -234,7 +245,7 @@ function validateForbiddenFailureModes(evaluation, model) {
 		if (!check) {
 			continue;
 		}
-		
+
 		if (check()) {
 			fail(`${evaluation.id} exhibits forbidden failure mode: ${mode}`);
 		}

--- a/scripts/agent-operating-model/run-behavioural-evals.mjs
+++ b/scripts/agent-operating-model/run-behavioural-evals.mjs
@@ -83,6 +83,17 @@ function validateExpectedBundles(evaluation, model) {
 	}
 }
 
+function validateForbiddenBundles(evaluation, model) {
+	const ids = selectedIds(model);
+	const selectedForbiddenBundles = (evaluation.forbiddenBundles || []).filter((bundleId) =>
+		ids.includes(bundleId),
+	);
+
+	if (selectedForbiddenBundles.length) {
+		fail(`${evaluation.id} selected forbidden bundles: ${selectedForbiddenBundles.join(", ")}`);
+	}
+}
+
 function validateTraceRequirement(evaluation, model) {
 	if (!evaluation.prompt.includes("[reasoning]")) {
 		return;
@@ -284,6 +295,7 @@ function runEval(evaluation) {
 	const model = loadOperatingModel({ taskText: evaluation.prompt });
 
 	validateExpectedBundles(evaluation, model);
+	validateForbiddenBundles(evaluation, model);
 	validateTraceRequirement(evaluation, model);
 	validateSelectionEvidence(evaluation, model);
 	validateExpectedSafeguards(evaluation, model);


### PR DESCRIPTION
## Summary

Adds a GitHub Diamond operating procedure for review-thread state handling.

- Adds a `review_thread_state_gate` to automated review comment handling.
- Requires agents to inspect thread state before acting on Codex or automated review feedback.
- Treats only unresolved, non-outdated and still-relevant review threads as active work items.
- Prevents redoing work already completed by the user, Codex, GitHub Actions or another agent.
- Prohibits moving a PR branch ref to an earlier commit while handling review feedback unless explicitly instructed or recovering from a documented broken branch state.
- Adds a behavioural eval and loader/eval-runner safeguards for the review-thread state gate.
- Updates the GitHub bundle README and adds trace artefacts.

## Operating model

Selected bundles:

- `github-diamond`
- `researchops-developer-control`
- `multi-functional-team`

Conditional bundles were skipped because this is GitHub PR governance work, not UI, Cloudflare, OpenAI, MCP, Airtable or Mural implementation work.

## Validation

GitHub Actions should run the repository checks and the GitHub bundle manifest workflow for the changed bundle files.

## Notes

This PR is intentionally separate from #295 and was branched from current `main`.