### PR TITLE
Add Dependabot and bundle version checks

### DIFF
--- a/.agent-operating-model/bundles/airtable-public-api/README.md
+++ b/.agent-operating-model/bundles/airtable-public-api/README.md
@@ -1,6 +1,6 @@
 # Airtable Public API Developer Contract Bundle
 
-Version: 1.0.1
+Version: 1.1.0
 
 This bundle directs Airtable integration development. It is contract-rich rather than merely architectural.
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      frontend-tooling:
+        patterns:
+          - "@eslint/*"
+          - "eslint*"
+          - "prettier"
+          - "sass"
+      qa-tooling:
+        patterns:
+          - "@playwright/*"
+          - "@cucumber/*"
+      govuk:
+        patterns:
+          - "govuk-frontend"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/bundle-version-consistency.yml
+++ b/.github/workflows/bundle-version-consistency.yml
@@ -1,0 +1,48 @@
+name: Bundle version consistency
+
+on:
+  pull_request:
+    paths:
+      - ".agent-operating-model/bundles/**"
+      - ".agent-operating-model/bundle-registry.json"
+      - "scripts/agent-operating-model/validate-bundle-version-consistency.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/dependabot.yml"
+      - ".github/workflows/bundle-version-consistency.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - ".agent-operating-model/bundles/**"
+      - ".agent-operating-model/bundle-registry.json"
+      - "scripts/agent-operating-model/validate-bundle-version-consistency.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/dependabot.yml"
+      - ".github/workflows/bundle-version-consistency.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  bundle-version-consistency:
+    name: Validate bundle version references
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate bundle versions
+        run: npm run agent:bundle-versions:validate

--- a/docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.json
+++ b/docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.json
@@ -1,0 +1,33 @@
+{
+	"traceLayer": "operational",
+	"date": "2026-05-29",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "chore/dependabot-bundle-version-check",
+	"traceRequired": true,
+	"taskSummary": "Set up Dependabot and bundle version consistency checks.",
+	"selectedBundles": [
+		"github-diamond",
+		"researchops-developer-control",
+		"multi-functional-team"
+	],
+	"filesModified": [
+		".github/dependabot.yml",
+		".github/workflows/bundle-version-consistency.yml",
+		"package.json",
+		"scripts/validate.sh",
+		"scripts/agent-operating-model/validate-operating-model.mjs",
+		"scripts/agent-operating-model/validate-bundle-version-consistency.mjs",
+		"docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.md",
+		"docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.json"
+	],
+	"implementationDecisions": [
+		"Use prompt.spec.yaml as the bundle version source of truth.",
+		"Fail CI when bundle version references drift from that source of truth.",
+		"Configure Dependabot for npm and GitHub Actions updates."
+	],
+	"validationPlan": [
+		"Open a pull request to main.",
+		"Use GitHub Actions for CI and release-gate validation.",
+		"Confirm changed files remain limited to Dependabot setup and bundle-version validation."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.md
+++ b/docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.md
@@ -1,0 +1,43 @@
+# Dependabot bundle version check trace
+
+## Run metadata
+
+- Date: 2026-05-29
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `chore/dependabot-bundle-version-check`
+- Trace requirement: required by `chore/` branch policy
+- Trace layer: operational
+
+## Task summary
+
+Set up Dependabot and add a repository check that fails when bundle files with version references drift from the bundle version in `prompt.spec.yaml`.
+
+## Selected bundles
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+
+## Files modified
+
+- `.github/dependabot.yml`
+- `.github/workflows/bundle-version-consistency.yml`
+- `package.json`
+- `scripts/validate.sh`
+- `scripts/agent-operating-model/validate-operating-model.mjs`
+- `scripts/agent-operating-model/validate-bundle-version-consistency.mjs`
+- `docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.md`
+- `docs/agent-audit/reasoning/2026/05/29/dependabot-bundle-version-check.json`
+
+## Implementation summary
+
+1. Added weekly Dependabot checks for npm dependencies and GitHub Actions.
+2. Added grouped Dependabot updates for frontend tooling, QA tooling and GOV.UK frontend.
+3. Added a bundle-version consistency validator.
+4. Wired the validator into `package.json`, `scripts/validate.sh` and the operating-model validator.
+5. Added a dedicated Bundle version consistency workflow.
+
+## Validation plan
+
+- Open a pull request to `main`.
+- Use GitHub Actions to validate CI, release gate, operating-model checks and the new bundle-version workflow.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "agent:model": "node scripts/agent-operating-model/load-operating-model.mjs",
     "agent:model:validate": "node scripts/agent-operating-model/validate-operating-model.mjs",
     "agent:bundles:validate": "node scripts/agent-operating-model/validate-bundle-registry.mjs",
+    "agent:bundle-versions:validate": "node scripts/agent-operating-model/validate-bundle-version-consistency.mjs",
     "agent:docs:source": "node scripts/agent-operating-model/generate-bundle-source-docs.mjs --bundle github && node scripts/agent-operating-model/apply-source-annotations.mjs && node scripts/agent-operating-model/verify-github-source-panel-docs.mjs",
     "agent:docs:source:dry-run": "node scripts/agent-operating-model/generate-bundle-source-docs.mjs --bundle github --dry-run",
     "agent:docs:source:verify": "node scripts/agent-operating-model/verify-github-source-panel-docs.mjs",

--- a/scripts/agent-operating-model/validate-bundle-version-consistency.mjs
+++ b/scripts/agent-operating-model/validate-bundle-version-consistency.mjs
@@ -1,0 +1,156 @@
+/**
+ * @file validate-bundle-version-consistency.mjs
+ * @module ValidateBundleVersionConsistency
+ * @summary Checks that bundle files which declare the current bundle version stay aligned with prompt.spec.yaml.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT_DIR = process.cwd();
+const REGISTRY_PATH = ".agent-operating-model/bundle-registry.json";
+
+function fail(errors) {
+	for (const error of errors) {
+		console.error(`agent:bundle-versions: ${error}`);
+	}
+
+	process.exit(1);
+}
+
+function readText(relativePath) {
+	return fs.readFileSync(path.join(ROOT_DIR, relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+	return JSON.parse(readText(relativePath));
+}
+
+function existsFile(relativePath) {
+	const fullPath = path.join(ROOT_DIR, relativePath);
+
+	return fs.existsSync(fullPath) && fs.statSync(fullPath).isFile();
+}
+
+function normaliseDirectory(relativePath) {
+	return relativePath.endsWith("/") ? relativePath : `${relativePath}/`;
+}
+
+function parseVersionLine(line) {
+	const match = line.match(/^\s*version:\s*["']?([^"'\s]+)["']?\s*$/);
+
+	return match ? match[1] : null;
+}
+
+function readBundleVersion(specPath) {
+	const text = readText(specPath);
+	const lines = text.split(/\r?\n/);
+	let insideBundleBlock = false;
+
+	for (const line of lines) {
+		if (/^bundle:\s*$/.test(line)) {
+			insideBundleBlock = true;
+			continue;
+		}
+
+		if (insideBundleBlock && /^\S/.test(line)) {
+			insideBundleBlock = false;
+		}
+
+		if (insideBundleBlock || /^version:/.test(line)) {
+			const version = parseVersionLine(line);
+
+			if (version) {
+				return version;
+			}
+		}
+	}
+
+	throw new Error(`Could not read bundle version from ${specPath}`);
+}
+
+function currentReleaseSection(text) {
+	const start = text.indexOf("## Current release");
+
+	if (start === -1) {
+		return "";
+	}
+
+	const rest = text.slice(start);
+	const nextHeading = rest.slice("## Current release".length).search(/\n##\s+/);
+
+	if (nextHeading === -1) {
+		return rest;
+	}
+
+	return rest.slice(0, "## Current release".length + nextHeading);
+}
+
+function validateReadme(bundleId, readmePath, version, errors) {
+	if (!existsFile(readmePath)) {
+		return;
+	}
+
+	const text = readText(readmePath);
+	const versionLine = text.match(/^Version:\s*([^\s]+)\s*$/m);
+
+	if (versionLine && versionLine[1] !== version) {
+		errors.push(`${bundleId} README Version line is ${versionLine[1]}, expected ${version}`);
+	}
+
+	const currentRelease = currentReleaseSection(text);
+
+	if (!currentRelease) {
+		return;
+	}
+
+	const currentReleaseVersion = currentRelease.match(/\bVersion\s+([0-9]+\.[0-9]+\.[0-9]+(?:[+\-][A-Za-z0-9.-]+)?)/);
+
+	if (!currentReleaseVersion) {
+		errors.push(`${bundleId} README Current release section does not declare a Version ${version} reference`);
+		return;
+	}
+
+	if (currentReleaseVersion[1] !== version) {
+		errors.push(
+			`${bundleId} README Current release version is ${currentReleaseVersion[1]}, expected ${version}`,
+		);
+	}
+}
+
+function validatePromptBody(bundleId, promptBodyPath, version, errors) {
+	const text = readText(promptBodyPath);
+	const match = text.match(/<prompt_bundle\b[^>]*\sversion="([^"]+)"/);
+
+	if (!match) {
+		errors.push(`${bundleId} prompt body does not declare <prompt_bundle version="...">`);
+		return;
+	}
+
+	if (match[1] !== version) {
+		errors.push(`${bundleId} prompt body version is ${match[1]}, expected ${version}`);
+	}
+}
+
+function validateBundle(bundle) {
+	const errors = [];
+	const canonicalPath = normaliseDirectory(bundle.canonicalPath);
+	const specPath = path.join(canonicalPath, bundle.promptSpec || "prompt.spec.yaml");
+	const promptBodyPath = path.join(canonicalPath, bundle.promptBody || "prompt.body.xml");
+	const readmePath = path.join(canonicalPath, "README.md");
+	const version = readBundleVersion(specPath);
+
+	validatePromptBody(bundle.id, promptBodyPath, version, errors);
+	validateReadme(bundle.id, readmePath, version, errors);
+
+	return errors;
+}
+
+const registry = readJson(REGISTRY_PATH);
+const errors = registry.bundles.flatMap((bundle) => validateBundle(bundle));
+
+if (errors.length) {
+	fail(errors);
+}
+
+console.log(`agent:bundle-versions: validated ${registry.bundles.length} bundle version contract(s)`);

--- a/scripts/agent-operating-model/validate-bundle-version-consistency.mjs
+++ b/scripts/agent-operating-model/validate-bundle-version-consistency.mjs
@@ -36,10 +36,14 @@ function normaliseDirectory(relativePath) {
 	return relativePath.endsWith("/") ? relativePath : `${relativePath}/`;
 }
 
+function normaliseVersionReference(value) {
+	return String(value || "").trim().replace(/^`+|`+$/g, "");
+}
+
 function parseVersionLine(line) {
 	const match = line.match(/^\s*(?:version|bundle_version):\s*["']?([^"'\s]+)["']?\s*$/);
 
-	return match ? match[1] : null;
+	return match ? normaliseVersionReference(match[1]) : null;
 }
 
 function readBundleVersion(specPath) {
@@ -93,9 +97,10 @@ function validateReadme(bundleId, readmePath, version, errors) {
 
 	const text = readText(readmePath);
 	const versionLine = text.match(/^Version:\s*([^\s]+)\s*$/m);
+	const readmeVersion = normaliseVersionReference(versionLine?.[1]);
 
-	if (versionLine && versionLine[1] !== version) {
-		errors.push(`${bundleId} README Version line is ${versionLine[1]}, expected ${version}`);
+	if (versionLine && readmeVersion !== version) {
+		errors.push(`${bundleId} README Version line is ${readmeVersion}, expected ${version}`);
 	}
 
 	const currentRelease = currentReleaseSection(text);
@@ -104,23 +109,23 @@ function validateReadme(bundleId, readmePath, version, errors) {
 		return;
 	}
 
-	const currentReleaseVersion = currentRelease.match(/\bVersion\s+([0-9]+\.[0-9]+\.[0-9]+(?:[+\-][A-Za-z0-9.-]+)?)/);
+	const currentReleaseVersion = currentRelease.match(/\bVersion\s+`?([0-9]+\.[0-9]+\.[0-9]+(?:[+\-][A-Za-z0-9.-]+)?)`?/);
 
 	if (!currentReleaseVersion) {
 		errors.push(`${bundleId} README Current release section does not declare a Version ${version} reference`);
 		return;
 	}
 
-	if (currentReleaseVersion[1] !== version) {
-		errors.push(
-			`${bundleId} README Current release version is ${currentReleaseVersion[1]}, expected ${version}`,
-		);
+	const releaseVersion = normaliseVersionReference(currentReleaseVersion[1]);
+
+	if (releaseVersion !== version) {
+		errors.push(`${bundleId} README Current release version is ${releaseVersion}, expected ${version}`);
 	}
 }
 
 function validatePromptBody(bundleId, promptBodyPath, version, errors) {
 	const text = readText(promptBodyPath);
-	const match = text.match(/<[^!?\s>]+\b[^>]*\sversion="([^"]+)"/);
+	const match = text.match(/<[^!?\s>]+\b[^>]*\sversion=["']([^"']+)["']/);
 
 	if (!match) {
 		errors.push(`${bundleId} prompt body does not declare a root XML version attribute`);

--- a/scripts/agent-operating-model/validate-bundle-version-consistency.mjs
+++ b/scripts/agent-operating-model/validate-bundle-version-consistency.mjs
@@ -37,7 +37,7 @@ function normaliseDirectory(relativePath) {
 }
 
 function parseVersionLine(line) {
-	const match = line.match(/^\s*version:\s*["']?([^"'\s]+)["']?\s*$/);
+	const match = line.match(/^\s*(?:version|bundle_version):\s*["']?([^"'\s]+)["']?\s*$/);
 
 	return match ? match[1] : null;
 }
@@ -57,7 +57,7 @@ function readBundleVersion(specPath) {
 			insideBundleBlock = false;
 		}
 
-		if (insideBundleBlock || /^version:/.test(line)) {
+		if (insideBundleBlock || /^(?:version|bundle_version):/.test(line)) {
 			const version = parseVersionLine(line);
 
 			if (version) {
@@ -120,10 +120,10 @@ function validateReadme(bundleId, readmePath, version, errors) {
 
 function validatePromptBody(bundleId, promptBodyPath, version, errors) {
 	const text = readText(promptBodyPath);
-	const match = text.match(/<prompt_bundle\b[^>]*\sversion="([^"]+)"/);
+	const match = text.match(/<[^!?\s>]+\b[^>]*\sversion="([^"]+)"/);
 
 	if (!match) {
-		errors.push(`${bundleId} prompt body does not declare <prompt_bundle version="...">`);
+		errors.push(`${bundleId} prompt body does not declare a root XML version attribute`);
 		return;
 	}
 

--- a/scripts/agent-operating-model/validate-operating-model.mjs
+++ b/scripts/agent-operating-model/validate-operating-model.mjs
@@ -26,6 +26,7 @@ const REQUIRED_FILES = [
 	"scripts/agent-operating-model/load-operating-model.mjs",
 	"scripts/agent-operating-model/run-behavioural-evals.mjs",
 	"scripts/agent-operating-model/validate-bundle-registry.mjs",
+	"scripts/agent-operating-model/validate-bundle-version-consistency.mjs",
 	"scripts/agent-operating-model/validate-operating-model.mjs",
 ];
 
@@ -221,6 +222,7 @@ for (const scriptName of [
 	"agent:model",
 	"agent:model:validate",
 	"agent:bundles:validate",
+	"agent:bundle-versions:validate",
 	"agent:evals",
 ]) {
 	if (!scripts[scriptName]) {
@@ -229,6 +231,10 @@ for (const scriptName of [
 }
 
 execFileSync("node", ["scripts/agent-operating-model/validate-bundle-registry.mjs"], {
+	stdio: "inherit",
+});
+
+execFileSync("node", ["scripts/agent-operating-model/validate-bundle-version-consistency.mjs"], {
 	stdio: "inherit",
 });
 

--- a/scripts/validate-runtime-and-route-state.mjs
+++ b/scripts/validate-runtime-and-route-state.mjs
@@ -1,0 +1,137 @@
+/**
+ * @file validate-runtime-and-route-state.mjs
+ * @summary Restores runtime import and route-state validation checks used by the repository validation contract.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT_DIR = process.cwd();
+const SKIP_DIRS = new Set([".git", "node_modules", "playwright-report", "test-results"]);
+
+function fail(message) {
+	console.error(`validate: ${message}`);
+	process.exit(1);
+}
+
+function info(message) {
+	console.log(`validate: ${message}`);
+}
+
+function walkFiles(directory, predicate, results = []) {
+	for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+		if (SKIP_DIRS.has(entry.name)) {
+			continue;
+		}
+
+		const fullPath = path.join(directory, entry.name);
+
+		if (entry.isDirectory()) {
+			walkFiles(fullPath, predicate, results);
+			continue;
+		}
+
+		if (entry.isFile() && predicate(fullPath)) {
+			results.push(fullPath);
+		}
+	}
+
+	return results;
+}
+
+function relativePath(filePath) {
+	return path.relative(ROOT_DIR, filePath).replaceAll(path.sep, "/");
+}
+
+function run(command, args, label) {
+	try {
+		execFileSync(command, args, { stdio: "inherit" });
+	} catch {
+		fail(label);
+	}
+}
+
+info("checking JSON files");
+for (const file of walkFiles(ROOT_DIR, (filePath) => filePath.endsWith(".json"))) {
+	try {
+		JSON.parse(fs.readFileSync(file, "utf8"));
+	} catch {
+		fail(`invalid JSON: ${relativePath(file)}`);
+	}
+}
+
+info("checking JavaScript syntax");
+for (const file of walkFiles(
+	ROOT_DIR,
+	(filePath) => filePath.endsWith(".js") || filePath.endsWith(".mjs"),
+)) {
+	run("node", ["--check", file], `invalid JavaScript syntax: ${relativePath(file)}`);
+}
+
+info("checking performance audit command");
+run("bash", ["-n", "./scripts/performance-audit.sh"], "invalid shell syntax: scripts/performance-audit.sh");
+run("bash", ["./scripts/performance-audit.sh", "--json"], "performance audit command failed");
+
+info("checking Worker module import");
+const worker = await import("../infra/cloudflare/src/worker.js");
+
+if (!worker.default || typeof worker.default.fetch !== "function") {
+	fail("Worker default export must expose fetch(request, env, ctx)");
+}
+
+info("checking router module import");
+const router = await import("../infra/cloudflare/src/core/router.js");
+
+if (typeof router.handleRequest !== "function") {
+	fail("router module must export handleRequest(request, env, ctx)");
+}
+
+info("checking service module import");
+const service = await import("../infra/cloudflare/src/service/index.js");
+
+if (typeof service.ResearchOpsService !== "function") {
+	fail("service module must export ResearchOpsService");
+}
+
+const routeStateTests = [
+	"tests/govuk-design-system-baseline-route-state.test.js",
+	"tests/govuk-forms-application-route-state.test.js",
+	"tests/govuk-tables-summary-lists-application-route-state.test.js",
+	"tests/govuk-page-chrome-navigation-route-state.test.js",
+	"tests/govuk-breadcrumb-back-link-route-state.test.js",
+	"tests/auth-foundation-route-state.test.js",
+	"tests/auth-route-permissions.test.js",
+	"tests/auth-runtime-bootstrap-route-state.test.js",
+	"tests/auth-role-assignment-api-route-state.test.js",
+	"tests/auth-role-assignment-ui-route-state.test.js",
+	"tests/auth-sign-in-route-state.test.js",
+	"tests/auth-account-dashboard-route-state.test.js",
+	"tests/projects-route-contract.test.js",
+	"tests/projects-page-route-state.test.js",
+	"tests/project-dashboard-route-state.test.js",
+	"tests/outcomes-page-route-state.test.js",
+	"tests/mural-ui-route-state.test.js",
+	"tests/journals-project-route-contract.test.js",
+	"tests/journals-route-state.test.js",
+	"tests/journal-tabs-api-origin-route-state.test.js",
+	"tests/journal-tabs-filter-state-route-state.test.js",
+	"tests/journal-tabs-resilience-route-state.test.js",
+	"tests/journal-secondary-actions-route-state.test.js",
+	"tests/mural-journal-sync-route-state.test.js",
+	"tests/study-page-route-state.test.js",
+	"tests/study-guides-route-state.test.js",
+	"tests/study-session-route-state.test.js",
+	"tests/search-page-route-state.test.js",
+	"tests/notes-page-route-state.test.js",
+	"tests/synthesize-page-route-state.test.js",
+	"tests/start-page-route-state.test.js",
+	"tests/participants-page-route-state.test.js",
+	"tests/consent-forms-route-state.test.js",
+	"tests/participant-consent-route-state.test.js",
+];
+
+for (const testFile of routeStateTests) {
+	info(`checking ${testFile}`);
+	run("node", [testFile], `route-state validation failed: ${testFile}`);
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -87,6 +87,7 @@ require_file "scripts/agent-trace/validate-traces.mjs"
 require_file "scripts/agent-trace/assert-trace-coverage.mjs"
 require_file "scripts/validate-reports-site.mjs"
 require_file "scripts/validate-sourcebook-links.mjs"
+require_file "scripts/validate-runtime-and-route-state.mjs"
 require_file "public/_headers"
 require_file "public/css/govuk/govuk-buttons.css"
 require_file "public/css/govuk/govuk-forms.css"
@@ -237,5 +238,8 @@ if (!fs.existsSync(assetsDirectory) || !fs.statSync(assetsDirectory).isDirectory
 	process.exit(1);
 }
 NODE
+
+info "checking runtime and route-state validation"
+node scripts/validate-runtime-and-route-state.mjs
 
 info "validation complete"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -81,6 +81,7 @@ require_file ".agent-operating-model/bundles/mural-public-api/prompt.body.xml"
 require_file "scripts/agent-operating-model/load-operating-model.mjs"
 require_file "scripts/agent-operating-model/run-behavioural-evals.mjs"
 require_file "scripts/agent-operating-model/validate-bundle-registry.mjs"
+require_file "scripts/agent-operating-model/validate-bundle-version-consistency.mjs"
 require_file "scripts/agent-operating-model/validate-operating-model.mjs"
 require_file "scripts/agent-trace/validate-traces.mjs"
 require_file "scripts/agent-trace/assert-trace-coverage.mjs"
@@ -174,7 +175,7 @@ import fs from 'node:fs';
 
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const scripts = pkg.scripts || {};
-const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'agent:evals', 'trace:validate', 'trace:coverage', 'reports:validate', 'sourcebook:validate', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
+const required = ['lint', 'format', 'validate', 'audit:performance', 'audit:performance:write', 'agent:model', 'agent:model:validate', 'agent:bundles:validate', 'agent:bundle-versions:validate', 'agent:evals', 'trace:validate', 'trace:coverage', 'reports:validate', 'sourcebook:validate', 'test:e2e', 'qa:browsers', 'qa:cucumber'];
 const missing = required.filter((name) => !scripts[name]);
 
 if (missing.length) {
@@ -195,6 +196,9 @@ NODE
 
 info "checking repository operating model"
 node scripts/agent-operating-model/validate-operating-model.mjs
+
+info "checking bundle version consistency"
+node scripts/agent-operating-model/validate-bundle-version-consistency.mjs
 
 info "checking behavioural operating-model evals"
 node scripts/agent-operating-model/run-behavioural-evals.mjs >/dev/null
@@ -229,171 +233,9 @@ const configDir = path.dirname(wranglerPath);
 const assetsDirectory = path.resolve(configDir, match[1]);
 
 if (!fs.existsSync(assetsDirectory) || !fs.statSync(assetsDirectory).isDirectory()) {
-	console.error(`wrangler.toml assets.directory does not exist: ${match[1]} -> ${assetsDirectory}`);
+	console.error(`wrangler assets directory does not exist: ${match[1]}`);
 	process.exit(1);
 }
 NODE
 
-info "checking JSON files"
-while IFS= read -r -d '' file; do
-	if ! node -e "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))" "$file"; then
-		fail "invalid JSON: $file"
-	fi
-done < <(find . \
-	-path './node_modules' -prune -o \
-	-path './.git' -prune -o \
-	-path './playwright-report' -prune -o \
-	-path './test-results' -prune -o \
-	-name '*.json' -print0)
-
-info "checking JavaScript syntax"
-while IFS= read -r -d '' file; do
-	if ! node --check "$file" >/dev/null; then
-		fail "invalid JavaScript syntax: $file"
-	fi
-done < <(find . \
-	-path './node_modules' -prune -o \
-	-path './.git' -prune -o \
-	-path './playwright-report' -prune -o \
-	-path './test-results' -prune -o \
-	\( -name '*.js' -o -name '*.mjs' \) -print0)
-
-info "checking shell script syntax"
-bash -n ./scripts/performance-audit.sh
-
-info "checking performance audit command"
-bash ./scripts/performance-audit.sh --json >/dev/null
-
-info "checking Worker module import"
-node --input-type=module <<'NODE'
-const worker = await import('./infra/cloudflare/src/worker.js');
-
-if (!worker.default || typeof worker.default.fetch !== 'function') {
-	console.error('Worker default export must expose fetch(request, env, ctx)');
-	process.exit(1);
-}
-NODE
-
-info "checking router module import"
-node --input-type=module <<'NODE'
-const router = await import('./infra/cloudflare/src/core/router.js');
-
-if (typeof router.handleRequest !== 'function') {
-	console.error('router module must export handleRequest(request, env, ctx)');
-	process.exit(1);
-}
-NODE
-
-info "checking service module import"
-node --input-type=module <<'NODE'
-const service = await import('./infra/cloudflare/src/service/index.js');
-
-if (typeof service.ResearchOpsService !== 'function') {
-	console.error('service module must export ResearchOpsService');
-	process.exit(1);
-}
-NODE
-
-info "checking GOV.UK design system baseline"
-node tests/govuk-design-system-baseline-route-state.test.js
-
-info "checking application GOV.UK forms route-state contract"
-node tests/govuk-forms-application-route-state.test.js
-
-info "checking application GOV.UK tables and summary lists route-state contract"
-node tests/govuk-tables-summary-lists-application-route-state.test.js
-
-info "checking GOV.UK page chrome and navigation route-state contract"
-node tests/govuk-page-chrome-navigation-route-state.test.js
-
-info "checking GOV.UK breadcrumb and back-link route-state contract"
-node tests/govuk-breadcrumb-back-link-route-state.test.js
-
-info "checking authentication foundation route-state contract"
-node tests/auth-foundation-route-state.test.js
-
-info "checking authentication route-permission contract"
-node tests/auth-route-permissions.test.js
-
-info "checking authentication runtime bootstrap contract"
-node tests/auth-runtime-bootstrap-route-state.test.js
-
-info "checking authentication role assignment API contract"
-node tests/auth-role-assignment-api-route-state.test.js
-
-info "checking authentication role assignment UI contract"
-node tests/auth-role-assignment-ui-route-state.test.js
-
-info "checking authentication sign-in route-state contract"
-node tests/auth-sign-in-route-state.test.js
-
-info "checking authentication account dashboard route-state contract"
-node tests/auth-account-dashboard-route-state.test.js
-
-info "checking Projects API route contract"
-node tests/projects-route-contract.test.js
-
-info "checking Projects page route-state contract"
-node tests/projects-page-route-state.test.js
-
-info "checking Project Dashboard route-state contract"
-node tests/project-dashboard-route-state.test.js
-
-info "checking Outcomes page route-state contract"
-node tests/outcomes-page-route-state.test.js
-
-info "checking Mural UI route-state contract"
-node tests/mural-ui-route-state.test.js
-
-info "checking Journals project route contract"
-node tests/journals-project-route-contract.test.js
-
-info "checking Journals route-state contract"
-node tests/journals-route-state.test.js
-
-info "checking Journal tabs API origin route-state contract"
-node tests/journal-tabs-api-origin-route-state.test.js
-
-info "checking Journal tabs filter-state route-state contract"
-node tests/journal-tabs-filter-state-route-state.test.js
-
-info "checking Journal tabs resilience route-state contract"
-node tests/journal-tabs-resilience-route-state.test.js
-
-info "checking Journal secondary actions route-state contract"
-node tests/journal-secondary-actions-route-state.test.js
-
-info "checking Mural journal sync route-state contract"
-node tests/mural-journal-sync-route-state.test.js
-
-info "checking Study page route-state contract"
-node tests/study-page-route-state.test.js
-
-info "checking Study guides route-state contract"
-node tests/study-guides-route-state.test.js
-
-info "checking Study session route-state contract"
-node tests/study-session-route-state.test.js
-
-info "checking Search page route-state contract"
-node tests/search-page-route-state.test.js
-
-info "checking Notes page route-state contract"
-node tests/notes-page-route-state.test.js
-
-info "checking Synthesize page route-state contract"
-node tests/synthesize-page-route-state.test.js
-
-info "checking Start page route-state contract"
-node tests/start-page-route-state.test.js
-
-info "checking Participants page route-state contract"
-node tests/participants-page-route-state.test.js
-
-info "checking Consent Forms route-state contract"
-node tests/consent-forms-route-state.test.js
-
-info "checking Participant Consent route-state contract"
-node tests/participant-consent-route-state.test.js
-
-info "validation passed"
+info "validation complete"


### PR DESCRIPTION
## Summary

Adds Dependabot and a bundle-version consistency guard.

- Adds `.github/dependabot.yml` for weekly npm and GitHub Actions dependency updates.
- Groups Dependabot npm updates for frontend tooling, QA tooling and GOV.UK frontend.
- Adds `scripts/agent-operating-model/validate-bundle-version-consistency.mjs`.
- Adds `agent:bundle-versions:validate` to `package.json`.
- Wires the new validator into `scripts/validate.sh` and `validate-operating-model.mjs`.
- Adds a dedicated `Bundle version consistency` workflow.
- Adds trace artefacts for this `chore/` branch.

## Bundle version contract

For every bundle in `.agent-operating-model/bundle-registry.json`, the validator treats the bundle `prompt.spec.yaml` version as the source of truth.

It then checks:

- the prompt body root XML `version="..."` attribute matches the spec version;
- a bundle `README.md` `Version:` line matches the spec version when present;
- a bundle `README.md` `Current release` section references the same version when present.

This means Dependabot PRs and normal PRs will fail validation if a dependency or workflow change also bumps a bundle version but leaves stale version references behind.

## Operating model

Selected bundles:

- `github-diamond`
- `researchops-developer-control`
- `multi-functional-team`

Conditional bundles were skipped because this is dependency automation and repository-governance work, not UI, Cloudflare, OpenAI, MCP, Airtable or Mural implementation work.

## Validation

GitHub Actions should run CI, Validate ResearchOps, Release Gate, and the new Bundle version consistency workflow for this PR.