### PR TITLE
Migrate generated Discussion Guides rows to GOV.UK table classes

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.json
+++ b/docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.json
@@ -1,0 +1,69 @@
+{
+	"date": "2026-05-30",
+	"traceType": "operational-audit-trace",
+	"branch": "fix/govuk-guides-generated-table-rows",
+	"traceRequired": true,
+	"taskSummary": "Migrate generated Discussion Guides table rows to GOV.UK table classes for Issue #110.",
+	"operatingModelFilesLoaded": [
+		"README.md",
+		"AGENTS.md",
+		"RECENT_LEARNINGS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/bootstrap-checklist.md",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/trace-layers.md",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/",
+			"reason": "Always loaded for repository-affecting work."
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+			"reason": "Always loaded for ResearchOps platform work."
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+			"reason": "Always loaded for government product assurance."
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+			"reason": "Selected because the task changes GOV.UK table markup and frontend accessibility-related semantics."
+		}
+	],
+	"skippedBundles": [
+		"cloudflare",
+		"openai-platform",
+		"mcp-agent-tooling",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"filesRead": [
+		"public/components/guides/guides-page.js",
+		"GitHub Issue #110"
+	],
+	"filesChanged": [
+		"public/components/guides/guides-page.js",
+		"docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.md",
+		"docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.json"
+	],
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint"
+	],
+	"validationRunInConnector": [],
+	"residualRisks": [
+		"Validation has not been run locally in this connector context.",
+		"Manual browser checks are still required for the Discussion Guides page."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.md
+++ b/docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.md
@@ -1,0 +1,98 @@
+# Agent trace — GOV.UK guide generated table rows
+
+**Date:** 2026-05-30  
+**Trace type:** operational audit trace  
+**Branch:** `fix/govuk-guides-generated-table-rows`  
+**Scope:** Discussion Guides generated table rows and fallback table skeleton
+
+## Evidence boundary
+
+This trace records repository evidence, implementation decisions, files read, files changed, validation expected and residual risk.
+
+It does not expose private chain-of-thought.
+
+## Original task summary
+
+Handle Issue #110 by migrating generated Discussion Guides table rows in `public/components/guides/guides-page.js` to GOV.UK table classes.
+
+## Operating model files loaded
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Selected bundles
+
+Always-load bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+
+Conditional bundles:
+
+- `.agent-operating-model/bundles/govuk-design-system/` because the task changes GOV.UK table markup, page UI and accessibility-related table semantics.
+
+Skipped bundles:
+
+- `.agent-operating-model/bundles/cloudflare/`
+- `.agent-operating-model/bundles/openai/`
+- `.agent-operating-model/bundles/mcp-agent-tooling/`
+- `.agent-operating-model/bundles/airtable-public-api/`
+- `.agent-operating-model/bundles/mural-public-api/`
+
+## Branch-prefix trace decision
+
+The branch starts with `fix/`, so trace artefacts are required by the repository trace policy.
+
+## Files inspected
+
+- `public/components/guides/guides-page.js`
+- Issue #110 body and acceptance notes
+
+## Files changed
+
+- `public/components/guides/guides-page.js`
+- `docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.md`
+- `docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.json`
+
+## Implementation summary
+
+The implementation updates the Discussion Guides fallback table skeleton and generated guide rows so they use GOV.UK table classes.
+
+The change:
+
+- changes the fallback table to `govuk-table`
+- adds `govuk-table__head`, `govuk-table__body`, `govuk-table__row`, `govuk-table__header` and `govuk-table__cell`
+- adds GOV.UK row and cell classes to loading, empty and error helper rows
+- adds `govuk-table__row` to generated guide rows
+- keeps the existing `link-like` Open button and `data-open` behaviour unchanged
+
+## Validation expected
+
+Automated checks to run in CI:
+
+- `npm run validate`
+- `npm run lint`
+
+Manual checks:
+
+- Open `/pages/study/guides/?pid=<known-project-id>&sid=<known-study-id>`.
+- Confirm generated rows align under the correct columns.
+- Confirm the Open guide action still opens the selected guide.
+- Confirm loading, empty and error rows render correctly.
+- Confirm editor, drawers and variables remain unchanged.
+
+## Residual risk
+
+Validation has not been run locally in this connector context. CI and manual browser checks remain the source of truth for readiness.

--- a/public/components/guides/guides-page.js
+++ b/public/components/guides/guides-page.js
@@ -411,18 +411,18 @@ function ensureGuidesTableSkeleton() {
 	wrapper.id = "guides-fallback-wrapper";
 	wrapper.className = "table-wrap";
 	wrapper.innerHTML = `
-    <table class="table" role="table" id="guides-table">
-      <thead>
-        <tr>
-          <th scope="col">Title</th>
-          <th scope="col">Status</th>
-          <th scope="col">Version</th>
-          <th scope="col">Updated</th>
-          <th scope="col">Owner</th>
-          <th scope="col"><span class="sr-only">Actions</span></th>
+    <table class="govuk-table" id="guides-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Title</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header">Version</th>
+          <th scope="col" class="govuk-table__header">Updated</th>
+          <th scope="col" class="govuk-table__header">Owner</th>
+          <th scope="col" class="govuk-table__header"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>
-      <tbody id="guides-tbody"></tbody>
+      <tbody id="guides-tbody" class="govuk-table__body"></tbody>
     </table>
   `;
 	host.appendChild(wrapper);
@@ -466,7 +466,7 @@ async function loadGuides(studyId, opts = {}) {
 			console.error("[guides] tbody is null, cannot paint");
 		}
 	};
-	const row = (msg) => `<tr><td colspan="6" class="muted">${escapeHtml(msg)}</td></tr>`;
+	const row = (msg) => `<tr class="govuk-table__row"><td colspan="6" class="govuk-table__cell muted">${escapeHtml(msg)}</td></tr>`;
 
 	// Show loading row, then *immediately* kill any external loaders
 	paint(row("Loading…"));
@@ -523,6 +523,7 @@ async function loadGuides(studyId, opts = {}) {
 		const fr = document.createDocumentFragment();
 		for (const g of guides) {
 			const tr = document.createElement("tr");
+			tr.className = "govuk-table__row";
 
 			// Format the updated date
 			let dateStr = "—";
@@ -542,12 +543,12 @@ async function loadGuides(studyId, opts = {}) {
 			}
 
 			tr.innerHTML = `
-        <td>${escapeHtml(g.title || "Untitled")}</td>
-        <td>${escapeHtml(g.status || "draft")}</td>
-        <td>v${Number.isFinite(g.version) ? g.version : (parseInt(g.version,10) || 0)}</td>
-        <td>${dateStr}</td>
-        <td>${escapeHtml(g.createdBy?.name || "—")}</td>
-        <td><button class="link-like" data-open="${g.id}">Open</button></td>`;
+        <td class="govuk-table__cell">${escapeHtml(g.title || "Untitled")}</td>
+        <td class="govuk-table__cell">${escapeHtml(g.status || "draft")}</td>
+        <td class="govuk-table__cell">v${Number.isFinite(g.version) ? g.version : (parseInt(g.version,10) || 0)}</td>
+        <td class="govuk-table__cell">${dateStr}</td>
+        <td class="govuk-table__cell">${escapeHtml(g.createdBy?.name || "—")}</td>
+        <td class="govuk-table__cell"><button class="link-like" data-open="${g.id}">Open</button></td>`;
 			fr.appendChild(tr);
 		}
 


### PR DESCRIPTION
## Summary

Migrates the generated Discussion Guides table rows and fallback table skeleton in `public/components/guides/guides-page.js` to GOV.UK table classes.

Closes #110.

## Changes

- Update the fallback guides table skeleton to use `govuk-table`, `govuk-table__head`, `govuk-table__row`, `govuk-table__header`, and `govuk-table__body`.
- Update loading, empty and error helper rows to use `govuk-table__row` and `govuk-table__cell`.
- Update generated guide rows to use `govuk-table__row` and `govuk-table__cell`.
- Preserve the existing `link-like` Open action and `data-open` behaviour.
- Add required operating-model trace artefacts for the `fix/` branch.

## GOV.UK Design System alignment

- Keeps table styling owned by the global GOV.UK table stylesheet.
- Does not move table styling into `public/css/guides.css`.
- Keeps generated row structure aligned with the static Discussion Guides table shell migration.

## Trace

- `docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.md`
- `docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.json`

## Changed-file verification

Changed files: 3

- `public/components/guides/guides-page.js`
- `docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.md`
- `docs/agent-audit/reasoning/2026/05/30/govuk-guides-generated-table-rows.json`

Branch comparison: 3 commits ahead of `main`, 0 behind.

## Validation

Not run locally in this connector context.

Ready for GitHub checks to run:

- `npm run validate`
- `npm run lint`

## Manual browser checks

Open:

`/pages/study/guides/?pid=<known-project-id>&sid=<known-study-id>`

Confirm:

- Guides list header renders as a GOV.UK table.
- Generated rows align under the correct columns.
- Open guide action still opens the selected guide.
- Loading, empty and error rows still render correctly.
- Editor, drawers and variables remain unchanged.
