### PR TITLE
Migrate generated Journal entry actions to GOV.UK button classes

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json
+++ b/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json
@@ -1,0 +1,71 @@
+{
+	"date": "2026-05-30",
+	"traceType": "operational-audit-trace",
+	"branch": "fix/govuk-journal-generated-buttons",
+	"traceRequired": true,
+	"taskSummary": "Migrate generated Journal entry actions to GOV.UK button classes for Issue #106.",
+	"operatingModelFilesLoaded": [
+		"README.md",
+		"AGENTS.md",
+		"RECENT_LEARNINGS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/bootstrap-checklist.md",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/trace-layers.md",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/",
+			"reason": "Always loaded for repository-affecting work."
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+			"reason": "Always loaded for ResearchOps platform work."
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+			"reason": "Always loaded for government product assurance."
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+			"reason": "Selected because the task changes GOV.UK button classes and frontend route-state checks."
+		}
+	],
+	"skippedBundles": [
+		"cloudflare",
+		"openai-platform",
+		"mcp-agent-tooling",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"filesRead": [
+		"public/js/journal-tabs.js",
+		"tests/journals-route-state.test.js",
+		"GitHub Issue #106"
+	],
+	"filesChanged": [
+		"public/js/journal-tabs.js",
+		"tests/journals-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md",
+		"docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json"
+	],
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint"
+	],
+	"validationRunInConnector": [],
+	"residualRisks": [
+		"Validation has not been run locally in this connector context.",
+		"Manual browser checks are still required for the Reflexive Journals page."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json
+++ b/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json
@@ -51,11 +51,14 @@
 	"filesRead": [
 		"public/js/journal-tabs.js",
 		"tests/journals-route-state.test.js",
-		"GitHub Issue #106"
+		"tests/journal-tabs-filter-state-route-state.test.js",
+		"GitHub Issue #106",
+		"PR #311 CI and release-gate artefacts"
 	],
 	"filesChanged": [
 		"public/js/journal-tabs.js",
 		"tests/journals-route-state.test.js",
+		"tests/journal-tabs-filter-state-route-state.test.js",
 		"docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md",
 		"docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json"
 	],
@@ -64,8 +67,18 @@
 		"npm run lint"
 	],
 	"validationRunInConnector": [],
+	"ciFailureHandling": {
+		"observedFailedWorkflows": [
+			"Validate ResearchOps",
+			"Worker CI",
+			"CI",
+			"Release Gate"
+		],
+		"rootCause": "An obsolete route-state assertion in tests/journal-tabs-filter-state-route-state.test.js expected the legacy btn-quiet danger delete button after the GOV.UK button migration.",
+		"fix": "Updated the test to expect the GOV.UK warning button and exclude the legacy btn-quiet danger button."
+	},
 	"residualRisks": [
-		"Validation has not been run locally in this connector context.",
+		"Validation has not been run locally in this connector context because this environment cannot clone the repository from GitHub.",
 		"Manual browser checks are still required for the Reflexive Journals page."
 	]
 }

--- a/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md
+++ b/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md
@@ -1,0 +1,100 @@
+# Agent trace — GOV.UK journal generated buttons
+
+**Date:** 2026-05-30  
+**Trace type:** operational audit trace  
+**Branch:** `fix/govuk-journal-generated-buttons`  
+**Scope:** generated Reflexive Journal entry actions and route-state regression coverage
+
+## Evidence boundary
+
+This trace records repository evidence, implementation decisions, files read, files changed, validation expected and residual risk.
+
+It does not expose private chain-of-thought.
+
+## Original task summary
+
+Handle Issue #106 by migrating generated Journal entry `Edit` and `Delete` actions in `public/js/journal-tabs.js` to GOV.UK button classes, and adding route-state assertions in `tests/journals-route-state.test.js`.
+
+## Operating model files loaded
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Selected bundles
+
+Always-load bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+
+Conditional bundles:
+
+- `.agent-operating-model/bundles/govuk-design-system/` because the task changes GOV.UK button classes, generated page UI and route-state accessibility-related presentation coverage.
+
+Skipped bundles:
+
+- `.agent-operating-model/bundles/cloudflare/`
+- `.agent-operating-model/bundles/openai/`
+- `.agent-operating-model/bundles/mcp-agent-tooling/`
+- `.agent-operating-model/bundles/airtable-public-api/`
+- `.agent-operating-model/bundles/mural-public-api/`
+
+## Branch-prefix trace decision
+
+The branch starts with `fix/`, so trace artefacts are required by the repository trace policy.
+
+## Files inspected
+
+- `public/js/journal-tabs.js`
+- `tests/journals-route-state.test.js`
+- GitHub Issue #106
+
+## Files changed
+
+- `public/js/journal-tabs.js`
+- `tests/journals-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md`
+- `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json`
+
+## Implementation summary
+
+The implementation updates generated Journal entry action markup from legacy `btn-quiet` classes to the global GOV.UK button foundation.
+
+The change:
+
+- changes `Edit` to `govuk-button govuk-button--secondary`
+- changes `Delete` to `govuk-button govuk-button--warning`
+- preserves the existing `href`, `type`, `data-act`, `data-id` and delete handler contract
+- adds route-state checks for the new button classes
+- adds a route-state check that `btn-quiet` is no longer used in the journal tabs module
+
+## Validation expected
+
+Automated checks to run in CI:
+
+- `npm run validate`
+- `npm run lint`
+
+Manual checks:
+
+- Open `/pages/projects/journals/?id=<known-project-id>`.
+- Confirm Journal entry `Edit` actions render correctly.
+- Confirm Journal entry `Delete` actions render as warning buttons.
+- Confirm the delete handler still prompts and deletes correctly.
+- Confirm entry cards, filter chips, Mural sync, tabs and coding panel behaviour are unchanged.
+
+## Residual risk
+
+Validation has not been run locally in this connector context. CI and manual browser checks remain the source of truth for readiness.

--- a/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md
+++ b/docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md
@@ -59,12 +59,15 @@ The branch starts with `fix/`, so trace artefacts are required by the repository
 
 - `public/js/journal-tabs.js`
 - `tests/journals-route-state.test.js`
+- `tests/journal-tabs-filter-state-route-state.test.js`
 - GitHub Issue #106
+- CI and release-gate artefacts for PR #311
 
 ## Files changed
 
 - `public/js/journal-tabs.js`
 - `tests/journals-route-state.test.js`
+- `tests/journal-tabs-filter-state-route-state.test.js`
 - `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md`
 - `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json`
 
@@ -79,6 +82,19 @@ The change:
 - preserves the existing `href`, `type`, `data-act`, `data-id` and delete handler contract
 - adds route-state checks for the new button classes
 - adds a route-state check that `btn-quiet` is no longer used in the journal tabs module
+- updates the journal tabs filter-state route test so it expects the GOV.UK warning delete button and no longer expects the legacy `btn-quiet danger` button
+
+## CI failure handling
+
+The first PR run failed in `Validate ResearchOps`, `Worker CI`, `CI` and `Release Gate`.
+
+The release-gate artefact showed the blocking root cause was an obsolete route-state assertion in `tests/journal-tabs-filter-state-route-state.test.js` expecting:
+
+```text
+<button type="button" class="btn-quiet danger"
+```
+
+That assertion is no longer valid after the GOV.UK button migration and has been updated to expect the new GOV.UK warning button.
 
 ## Validation expected
 
@@ -97,4 +113,4 @@ Manual checks:
 
 ## Residual risk
 
-Validation has not been run locally in this connector context. CI and manual browser checks remain the source of truth for readiness.
+Validation has not been run locally in this connector context because this environment cannot clone the repository from GitHub. CI and manual browser checks remain the source of truth for readiness.

--- a/public/js/journal-tabs.js
+++ b/public/js/journal-tabs.js
@@ -340,7 +340,7 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 							</a>
 						</div>
 						<div class="entry-actions" role="group">
-							<a class="govuk-button govuk-button--secondary" href="${ROUTES.editEntry(en.id)}">Edit</a>
+							<a class="govuk-button govuk-button--secondary" href="${ROUTES.editEntry(en.id)}" role="button" draggable="false" data-module="govuk-button">Edit</a>
 							<button type="button" class="govuk-button govuk-button--warning" data-act="delete" data-id="${esc(en.id)}">Delete</button>
 						</div>
 					</header>

--- a/public/js/journal-tabs.js
+++ b/public/js/journal-tabs.js
@@ -340,8 +340,8 @@ import { runTimeline, runCooccurrence, runRetrieval, runExport } from './caqdas-
 							</a>
 						</div>
 						<div class="entry-actions" role="group">
-							<a class="btn-quiet" href="${ROUTES.editEntry(en.id)}">Edit</a>
-							<button type="button" class="btn-quiet danger" data-act="delete" data-id="${esc(en.id)}">Delete</button>
+							<a class="govuk-button govuk-button--secondary" href="${ROUTES.editEntry(en.id)}">Edit</a>
+							<button type="button" class="govuk-button govuk-button--warning" data-act="delete" data-id="${esc(en.id)}">Delete</button>
 						</div>
 					</header>
 					<div class="entry-content">${esc(snippet)}${wasShortened ? ` <a class="read-more" href="${ROUTES.viewEntry(en.id)}">Read full entry</a>` : ''}</div>

--- a/tests/journal-tabs-filter-state-route-state.test.js
+++ b/tests/journal-tabs-filter-state-route-state.test.js
@@ -26,8 +26,9 @@ includes("categoryKey: normalizeCategoryKey(rawCategory)");
 includes("filter === 'all' || String(en.categoryKey || normalizeCategoryKey(en.category)).toLowerCase() === filter");
 includes("data-category=\"${esc(en.categoryKey || normalizeCategoryKey(en.category))}\"");
 includes("wrap.innerHTML = emptyEntriesHtml(); return;");
-includes("<button type=\"button\" class=\"btn-quiet danger\"");
+includes("<button type=\"button\" class=\"govuk-button govuk-button--warning\"");
 
+excludes("<button type=\"button\" class=\"btn-quiet danger\"");
 excludes("const empty = document.getElementById('empty-journal');");
 excludes("wrap.innerHTML = ''; if (empty) empty.hidden = false; return;");
 excludes("String(en.category || '').toLowerCase() === filter");

--- a/tests/journals-route-state.test.js
+++ b/tests/journals-route-state.test.js
@@ -74,6 +74,9 @@ includes(projectContextSource, "function setProjectParentLink", "project context
 includes(caqdasSource, "flashError('Enter a term to search.', 'retrieval-q')", "CAQDAS analysis module");
 includes(caqdasSource, "setRetrievalError('Enter a term to search.')", "CAQDAS analysis module");
 includes(tabsSource, "tab:shown", "journal tabs module");
+includes(tabsSource, "govuk-button govuk-button--secondary", "journal tabs module");
+includes(tabsSource, "govuk-button govuk-button--warning", "journal tabs module");
+excludes(tabsSource, "btn-quiet", "journal tabs module")
 includes(muralSyncSource, "mural", "journal mural sync module");
 includes(excerptsSource, "function renderEntries", "journal excerpts module");
 includes(excerptsSource, "function loadEntries", "journal excerpts module");

--- a/tests/journals-route-state.test.js
+++ b/tests/journals-route-state.test.js
@@ -76,7 +76,7 @@ includes(caqdasSource, "setRetrievalError('Enter a term to search.')", "CAQDAS a
 includes(tabsSource, "tab:shown", "journal tabs module");
 includes(tabsSource, "govuk-button govuk-button--secondary", "journal tabs module");
 includes(tabsSource, "govuk-button govuk-button--warning", "journal tabs module");
-excludes(tabsSource, "btn-quiet", "journal tabs module")
+excludes(tabsSource, "btn-quiet", "journal tabs module");
 includes(muralSyncSource, "mural", "journal mural sync module");
 includes(excerptsSource, "function renderEntries", "journal excerpts module");
 includes(excerptsSource, "function loadEntries", "journal excerpts module");


### PR DESCRIPTION
## Summary

Migrates generated Reflexive Journal entry actions in `public/js/journal-tabs.js` from legacy quiet button classes to the global GOV.UK button foundation.

Closes #106.

## Changes

- Update generated Journal entry `Edit` actions to use `govuk-button govuk-button--secondary`.
- Update generated Journal entry `Delete` actions to use `govuk-button govuk-button--warning`.
- Preserve existing `href`, `type`, `data-act`, `data-id` and delete handler behaviour.
- Add route-state assertions for the GOV.UK button classes.
- Add a route-state assertion that `btn-quiet` is no longer present in the journal tabs module.
- Update the journal tabs filter-state route test so it expects the GOV.UK warning delete button instead of the legacy `btn-quiet danger` button.
- Add required operating-model trace artefacts for the `fix/` branch.

## GOV.UK Design System alignment

- Uses the existing global GOV.UK button foundation.
- Does not move button styling into route CSS.
- Keeps generated action behaviour unchanged while migrating presentation classes.

## CI failure handling

The first PR run failed because `tests/journal-tabs-filter-state-route-state.test.js` still expected the old generated delete button:

```text
<button type="button" class="btn-quiet danger"
```

That assertion is now updated to expect:

```text
<button type="button" class="govuk-button govuk-button--warning"
```

The test also now excludes the legacy `btn-quiet danger` delete button.

## Trace

- `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md`
- `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json`

## Changed-file verification

Changed files: 5

- `public/js/journal-tabs.js`
- `tests/journals-route-state.test.js`
- `tests/journal-tabs-filter-state-route-state.test.js`
- `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.md`
- `docs/agent-audit/reasoning/2026/05/30/govuk-journal-generated-buttons.json`

Branch comparison: 8 commits ahead of `main`, 0 behind.

## Validation

Not run locally in this connector context because the environment could not clone the repository from GitHub.

Ready for GitHub checks to run:

- `npm run validate`
- `npm run lint`

## Manual browser checks

Open:

`/pages/projects/journals/?id=<known-project-id>`

Confirm:

- Journal entry `Edit` actions render correctly.
- Journal entry `Delete` actions render as warning buttons.
- The delete handler still prompts and deletes correctly.
- Entry cards, filter chips, Mural sync, tabs and coding panel behaviour are unchanged.
