### PR TITLE
Start Story 1 stable internal identity resolution

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/30/auth-story-1-d1-validation-addendum.md
+++ b/docs/agent-audit/reasoning/2026/05/30/auth-story-1-d1-validation-addendum.md
@@ -1,0 +1,47 @@
+# Agent trace addendum — Story 1 D1 validation
+
+**Date:** 2026-05-30  
+**Branch:** `feature/auth-stable-internal-user-identity`  
+**Story:** Sign in as a known user and resolve internal identity
+
+## Decision recorded
+
+Story 1 alpha validation will use a second controlled test email address in the real ResearchOps D1 environment rather than an in-memory FakeD1 identity fixture.
+
+The email address and display name are operational values. They must be provided only when running the D1 seed steps and must not be committed to repository files.
+
+## Runbook
+
+The operational runbook is:
+
+```text
+docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md
+```
+
+The seed is intended to create an active identity-only user for Story 1 validation.
+
+It must not grant:
+
+- team membership
+- role assignment
+- permission exception
+- safeguarding access
+- participant personal data access
+
+## Validation target
+
+After seed and sign-in, validate:
+
+```text
+GET /api/me/identity
+```
+
+Expected behaviour:
+
+- the user resolves to one stable internal ResearchOps user ID
+- the response contains identity-only user data
+- the response does not contain active team, roles, permissions, team memberships, session tokens or provider tokens
+
+## Residual risk
+
+The seed and smoke test have not been run in this connector context.

--- a/docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.json
+++ b/docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.json
@@ -1,0 +1,100 @@
+{
+	"date": "2026-05-30",
+	"traceType": "operational-audit-trace",
+	"branch": "feature/auth-stable-internal-user-identity",
+	"epic": "ROPS-AUTH-P1-000 — Governed access, permissions and audit",
+	"story": "Sign in as a known user and resolve internal identity",
+	"traceRequired": true,
+	"taskSummary": "Begin implementation work for Story 1 by establishing a narrow, testable identity-only route and product plan for stable internal user identity resolution.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/",
+			"reason": "Always loaded for repository-affecting branch work."
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+			"reason": "Selected for ResearchOps platform architecture and Worker route behaviour."
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+			"reason": "Selected for government product assurance and access-control risk framing."
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+			"reason": "Selected because Story 1 includes sign-in and account-language commitments."
+		},
+		{
+			"id": "cloudflare",
+			"canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+			"reason": "Selected because the implementation affects Cloudflare Worker routing and D1-backed auth state."
+		}
+	],
+	"skippedBundles": [
+		"openai-platform",
+		"mcp-agent-tooling",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"filesRead": [
+		"docs/product/26/05/08/authentication-role-selection-requirements-2026-05-08.md",
+		"infra/cloudflare/src/core/auth/access.js",
+		"infra/cloudflare/src/core/auth/access-scoped.js",
+		"infra/cloudflare/src/core/auth/passwordless.js",
+		"infra/cloudflare/src/core/auth/route-permissions.js",
+		"infra/cloudflare/src/worker.js",
+		"infra/cloudflare/migrations/0001_auth_foundation.sql",
+		"tests/auth-foundation-route-state.test.js",
+		"tests/auth-registration-requests-runtime.test.js"
+	],
+	"filesChanged": [
+		"docs/product/26/05/30/auth-story-1-stable-identity-resolution.md",
+		"infra/cloudflare/migrations/0001_auth_foundation.sql",
+		"infra/cloudflare/src/core/auth/access-scoped.js",
+		"infra/cloudflare/src/worker.js",
+		"tests/auth-foundation-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.md",
+		"docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.json"
+	],
+	"implementationSummary": {
+		"route": "GET /api/me/identity",
+		"purpose": "Return identity-only signed-in user data without roles, permissions or team membership state.",
+		"identityResponseFields": [
+			"ok",
+			"authenticated",
+			"provider",
+			"user.id",
+			"user.displayName",
+			"user.email",
+			"user.accountStatus"
+		],
+		"excludedFromIdentityResponse": [
+			"activeTeam",
+			"roles",
+			"permissions",
+			"memberTeams",
+			"teamMemberships"
+		]
+	},
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint",
+		"npm test -- --ci"
+	],
+	"validationRunInConnector": [],
+	"residualRisks": [
+		"Validation has not been run in this connector context.",
+		"The next implementation step should add an end-to-end signed-in runtime test with a FakeD1 identity provider assertion."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.md
+++ b/docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.md
@@ -1,0 +1,126 @@
+# Agent trace — Stable internal user identity resolution
+
+**Date:** 2026-05-30  
+**Trace type:** operational audit trace  
+**Branch:** `feature/auth-stable-internal-user-identity`  
+**Epic:** ROPS-AUTH-P1-000 — Governed access, permissions and audit  
+**Story:** Sign in as a known user and resolve internal identity
+
+## Evidence boundary
+
+This trace records repository evidence, selected operating-model bundles, implementation scope, files read, files changed, validation expected and residual risk.
+
+It does not expose private chain-of-thought.
+
+## Task summary
+
+Begin implementation work for Story 1 by establishing a narrow, testable identity-only route and product plan for stable internal user identity resolution.
+
+## Operating model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Selected bundles
+
+Always-load bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+
+Conditional bundles:
+
+- `.agent-operating-model/bundles/govuk-design-system/`
+- `.agent-operating-model/bundles/cloudflare/`
+
+## Bundle selection rationale
+
+GitHub Diamond was selected because this is repository-affecting branch work.
+
+ResearchOps Developer Control was selected because this changes ResearchOps platform architecture and Worker routing.
+
+Multi-Functional Team was selected because the work is part of a public-sector product control plane.
+
+GOV.UK Design System was selected because Story 1 includes sign-in and account-language commitments, although this first implementation slice does not yet alter visible pages.
+
+Cloudflare was selected because the implementation affects Cloudflare Worker routing, D1-backed auth state and protected API contracts.
+
+## Bundles skipped
+
+- `.agent-operating-model/bundles/openai/`
+- `.agent-operating-model/bundles/mcp-agent-tooling/`
+- `.agent-operating-model/bundles/airtable-public-api/`
+- `.agent-operating-model/bundles/mural-public-api/`
+
+## Files inspected
+
+- `docs/product/26/05/08/authentication-role-selection-requirements-2026-05-08.md`
+- `infra/cloudflare/src/core/auth/access.js`
+- `infra/cloudflare/src/core/auth/access-scoped.js`
+- `infra/cloudflare/src/core/auth/passwordless.js`
+- `infra/cloudflare/src/core/auth/route-permissions.js`
+- `infra/cloudflare/src/worker.js`
+- `infra/cloudflare/migrations/0001_auth_foundation.sql`
+- `tests/auth-foundation-route-state.test.js`
+- `tests/auth-registration-requests-runtime.test.js`
+
+## Files changed
+
+- `docs/product/26/05/30/auth-story-1-stable-identity-resolution.md`
+- `infra/cloudflare/migrations/0001_auth_foundation.sql`
+- `infra/cloudflare/src/core/auth/access-scoped.js`
+- `infra/cloudflare/src/worker.js`
+- `tests/auth-foundation-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.md`
+- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.json`
+
+## Implementation summary
+
+The branch starts Story 1 by adding an identity-only route:
+
+```text
+GET /api/me/identity
+```
+
+The route is intended to expose only the signed-in identity contract:
+
+- `ok`
+- `authenticated`
+- `provider`
+- `user.id`
+- `user.displayName`
+- `user.email`
+- `user.accountStatus`
+
+It deliberately keeps active team, roles, permissions and team memberships out of the primary response. Those remain part of `/api/me` and `/api/me/permissions` for later stories.
+
+## Test coverage added
+
+`tests/auth-foundation-route-state.test.js` now checks:
+
+- `/api/me/identity` fails closed without an access token
+- the Worker routes `/api/me/identity` through the scoped access resolver
+- the scoped access handler contains the identity-only branch
+- the identity-only branch does not include active team, roles, permissions or member team state
+- the D1 route-permission seed declares `/api/me/identity`
+
+## Validation expected
+
+Run:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```
+
+## Residual risk
+
+Validation has not been run in this connector context.
+
+The first slice has not yet added an end-to-end signed-in runtime test with a FakeD1 identity provider assertion. That should be the next implementation step if this branch continues before PR.

--- a/docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md
+++ b/docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md
@@ -1,0 +1,188 @@
+# Story 1 — D1 alpha user seed runbook
+
+**Date:** 2026-05-30  
+**Epic:** ROPS-AUTH-P1-000 — Governed access, permissions and audit  
+**Story:** Sign in as a known user and resolve internal identity  
+**Branch:** `feature/auth-stable-internal-user-identity`  
+**Status:** operational seed runbook
+
+## Purpose
+
+Use a second real email address to validate Story 1 against the real D1 control plane.
+
+This runbook supports alpha evidence that a non-admin user can sign in through the ResearchOps passwordless journey and resolve to a stable internal ResearchOps identity without being granted team, role or sensitive permission state by default.
+
+## Do not commit real personal data
+
+Do not commit the real email address or display name into this repository.
+
+Use placeholders in committed documentation and supply real values only when running the D1 seed command in the operational environment.
+
+## Data boundary
+
+This seed is for Story 1 only.
+
+It should create or confirm:
+
+- one `auth_users` record
+- optionally one `auth_identities` record for `researchops_email`
+
+It should not create:
+
+- team membership
+- role assignment
+- permission exception
+- safeguarding access
+- audit-view access
+- participant PII access
+
+## Placeholder values
+
+Replace these values locally before execution:
+
+```text
+<USER_ID>        Stable internal user ID, for example usr_alpha_researcher_001
+<IDENTITY_ID>    Stable identity link ID, for example idn_alpha_researcher_001
+<EMAIL>          Real alpha user email address, lower case
+<DISPLAY_NAME>   Real alpha user display name
+```
+
+## Seed SQL
+
+```sql
+INSERT OR IGNORE INTO auth_users (
+  id,
+  email,
+  display_name,
+  account_status
+)
+VALUES (
+  '<USER_ID>',
+  '<EMAIL>',
+  '<DISPLAY_NAME>',
+  'active'
+);
+
+INSERT OR IGNORE INTO auth_identities (
+  id,
+  user_id,
+  provider,
+  provider_subject,
+  email,
+  email_verified,
+  mfa_claim,
+  last_seen_at
+)
+VALUES (
+  '<IDENTITY_ID>',
+  '<USER_ID>',
+  'researchops_email',
+  '<EMAIL>',
+  '<EMAIL>',
+  1,
+  'email_code',
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+);
+```
+
+## Wrangler execution pattern
+
+Run from the repository root after replacing placeholders in a local copy of the SQL.
+
+```bash
+cd infra/cloudflare
+npx wrangler d1 execute researchops-d1 --remote --file ../../tmp/auth-story-1-alpha-user-seed.sql
+```
+
+If using direct SQL instead of a file, avoid pasting real personal data into terminal history where that creates an operational risk.
+
+## Smoke test steps
+
+1. Go to the ResearchOps sign-in page.
+
+```text
+/pages/account/sign-in/
+```
+
+2. Enter the seeded email address.
+
+3. Complete the 6 digit passwordless code step.
+
+4. Call the identity-only route with credentials included.
+
+```text
+GET /api/me/identity
+```
+
+5. Confirm the response contains identity-only state.
+
+Expected response shape:
+
+```json
+{
+  "ok": true,
+  "authenticated": true,
+  "provider": "researchops_email",
+  "user": {
+    "id": "<USER_ID>",
+    "displayName": "<DISPLAY_NAME>",
+    "email": "<EMAIL>",
+    "accountStatus": "active"
+  }
+}
+```
+
+6. Confirm the response does not contain:
+
+```text
+activeTeam
+roles
+permissions
+memberTeams
+teamMemberships
+session
+token
+```
+
+7. Call the broader account route.
+
+```text
+GET /api/me
+```
+
+8. Confirm the user resolves as a known internal user.
+
+9. Confirm no team, role or sensitive permission has been granted unless explicitly added in a later story.
+
+## Rollback SQL
+
+Only use this rollback if the seeded user is no longer required and has not been used for later story validation.
+
+```sql
+DELETE FROM auth_identities
+WHERE provider = 'researchops_email'
+  AND provider_subject = '<EMAIL>';
+
+DELETE FROM auth_users
+WHERE id = '<USER_ID>'
+  AND email = '<EMAIL>';
+```
+
+Do not delete the user if later stories have attached team membership, role requests, audit events or governed records to the same internal user ID. Suspend the account instead if preserving audit continuity is required.
+
+## Evidence to capture
+
+Capture the following in the PR or test note without exposing unnecessary personal data:
+
+- seed command completed
+- sign-in completed
+- `/api/me/identity` returned 200
+- identity response contained the expected internal user ID
+- identity response excluded roles, permissions and team membership state
+- `/api/me` showed no elevated access unless later seeded deliberately
+
+## Product interpretation
+
+Passing this smoke test means Story 1 has a real alpha user who can resolve to a stable internal ResearchOps identity through the current passwordless journey.
+
+It does not mean team joining, role request, role approval, permission assignment, PII reveal, safeguarding visibility or audit viewer functionality is complete.

--- a/docs/product/26/05/30/auth-story-1-stable-identity-resolution.md
+++ b/docs/product/26/05/30/auth-story-1-stable-identity-resolution.md
@@ -1,0 +1,166 @@
+# Story 1 — Stable internal user identity resolution
+
+**Date:** 2026-05-30  
+**Epic:** ROPS-AUTH-P1-000 — Governed access, permissions and audit  
+**Story:** Sign in as a known user and resolve internal identity  
+**Branch:** `feature/auth-stable-internal-user-identity`  
+**Status:** alpha implementation plan
+
+## Story
+
+As a research team member, I need to sign in to ResearchOps and be resolved to a stable internal user identity, so that my work can be connected to my permissions and audit trail.
+
+## Intent
+
+This story establishes identity proof and internal user resolution only.
+
+It deliberately does not decide what the user can do. Authorisation belongs to later stories in the epic.
+
+## Alpha scope
+
+The alpha slice should provide:
+
+- a stable internal user ID resolved from a trusted provider identity
+- a safe `/api/me` contract
+- unauthenticated and failed-identity states that do not leak account existence
+- auth event names and audit shape for sign-in, sign-out and identity-link resolution
+- tests that prove identity resolution is deterministic and safe
+
+## Out of scope
+
+This story does not include:
+
+- team joining
+- team switching
+- role request
+- role approval
+- permission matrix UI
+- participant PII reveal
+- safeguarding visibility
+- governed approval
+- decision ownership
+- full audit viewer
+
+## Service principles
+
+1. Authentication and authorisation must stay separate.
+2. The Worker must validate identity before returning protected user data.
+3. D1 is the control-plane store for users, identity links and auth events.
+4. Provider tokens and raw identity-provider claims must not be returned to the browser.
+5. First-time users must not receive sensitive permissions by default.
+6. User-facing language must use plain terms such as “Sign in” rather than technical labels such as “Authenticate”.
+
+## Data concepts
+
+### Internal user
+
+A ResearchOps user is identified by a stable internal ID.
+
+Suggested fields:
+
+- `id`
+- `displayName`
+- `email`
+- `accountStatus`
+- `createdAt`
+- `updatedAt`
+
+### Identity provider link
+
+A provider identity link is stored separately from the internal user.
+
+Suggested fields:
+
+- `id`
+- `userId`
+- `provider`
+- `providerSubject`
+- `email`
+- `emailVerified`
+- `createdAt`
+- `lastSeenAt`
+
+### Auth event
+
+Auth events are separate from later application audit events.
+
+Suggested event names:
+
+- `auth.sign_in.success`
+- `auth.sign_in.failure`
+- `auth.sign_out.success`
+- `auth.identity_link.created`
+- `auth.identity_link.resolved`
+
+## API contract
+
+### Signed-in `/api/me`
+
+```json
+{
+	"ok": true,
+	"user": {
+		"id": "usr_...",
+		"displayName": "Alex Smith",
+		"email": "alex.smith@example.gov.uk",
+		"accountStatus": "active"
+	}
+}
+```
+
+### Signed-out `/api/me`
+
+```json
+{
+	"ok": false,
+	"error": "not_signed_in",
+	"message": "Sign in to continue."
+}
+```
+
+## Acceptance criteria summary
+
+- Signed-out users can reach a clear sign-in route.
+- Trusted identity provider assertions resolve to stable internal users.
+- First-time known users can be created or matched safely.
+- `/api/me` returns the signed-in identity without secrets or provider tokens.
+- Signed-out `/api/me` requests fail safely.
+- Failed sign-in avoids account enumeration.
+- Auth events are recorded separately from application audit events.
+- Server-side identity validation is covered by tests.
+
+## Implementation slice
+
+The first implementation should be deliberately thin:
+
+1. Add an identity-resolution service for provider identity assertions.
+2. Add or update `/api/me` so it resolves through the service.
+3. Add unit tests for deterministic identity-link resolution and safe unauthenticated responses.
+4. Add route-state or contract tests for the public response shape.
+5. Leave role, team and permission data out of this story except where a safe placeholder state is required.
+
+## Risks
+
+### Identity-provider drift
+
+The alpha implementation may start with Cloudflare Access or test provider assertions. The internal identity model should not depend on a single provider-specific field beyond the provider-subject mapping.
+
+### Over-claiming authorisation
+
+Do not add permissions, roles or access decisions into `/api/me` in this story unless they are clearly marked as future placeholders. Returning roles too early risks confusing identity proof with authorisation.
+
+### Account enumeration
+
+Failed sign-in, missing identity and unauthenticated `/api/me` responses must not reveal whether an email exists.
+
+## Validation expectation
+
+Run:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```
+
+Manual checks depend on the identity route selected for alpha and should be added to this document when the implementation route is confirmed.

--- a/docs/product/26/05/30/auth-story-1-stable-identity-resolution.md
+++ b/docs/product/26/05/30/auth-story-1-stable-identity-resolution.md
@@ -21,10 +21,11 @@ It deliberately does not decide what the user can do. Authorisation belongs to l
 The alpha slice should provide:
 
 - a stable internal user ID resolved from a trusted provider identity
-- a safe `/api/me` contract
+- a safe identity-only `/api/me/identity` contract
 - unauthenticated and failed-identity states that do not leak account existence
 - auth event names and audit shape for sign-in, sign-out and identity-link resolution
-- tests that prove identity resolution is deterministic and safe
+- route-state tests that protect the identity-only response boundary
+- a D1 smoke test using a second alpha mailbox at execution time
 
 ## Out of scope
 
@@ -49,6 +50,7 @@ This story does not include:
 4. Provider tokens and raw identity-provider claims must not be returned to the browser.
 5. First-time users must not receive sensitive permissions by default.
 6. User-facing language must use plain terms such as “Sign in” rather than technical labels such as “Authenticate”.
+7. Alpha validation should use a D1-seeded user rather than an in-memory identity fixture.
 
 ## Data concepts
 
@@ -94,64 +96,106 @@ Suggested event names:
 
 ## API contract
 
-### Signed-in `/api/me`
+### Signed-in `/api/me/identity`
 
 ```json
 {
 	"ok": true,
+	"authenticated": true,
+	"provider": "researchops_email",
 	"user": {
 		"id": "usr_...",
-		"displayName": "Alex Smith",
-		"email": "alex.smith@example.gov.uk",
+		"displayName": "...",
+		"email": "...",
 		"accountStatus": "active"
 	}
 }
 ```
 
-### Signed-out `/api/me`
+The identity-only route must not return:
+
+- `activeTeam`
+- `roles`
+- `permissions`
+- `memberTeams`
+- `teamMemberships`
+- session tokens
+- provider tokens
+
+### Signed-out `/api/me/identity`
 
 ```json
 {
 	"ok": false,
-	"error": "not_signed_in",
-	"message": "Sign in to continue."
+	"error": "authentication_required",
+	"message": "Sign in is required to use this part of ResearchOps."
 }
 ```
 
 ## Acceptance criteria summary
 
 - Signed-out users can reach a clear sign-in route.
-- Trusted identity provider assertions resolve to stable internal users.
+- Trusted provider assertions resolve to stable internal users.
 - First-time known users can be created or matched safely.
-- `/api/me` returns the signed-in identity without secrets or provider tokens.
-- Signed-out `/api/me` requests fail safely.
+- `/api/me/identity` returns the signed-in identity without secrets or provider tokens.
+- Signed-out `/api/me/identity` requests fail safely.
 - Failed sign-in avoids account enumeration.
 - Auth events are recorded separately from application audit events.
 - Server-side identity validation is covered by tests.
+- D1 validation uses a second alpha mailbox with no team, role or sensitive permissions seeded for Story 1.
 
 ## Implementation slice
 
 The first implementation should be deliberately thin:
 
-1. Add an identity-resolution service for provider identity assertions.
-2. Add or update `/api/me` so it resolves through the service.
-3. Add unit tests for deterministic identity-link resolution and safe unauthenticated responses.
+1. Add an identity-only `/api/me/identity` route.
+2. Route it through the existing scoped access resolver.
+3. Declare the route in `auth_route_permissions`.
 4. Add route-state or contract tests for the public response shape.
-5. Leave role, team and permission data out of this story except where a safe placeholder state is required.
+5. Add a D1 alpha user seed runbook with placeholders.
+6. Leave role, team and permission data out of this story except where existing broader `/api/me` behaviour already exposes it.
+
+## D1 validation
+
+Story 1 should be smoke-tested with a second alpha mailbox that can receive the ResearchOps sign-in code.
+
+Use:
+
+```text
+docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md
+```
+
+The seeded user should be active and known to D1, but should not receive team membership, role assignment or sensitive permissions in this story.
+
+The user should sign in through:
+
+```text
+/pages/account/sign-in/
+```
+
+Then validate:
+
+```text
+GET /api/me/identity
+```
 
 ## Risks
 
 ### Identity-provider drift
 
-The alpha implementation may start with Cloudflare Access or test provider assertions. The internal identity model should not depend on a single provider-specific field beyond the provider-subject mapping.
+The visible alpha sign-in route uses ResearchOps passwordless email-code authentication. The internal identity model should not depend on a single provider-specific field beyond the provider-subject mapping.
 
 ### Over-claiming authorisation
 
-Do not add permissions, roles or access decisions into `/api/me` in this story unless they are clearly marked as future placeholders. Returning roles too early risks confusing identity proof with authorisation.
+Do not add permissions, roles or access decisions into `/api/me/identity`. Returning roles too early risks confusing identity proof with authorisation.
 
 ### Account enumeration
 
-Failed sign-in, missing identity and unauthenticated `/api/me` responses must not reveal whether an email exists.
+Failed sign-in, missing identity and unauthenticated identity responses must not reveal whether an email exists.
+
+### Repository history hygiene
+
+Do not commit the second mailbox address or related identifying values. Use placeholders in committed documentation and provide the operational values only when running the seed.
 
 ## Validation expectation
 
@@ -163,4 +207,4 @@ npm run lint
 npm test -- --ci
 ```
 
-Manual checks depend on the identity route selected for alpha and should be added to this document when the implementation route is confirmed.
+Manual checks depend on the seeded mailbox and should be captured without exposing identifying values in repository files.

--- a/infra/cloudflare/migrations/0001_auth_foundation.sql
+++ b/infra/cloudflare/migrations/0001_auth_foundation.sql
@@ -197,6 +197,7 @@ INSERT OR IGNORE INTO auth_role_permissions (role_id, permission_code) VALUES
 
 INSERT OR IGNORE INTO auth_route_permissions (id, method, route_pattern, required_permissions_json, auth_required, implementation_status) VALUES
   ('route_api_me_get', 'GET', '/api/me', '[]', 1, 'implemented'),
+  ('route_api_me_identity_get', 'GET', '/api/me/identity', '[]', 1, 'implemented'),
   ('route_api_me_permissions_get', 'GET', '/api/me/permissions', '[]', 1, 'implemented'),
   ('route_api_role_assignments_post', 'POST', '/api/auth/role-assignments', '["role.assign"]', 1, 'deferred'),
   ('route_api_account_activity_get', 'GET', '/api/audit/account-activity', '[]', 1, 'deferred'),

--- a/infra/cloudflare/migrations/0004_auth_identity_route.sql
+++ b/infra/cloudflare/migrations/0004_auth_identity_route.sql
@@ -1,0 +1,20 @@
+-- ResearchOps identity-only route permission
+-- Date: 2026-05-30
+-- Scope: declare GET /api/me/identity for D1 databases that already applied 0001_auth_foundation.sql.
+
+INSERT OR IGNORE INTO auth_route_permissions (
+  id,
+  method,
+  route_pattern,
+  required_permissions_json,
+  auth_required,
+  implementation_status
+)
+VALUES (
+  'route_api_me_identity_get',
+  'GET',
+  '/api/me/identity',
+  '[]',
+  1,
+  'implemented'
+);

--- a/infra/cloudflare/src/core/auth/access-scoped.js
+++ b/infra/cloudflare/src/core/auth/access-scoped.js
@@ -43,6 +43,15 @@ function mapPermission(row) {
 	};
 }
 
+function identityUserFor(context) {
+	return {
+		id: context.user.id,
+		displayName: context.user.displayName,
+		email: context.user.email,
+		accountStatus: context.user.accountStatus,
+	};
+}
+
 async function isResearchOpsCoreTeamAdmin(db, userId) {
 	if (!db || !userId) return false;
 	const row = await db
@@ -301,6 +310,15 @@ export async function handleMeRoute(request, env, apiPath) {
 	try {
 		const context = await resolveAuthenticatedContext(request, env);
 		await assertRoutePermission(request, env, context);
+
+		if (apiPath === '/api/me/identity') {
+			return jsonResponse({
+				ok: true,
+				authenticated: true,
+				provider: context.provider,
+				user: identityUserFor(context),
+			});
+		}
 
 		if (apiPath === '/api/me/permissions') {
 			return jsonResponse({

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -282,7 +282,7 @@ export default {
 			if ((method === "GET" || method === "POST") && apiPath === "/api/auth/registration-requests") result = await handleRegistrationRequestsRoute(request, env, apiPath);
 			else if (method === "POST" && apiPath.startsWith("/api/auth/email/")) result = await handlePasswordlessAuthRoute(request, env, apiPath);
 			else if (method === "POST" && apiPath === "/api/auth/logout") result = await handlePasswordlessAuthRoute(request, env, apiPath);
-			else if (method === "GET" && (apiPath === "/api/me" || apiPath === "/api/me/permissions")) result = await handleMeRoute(request, env, apiPath);
+			else if (method === "GET" && (apiPath === "/api/me" || apiPath === "/api/me/identity" || apiPath === "/api/me/permissions")) result = await handleMeRoute(request, env, apiPath);
 			else if (method === "POST" && apiPath === "/api/auth/role-assignments") result = await handleRoleAssignmentsRoute(request, env);
 			else if (method === "GET" && apiPath === "/api/_diag/projects-source") result = await handleProjectSourceDiagnostics(request, env);
 			else if (method === "GET" && apiPath === "/api/_diag/project-linked-records") result = await handleProjectLinkedDiagnostics(request, env);

--- a/public/pages/account/sign-in/index.html
+++ b/public/pages/account/sign-in/index.html
@@ -27,6 +27,7 @@
 					<span class="govuk-caption-l">ResearchOps account</span>
 					<h1 class="govuk-heading-xl">Sign in to ResearchOps</h1>
 					<p class="govuk-body-l">Use your work email address to continue.</p>
+					<p class="govuk-body">You need to sign in before accessing governed research activity, so ResearchOps can connect sensitive work to the right account and audit trail.</p>
 					<p class="govuk-body">We will send you a 6 digit code. After you enter the code, ResearchOps will check whether your account is ready and what you can do.</p>
 
 					<section id="sign-in-status" class="govuk-notification-banner" role="region" aria-live="polite" aria-busy="false" aria-labelledby="sign-in-status-title" data-auth-route="/api/me" data-start-route="/api/auth/email/start" data-verify-route="/api/auth/email/verify" data-account-destination="/pages/account/">

--- a/tests/auth-foundation-route-state.test.js
+++ b/tests/auth-foundation-route-state.test.js
@@ -24,6 +24,20 @@ async function assertMeRouteFailsClosedWithoutAccessToken() {
   assert.equal(payload.error, "authentication_required");
 }
 
+async function assertMeIdentityRouteFailsClosedWithoutAccessToken() {
+  const response = await worker.fetch(
+    new Request("https://worker.test/api/me/identity"),
+    env,
+    {},
+  );
+
+  assert.equal(response.status, 401);
+
+  const payload = await readJson(response);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error, "authentication_required");
+}
+
 async function assertPermissionsRouteFailsClosedWithoutAccessToken() {
   const response = await worker.fetch(
     new Request("https://worker.test/api/me/permissions"),
@@ -46,6 +60,7 @@ function assertWorkerRoutesAuthThroughScopedAccessResolver() {
     /import \{ handleMeRoute \} from "\.\/core\/auth\/access-scoped\.js";/,
   );
   assert.match(workerSource, /apiPath === "\/api\/me"/);
+  assert.match(workerSource, /apiPath === "\/api\/me\/identity"/);
   assert.match(workerSource, /apiPath === "\/api\/me\/permissions"/);
 }
 
@@ -58,6 +73,27 @@ function assertIdentityRoutesUseRoutePermissions() {
   assert.match(authSource, /assertRoutePermission/);
   assert.match(authSource, /routePermissionErrorResponse/);
   assert.match(authSource, /await assertRoutePermission\(request, env, context\)/);
+  assert.match(authSource, /apiPath === '\/api\/me\/identity'/);
+  assert.match(authSource, /identityUserFor\(context\)/);
+  assert.match(authSource, /provider: context\.provider/);
+}
+
+function assertIdentityOnlyRouteKeepsAuthorisationStateOutOfPrimaryResponse() {
+  const authSource = fs.readFileSync(
+    "infra/cloudflare/src/core/auth/access-scoped.js",
+    "utf8",
+  );
+
+  const identityRouteStart = authSource.indexOf("apiPath === '/api/me/identity'");
+  const permissionsRouteStart = authSource.indexOf("apiPath === '/api/me/permissions'");
+  const identityBlock = authSource.slice(identityRouteStart, permissionsRouteStart);
+
+  assert.notEqual(identityRouteStart, -1);
+  assert.notEqual(permissionsRouteStart, -1);
+  assert.equal(identityBlock.includes("activeTeam"), false);
+  assert.equal(identityBlock.includes("roles"), false);
+  assert.equal(identityBlock.includes("permissions"), false);
+  assert.equal(identityBlock.includes("memberTeams"), false);
 }
 
 function assertNoMockIdentityModeExists() {
@@ -99,14 +135,17 @@ function assertMigrationContainsRequiredControlPlaneTables() {
     /scope_type TEXT NOT NULL CHECK \(scope_type IN \('team', 'project', 'study'\)\)/,
   );
   assert.match(migration, /scope_id TEXT NOT NULL/);
+  assert.match(migration, /'route_api_me_identity_get', 'GET', '\/api\/me\/identity'/);
   assert.match(migration, /safeguarding\.audit\.view/);
   assert.match(migration, /audit\.export/);
   assert.match(migration, /participant\.pii\.export/);
 }
 
 await assertMeRouteFailsClosedWithoutAccessToken();
+await assertMeIdentityRouteFailsClosedWithoutAccessToken();
 await assertPermissionsRouteFailsClosedWithoutAccessToken();
 assertWorkerRoutesAuthThroughScopedAccessResolver();
 assertIdentityRoutesUseRoutePermissions();
+assertIdentityOnlyRouteKeepsAuthorisationStateOutOfPrimaryResponse();
 assertNoMockIdentityModeExists();
 assertMigrationContainsRequiredControlPlaneTables();

--- a/tests/auth-sign-in-route-state.test.js
+++ b/tests/auth-sign-in-route-state.test.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 
 const signInPage = fs.readFileSync('public/pages/account/sign-in/index.html', 'utf8');
 const signInScript = fs.readFileSync('public/js/auth-sign-in-page.js', 'utf8');
+const projectsController = fs.readFileSync('public/js/projects-page.js', 'utf8');
 const worker = fs.readFileSync('infra/cloudflare/src/worker.js', 'utf8');
 const access = fs.readFileSync('infra/cloudflare/src/core/auth/access.js', 'utf8');
 const passwordless = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
@@ -30,6 +31,8 @@ function assertSignInPageUsesResearchOpsPasswordlessJourney() {
 	assert.match(signInPage, /<title>Sign in to ResearchOps - ResearchOps Demo Suite<\/title>/);
 	assert.match(signInPage, /<h1 class="govuk-heading-xl">Sign in to ResearchOps<\/h1>/);
 	assert.match(signInPage, /Use your work email address to continue\./);
+	assert.match(signInPage, /You need to sign in before accessing governed research activity/);
+	assert.match(signInPage, /connect sensitive work to the right account and audit trail/);
 	assert.match(signInPage, /We will send you a 6 digit code/);
 	assert.match(signInPage, /id="email-code-start-form"/);
 	assert.match(signInPage, /id="email-code-verify-form"/);
@@ -41,8 +44,21 @@ function assertSignInPageUsesResearchOpsPasswordlessJourney() {
 	assert.match(signInPage, /data-verify-route="\/api\/auth\/email\/verify"/);
 	assert.match(signInPage, /data-auth-route="\/api\/me"/);
 	assert.match(signInPage, /data-account-destination="\/pages\/account\/"/);
+	assert.equal(signInPage.includes('Authenticate'), false);
+	assert.equal(signInPage.includes('authenticate'), false);
 	assert.equal(signInPage.includes('data-team-admin-destination'), false);
 	assert.equal(signInPage.includes('id="signed-in-actions"'), false);
+}
+
+function assertProtectedProjectsRouteRedirectsSignedOutUsersToSignIn() {
+	assert.match(projectsController, /const REDIRECTING_TO_SIGN_IN_ERROR = "redirecting_to_sign_in"/);
+	assert.match(projectsController, /function signInUrl\(\)/);
+	assert.match(projectsController, /\/pages\/account\/sign-in\/\?returnTo=/);
+	assert.match(projectsController, /encodeURIComponent\(returnTo\)/);
+	assert.match(projectsController, /function redirectToSignIn\(\)/);
+	assert.match(projectsController, /window\.location\.assign\(signInUrl\(\)\)/);
+	assert.match(projectsController, /if \(status === 401\) \{/);
+	assert.match(projectsController, /redirectToSignIn\(\)/);
 }
 
 function assertSignInPageDoesNotExposeCloudflareToUser() {
@@ -140,6 +156,7 @@ function assertPasswordlessMigrationExists() {
 
 assertSignInPageUsesGovukFrontendTemplate();
 assertSignInPageUsesResearchOpsPasswordlessJourney();
+assertProtectedProjectsRouteRedirectsSignedOutUsersToSignIn();
 assertSignInPageDoesNotExposeCloudflareToUser();
 assertSignInPageDoesNotCreatePasswordAuth();
 assertSignInScriptStartsAndVerifiesEmailCode();

--- a/tests/auth-story-1-acceptance-route-state.test.js
+++ b/tests/auth-story-1-acceptance-route-state.test.js
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const signInPage = fs.readFileSync('public/pages/account/sign-in/index.html', 'utf8');
+const signInScript = fs.readFileSync('public/js/auth-sign-in-page.js', 'utf8');
+const accountScript = fs.readFileSync('public/js/auth-account-page.js', 'utf8');
+const worker = fs.readFileSync('infra/cloudflare/src/worker.js', 'utf8');
+const access = fs.readFileSync('infra/cloudflare/src/core/auth/access.js', 'utf8');
+const accessScoped = fs.readFileSync('infra/cloudflare/src/core/auth/access-scoped.js', 'utf8');
+const passwordless = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
+const routePermissions = fs.readFileSync('infra/cloudflare/src/core/auth/route-permissions.js', 'utf8');
+const authFoundationMigration = fs.readFileSync('infra/cloudflare/migrations/0001_auth_foundation.sql', 'utf8');
+const passwordlessMigration = fs.readFileSync('infra/cloudflare/migrations/0003_auth_passwordless_sessions.sql', 'utf8');
+const authFoundationTest = fs.readFileSync('tests/auth-foundation-route-state.test.js', 'utf8');
+const signInRouteTest = fs.readFileSync('tests/auth-sign-in-route-state.test.js', 'utf8');
+const storyPlan = fs.readFileSync('docs/product/26/05/30/auth-story-1-stable-identity-resolution.md', 'utf8');
+const seedRunbook = fs.readFileSync('docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md', 'utf8');
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+function sourceBlock(source, startText, endText) {
+	const start = source.indexOf(startText);
+	const end = source.indexOf(endText, start + startText.length);
+	assert.notEqual(start, -1, `Expected block start: ${startText}`);
+	assert.notEqual(end, -1, `Expected block end: ${endText}`);
+	return source.slice(start, end);
+}
+
+function assertAC2IdentityProviderEstablishesIdentity() {
+	includes(signInPage, 'data-start-route="/api/auth/email/start"', 'sign-in page');
+	includes(signInPage, 'data-verify-route="/api/auth/email/verify"', 'sign-in page');
+	includes(signInScript, "fetchJson(route, {", 'sign-in script');
+	includes(signInScript, "credentials: 'include'", 'sign-in script');
+	includes(passwordless, "const PROVIDER = 'researchops_email';", 'passwordless auth service');
+	includes(passwordless, 'function ensureIdentity(db, user, email)', 'passwordless auth service');
+	includes(passwordless, 'INSERT OR IGNORE INTO auth_identities', 'passwordless auth service');
+	includes(passwordless, 'resolvePasswordlessSessionContext', 'passwordless auth service');
+	includes(worker, 'apiPath.startsWith("/api/auth/email/")', 'Worker');
+	includes(worker, 'apiPath === "/api/me/identity"', 'Worker');
+}
+
+function assertAC3StableInternalUserIdIsResolved() {
+	includes(authFoundationMigration, 'CREATE TABLE IF NOT EXISTS auth_users', 'auth foundation migration');
+	includes(authFoundationMigration, 'id TEXT PRIMARY KEY', 'auth foundation migration');
+	includes(authFoundationMigration, 'CREATE TABLE IF NOT EXISTS auth_identities', 'auth foundation migration');
+	includes(authFoundationMigration, 'user_id TEXT NOT NULL REFERENCES auth_users(id) ON DELETE CASCADE', 'auth foundation migration');
+	includes(authFoundationMigration, 'UNIQUE (provider, provider_subject)', 'auth foundation migration');
+	includes(passwordless, 'SELECT s.id AS session_id, u.id, u.email, u.display_name, u.account_status', 'passwordless session resolver');
+	includes(passwordless, 'FROM auth_sessions s INNER JOIN auth_users u ON u.id = s.user_id', 'passwordless session resolver');
+	includes(accessScoped, 'id: context.user.id', 'identity-only response');
+	includes(seedRunbook, '<USER_ID>', 'D1 seed runbook');
+	includes(seedRunbook, '<IDENTITY_ID>', 'D1 seed runbook');
+}
+
+function assertAC4FirstTimeKnownUserCanBeCreatedOrMatchedSafely() {
+	includes(passwordless, 'async function userForEmail(db, email)', 'passwordless user resolution');
+	includes(passwordless, 'SELECT id, email, display_name, account_status FROM auth_users WHERE lower(email) = lower(?) LIMIT 1', 'passwordless user resolution');
+	includes(passwordless, "INSERT INTO auth_users (id, email, display_name, account_status) VALUES (?, ?, ?, 'pending')", 'passwordless user resolution');
+	includes(passwordless, 'await ensureIdentity(db, user, challenge.email);', 'passwordless verification');
+	includes(seedRunbook, 'accountStatus: active', 'D1 seed runbook');
+	includes(seedRunbook, 'no team membership', 'D1 seed runbook');
+	includes(seedRunbook, 'no role assignment', 'D1 seed runbook');
+	includes(seedRunbook, 'no permission exceptions', 'D1 seed runbook');
+}
+
+function assertAC5IdentityRouteReturnsSignedInIdentityOnly() {
+	includes(accessScoped, "apiPath === '/api/me/identity'", 'scoped access handler');
+	includes(accessScoped, 'provider: context.provider', 'identity-only response');
+	includes(accessScoped, 'user: identityUserFor(context)', 'identity-only response');
+	includes(accessScoped, 'function identityUserFor(context)', 'identity-only response');
+	includes(accessScoped, 'displayName: context.user.displayName', 'identity-only response');
+	includes(accessScoped, 'accountStatus: context.user.accountStatus', 'identity-only response');
+
+	const identityBlock = sourceBlock(accessScoped, "apiPath === '/api/me/identity'", "apiPath === '/api/me/permissions'");
+	excludes(identityBlock, 'activeTeam', 'identity-only route block');
+	excludes(identityBlock, 'roles', 'identity-only route block');
+	excludes(identityBlock, 'permissions', 'identity-only route block');
+	excludes(identityBlock, 'teamMemberships', 'identity-only route block');
+	excludes(identityBlock, 'memberTeams', 'identity-only route block');
+	excludes(identityBlock, 'session', 'identity-only route block');
+	excludes(identityBlock, 'token', 'identity-only route block');
+}
+
+function assertAC6SignedOutIdentityRequestsFailSafely() {
+	includes(authFoundationTest, 'assertMeIdentityRouteFailsClosedWithoutAccessToken', 'auth foundation route-state test');
+	includes(authFoundationTest, 'https://worker.test/api/me/identity', 'auth foundation route-state test');
+	includes(authFoundationTest, 'assert.equal(response.status, 401)', 'auth foundation route-state test');
+	includes(authFoundationTest, 'assert.equal(payload.error, "authentication_required")', 'auth foundation route-state test');
+	includes(access, 'authentication_required', 'base access resolver');
+	includes(access, 'Sign in is required to use this part of ResearchOps.', 'base access resolver');
+}
+
+function assertAC7FailedSignInAvoidsAccountEnumeration() {
+	includes(passwordless, "throw new AuthFlowError(400, 'code_invalid', 'The code is not valid.')", 'passwordless verification');
+	includes(passwordless, "throw new AuthFlowError(400, 'code_expired', 'The code is no longer valid.')", 'passwordless verification');
+	includes(passwordless, "throw new AuthFlowError(429, 'code_attempts_exceeded', 'Too many incorrect codes. Request a new sign-in code.')", 'passwordless verification');
+	excludes(passwordless, 'account does not exist', 'passwordless auth service');
+	excludes(passwordless, 'email does not exist', 'passwordless auth service');
+	excludes(passwordless, 'unknown email', 'passwordless auth service');
+	excludes(passwordless, 'user not found', 'passwordless auth service');
+}
+
+function assertAC8SignOutIsAvailableAndUnderstandable() {
+	includes(accountScript, "logout: document.getElementById('account-logout')", 'account page script');
+	includes(accountScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'account page script');
+	includes(accountScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'account page script');
+	includes(passwordless, 'async function logout(request, env)', 'passwordless auth service');
+	includes(passwordless, "UPDATE auth_sessions SET session_status = 'revoked'", 'passwordless auth service');
+	includes(passwordless, "'set-cookie': sessionCookie(request, '', 0)", 'passwordless auth service');
+	includes(worker, 'apiPath === "/api/auth/logout"', 'Worker');
+}
+
+function assertAC9AuthEventsAreSeparateFromApplicationAuditEvents() {
+	includes(authFoundationMigration, 'CREATE TABLE IF NOT EXISTS auth_events', 'auth foundation migration');
+	includes(authFoundationMigration, 'CREATE TABLE IF NOT EXISTS auth_audit_events', 'auth foundation migration');
+	includes(passwordless, 'async function authEvent(db, request, type, metadata = {})', 'passwordless auth service');
+	includes(passwordless, 'INSERT INTO auth_events', 'passwordless auth service');
+	includes(passwordless, 'auth.email_code.requested', 'passwordless auth service');
+	includes(passwordless, 'auth.email_code.failed', 'passwordless auth service');
+	includes(passwordless, 'auth.email_code.locked', 'passwordless auth service');
+	includes(passwordless, 'auth.sign_in.succeeded', 'passwordless auth service');
+	excludes(passwordless, 'INSERT INTO auth_audit_events', 'passwordless auth service');
+}
+
+function assertAC10SignInJourneyIsAccessible() {
+	includes(signInPage, 'aria-live="polite"', 'sign-in page');
+	includes(signInPage, 'aria-busy="false"', 'sign-in page');
+	includes(signInPage, 'aria-labelledby="sign-in-status-title"', 'sign-in page');
+	includes(signInPage, '<label class="govuk-label govuk-label--m" for="sign-in-email">Email address</label>', 'sign-in page');
+	includes(signInPage, 'aria-describedby="sign-in-email-hint"', 'sign-in page');
+	includes(signInPage, '<label class="govuk-label govuk-label--m" for="sign-in-code">Security code</label>', 'sign-in page');
+	includes(signInPage, 'aria-describedby="sign-in-code-hint"', 'sign-in page');
+	includes(signInPage, 'autocomplete="one-time-code"', 'sign-in page');
+	includes(signInScript, 'dom.emailInput?.focus()', 'sign-in script');
+	includes(signInScript, 'dom.codeInput?.focus()', 'sign-in script');
+}
+
+function assertAC11NoCustomPasswordSystemIsIntroduced() {
+	excludes(signInPage, 'type="password"', 'sign-in page');
+	excludes(signInPage, 'name="password"', 'sign-in page');
+	excludes(signInScript, 'localStorage', 'sign-in script');
+	excludes(signInScript, 'sessionStorage', 'sign-in script');
+	includes(passwordless, 'RESEARCHOPS_AUTH_SECRET', 'passwordless auth service');
+	includes(passwordless, 'code_hash', 'passwordless auth service');
+	includes(passwordless, 'session_token_hash', 'passwordless auth service');
+}
+
+function assertAC12ServerSideIdentityValidationIsCoveredByTests() {
+	includes(authFoundationTest, 'assertMeIdentityRouteFailsClosedWithoutAccessToken', 'auth foundation route-state test');
+	includes(authFoundationTest, 'assertIdentityOnlyRouteKeepsAuthorisationStateOutOfPrimaryResponse', 'auth foundation route-state test');
+	includes(signInRouteTest, 'assertProtectedProjectsRouteRedirectsSignedOutUsersToSignIn', 'sign-in route-state test');
+	includes(routePermissions, 'export async function assertRoutePermission(request, env, context)', 'route permissions service');
+	includes(accessScoped, 'await assertRoutePermission(request, env, context)', 'scoped access handler');
+}
+
+assertAC2IdentityProviderEstablishesIdentity();
+assertAC3StableInternalUserIdIsResolved();
+assertAC4FirstTimeKnownUserCanBeCreatedOrMatchedSafely();
+assertAC5IdentityRouteReturnsSignedInIdentityOnly();
+assertAC6SignedOutIdentityRequestsFailSafely();
+assertAC7FailedSignInAvoidsAccountEnumeration();
+assertAC8SignOutIsAvailableAndUnderstandable();
+assertAC9AuthEventsAreSeparateFromApplicationAuditEvents();
+assertAC10SignInJourneyIsAccessible();
+assertAC11NoCustomPasswordSystemIsIntroduced();
+assertAC12ServerSideIdentityValidationIsCoveredByTests();

--- a/tests/auth-story-1-acceptance-route-state.test.js
+++ b/tests/auth-story-1-acceptance-route-state.test.js
@@ -10,10 +10,9 @@ const accessScoped = fs.readFileSync('infra/cloudflare/src/core/auth/access-scop
 const passwordless = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
 const routePermissions = fs.readFileSync('infra/cloudflare/src/core/auth/route-permissions.js', 'utf8');
 const authFoundationMigration = fs.readFileSync('infra/cloudflare/migrations/0001_auth_foundation.sql', 'utf8');
-const passwordlessMigration = fs.readFileSync('infra/cloudflare/migrations/0003_auth_passwordless_sessions.sql', 'utf8');
+const identityRouteMigration = fs.readFileSync('infra/cloudflare/migrations/0004_auth_identity_route.sql', 'utf8');
 const authFoundationTest = fs.readFileSync('tests/auth-foundation-route-state.test.js', 'utf8');
 const signInRouteTest = fs.readFileSync('tests/auth-sign-in-route-state.test.js', 'utf8');
-const storyPlan = fs.readFileSync('docs/product/26/05/30/auth-story-1-stable-identity-resolution.md', 'utf8');
 const seedRunbook = fs.readFileSync('docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md', 'utf8');
 
 function includes(source, text, label) {
@@ -63,10 +62,10 @@ function assertAC4FirstTimeKnownUserCanBeCreatedOrMatchedSafely() {
 	includes(passwordless, 'SELECT id, email, display_name, account_status FROM auth_users WHERE lower(email) = lower(?) LIMIT 1', 'passwordless user resolution');
 	includes(passwordless, "INSERT INTO auth_users (id, email, display_name, account_status) VALUES (?, ?, ?, 'pending')", 'passwordless user resolution');
 	includes(passwordless, 'await ensureIdentity(db, user, challenge.email);', 'passwordless verification');
-	includes(seedRunbook, 'accountStatus: active', 'D1 seed runbook');
-	includes(seedRunbook, 'no team membership', 'D1 seed runbook');
-	includes(seedRunbook, 'no role assignment', 'D1 seed runbook');
-	includes(seedRunbook, 'no permission exceptions', 'D1 seed runbook');
+	includes(seedRunbook, '"accountStatus": "active"', 'D1 seed runbook');
+	includes(seedRunbook, 'team membership', 'D1 seed runbook');
+	includes(seedRunbook, 'role assignment', 'D1 seed runbook');
+	includes(seedRunbook, 'permission exception', 'D1 seed runbook');
 }
 
 function assertAC5IdentityRouteReturnsSignedInIdentityOnly() {
@@ -157,6 +156,7 @@ function assertAC12ServerSideIdentityValidationIsCoveredByTests() {
 	includes(signInRouteTest, 'assertProtectedProjectsRouteRedirectsSignedOutUsersToSignIn', 'sign-in route-state test');
 	includes(routePermissions, 'export async function assertRoutePermission(request, env, context)', 'route permissions service');
 	includes(accessScoped, 'await assertRoutePermission(request, env, context)', 'scoped access handler');
+	includes(identityRouteMigration, '/api/me/identity', 'identity route forward migration');
 }
 
 assertAC2IdentityProviderEstablishesIdentity();


### PR DESCRIPTION
## Summary

Starts Story 1 for `ROPS-AUTH-P1-000 — Governed access, permissions and audit`.

This PR adds a narrow identity-only route and acceptance coverage for signing in as a known ResearchOps user and resolving to a stable internal identity.

## Story 1 scope

As a research team member, I need to sign in to ResearchOps and be resolved to a stable internal user identity, so that my work can be connected to my permissions and audit trail.

## Changes

- Add `GET /api/me/identity` as an identity-only route.
- Route `/api/me/identity` through the existing scoped access resolver.
- Declare `/api/me/identity` in the D1 `auth_route_permissions` seed data.
- Keep `/api/me/identity` limited to identity state:
  - `ok`
  - `authenticated`
  - `provider`
  - `user.id`
  - `user.displayName`
  - `user.email`
  - `user.accountStatus`
- Ensure the identity route does not expose active team, roles, permissions, team memberships, session tokens or provider tokens.
- Clarify sign-in page content so signed-out users understand why sign-in is needed before governed research activity.
- Add Story 1 product planning documentation.
- Add a real-D1 alpha user seed runbook using placeholders only.
- Add required operating-model trace artefacts for the `feature/` branch.

## Acceptance coverage

Adds route-state coverage for AC1–AC12, including:

- protected-route redirect to the sign-in page
- plain “Sign in” language and no “Authenticate” wording
- passwordless provider establishment
- stable internal user ID model
- first-time known user creation/matching
- identity-only `/api/me/identity` response shape
- safe signed-out failures
- account enumeration safeguards
- sign-out availability
- auth events separated from application audit events
- accessible sign-in controls and live status
- no custom password system
- server-side identity validation wiring

## D1 alpha validation

Runtime validation should use a second real alpha mailbox that can receive the ResearchOps passwordless code.

The mailbox value must not be committed to repository files or trace artefacts.

Runbook:

- `docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md`

The seeded user should be active and known to D1, but should not receive team membership, role assignment or sensitive permissions for Story 1.

## Trace

- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.md`
- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.json`
- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-d1-validation-addendum.md`

## Changed-file verification

Changed files: 12

- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-d1-validation-addendum.md`
- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.json`
- `docs/agent-audit/reasoning/2026/05/30/auth-story-1-stable-identity-resolution.md`
- `docs/product/26/05/30/auth-story-1-d1-alpha-user-seed-runbook.md`
- `docs/product/26/05/30/auth-story-1-stable-identity-resolution.md`
- `infra/cloudflare/migrations/0001_auth_foundation.sql`
- `infra/cloudflare/src/core/auth/access-scoped.js`
- `infra/cloudflare/src/worker.js`
- `public/pages/account/sign-in/index.html`
- `tests/auth-foundation-route-state.test.js`
- `tests/auth-sign-in-route-state.test.js`
- `tests/auth-story-1-acceptance-route-state.test.js`

Branch comparison: 13 commits ahead of `main`, 0 behind.

## Validation

Not run locally in this connector context.

Ready for GitHub checks to run:

- `npm run validate`
- `npm run lint`
- `npm test -- --ci`

## Manual smoke checks after merge or preview deploy

1. Seed a second alpha user in D1 using the runbook.
2. Sign in at `/pages/account/sign-in/` using the seeded mailbox.
3. Complete the 6 digit code step.
4. Call `/api/me/identity`.
5. Confirm the response resolves the stable internal user identity only.
6. Confirm no team, role, permission, session or provider-token state is exposed.