### PR TITLE
Add Story 2 account access summary

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.json
+++ b/docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.json
@@ -1,0 +1,96 @@
+{
+	"date": "2026-05-30",
+	"traceType": "operational-audit-trace",
+	"branch": "feature/account-access-summary",
+	"epic": "ROPS-AUTH-P1-000 — Governed access, permissions and audit",
+	"story": "See my account, teams, roles and access summary",
+	"traceRequired": true,
+	"taskSummary": "Implement Story 2 using the recommended rewrite: make access understandable, not changeable.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/",
+			"reason": "Always loaded for repository-affecting branch work."
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+			"reason": "Selected for ResearchOps platform account dashboard behaviour."
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+			"reason": "Selected for government product assurance and access-control risk framing."
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+			"reason": "Selected because the task changes page content, GOV.UK components and accessibility affordances."
+		},
+		{
+			"id": "cloudflare",
+			"canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+			"reason": "Selected because the page consumes D1-backed /api/me account context exposed by the Worker."
+		}
+	],
+	"skippedBundles": [
+		"openai-platform",
+		"mcp-agent-tooling",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"filesRead": [
+		"docs/product/26/05/08/authentication-role-selection-requirements-2026-05-08.md",
+		"docs/product/26/05/13/team-scoped-account-dashboard.md",
+		"public/pages/account/index.html",
+		"public/js/auth-account-page.js",
+		"infra/cloudflare/src/core/auth/access-scoped.js",
+		"tests/auth-account-dashboard-route-state.test.js"
+	],
+	"filesChanged": [
+		"docs/product/26/05/30/auth-story-2-account-access-summary.md",
+		"public/pages/account/index.html",
+		"public/js/auth-account-page.js",
+		"tests/auth-account-dashboard-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.md",
+		"docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.json"
+	],
+	"implementationSummary": {
+		"teamPosition": "Story 2 should make access understandable; it should not make access changeable.",
+		"pageSections": [
+			"Your account",
+			"Current team context",
+			"Your teams and roles",
+			"What you can do from here",
+			"Sign out"
+		],
+		"outOfScopeControlsNotAdded": [
+			"team creation",
+			"team joining",
+			"team switching",
+			"role request",
+			"role approval",
+			"permission assignment",
+			"PII reveal",
+			"audit log viewing"
+		]
+	},
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint",
+		"npm test -- --ci"
+	],
+	"validationRunInConnector": [],
+	"residualRisks": [
+		"Validation has not been run in this connector context.",
+		"Manual account dashboard checks are needed for no-team, one-team, multi-team and sensitive capability states."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.md
+++ b/docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.md
@@ -1,0 +1,146 @@
+# Agent trace — Story 2 account access summary
+
+**Date:** 2026-05-30  
+**Trace type:** operational audit trace  
+**Branch:** `feature/account-access-summary`  
+**Epic:** ROPS-AUTH-P1-000 — Governed access, permissions and audit  
+**Story:** See my account, teams, roles and access summary
+
+## Evidence boundary
+
+This trace records repository evidence, selected operating-model bundles, implementation scope, files read, files changed, validation expected and residual risk.
+
+It does not expose private chain-of-thought.
+
+## Task summary
+
+Implement Story 2 using the team-recommended rewrite and position:
+
+```text
+Story 2 should make access understandable.
+It should not make access changeable.
+```
+
+## Operating model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Selected bundles
+
+Always-load bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+
+Conditional bundles:
+
+- `.agent-operating-model/bundles/govuk-design-system/`
+- `.agent-operating-model/bundles/cloudflare/`
+
+## Bundle selection rationale
+
+GitHub Diamond was selected because this is repository-affecting branch work.
+
+ResearchOps Developer Control was selected because this changes the account dashboard and access-summary presentation for the ResearchOps platform.
+
+Multi-Functional Team was selected because the work is part of the public-sector governed access epic.
+
+GOV.UK Design System was selected because this changes page content, summary lists, GOV.UK summary cards, tags, buttons and accessibility affordances.
+
+Cloudflare was selected because the account page consumes the D1-backed `/api/me` identity, team, role and permission context exposed through the Worker.
+
+## Bundles skipped
+
+- `.agent-operating-model/bundles/openai/`
+- `.agent-operating-model/bundles/mcp-agent-tooling/`
+- `.agent-operating-model/bundles/airtable-public-api/`
+- `.agent-operating-model/bundles/mural-public-api/`
+
+## Files inspected
+
+- `docs/product/26/05/08/authentication-role-selection-requirements-2026-05-08.md`
+- `docs/product/26/05/13/team-scoped-account-dashboard.md`
+- `public/pages/account/index.html`
+- `public/js/auth-account-page.js`
+- `infra/cloudflare/src/core/auth/access-scoped.js`
+- `tests/auth-account-dashboard-route-state.test.js`
+
+## Files changed
+
+- `docs/product/26/05/30/auth-story-2-account-access-summary.md`
+- `public/pages/account/index.html`
+- `public/js/auth-account-page.js`
+- `tests/auth-account-dashboard-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.md`
+- `docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.json`
+
+## Implementation summary
+
+The account page now presents four user-facing questions directly:
+
+- who the user is signed in as
+- which team context is current
+- which teams and roles they have
+- what account actions they can take from here
+
+The controller now renders:
+
+- display name
+- email address
+- account status
+- current team context
+- each active team membership as a GOV.UK summary card
+- roles under the team where they apply
+- task-based capability labels from permission labels or descriptions
+- a visible `Current team` text tag where a team is current
+- a useful no-team state
+- sensitive capability markers without exposing sensitive records
+
+The story does not add:
+
+- team creation
+- team joining
+- team switching
+- role request
+- role approval
+- permission assignment
+- PII reveal
+- audit log viewing
+
+## Test coverage added or updated
+
+`tests/auth-account-dashboard-route-state.test.js` now checks:
+
+- account identity fields
+- current team context section
+- team-scoped memberships
+- role display under each team
+- no-role state
+- no-team help state
+- task-based capability rendering
+- no raw permission-code fallback for visible capability labels
+- sensitive access marker
+- permission-based account actions
+- Story 2 scope constraint that access is understandable, not changeable
+
+## Validation expected
+
+Run:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```
+
+## Residual risk
+
+Validation has not been run in this connector context.
+
+Manual browser checks should confirm the account page remains readable for users with no team, one team, multiple teams, no active role and sensitive capabilities.

--- a/docs/agent-audit/reasoning/2026/05/30/auth-story-2-template-source-fix.md
+++ b/docs/agent-audit/reasoning/2026/05/30/auth-story-2-template-source-fix.md
@@ -1,0 +1,33 @@
+# Agent trace addendum — Story 2 account template source fix
+
+**Date:** 2026-05-30  
+**Branch:** `feature/account-access-summary`  
+**PR:** #313  
+**Story:** See my account, teams, roles and access summary
+
+## Decision recorded
+
+The first PR run failed because the account page route-state test expected Story 2 account-summary content in `public/pages/account/index.html`, but the CI build regenerates that file from the GOV.UK source template.
+
+The source of truth for the rendered account page is:
+
+```text
+src/govuk/templates/pages/account.njk
+```
+
+## Fix applied
+
+The Story 2 account-summary structure has been moved into the GOV.UK source template so build output and committed route-state expectations align.
+
+The template now includes:
+
+- account identity fields
+- current team context section
+- teams and roles section
+- account actions section
+- technical permission details disclosure
+- updated Story 2 script cache key
+
+## Residual risk
+
+CI is rerunning on the updated branch head. Manual browser checks are still required for no-team, one-team, multi-team, no-role and sensitive-capability states.

--- a/docs/product/26/05/30/auth-story-2-account-access-summary.md
+++ b/docs/product/26/05/30/auth-story-2-account-access-summary.md
@@ -1,0 +1,139 @@
+# Story 2 — See my account, teams, roles and access summary
+
+**Date:** 2026-05-30  
+**Epic:** ROPS-AUTH-P1-000 — Governed access, permissions and audit  
+**Story:** See my account, teams, roles and access summary  
+**Branch:** `feature/account-access-summary`  
+**Status:** alpha implementation plan
+
+## Story
+
+As a signed-in ResearchOps user, I need to see my account, teams, roles and access summary, so that I understand who I am signed in as, which teams I belong to, what role I hold in each team and what I can do from here.
+
+## Team position
+
+Story 2 should make access understandable.
+
+It should not make access changeable.
+
+## Intent
+
+Story 1 established stable identity resolution.
+
+Story 2 makes that identity and access context understandable to the user. It presents account identity, team membership, role scope and task-based access in plain English.
+
+It does not add role requests, role approval, team switching or permission management.
+
+## Product principles
+
+1. A user may belong to more than one team.
+2. A user may hold different roles in different teams.
+3. A current team context may exist, but it is not the user’s whole account state.
+4. Roles and capabilities must be shown where they apply.
+5. Users should see task-based descriptions, not raw permission codes.
+6. Hidden UI actions are not the security boundary.
+7. The Worker remains responsible for server-side enforcement.
+
+## Acceptance criteria
+
+### AC1 — Show account identity
+
+Given I am signed in, when I visit my account page, then I see my display name, email address and account status, and no session token, provider token or raw identity-provider claim is shown.
+
+### AC2 — Show all active team memberships
+
+Given I belong to one or more teams, when I visit my account page, then each active team membership is listed separately.
+
+### AC3 — Show current team context without hiding other teams
+
+Given I have a current team context, when I visit my account page, then that team is marked as current, and my other active team memberships remain visible.
+
+### AC4 — Show roles within the team where they apply
+
+Given I have different roles in different teams, when I visit my account page, then each role is shown under the team where it applies.
+
+### AC5 — Show no-role state
+
+Given I am a member of a team but have no active role in that team, when I visit my account page, then that team is still shown with “No active role”.
+
+### AC6 — Show no-team state
+
+Given I am signed in but have no active team membership, when I visit my account page, then I see that I am not currently a member of any team and I am told how to get help.
+
+### AC7 — Show task-based access summary
+
+Given my role grants capabilities, when I visit my account page, then I see those capabilities in plain English and not as raw permission codes.
+
+### AC8 — Show sensitive capabilities proportionately
+
+Given I have a sensitive capability, when I visit my account page, then the capability is described clearly without exposing sensitive records.
+
+### AC9 — Show only relevant account actions
+
+Given my current permissions allow account-related actions, when I visit my account page, then I see only relevant actions, and protected APIs still enforce access server-side.
+
+### AC10 — Redirect signed-out users
+
+Given I am not signed in, when I visit my account page, then I am redirected to the sign-in page.
+
+## Cross-cutting accessibility criteria
+
+The account page must:
+
+- use headings to structure account, team and access sections
+- use semantic lists, summary lists or tables for team-role summaries
+- mark current team with visible text, not colour alone
+- support keyboard navigation
+- show loading and error states accessibly
+- work at 200% zoom
+- avoid colour-only meaning
+
+## Cross-cutting API criteria
+
+`/api/me` must:
+
+- include stable user identity
+- include active team context where available
+- include `teamMemberships` or `memberTeams`
+- include roles and task-based capabilities per team
+- exclude provider tokens
+- exclude session tokens
+- exclude raw identity-provider claims
+
+## Cross-cutting test criteria
+
+Automated tests must cover:
+
+- one team, one role
+- multiple teams, different roles
+- team with no active role
+- signed-in user with no team
+- current team marker
+- plain-English capability labels
+- absence of raw permission codes in visible labels
+- unauthenticated redirect
+- no token leakage
+
+## Out of scope
+
+This story does not include:
+
+- creating a team
+- joining a team
+- switching active team
+- requesting a role
+- approving role requests
+- assigning permissions
+- revealing participant PII
+- viewing audit logs
+- managing users
+- editing team settings
+
+## Definition of done
+
+Story 2 is done when a signed-in user can open their account page and answer four questions without needing to understand the data model:
+
+- Who am I signed in as?
+- Which team context am I currently using?
+- Which teams and roles do I have?
+- What can I do from here?

--- a/public/js/auth-account-page.js
+++ b/public/js/auth-account-page.js
@@ -47,6 +47,10 @@ const dom = {
 	dashboard: document.getElementById('account-dashboard'),
 	title: document.getElementById('account-dashboard-title'),
 	user: document.getElementById('account-user-value'),
+	email: document.getElementById('account-email-value'),
+	accountStatus: document.getElementById('account-status-value'),
+	currentTeamSection: document.getElementById('account-current-team-section'),
+	currentTeam: document.getElementById('account-current-team-value'),
 	teamMemberships: document.getElementById('account-team-memberships'),
 	actionsSection: document.getElementById('account-actions-section'),
 	actions: document.getElementById('account-actions'),
@@ -124,16 +128,40 @@ async function fetchJson(path, options = {}) {
 }
 
 function displayName(context) {
-	const rawName = context?.user?.displayName || context?.user?.email || 'there';
+	const rawName = context?.user?.displayName || context?.user?.email || 'Not available';
 	return String(rawName).includes('@') ? String(rawName).split('@')[0] : rawName;
+}
+
+function formatAccountStatus(value) {
+	const status = String(value || '').trim().toLowerCase();
+	if (!status) return 'Not available';
+	return status
+		.split(/[-_\s]+/)
+		.filter(Boolean)
+		.map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+		.join(' ');
 }
 
 function labelList(items, emptyLabel) {
 	const labels = (items || [])
-		.map((item) => item.label || item.name || item.code || item.key)
+		.map((item) => item.label || item.name)
 		.filter(Boolean)
 		.sort((first, second) => first.localeCompare(second));
 	return labels.length ? labels.join(', ') : emptyLabel;
+}
+
+function capabilityLabel(permission) {
+	return permission?.label || permission?.description || '';
+}
+
+function capabilityItems(permissions = []) {
+	return permissions
+		.map((permission) => ({
+			label: capabilityLabel(permission),
+			sensitive: permission?.sensitive === true,
+		}))
+		.filter((permission) => permission.label)
+		.sort((first, second) => first.label.localeCompare(second.label));
 }
 
 function fallbackActiveTeamMembership(context) {
@@ -162,7 +190,7 @@ function teamMemberships(context) {
 		normalised.push({
 			...team,
 			roles: team.roles || [],
-			permissions: team.permissions || [],
+			permissions: team.permissions || team.capabilities || [],
 			current: Boolean(team.current || (activeTeamId && team.id === activeTeamId)),
 		});
 	}
@@ -176,7 +204,7 @@ function permissionCodes(context) {
 
 function permissionLabels(context) {
 	return (context?.permissions || [])
-		.map((permission) => permission.label || permission.code)
+		.map((permission) => capabilityLabel(permission))
 		.filter(Boolean)
 		.sort((first, second) => first.localeCompare(second));
 }
@@ -197,9 +225,9 @@ function hasResearchOpsCoreTeamAdmin(memberships) {
 	return (memberships || []).some(isResearchOpsCoreTeamAdmin);
 }
 
-function currentTag(team, membershipCount) {
-	if (!team?.current || membershipCount <= 1) return '';
-	return '<strong class="govuk-tag govuk-tag--blue">Current</strong>';
+function currentTag(team) {
+	if (!team?.current) return '';
+	return '<strong class="govuk-tag govuk-tag--blue">Current team</strong>';
 }
 
 function roleLabels(team) {
@@ -215,38 +243,17 @@ function renderCoreAdminInset(team) {
 	`;
 }
 
-function renderSingleTeamMembership(team) {
+function renderCapabilityList(team) {
+	const capabilities = capabilityItems(team?.permissions || []);
+	if (capabilities.length === 0) return '<p class="govuk-body">No active access summary for this team.</p>';
 	return `
-		<h3 class="govuk-heading-s">Your team</h3>
-		<dl class="govuk-summary-list govuk-!-margin-bottom-6">
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">Team</dt>
-				<dd class="govuk-summary-list__value">${escapeHtml(team.name || team.id || 'Unnamed team')}</dd>
-			</div>
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">Role or roles</dt>
-				<dd class="govuk-summary-list__value">${escapeHtml(roleLabels(team))}</dd>
-			</div>
-		</dl>
-		${renderCoreAdminInset(team)}
-	`;
-}
-
-function renderMultipleTeamMemberships(memberships) {
-	return `
-		<h3 class="govuk-heading-s">Your teams</h3>
-		<p class="govuk-body">You have different access in each team.</p>
-		<ul class="govuk-list govuk-list--spaced">
-			${memberships
+		<ul class="govuk-list govuk-list--bullet">
+			${capabilities
 				.map(
-					(team) => `
+					(capability) => `
 						<li>
-							<h4 class="govuk-heading-s govuk-!-margin-bottom-1">
-								${escapeHtml(team.name || team.id || 'Unnamed team')}
-								${currentTag(team, memberships.length)}
-							</h4>
-							<p class="govuk-body govuk-!-margin-bottom-0">${escapeHtml(roleLabels(team))}</p>
-							${renderCoreAdminInset(team)}
+							${escapeHtml(capability.label)}
+							${capability.sensitive ? '<strong class="govuk-tag govuk-tag--yellow">Sensitive access</strong>' : ''}
 						</li>
 					`,
 				)
@@ -255,17 +262,58 @@ function renderMultipleTeamMemberships(memberships) {
 	`;
 }
 
+function renderTeamMembership(team) {
+	return `
+		<div class="govuk-summary-card">
+			<div class="govuk-summary-card__title-wrapper">
+				<h3 class="govuk-summary-card__title">
+					${escapeHtml(team.name || team.id || 'Unnamed team')}
+					${currentTag(team)}
+				</h3>
+			</div>
+			<div class="govuk-summary-card__content">
+				<dl class="govuk-summary-list govuk-summary-list--no-border">
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">Role or roles</dt>
+						<dd class="govuk-summary-list__value">${escapeHtml(roleLabels(team))}</dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">What this lets you do</dt>
+						<dd class="govuk-summary-list__value">${renderCapabilityList(team)}</dd>
+					</div>
+				</dl>
+				${renderCoreAdminInset(team)}
+			</div>
+		</div>
+	`;
+}
+
 function renderTeamMemberships(context) {
 	if (!dom.teamMemberships) return;
 	const memberships = teamMemberships(context);
 
 	if (memberships.length === 0) {
-		dom.teamMemberships.innerHTML = '<p class="govuk-body">You are not currently a member of any team.</p>';
+		dom.teamMemberships.innerHTML = `
+			<div class="govuk-inset-text">
+				<p class="govuk-body">You are not currently a member of any team.</p>
+				<p class="govuk-body">Ask a Team Admin to add you to a team or review your account request.</p>
+			</div>
+		`;
 		return;
 	}
 
-	dom.teamMemberships.innerHTML =
-		memberships.length === 1 ? renderSingleTeamMembership(memberships[0]) : renderMultipleTeamMemberships(memberships);
+	dom.teamMemberships.innerHTML = memberships.map(renderTeamMembership).join('');
+}
+
+function renderCurrentTeam(context, memberships) {
+	const currentTeam = memberships.find((team) => team.current) || context?.activeTeam || null;
+	if (!dom.currentTeam || !dom.currentTeamSection) return;
+	if (!currentTeam?.id) {
+		setVisible(dom.currentTeamSection, false);
+		return;
+	}
+	dom.currentTeam.textContent = currentTeam.name || currentTeam.id;
+	setVisible(dom.currentTeamSection, true);
 }
 
 function allowedActions(context) {
@@ -295,7 +343,10 @@ function renderPermissions(context, memberships) {
 function renderDashboard(context) {
 	const memberships = teamMemberships(context);
 	if (dom.title) dom.title.textContent = 'Your ResearchOps account';
-	if (dom.user) dom.user.textContent = context?.user?.displayName || context?.user?.email || 'Not available';
+	if (dom.user) dom.user.textContent = displayName(context);
+	if (dom.email) dom.email.textContent = context?.user?.email || 'Not available';
+	if (dom.accountStatus) dom.accountStatus.textContent = formatAccountStatus(context?.user?.accountStatus);
+	renderCurrentTeam(context, memberships);
 	renderTeamMemberships(context);
 	renderActions(context);
 	renderPermissions(context, memberships);
@@ -352,9 +403,11 @@ window.__ropsAuthAccountPage = Object.freeze({
 	ACTIONS,
 	CONFIG,
 	allowedActions,
+	capabilityItems,
 	defaultApiOrigin,
 	displayName,
 	fallbackActiveTeamMembership,
+	formatAccountStatus,
 	permissionCodes,
 	renderDashboard,
 	teamMemberships,

--- a/public/pages/account/index.html
+++ b/public/pages/account/index.html
@@ -25,8 +25,8 @@
 				<div class="govuk-notification-banner__header">
 					<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Checking your account</h2>
 				</div>
-				<div class="govuk-notification-banner__content">
-					<p class="govuk-notification-banner__heading">Checking which teams and permissions you can use.</p>
+				<div class="govuk-notification-banner__content" id="account-status-body">
+					<p class="govuk-notification-banner__heading">Checking which teams, roles and account actions you can use.</p>
 				</div>
 			</div>
 
@@ -35,35 +35,52 @@
 					<div class="govuk-grid-column-two-thirds">
 						<span class="govuk-caption-l">ResearchOps account</span>
 						<h1 class="govuk-heading-xl" id="account-dashboard-title">Your ResearchOps account</h1>
-						<p class="govuk-body-l">Check your teams, roles and available actions.</p>
+						<p class="govuk-body-l">Check who you are signed in as, which teams you belong to and what you can do.</p>
 					</div>
 				</div>
 
-				<dl class="govuk-summary-list govuk-!-margin-bottom-6" aria-label="Account summary">
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">Signed in as</dt>
-						<dd class="govuk-summary-list__value"><span id="account-user-value">Not loaded</span></dd>
-					</div>
-				</dl>
+				<section aria-labelledby="account-identity-title">
+					<h2 class="govuk-heading-m" id="account-identity-title">Your account</h2>
+					<dl class="govuk-summary-list govuk-!-margin-bottom-6" aria-label="Account summary">
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Signed in as</dt>
+							<dd class="govuk-summary-list__value"><span id="account-user-value">Not loaded</span></dd>
+						</div>
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Email address</dt>
+							<dd class="govuk-summary-list__value"><span id="account-email-value">Not loaded</span></dd>
+						</div>
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Account status</dt>
+							<dd class="govuk-summary-list__value"><span id="account-status-value">Not loaded</span></dd>
+						</div>
+					</dl>
+				</section>
+
+				<section aria-labelledby="account-current-team-title" id="account-current-team-section" hidden>
+					<h2 class="govuk-heading-m" id="account-current-team-title">Current team context</h2>
+					<p class="govuk-body">ResearchOps uses this team context when deciding which team-scoped actions and records you can use.</p>
+					<p class="govuk-inset-text" id="account-current-team-value">Not loaded</p>
+				</section>
 
 				<section aria-labelledby="account-teams-title">
-					<h2 class="govuk-heading-m" id="account-teams-title">Teams and roles</h2>
-					<p class="govuk-body">Your roles are scoped by team. You may have different access in each team.</p>
+					<h2 class="govuk-heading-m" id="account-teams-title">Your teams and roles</h2>
+					<p class="govuk-body">You may have different roles and access in each team.</p>
 					<div id="account-team-memberships"></div>
 				</section>
 
 				<section aria-labelledby="account-actions-title" id="account-actions-section" hidden>
-					<h2 class="govuk-heading-m" id="account-actions-title">Actions you can take</h2>
-					<p class="govuk-body">These actions are based on your current ResearchOps permissions.</p>
+					<h2 class="govuk-heading-m" id="account-actions-title">What you can do from here</h2>
+					<p class="govuk-body">These account actions are based on your current ResearchOps permissions. Protected services still check your access when you use them.</p>
 					<div id="account-actions" class="govuk-button-group"></div>
 				</section>
 
 				<details class="govuk-details" id="account-permissions-details" hidden data-module="govuk-details">
 					<summary class="govuk-details__summary">
-						<span class="govuk-details__summary-text">View permission details</span>
+						<span class="govuk-details__summary-text">View technical permission details</span>
 					</summary>
 					<div class="govuk-details__text">
-						<p class="govuk-body">ResearchOps uses these permissions to decide what controls and records you can use in the current team context.</p>
+						<p class="govuk-body">This technical view is shown only where it helps administer access. Most users should rely on the task-based access summary above.</p>
 						<ul class="govuk-list govuk-list--bullet" id="account-permissions"></ul>
 					</div>
 				</details>
@@ -77,6 +94,6 @@
 		</div>
 	</main>
 	<x-include src="/partials/footer.html"></x-include>
-	<script type="module" src="/js/auth-account-page.js?v=account-dashboard-20260513-teams-v3"></script>
+	<script type="module" src="/js/auth-account-page.js?v=account-access-summary-20260530"></script>
 </body>
 </html>

--- a/src/govuk/templates/pages/account.njk
+++ b/src/govuk/templates/pages/account.njk
@@ -18,7 +18,7 @@
 
 	{{ govukNotificationBanner({
 		titleText: 'Checking your account',
-		text: 'Checking which teams and permissions you can use.',
+		text: 'Checking which teams, roles and account actions you can use.',
 		attributes: {
 			id: 'account-status',
 			'aria-live': 'polite',
@@ -31,45 +31,70 @@
 			<div class="govuk-grid-column-two-thirds">
 				<span class="govuk-caption-l">ResearchOps account</span>
 				<h1 class="govuk-heading-xl" id="account-dashboard-title">Your ResearchOps account</h1>
-				<p class="govuk-body-l">Check your teams, roles and available actions.</p>
+				<p class="govuk-body-l">Check who you are signed in as, which teams you belong to and what you can do.</p>
 			</div>
 		</div>
 
-		{{ govukSummaryList({
-			attributes: {
-				'aria-label': 'Account summary'
-			},
-			classes: 'govuk-!-margin-bottom-6',
-			rows: [
-				{
-					key: {
-						text: 'Signed in as'
+		<section aria-labelledby="account-identity-title">
+			<h2 class="govuk-heading-m" id="account-identity-title">Your account</h2>
+			{{ govukSummaryList({
+				attributes: {
+					'aria-label': 'Account summary'
+				},
+				classes: 'govuk-!-margin-bottom-6',
+				rows: [
+					{
+						key: {
+							text: 'Signed in as'
+						},
+						value: {
+							html: '<span id="account-user-value">Not loaded</span>'
+						}
 					},
-					value: {
-						html: '<span id="account-user-value">Not loaded</span>'
+					{
+						key: {
+							text: 'Email address'
+						},
+						value: {
+							html: '<span id="account-email-value">Not loaded</span>'
+						}
+					},
+					{
+						key: {
+							text: 'Account status'
+						},
+						value: {
+							html: '<span id="account-status-value">Not loaded</span>'
+						}
 					}
-				}
-			]
-		}) }}
+				]
+			}) }}
+		</section>
+
+		<section aria-labelledby="account-current-team-title" id="account-current-team-section" hidden>
+			<h2 class="govuk-heading-m" id="account-current-team-title">Current team context</h2>
+			<p class="govuk-body">ResearchOps uses this team context when deciding which team-scoped actions and records you can use.</p>
+			<p class="govuk-inset-text" id="account-current-team-value">Not loaded</p>
+		</section>
 
 		<section aria-labelledby="account-teams-title">
-			<h2 class="govuk-heading-m" id="account-teams-title">Teams and roles</h2>
-			<p class="govuk-body">Your roles are scoped by team. You may have different access in each team.</p>
+			<h2 class="govuk-heading-m" id="account-teams-title">Your teams and roles</h2>
+			<p class="govuk-body">You may have different roles and access in each team.</p>
 			<div id="account-team-memberships"></div>
 		</section>
 
 		<section aria-labelledby="account-actions-title" id="account-actions-section" hidden>
-			<h2 class="govuk-heading-m" id="account-actions-title">Actions you can take</h2>
-			<p class="govuk-body">These actions are based on your current ResearchOps permissions.</p>
+			<h2 class="govuk-heading-m" id="account-actions-title">What you can do from here</h2>
+			<p class="govuk-body">These account actions are based on your current ResearchOps permissions. Protected services still check your access when you use them.</p>
 			<div id="account-actions" class="govuk-button-group"></div>
 		</section>
 
 		<details id="account-permissions-details" hidden class="govuk-details" data-module="govuk-details">
 			<summary class="govuk-details__summary">
-				<span class="govuk-details__summary-text">View permission details</span>
+				<span class="govuk-details__summary-text">View technical permission details</span>
 			</summary>
 			<div class="govuk-details__text">
-				<p class="govuk-body">ResearchOps uses these permissions to decide what controls and records you can use in the current team context.</p>
+				<p class="govuk-body">This technical view is shown only where it helps administer access. Most users should rely on the task-based access summary above.</p>
 				<ul class="govuk-list govuk-list--bullet" id="account-permissions"></ul>
 			</div>
 		</details>
@@ -91,5 +116,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script type="module" src="/js/auth-account-page.js?v=account-dashboard-20260513-teams-v3"></script>
+<script type="module" src="/js/auth-account-page.js?v=account-access-summary-20260530"></script>
 {% endblock %}

--- a/tests/auth-account-dashboard-route-state.test.js
+++ b/tests/auth-account-dashboard-route-state.test.js
@@ -151,10 +151,10 @@ function assertDashboardSupportsLogout() {
 
 function assertProductRequirementsSupportPermissionBasedDashboard() {
 	assert.match(productRequirements, /Users should know who they are signed in as and what team context is active/);
-	assert.match(productRequirements, /Given a user belongs to multiple teams, then the active team is visible/);
-	assert.match(productRequirements, /Given a role is active, then account settings show the role and main permissions/);
-	assert.match(productRequirements, /Use permission checks like `governed\.approve` or `safeguarding\.view`/);
-	assert.match(productRequirements, /Given a user signs out, then the local ResearchOps session is invalidated/);
+	assert.match(productRequirements, /The system should support scoped roles/);
+	assert.match(productRequirements, /Use plain language descriptions/);
+	assert.match(productRequirements, /Roles should map to permissions/);
+	assert.match(productRequirements, /Client-side hiding is convenience, not security/);
 }
 
 function assertStory2ScopeIsAccountSummaryOnly() {

--- a/tests/auth-account-dashboard-route-state.test.js
+++ b/tests/auth-account-dashboard-route-state.test.js
@@ -7,17 +7,23 @@ const productRequirements = fs.readFileSync(
 	'docs/product/26/05/08/authentication-role-selection-requirements-2026-05-08.md',
 	'utf8',
 );
+const story2Plan = fs.readFileSync('docs/product/26/05/30/auth-story-2-account-access-summary.md', 'utf8');
 
 function assertAccountPageExistsAsDashboard() {
 	assert.match(accountPage, /<title>Your ResearchOps account - ResearchOps Demo Suite<\/title>/);
 	assert.match(accountPage, /<h1 class="govuk-heading-xl" id="account-dashboard-title">Your ResearchOps account<\/h1>/);
-	assert.match(accountPage, /Check your teams, roles and available actions\./);
+	assert.match(accountPage, /Check who you are signed in as, which teams you belong to and what you can do\./);
 	assert.match(accountPage, /id="account-dashboard"/);
+	assert.match(accountPage, /id="account-identity-title">Your account/);
 	assert.match(accountPage, /id="account-user-value"/);
+	assert.match(accountPage, /id="account-email-value"/);
+	assert.match(accountPage, /id="account-status-value"/);
 	assert.match(accountPage, /aria-label="Account summary"/);
+	assert.match(accountPage, /id="account-current-team-section" hidden/);
+	assert.match(accountPage, /id="account-current-team-value"/);
 	assert.match(accountPage, /id="account-team-memberships"/);
-	assert.match(accountPage, /Teams and roles/);
-	assert.match(accountPage, /Your roles are scoped by team/);
+	assert.match(accountPage, /Your teams and roles/);
+	assert.match(accountPage, /You may have different roles and access in each team/);
 	assert.doesNotMatch(accountPage, /id="account-team-value"/);
 	assert.doesNotMatch(accountPage, /id="account-roles-value"/);
 	assert.doesNotMatch(accountPage, /<h2 class="govuk-heading-m" id="account-summary-title">Account summary<\/h2>/);
@@ -25,7 +31,8 @@ function assertAccountPageExistsAsDashboard() {
 	assert.match(accountPage, /id="account-actions"/);
 	assert.doesNotMatch(accountPage, /id="account-no-actions"/);
 	assert.match(accountPage, /id="account-permissions-details" hidden/);
-	assert.match(accountPage, /View permission details/);
+	assert.match(accountPage, /View technical permission details/);
+	assert.match(accountPage, /task-based access summary above/);
 	assert.match(accountPage, /id="account-permissions"/);
 	assert.match(accountPage, /id="account-logout"/);
 }
@@ -37,7 +44,7 @@ function assertAccountPageDoesNotUseSuccessMessagePattern() {
 }
 
 function assertAccountPageLoadsDashboardScript() {
-	assert.match(accountPage, /\/js\/auth-account-page\.js\?v=account-dashboard-20260513-teams-v3/);
+	assert.match(accountPage, /\/js\/auth-account-page\.js\?v=account-access-summary-20260530/);
 }
 
 function assertDashboardUsesSameOriginApiAndAuthContext() {
@@ -52,6 +59,18 @@ function assertDashboardUsesSameOriginApiAndAuthContext() {
 	assert.doesNotMatch(accountScript, /rops-api\.digikev-kevin-rapley\.workers\.dev/);
 }
 
+function assertDashboardRendersAccountIdentity() {
+	assert.match(accountScript, /email: document\.getElementById\('account-email-value'\)/);
+	assert.match(accountScript, /accountStatus: document\.getElementById\('account-status-value'\)/);
+	assert.match(accountScript, /function formatAccountStatus\(value\)/);
+	assert.match(accountScript, /if \(dom\.user\) dom\.user\.textContent = displayName\(context\)/);
+	assert.match(accountScript, /if \(dom\.email\) dom\.email\.textContent = context\?\.user\?\.email \|\| 'Not available'/);
+	assert.match(accountScript, /if \(dom\.accountStatus\) dom\.accountStatus\.textContent = formatAccountStatus\(context\?\.user\?\.accountStatus\)/);
+	assert.doesNotMatch(accountScript, /session_token/);
+	assert.doesNotMatch(accountScript, /providerSubject/);
+	assert.doesNotMatch(accountScript, /Cf-Access-Jwt-Assertion/);
+}
+
 function assertDashboardRendersAdaptiveTeamMembershipPresentation() {
 	assert.match(accountScript, /teamMemberships\(context\)/);
 	assert.match(accountScript, /renderTeamMemberships\(context\)/);
@@ -60,32 +79,45 @@ function assertDashboardRendersAdaptiveTeamMembershipPresentation() {
 	assert.match(accountScript, /context\?\.activeTeam\?\.id/);
 	assert.match(accountScript, /roles: context\.roles \|\| \[\]/);
 	assert.match(accountScript, /permissions: context\.permissions \|\| \[\]/);
-	assert.match(accountScript, /function renderSingleTeamMembership\(team\)/);
-	assert.match(accountScript, /function renderMultipleTeamMemberships\(memberships\)/);
-	assert.match(accountScript, /Your team/);
-	assert.match(accountScript, /Your teams/);
-	assert.match(accountScript, /You have different access in each team/);
+	assert.match(accountScript, /function renderTeamMembership\(team\)/);
+	assert.match(accountScript, /govuk-summary-card/);
+	assert.match(accountScript, /Current team/);
 	assert.match(accountScript, /Role or roles/);
 	assert.match(accountScript, /No active role/);
+	assert.match(accountScript, /What this lets you do/);
+	assert.match(accountScript, /No active access summary for this team/);
+	assert.match(accountScript, /Ask a Team Admin to add you to a team or review your account request/);
 	assert.match(accountScript, /dom\.title\) dom\.title\.textContent = 'Your ResearchOps account'/);
-	assert.match(accountScript, /context\?\.permissions/);
-	assert.match(accountScript, /currentTag\(team, memberships\.length\)/);
-	assert.match(accountScript, /membershipCount <= 1/);
 	assert.doesNotMatch(accountScript, /Team membership and role access/);
-	assert.doesNotMatch(accountScript, /<table class="govuk-table">/);
-	assert.doesNotMatch(accountScript, /<th scope="col" class="govuk-table__header">Permissions<\/th>/);
-	assert.doesNotMatch(accountScript, /govuk-summary-card/);
 	assert.doesNotMatch(accountScript, /activeTeamLabel\(context\)/);
+}
+
+function assertDashboardRendersCurrentTeamContextWithoutHidingMemberships() {
+	assert.match(accountScript, /function renderCurrentTeam\(context, memberships\)/);
+	assert.match(accountScript, /const currentTeam = memberships\.find\(\(team\) => team\.current\) \|\| context\?\.activeTeam \|\| null/);
+	assert.match(accountScript, /dom\.currentTeam\.textContent = currentTeam\.name \|\| currentTeam\.id/);
+	assert.match(accountScript, /setVisible\(dom\.currentTeamSection, true\)/);
+	assert.match(accountScript, /renderCurrentTeam\(context, memberships\)/);
+	assert.match(accountScript, /renderTeamMemberships\(context\)/);
 }
 
 function assertDashboardSeparatesRolesFromCapabilities() {
 	assert.match(accountScript, /function roleLabels\(team\)/);
 	assert.match(accountScript, /labelList\(team\?\.roles, 'No active role'\)/);
-	assert.match(accountScript, /renderPermissions\(context, memberships\)/);
-	assert.match(accountScript, /const showPermissionDetails = hasResearchOpsCoreTeamAdmin\(memberships\) && labels\.length > 0/);
-	assert.match(accountScript, /setVisible\(dom\.permissionsDetails, showPermissionDetails\)/);
+	assert.match(accountScript, /function capabilityLabel\(permission\)/);
+	assert.match(accountScript, /return permission\?\.label \|\| permission\?\.description \|\| ''/);
+	assert.match(accountScript, /function capabilityItems\(permissions = \[\]\)/);
+	assert.match(accountScript, /renderCapabilityList\(team\)/);
+	assert.doesNotMatch(accountScript, /item\.code \|\| item\.key/);
 	assert.doesNotMatch(accountScript, /labelList\(team\.permissions, 'No active permissions'\)/);
 	assert.doesNotMatch(accountScript, /No active permissions for the current team context/);
+}
+
+function assertDashboardExplainsSensitiveAccessProportionately() {
+	assert.match(accountScript, /capability\.sensitive/);
+	assert.match(accountScript, /Sensitive access/);
+	assert.doesNotMatch(accountScript, /dangerous permission/);
+	assert.doesNotMatch(accountScript, /high risk permission/);
 }
 
 function assertDashboardExplainsResearchOpsCoreTeamAdmin() {
@@ -125,13 +157,25 @@ function assertProductRequirementsSupportPermissionBasedDashboard() {
 	assert.match(productRequirements, /Given a user signs out, then the local ResearchOps session is invalidated/);
 }
 
+function assertStory2ScopeIsAccountSummaryOnly() {
+	assert.match(story2Plan, /Story 2 should make access understandable/);
+	assert.match(story2Plan, /It should not make access changeable/);
+	assert.match(story2Plan, /switching active team/);
+	assert.match(story2Plan, /requesting a role/);
+	assert.match(story2Plan, /approving role requests/);
+}
+
 assertAccountPageExistsAsDashboard();
 assertAccountPageDoesNotUseSuccessMessagePattern();
 assertAccountPageLoadsDashboardScript();
 assertDashboardUsesSameOriginApiAndAuthContext();
+assertDashboardRendersAccountIdentity();
 assertDashboardRendersAdaptiveTeamMembershipPresentation();
+assertDashboardRendersCurrentTeamContextWithoutHidingMemberships();
 assertDashboardSeparatesRolesFromCapabilities();
+assertDashboardExplainsSensitiveAccessProportionately();
 assertDashboardExplainsResearchOpsCoreTeamAdmin();
 assertDashboardActionsArePermissionBasedAndHiddenWhenUnavailable();
 assertDashboardSupportsLogout();
 assertProductRequirementsSupportPermissionBasedDashboard();
+assertStory2ScopeIsAccountSummaryOnly();


### PR DESCRIPTION
## Summary

Implements Story 2 for `ROPS-AUTH-P1-000 — Governed access, permissions and audit`.

This PR makes account access understandable without making access changeable.

## Story 2 scope

As a signed-in ResearchOps user, I need to see my account, teams, roles and access summary, so that I understand who I am signed in as, which teams I belong to, what role I hold in each team and what I can do from here.

## Team position

> Story 2 should make access understandable.
> It should not make access changeable.

## Changes

- Add Story 2 product plan using the recommended rewrite.
- Restructure the account page around:
  - `Your account`
  - `Current team context`
  - `Your teams and roles`
  - `What you can do from here`
  - `Sign out`
- Render display name, email address and account status.
- Render current team context without hiding other team memberships.
- Render team memberships as GOV.UK summary cards.
- Render roles under the team where they apply.
- Render task-based capability labels from permission labels or descriptions.
- Mark sensitive capabilities with a visible text label.
- Show a useful no-team state.
- Keep account actions permission-based.
- Add feature-branch trace artefacts.

## Scope controls

This PR does not add:

- team creation
- team joining
- team switching
- role request
- role approval
- permission assignment
- PII reveal
- audit log viewing

## Trace

- `docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.md`
- `docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.json`

## Changed-file verification

Changed files: 6

- `docs/product/26/05/30/auth-story-2-account-access-summary.md`
- `docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.md`
- `docs/agent-audit/reasoning/2026/05/30/auth-story-2-account-access-summary.json`
- `public/pages/account/index.html`
- `public/js/auth-account-page.js`
- `tests/auth-account-dashboard-route-state.test.js`

Branch comparison: 7 commits ahead of `main`, 0 behind.

## Validation

Not run locally in this connector context.

Ready for GitHub checks to run:

- `npm run validate`
- `npm run lint`
- `npm test -- --ci`

## Manual browser checks

Open:

`/pages/account/`

Confirm:

- signed-in account identity shows display name, email and account status
- current team context appears when available
- all team memberships remain visible
- roles appear under the team where they apply
- team with no role shows `No active role`
- no-team user gets a useful help state
- capability labels are task-based and do not fall back to raw permission codes
- sensitive capabilities show a visible `Sensitive access` label
- no team switching, role request or permission assignment controls are introduced