### PR TITLE
Tighten team access request content

### DIFF
--- a/docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.json
+++ b/docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.json
@@ -1,0 +1,61 @@
+{
+	"date": "2026-05-30",
+	"traceType": "operational-audit-trace",
+	"branch": "content/team-access-request-copy-v2",
+	"relatedPr": 315,
+	"story": "Story 3 follow-up — Request access to a team",
+	"traceRequired": true,
+	"taskSummary": "Tighten the team access request page content while keeping the single field for team name or invitation code.",
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/",
+			"reason": "Always loaded for repository-affecting branch work."
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+			"reason": "Selected for ResearchOps account and access journey content."
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+			"reason": "Selected because the content affects a governed access flow."
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+			"reason": "Selected because the change affects GOV.UK copy, hints, form affordances and accessible descriptions."
+		}
+	],
+	"skippedBundles": [
+		"cloudflare",
+		"openai-platform",
+		"mcp-agent-tooling",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"filesChanged": [
+		"src/govuk/templates/pages/account-team-access.njk",
+		"public/pages/account/team-access/index.html",
+		"tests/auth-team-access-request-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.md",
+		"docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.json"
+	],
+	"implementationSummary": {
+		"singleFieldKept": true,
+		"backendBehaviourChanged": false,
+		"privacyHintLinkedToTextarea": true,
+		"controlsGroupedWithGovukButtonGroup": true
+	},
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint",
+		"npm test -- --ci"
+	],
+	"validationRunInConnector": [],
+	"residualRisks": [
+		"Validation has not been run in this connector context.",
+		"Manual assistive-technology checks should confirm the privacy hint is announced with the textarea."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.md
+++ b/docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.md
@@ -1,0 +1,112 @@
+# Agent trace — Team access request copy tightening
+
+**Date:** 2026-05-30  
+**Trace type:** operational audit trace  
+**Branch:** `content/team-access-request-copy-v2`  
+**Related PR:** #315  
+**Story:** Story 3 follow-up — Request access to a team
+
+## Evidence boundary
+
+This trace records repository evidence, selected operating-model bundles, implementation scope, files changed, validation expected and residual risk.
+
+It does not expose private chain-of-thought.
+
+## Task summary
+
+Tighten the team access request page content while keeping the agreed single input field for team name or invitation code.
+
+## Team position
+
+The single field remains acceptable for this slice.
+
+The page copy should make the input purpose clear, avoid implying search, and make the sensitive-information warning available to screen reader users at the point of input.
+
+## Operating model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Selected bundles
+
+Always-load bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+
+Conditional bundles:
+
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+## Bundle selection rationale
+
+GitHub Diamond was selected because this is repository-affecting branch work.
+
+ResearchOps Developer Control was selected because the page is part of the ResearchOps account and access journey.
+
+Multi-Functional Team was selected because the copy affects a governed access flow.
+
+GOV.UK Design System was selected because the changes affect GOV.UK page copy, hint text, form affordances and accessible descriptions.
+
+Cloudflare was not selected because this branch does not change Worker, D1 or API behaviour.
+
+## Files inspected
+
+- `src/govuk/templates/pages/account-team-access.njk`
+- `public/pages/account/team-access/index.html`
+- `tests/auth-team-access-request-route-state.test.js`
+
+## Files changed
+
+- `src/govuk/templates/pages/account-team-access.njk`
+- `public/pages/account/team-access/index.html`
+- `tests/auth-team-access-request-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.md`
+- `docs/agent-audit/reasoning/2026/05/30/team-access-request-copy-tightening.json`
+
+## Implementation summary
+
+The branch:
+
+- keeps one field labelled `Team name or invitation code`
+- replaces `team-scoped ResearchOps features` with plainer copy about research records that belong to a team
+- adds a `What happens next` section
+- improves the team-name or invitation-code hint
+- improves the optional message hint
+- adds a sensitive-information warning for the message field
+- links the sensitive-information warning to the textarea using `aria-describedby`
+- wraps the submit button and cancel link in a GOV.UK button group
+- updates route-state coverage for the revised copy and accessibility contract
+
+## Scope controls
+
+This branch does not add:
+
+- separate team-name and invitation-code fields
+- team search
+- invitation-code validation
+- approval workflow
+- role assignment
+- team creation
+- backend behaviour changes
+
+## Validation expected
+
+Run:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```
+
+## Residual risk
+
+Validation has not been run in this connector context.
+
+Manual browser checks should confirm that the privacy warning is read with the message textarea by assistive technology and that the page still keeps a single input field for team name or invitation code.

--- a/public/pages/account/team-access/index.html
+++ b/public/pages/account/team-access/index.html
@@ -65,9 +65,9 @@
 						<div class="govuk-form-group" id="team-access-message-group">
 							<label class="govuk-label govuk-label--m" for="team-access-message">Message to the Team Admin</label>
 							<div id="team-access-message-hint" class="govuk-hint">Optional. For example, explain which project, study or team activity you need access for.</div>
-							<p class="govuk-hint">Do not include participant names, contact details or sensitive research information.</p>
+							<p id="team-access-message-privacy-hint" class="govuk-hint">Do not include participant names, contact details or sensitive research information.</p>
 							<p id="team-access-message-error" class="govuk-error-message" hidden></p>
-							<textarea class="govuk-textarea" id="team-access-message" name="message" rows="5" maxlength="500" aria-describedby="team-access-message-hint"></textarea>
+							<textarea class="govuk-textarea" id="team-access-message" name="message" rows="5" maxlength="500" aria-describedby="team-access-message-hint team-access-message-privacy-hint"></textarea>
 						</div>
 
 						<div class="govuk-button-group">

--- a/public/pages/account/team-access/index.html
+++ b/public/pages/account/team-access/index.html
@@ -28,8 +28,15 @@
 				<div class="govuk-grid-column-two-thirds">
 					<span class="govuk-caption-l">ResearchOps account</span>
 					<h1 class="govuk-heading-xl">Request access to a team</h1>
-					<p class="govuk-body-l">Ask to join a team before using team-scoped ResearchOps features.</p>
-					<p class="govuk-body">A Team Admin needs to review your request before you can use that team’s research records. This request does not give you a role or sensitive access.</p>
+					<p class="govuk-body-l">Ask to join a team before using research records that belong to that team.</p>
+					<p class="govuk-body">A Team Admin must approve your request before you can use that team’s research records. This request will not give you a role or access to sensitive information.</p>
+
+					<h2 class="govuk-heading-m">What happens next</h2>
+					<ul class="govuk-list govuk-list--bullet">
+						<li>A Team Admin will review your request.</li>
+						<li>Your request will appear on your account page as “Awaiting approval”.</li>
+						<li>You cannot use this team’s research records until your request is approved.</li>
+					</ul>
 
 					<div class="govuk-error-summary" data-module="govuk-error-summary" id="team-access-error-summary" hidden>
 						<div role="alert">
@@ -50,20 +57,23 @@
 					<form id="team-access-request-form" novalidate data-submit-route="/api/team-access/requests" data-account-url="/pages/account/">
 						<div class="govuk-form-group" id="team-reference-group">
 							<label class="govuk-label govuk-label--m" for="team-reference">Team name or invitation code</label>
-							<div id="team-reference-hint" class="govuk-hint">Enter the team name or invitation code you were given.</div>
+							<div id="team-reference-hint" class="govuk-hint">Enter the team name, or paste the invitation code given to you by a Team Admin.</div>
 							<p id="team-reference-error" class="govuk-error-message" hidden></p>
 							<input class="govuk-input" id="team-reference" name="teamReference" type="text" autocomplete="off" aria-describedby="team-reference-hint">
 						</div>
 
 						<div class="govuk-form-group" id="team-access-message-group">
 							<label class="govuk-label govuk-label--m" for="team-access-message">Message to the Team Admin</label>
-							<div id="team-access-message-hint" class="govuk-hint">Optional. Include anything that will help the Team Admin review your request.</div>
+							<div id="team-access-message-hint" class="govuk-hint">Optional. For example, explain which project, study or team activity you need access for.</div>
+							<p class="govuk-hint">Do not include participant names, contact details or sensitive research information.</p>
 							<p id="team-access-message-error" class="govuk-error-message" hidden></p>
 							<textarea class="govuk-textarea" id="team-access-message" name="message" rows="5" maxlength="500" aria-describedby="team-access-message-hint"></textarea>
 						</div>
 
-						<button class="govuk-button" data-module="govuk-button" id="team-access-submit">Send request</button>
-						<a class="govuk-link" href="/pages/account/">Cancel and return to your account</a>
+						<div class="govuk-button-group">
+							<button class="govuk-button" data-module="govuk-button" id="team-access-submit">Send request</button>
+							<a class="govuk-link" href="/pages/account/">Cancel and return to your account</a>
+						</div>
 					</form>
 				</div>
 			</div>

--- a/src/govuk/templates/pages/account-team-access.njk
+++ b/src/govuk/templates/pages/account-team-access.njk
@@ -58,9 +58,9 @@
 				<div class="govuk-form-group" id="team-access-message-group">
 					<label class="govuk-label govuk-label--m" for="team-access-message">Message to the Team Admin</label>
 					<div id="team-access-message-hint" class="govuk-hint">Optional. For example, explain which project, study or team activity you need access for.</div>
-					<p class="govuk-hint">Do not include participant names, contact details or sensitive research information.</p>
+					<p id="team-access-message-privacy-hint" class="govuk-hint">Do not include participant names, contact details or sensitive research information.</p>
 					<p id="team-access-message-error" class="govuk-error-message" hidden></p>
-					<textarea class="govuk-textarea" id="team-access-message" name="message" rows="5" maxlength="500" aria-describedby="team-access-message-hint"></textarea>
+					<textarea class="govuk-textarea" id="team-access-message" name="message" rows="5" maxlength="500" aria-describedby="team-access-message-hint team-access-message-privacy-hint"></textarea>
 				</div>
 
 				<div class="govuk-button-group">

--- a/src/govuk/templates/pages/account-team-access.njk
+++ b/src/govuk/templates/pages/account-team-access.njk
@@ -21,8 +21,15 @@
 		<div class="govuk-grid-column-two-thirds">
 			<span class="govuk-caption-l">ResearchOps account</span>
 			<h1 class="govuk-heading-xl">Request access to a team</h1>
-			<p class="govuk-body-l">Ask to join a team before using team-scoped ResearchOps features.</p>
-			<p class="govuk-body">A Team Admin needs to review your request before you can use that team’s research records. This request does not give you a role or sensitive access.</p>
+			<p class="govuk-body-l">Ask to join a team before using research records that belong to that team.</p>
+			<p class="govuk-body">A Team Admin must approve your request before you can use that team’s research records. This request will not give you a role or access to sensitive information.</p>
+
+			<h2 class="govuk-heading-m">What happens next</h2>
+			<ul class="govuk-list govuk-list--bullet">
+				<li>A Team Admin will review your request.</li>
+				<li>Your request will appear on your account page as “Awaiting approval”.</li>
+				<li>You cannot use this team’s research records until your request is approved.</li>
+			</ul>
 
 			<div class="govuk-error-summary" data-module="govuk-error-summary" id="team-access-error-summary" hidden>
 				<div role="alert">
@@ -43,20 +50,23 @@
 			<form id="team-access-request-form" novalidate data-submit-route="/api/team-access/requests" data-account-url="/pages/account/">
 				<div class="govuk-form-group" id="team-reference-group">
 					<label class="govuk-label govuk-label--m" for="team-reference">Team name or invitation code</label>
-					<div id="team-reference-hint" class="govuk-hint">Enter the team name or invitation code you were given.</div>
+					<div id="team-reference-hint" class="govuk-hint">Enter the team name, or paste the invitation code given to you by a Team Admin.</div>
 					<p id="team-reference-error" class="govuk-error-message" hidden></p>
 					<input class="govuk-input" id="team-reference" name="teamReference" type="text" autocomplete="off" aria-describedby="team-reference-hint">
 				</div>
 
 				<div class="govuk-form-group" id="team-access-message-group">
 					<label class="govuk-label govuk-label--m" for="team-access-message">Message to the Team Admin</label>
-					<div id="team-access-message-hint" class="govuk-hint">Optional. Include anything that will help the Team Admin review your request.</div>
+					<div id="team-access-message-hint" class="govuk-hint">Optional. For example, explain which project, study or team activity you need access for.</div>
+					<p class="govuk-hint">Do not include participant names, contact details or sensitive research information.</p>
 					<p id="team-access-message-error" class="govuk-error-message" hidden></p>
 					<textarea class="govuk-textarea" id="team-access-message" name="message" rows="5" maxlength="500" aria-describedby="team-access-message-hint"></textarea>
 				</div>
 
-				<button class="govuk-button" data-module="govuk-button" id="team-access-submit">Send request</button>
-				<a class="govuk-link" href="/pages/account/">Cancel and return to your account</a>
+				<div class="govuk-button-group">
+					<button class="govuk-button" data-module="govuk-button" id="team-access-submit">Send request</button>
+					<a class="govuk-link" href="/pages/account/">Cancel and return to your account</a>
+				</div>
 			</form>
 		</div>
 	</div>

--- a/tests/auth-team-access-request-route-state.test.js
+++ b/tests/auth-team-access-request-route-state.test.js
@@ -74,6 +74,8 @@ for (const source of [template, page]) {
 	includes(source, 'Message to the Team Admin', 'team access page');
 	includes(source, 'Optional. For example, explain which project, study or team activity you need access for.', 'team access page');
 	includes(source, 'Do not include participant names, contact details or sensitive research information.', 'team access page');
+	includes(source, 'team-access-message-privacy-hint', 'team access page');
+	includes(source, 'aria-describedby="team-access-message-hint team-access-message-privacy-hint"', 'team access page');
 	includes(source, 'govuk-button-group', 'team access page');
 	includes(source, 'Send request', 'team access page');
 	includes(source, 'Cancel and return to your account', 'team access page');

--- a/tests/auth-team-access-request-route-state.test.js
+++ b/tests/auth-team-access-request-route-state.test.js
@@ -59,16 +59,25 @@ includes(renderScript, "pageTitle: 'Request access to a team - ResearchOps Demo 
 
 for (const source of [template, page]) {
 	includes(source, 'Request access to a team', 'team access page');
-	includes(source, 'Ask to join a team before using team-scoped ResearchOps features.', 'team access page');
-	includes(source, 'This request does not give you a role or sensitive access.', 'team access page');
+	includes(source, 'Ask to join a team before using research records that belong to that team.', 'team access page');
+	includes(source, 'A Team Admin must approve your request before you can use that team’s research records.', 'team access page');
+	includes(source, 'This request will not give you a role or access to sensitive information.', 'team access page');
+	includes(source, 'What happens next', 'team access page');
+	includes(source, 'Your request will appear on your account page as “Awaiting approval”.', 'team access page');
+	includes(source, 'You cannot use this team’s research records until your request is approved.', 'team access page');
 	includes(source, 'team-access-error-summary', 'team access page');
 	includes(source, 'team-access-error-list', 'team access page');
 	includes(source, 'team-access-request-form', 'team access page');
 	includes(source, 'data-submit-route="/api/team-access/requests"', 'team access page');
 	includes(source, 'Team name or invitation code', 'team access page');
+	includes(source, 'Enter the team name, or paste the invitation code given to you by a Team Admin.', 'team access page');
 	includes(source, 'Message to the Team Admin', 'team access page');
+	includes(source, 'Optional. For example, explain which project, study or team activity you need access for.', 'team access page');
+	includes(source, 'Do not include participant names, contact details or sensitive research information.', 'team access page');
+	includes(source, 'govuk-button-group', 'team access page');
 	includes(source, 'Send request', 'team access page');
 	includes(source, 'Cancel and return to your account', 'team access page');
+	excludes(source, 'team-scoped ResearchOps features', 'team access page');
 	excludes(source, 'Create a new team', 'team access page');
 	excludes(source, 'Approve request', 'team access page');
 	excludes(source, 'Assign role', 'team access page');


### PR DESCRIPTION
## Summary

Small content and markup follow-up for the Story 3 team access request page.

This keeps the single input field for team name or invitation code, but improves the supporting copy so the page is clearer and safer.

## Changes

- Replace `team-scoped ResearchOps features` wording with plainer language about research records that belong to a team.
- Clarify that a Team Admin must approve the request before records can be used.
- Add a `What happens next` section.
- Improve the single field hint for team name or invitation code.
- Improve the optional Team Admin message hint.
- Add a privacy warning not to include participant names, contact details or sensitive research information.
- Wrap the submit button and cancel link in a GOV.UK button group.
- Update route-state coverage for the revised copy.

## Scope controls

This PR does not add:

- separate team-name and invitation-code fields
- team search
- invitation-code validation
- approval workflow
- role assignment
- team creation
- backend behaviour changes

## Changed-file verification

Changed files: 3

- `src/govuk/templates/pages/account-team-access.njk`
- `public/pages/account/team-access/index.html`
- `tests/auth-team-access-request-route-state.test.js`

Branch comparison: 3 commits ahead of `main`, 0 behind.

## Validation

Not run locally in this connector context.

Ready for CI:

- `npm run validate`
- `npm run lint`
- `npm test -- --ci`

## Manual check

Open `/pages/account/team-access/` and confirm:

- the page keeps one field labelled `Team name or invitation code`
- the hint says users can enter the team name or paste the invitation code from a Team Admin
- `What happens next` explains the awaiting approval state
- the message field warns users not to include participant names, contact details or sensitive research information
- the submit and cancel controls are grouped consistently