### PR TITLE
Integrate govuk button macro for submit button

### DIFF
--- a/src/govuk/templates/pages/account-team-access.njk
+++ b/src/govuk/templates/pages/account-team-access.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/researchops.njk" %}
 
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
 <div class="govuk-width-container">
@@ -64,7 +65,9 @@
 				</div>
 
 				<div class="govuk-button-group">
-					<button class="govuk-button" data-module="govuk-button" id="team-access-submit">Send request</button>
+					{{ govukButton({
+						text: 'Send request'
+					}) }}
 					<a class="govuk-link" href="/pages/account/">Cancel and return to your account</a>
 				</div>
 			</form>

--- a/src/govuk/templates/pages/account-team-access.njk
+++ b/src/govuk/templates/pages/account-team-access.njk
@@ -66,7 +66,8 @@
 
 				<div class="govuk-button-group">
 					{{ govukButton({
-						text: 'Send request'
+						text: 'Send request',
+						id: 'team-access-submit'
 					}) }}
 					<a class="govuk-link" href="/pages/account/">Cancel and return to your account</a>
 				</div>


### PR DESCRIPTION
## What’s changing?
Changing static HTML markup for govuk button to nunjucks macro.

## Why?
It uses the canonical govuk frontend button macro to future proof and avoid any markup drift.

## How tested?
- [x] Unit tests
- [x] Manual checks
- [X] Accessibility checks

## Risk / rollout
- [X] Low  - no behavioural change
- [ ] Medium
- [ ] High - behind a feature flag
