### PR TITLE
Tolerate pending team access decision migration

### DIFF
--- a/infra/cloudflare/src/core/auth/team-access-requests.js
+++ b/infra/cloudflare/src/core/auth/team-access-requests.js
@@ -70,6 +70,20 @@ function assertAuthenticatedRouteContext(context) {
 	}
 }
 
+async function readTeamAccessRequestSchema(db) {
+	try {
+		const result = await db.prepare('PRAGMA table_info(auth_team_access_requests)').all();
+		const columns = new Set((result.results || []).map((row) => row.name).filter(Boolean));
+		return {
+			hasDecisionReason: columns.has('decision_reason'),
+		};
+	} catch {
+		return {
+			hasDecisionReason: false,
+		};
+	}
+}
+
 async function readJson(request) {
 	try {
 		const body = await request.json();
@@ -201,6 +215,8 @@ async function listTeamAccessRequests(request, env, context) {
 	const db = dbFor(env);
 	await assertRoutePermission(request, env, context);
 
+	const schema = await readTeamAccessRequestSchema(db);
+	const decisionReasonSelect = schema.hasDecisionReason ? 'r.decision_reason' : "'' AS decision_reason";
 	const result = await db
 		.prepare(`
 			SELECT
@@ -213,7 +229,7 @@ async function listTeamAccessRequests(request, env, context) {
 				r.requested_at,
 				r.cancelled_at,
 				r.decided_at,
-				r.decision_reason
+				${decisionReasonSelect}
 			FROM auth_team_access_requests r
 			LEFT JOIN auth_teams t ON t.id = r.team_id
 			WHERE r.requester_user_id = ?
@@ -400,6 +416,66 @@ function assertCanDecideTeamAccess(context, existing) {
 	}
 }
 
+async function markTeamAccessRequestApproved(db, requestId, decidedByUserId, schema) {
+	if (schema.hasDecisionReason) {
+		await db
+			.prepare(`
+				UPDATE auth_team_access_requests
+				SET request_status = 'approved',
+					decided_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+					decided_by_user_id = ?,
+					decision_reason = NULL
+				WHERE id = ?
+					AND request_status = 'pending'
+			`)
+			.bind(decidedByUserId, requestId)
+			.run();
+		return;
+	}
+
+	await db
+		.prepare(`
+			UPDATE auth_team_access_requests
+			SET request_status = 'approved',
+				decided_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+				decided_by_user_id = ?
+			WHERE id = ?
+				AND request_status = 'pending'
+		`)
+		.bind(decidedByUserId, requestId)
+		.run();
+}
+
+async function markTeamAccessRequestRejected(db, requestId, decidedByUserId, decisionReason, schema) {
+	if (schema.hasDecisionReason) {
+		await db
+			.prepare(`
+				UPDATE auth_team_access_requests
+				SET request_status = 'rejected',
+					decided_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+					decided_by_user_id = ?,
+					decision_reason = ?
+				WHERE id = ?
+					AND request_status = 'pending'
+			`)
+			.bind(decidedByUserId, decisionReason, requestId)
+			.run();
+		return;
+	}
+
+	await db
+		.prepare(`
+			UPDATE auth_team_access_requests
+			SET request_status = 'rejected',
+				decided_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+				decided_by_user_id = ?
+			WHERE id = ?
+				AND request_status = 'pending'
+		`)
+		.bind(decidedByUserId, requestId)
+		.run();
+}
+
 async function approveTeamAccessRequest(request, env, context) {
 	const db = dbFor(env);
 	assertAuthenticatedRouteContext(context);
@@ -416,18 +492,8 @@ async function approveTeamAccessRequest(request, env, context) {
 		throw new TeamAccessRequestError(409, 'team_member_already_active', 'This person is already a member of this team.');
 	}
 
-	await db
-		.prepare(`
-			UPDATE auth_team_access_requests
-			SET request_status = 'approved',
-				decided_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-				decided_by_user_id = ?,
-				decision_reason = NULL
-			WHERE id = ?
-				AND request_status = 'pending'
-		`)
-		.bind(context.user.id, requestId)
-		.run();
+	const schema = await readTeamAccessRequestSchema(db);
+	await markTeamAccessRequestApproved(db, requestId, context.user.id, schema);
 
 	await db
 		.prepare(`
@@ -465,18 +531,8 @@ async function rejectTeamAccessRequest(request, env, context) {
 	const existing = await readRequestForDecision(db, requestId);
 	assertCanDecideTeamAccess(context, existing);
 
-	await db
-		.prepare(`
-			UPDATE auth_team_access_requests
-			SET request_status = 'rejected',
-				decided_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-				decided_by_user_id = ?,
-				decision_reason = ?
-			WHERE id = ?
-				AND request_status = 'pending'
-		`)
-		.bind(context.user.id, decisionReason, requestId)
-		.run();
+	const schema = await readTeamAccessRequestSchema(db);
+	await markTeamAccessRequestRejected(db, requestId, context.user.id, decisionReason, schema);
 
 	await recordTeamAccessEvent(db, request, 'team.access.rejected', context, {
 		requestId,

--- a/tests/auth-team-access-review-route-state.test.js
+++ b/tests/auth-team-access-review-route-state.test.js
@@ -35,7 +35,15 @@ includes(migration, "'POST', '/api/team-access/requests/approve'", 'team access 
 includes(migration, "'POST', '/api/team-access/requests/reject'", 'team access review migration');
 
 includes(handler, 'function assertAuthenticatedRouteContext(context)', 'team access review handler');
+includes(handler, 'async function readTeamAccessRequestSchema(db)', 'team access review handler');
+includes(handler, "PRAGMA table_info(auth_team_access_requests)", 'team access review handler');
+includes(handler, "hasDecisionReason: columns.has('decision_reason')", 'team access review handler');
+includes(handler, "schema.hasDecisionReason ? 'r.decision_reason' : \"'' AS decision_reason\"", 'team access review handler');
 includes(handler, 'async function listTeamAccessReviewRequests(env, context)', 'team access review handler');
+includes(handler, 'async function markTeamAccessRequestApproved(db, requestId, decidedByUserId, schema)', 'team access review handler');
+includes(handler, 'async function markTeamAccessRequestRejected(db, requestId, decidedByUserId, decisionReason, schema)', 'team access review handler');
+includes(handler, 'markTeamAccessRequestApproved(db, requestId, context.user.id, schema)', 'team access review handler');
+includes(handler, 'markTeamAccessRequestRejected(db, requestId, context.user.id, decisionReason, schema)', 'team access review handler');
 includes(handler, "apiPath === '/api/team-access/requests/review'", 'team access review handler');
 includes(handler, "apiPath === '/api/team-access/requests/approve'", 'team access review handler');
 includes(handler, "apiPath === '/api/team-access/requests/reject'", 'team access review handler');


### PR DESCRIPTION
## Summary

Fixes the live post-merge error:

`Team access request could not be completed.`

The likely live failure is that the Worker route now reaches the approve/reject decision code, but the active D1 database may not yet have migration `0006_auth_team_access_review.sql` applied. That migration adds `auth_team_access_requests.decision_reason`. The decision code hard-depended on that column, so approve/reject could fall through to the generic 500 response.

## Changes

- Add schema detection for `auth_team_access_requests.decision_reason` using `PRAGMA table_info(auth_team_access_requests)`.
- Keep using `decision_reason` when the column exists.
- Fall back to `'' AS decision_reason` when listing requester access requests before the migration has landed.
- Omit `decision_reason` from approve/reject updates when the column is not present yet.
- Keep storing rejection reasons once migration `0006` has been applied.
- Update `tests/auth-team-access-review-route-state.test.js` to pin the migration-tolerant route contract.

## Scope controls

This hotfix does not change:

- D1 migrations
- route-permission declarations
- Team Admin authority checks
- self-approval blocking
- request status rules
- team membership semantics
- role assignment
- permission assignment

Approval still creates team membership only. It does not create roles or permission exceptions.

## Operational note

Migration `0006_auth_team_access_review.sql` should still be applied to live D1. This hotfix prevents the live journey from failing while deployment and schema state catch up, but rejection reason storage depends on the column being present.

## Validation

Not run locally in this connector context. Ready for CI.