### PR TITLE
Seed team access review D1 migration

### DIFF
--- a/.github/workflows/apply-d1-team-access-review.yml
+++ b/.github/workflows/apply-d1-team-access-review.yml
@@ -1,0 +1,143 @@
+name: Apply D1 Team Access Review
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "infra/cloudflare/migrations/0005_auth_team_access_requests.sql"
+      - "infra/cloudflare/migrations/0006_auth_team_access_review.sql"
+      - ".github/workflows/apply-d1-team-access-review.yml"
+  workflow_dispatch:
+    inputs:
+      confirm_database_name:
+        description: Type researchops-d1 to confirm the target D1 database
+        required: true
+        type: string
+      confirm_operation:
+        description: Type APPLY_TEAM_ACCESS_REVIEW to apply the team access migrations
+        required: true
+        type: string
+      run_post_apply_checks:
+        description: Run post-apply team access route and schema checks
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.90.0"
+  D1_DATABASE_NAME: "researchops-d1"
+  WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
+  TEAM_ACCESS_REQUESTS_MIGRATION: "infra/cloudflare/migrations/0005_auth_team_access_requests.sql"
+
+jobs:
+  apply:
+    name: Apply team access review migration to remote D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Confirm manual target
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm_database_name }}" != "${D1_DATABASE_NAME}" ]; then
+            echo "confirm_database_name must be ${D1_DATABASE_NAME}"
+            exit 1
+          fi
+
+          if [ "${{ inputs.confirm_operation }}" != "APPLY_TEAM_ACCESS_REVIEW" ]; then
+            echo "confirm_operation must be APPLY_TEAM_ACCESS_REVIEW"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Check migration file exists
+        run: test -f "${TEAM_ACCESS_REQUESTS_MIGRATION}"
+
+      - name: Apply team access request table migration to remote D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${TEAM_ACCESS_REQUESTS_MIGRATION}"
+
+      - name: Add decision reason column when missing
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --json \
+            --command "SELECT COUNT(*) AS total FROM pragma_table_info('auth_team_access_requests') WHERE name = 'decision_reason';" > decision-reason-column.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path('decision-reason-column.json').read_text())
+          text = json.dumps(data)
+          Path('decision-reason-needed.env').write_text('ADD_DECISION_REASON=false\n')
+          if '"total":0' in text or '"total": 0' in text:
+              Path('decision-reason-needed.env').write_text('ADD_DECISION_REASON=true\n')
+          PY
+
+          cat decision-reason-needed.env >> "${GITHUB_ENV}"
+
+      - name: Apply decision reason column migration
+        if: env.ADD_DECISION_REASON == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "ALTER TABLE auth_team_access_requests ADD COLUMN decision_reason TEXT;"
+
+      - name: Seed team access review route declarations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "INSERT OR IGNORE INTO auth_route_permissions (id, method, route_pattern, required_permissions_json, auth_required, implementation_status) VALUES ('route_api_team_access_requests_review_get', 'GET', '/api/team-access/requests/review', '[]', 1, 'implemented'), ('route_api_team_access_requests_approve_post', 'POST', '/api/team-access/requests/approve', '[]', 1, 'implemented'), ('route_api_team_access_requests_reject_post', 'POST', '/api/team-access/requests/reject', '[]', 1, 'implemented');"
+
+      - name: Check team access review schema and routes
+        if: ${{ github.event_name == 'push' || inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT name FROM pragma_table_info('auth_team_access_requests') WHERE name = 'decision_reason';"
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT method, route_pattern, implementation_status FROM auth_route_permissions WHERE route_pattern IN ('/api/team-access/requests', '/api/team-access/requests/review', '/api/team-access/requests/approve', '/api/team-access/requests/reject') ORDER BY route_pattern, method;"


### PR DESCRIPTION
## Summary

Fixes the missing D1 seed/apply path for team access review.

The file `infra/cloudflare/migrations/0006_auth_team_access_review.sql` exists, but repository inspection found no workflow or deploy path that applies it to live D1. Existing D1 apply workflows cover earlier auth migrations, and `deploy-worker.yml` applies passwordless, locked-status and registration-request migrations, but not the team access request/review migrations.

This PR adds a dedicated D1 apply workflow for the team access review journey.

## Changes

- Add `.github/workflows/apply-d1-team-access-review.yml`.
- Apply `infra/cloudflare/migrations/0005_auth_team_access_requests.sql` to ensure the request table exists.
- Add `auth_team_access_requests.decision_reason` only when missing.
- Seed the review, approve and reject route declarations with `INSERT OR IGNORE`.
- Add post-apply checks for the `decision_reason` column and team access route declarations.
- Run automatically on `main` when this workflow or the team access migration files change.
- Allow manual dispatch with explicit confirmation inputs.

## Operational effect

After this PR is merged into `main`, the workflow should apply the missing D1 setup to `researchops-d1`. That is the missing production seed/apply step for `0006_auth_team_access_review.sql`.

## Scope controls

This PR does not change Worker runtime code, page rendering, routes, D1 data beyond the intended schema/route seed, roles, permissions, or membership logic.

## Validation

Not run locally in this connector context. Ready for CI.