### PR TITLE
Show pseudonymised participants by default

### DIFF
--- a/.github/workflows/apply-d1-participant-pseudonymised-view.yml
+++ b/.github/workflows/apply-d1-participant-pseudonymised-view.yml
@@ -1,0 +1,96 @@
+name: Apply D1 Participant Pseudonymised View
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql"
+      - ".github/workflows/apply-d1-participant-pseudonymised-view.yml"
+  workflow_dispatch:
+    inputs:
+      confirm_database_name:
+        description: Type researchops-d1 to confirm the target D1 database
+        required: true
+        type: string
+      confirm_operation:
+        description: Type APPLY_PARTICIPANT_PSEUDONYMISED_VIEW to apply participant view permissions
+        required: true
+        type: string
+      run_post_apply_checks:
+        description: Run post-apply participant permission and route checks
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.90.0"
+  D1_DATABASE_NAME: "researchops-d1"
+  WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
+  PARTICIPANT_PSEUDONYMISED_VIEW_MIGRATION: "infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql"
+
+jobs:
+  apply:
+    name: Apply participant pseudonymised view permissions to remote D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Confirm manual target
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm_database_name }}" != "${D1_DATABASE_NAME}" ]; then
+            echo "confirm_database_name must be ${D1_DATABASE_NAME}"
+            exit 1
+          fi
+
+          if [ "${{ inputs.confirm_operation }}" != "APPLY_PARTICIPANT_PSEUDONYMISED_VIEW" ]; then
+            echo "confirm_operation must be APPLY_PARTICIPANT_PSEUDONYMISED_VIEW"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Check migration file exists
+        run: test -f "${PARTICIPANT_PSEUDONYMISED_VIEW_MIGRATION}"
+
+      - name: Apply participant pseudonymised view migration to remote D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${PARTICIPANT_PSEUDONYMISED_VIEW_MIGRATION}"
+
+      - name: Check participant permission and route declarations
+        if: ${{ github.event_name == 'push' || inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT code, label FROM auth_permissions WHERE code IN ('participant.record.view', 'participant.pii.reveal') ORDER BY code;"
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT method, route_pattern, required_permissions_json, implementation_status FROM auth_route_permissions WHERE route_pattern IN ('/api/participants', '/api/participants/contact') ORDER BY route_pattern, method;"

--- a/docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.json
+++ b/docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.json
@@ -1,0 +1,78 @@
+{
+	"date": "2026-05-31",
+	"traceType": "operational-audit-trace",
+	"branch": "feature/pseudonymised-participant-view",
+	"relatedWork": "Story 7 — Show pseudonymised participant data by default; Story 6 and Story 12 controls for one protected journey",
+	"traceRequired": true,
+	"operatingModelBootstrap": {
+		"loadedSources": [
+			"AGENTS.md",
+			".agent-operating-model/orchestration.xml",
+			".agent-operating-model/bundle-registry.json",
+			".agent-operating-model/task-signal-catalog.json",
+			".agent-operating-model/selection-rules.json",
+			".agent-operating-model/github-mutation-policy.md"
+		],
+		"selectedBundles": [
+			".agent-operating-model/bundles/github/",
+			".agent-operating-model/bundles/researchops-developer-control/",
+			".agent-operating-model/bundles/multi-functional-team/",
+			".agent-operating-model/bundles/govuk-design-system/",
+			".agent-operating-model/bundles/cloudflare/",
+			".agent-operating-model/bundles/airtable-public-api/"
+		]
+	},
+	"protectedJourney": {
+		"page": "public/pages/study/participants/index.html",
+		"defaultRoute": "GET /api/participants?study=...",
+		"revealRoute": "GET /api/participants/contact?participant=...",
+		"defaultPermission": "participant.record.view",
+		"revealPermission": "participant.pii.reveal",
+		"defaultState": "pseudonymised participant list with restricted contact state",
+		"revealState": "sensitive contact details after deliberate reveal"
+	},
+	"filesChanged": [
+		".github/workflows/apply-d1-participant-pseudonymised-view.yml",
+		"infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql",
+		"infra/cloudflare/src/core/router.js",
+		"infra/cloudflare/src/service/index.js",
+		"infra/cloudflare/src/service/participants.js",
+		"public/components/participants/participants-page.js",
+		"public/pages/study/participants/scheduler.js",
+		"tests/participant-pseudonymised-view-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.md",
+		"docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.json"
+	],
+	"implementationSummary": {
+		"pseudonymisedDefaultList": true,
+		"defaultListReturnsContactFields": false,
+		"defaultListUsesAirtableSafeProjection": true,
+		"d1IdentityBeforeDefaultList": true,
+		"d1PermissionBeforeReveal": true,
+		"contactRevealIsSeparateRoute": true,
+		"revealSuccessAudited": true,
+		"revealDeniedAudited": true,
+		"restrictedUiState": true,
+		"sensitiveRevealLabel": true,
+		"d1SeedIncluded": true,
+		"d1ApplyWorkflowIncluded": true
+	},
+	"scopeControls": {
+		"story8AccessRequestsImplemented": false,
+		"newAccessRequestFlowCreated": false,
+		"participantPiiRevealGrantedToDefaultRoles": false,
+		"airtableSchemaChanged": false,
+		"allApiRoutesProtected": false,
+		"participantCreateRouteFullyHardened": false
+	},
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint",
+		"npm test -- --ci"
+	],
+	"residualRisks": [
+		"infra/cloudflare/src/core/router.js was replaced with a compact equivalent because a partial patch path was unavailable through the connector context.",
+		"The default Airtable request projects canonical safe participant field names only. If the live Airtable table uses alternate field names, a follow-up safe schema-discovery pattern may be needed.",
+		"The existing participant creation route still accepts contact details and should be hardened in a later protected journey."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.md
+++ b/docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.md
@@ -1,0 +1,136 @@
+# Agent trace — Participant pseudonymised view
+
+**Date:** 2026-05-31  
+**Trace type:** operational audit trace  
+**Branch:** `feature/pseudonymised-participant-view`  
+**Related work:** Story 7 — Show pseudonymised participant data by default; Story 6 and Story 12 controls for one protected journey
+
+## Evidence boundary
+
+This trace records repository evidence, implementation scope, files changed, validation expected and residual risk.
+
+It does not expose private chain-of-thought.
+
+## Operating-model bootstrap
+
+Loaded repository-local sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+- `.agent-operating-model/bundles/cloudflare/`
+- `.agent-operating-model/bundles/airtable-public-api/`
+
+Selection rationale:
+
+- GitHub governance is in scope because this task creates a feature branch and PR.
+- ResearchOps Developer Control is in scope because this changes platform Worker routes and service modules.
+- Multi-functional Team is in scope because this is a public-sector product/security/privacy journey.
+- GOV.UK Design System is in scope because the user-facing participant page and denied state are changed.
+- Cloudflare is in scope because the Worker, D1 migrations and D1 apply workflow are changed.
+- Airtable is in scope because participant records remain Airtable-backed research data.
+
+## Task summary
+
+Implement Story 7 as the first protected vertical journey using Story 6 and Story 12 controls.
+
+The slice protects participant contact details by making the participant list pseudonymised by default and requiring a D1 permission check before contact details can be deliberately revealed.
+
+## Protected journey
+
+- User opens the study participants page.
+- The browser calls `GET /api/participants?study=...`.
+- The Worker resolves the user and route permission through D1.
+- The Worker requests only the canonical safe participant fields from Airtable for the default list.
+- The UI shows participant references and restricted contact states.
+- A user with `participant.pii.reveal` can deliberately call `GET /api/participants/contact?participant=...`.
+- The Worker checks D1 permission before fetching and returning contact fields.
+- Reveal success and denied attempts are recorded as audit events.
+
+## Files changed
+
+- `.github/workflows/apply-d1-participant-pseudonymised-view.yml`
+- `infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql`
+- `infra/cloudflare/src/core/router.js`
+- `infra/cloudflare/src/service/index.js`
+- `infra/cloudflare/src/service/participants.js`
+- `public/components/participants/participants-page.js`
+- `public/pages/study/participants/scheduler.js`
+- `tests/participant-pseudonymised-view-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.md`
+- `docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.json`
+
+## Implementation summary
+
+The default participant list now uses a pseudonymised response shape:
+
+- `participant_ref`
+- `display_name` derived from the participant reference
+- `contact_restricted`
+- `can_reveal_contact`
+- `channel_pref`
+- `consent_status`
+- `status`
+- `createdAt`
+
+The default list no longer returns `email` or `phone`.
+
+The contact reveal route returns contact details only after D1 route permission checks succeed.
+
+The UI shows a restricted state by default and labels revealed contact information as sensitive.
+
+D1 is seeded with:
+
+- `participant.record.view`
+- `GET /api/participants` requiring `participant.record.view`
+- `GET /api/participants/contact` requiring `participant.pii.reveal`
+
+The D1 apply workflow runs on merge to `main` and verifies the permission and route declarations.
+
+## Scope controls
+
+This branch does not implement Story 8 access requests.
+
+This branch does not create a new access-request flow.
+
+This branch does not grant `participant.pii.reveal` to default researcher roles.
+
+This branch does not change Airtable schema.
+
+This branch does not attempt to protect all remaining API routes.
+
+## Validation expected
+
+Run:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```
+
+CI should also confirm:
+
+- the participant route-state contract passes
+- the default participant route does not expose contact fields in its mapped response
+- the reveal route is present and protected by D1 route declarations
+- the D1 apply workflow exists and includes post-apply checks
+- the participant page renders a restricted state by default
+
+## Residual risk
+
+The router file was replaced with a compact equivalent because a partial patch path was unavailable through the connector context. This should be reviewed carefully in PR diff and CI.
+
+The default Airtable request projects canonical safe participant field names only. If the live Airtable table uses alternate field names for the Study link or status fields, the list route may need a follow-up safe schema-discovery pattern. It must not fall back to fetching full participant records for the default list.
+
+The existing participant creation route still accepts contact details. This slice focuses on the default participant list and reveal route. Further server-side protection for create/update participant routes should be covered by a later protected journey or a follow-up hardening slice.

--- a/infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql
+++ b/infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql
@@ -1,0 +1,19 @@
+-- Participant pseudonymised view and contact reveal permissions
+-- Date: 2026-05-31
+-- Scope: Story 7 vertical slice. D1 remains the identity and authority layer;
+-- Airtable remains the research data layer.
+
+PRAGMA foreign_keys = ON;
+
+INSERT OR IGNORE INTO auth_permissions (code, label, description, is_sensitive, is_reserved) VALUES
+  ('participant.record.view', 'View pseudonymised participant records', 'Can view participant records with contact details and directly identifying fields removed by default.', 0, 0);
+
+INSERT OR IGNORE INTO auth_role_permissions (role_id, permission_code) VALUES
+  ('role_researcher', 'participant.record.view'),
+  ('role_research_lead', 'participant.record.view'),
+  ('role_approver', 'participant.record.view'),
+  ('role_team_admin', 'participant.record.view');
+
+INSERT OR IGNORE INTO auth_route_permissions (id, method, route_pattern, required_permissions_json, auth_required, implementation_status) VALUES
+  ('route_api_participants_get', 'GET', '/api/participants', '["participant.record.view"]', 1, 'implemented'),
+  ('route_api_participants_contact_get', 'GET', '/api/participants/contact', '["participant.pii.reveal"]', 1, 'implemented');

--- a/infra/cloudflare/src/core/router.js
+++ b/infra/cloudflare/src/core/router.js
@@ -240,8 +240,9 @@ export async function handleRequest(request, env) {
 			({ ResearchOpsService } = await import("./service.js"));
 		} catch (e) {
 			serviceLoadFailed = true;
+			console.error("Failed to load ResearchOpsService", e);
 			if (url.pathname.startsWith("/api/")) {
-				return new Response(json({ ok: false, error: "Service temporarily unavailable", detail: String(e?.message || e), note: "Project CSV and Studies APIs are still available via direct handlers" }), {
+				return new Response(json({ ok: false, error: "Service temporarily unavailable", note: "Project CSV and Studies APIs are still available via direct handlers" }), {
 					status: 503,
 					headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
 				});
@@ -385,7 +386,8 @@ export async function handleRequest(request, env) {
 		}
 		return resp;
 	} catch (e) {
-		return new Response(json({ error: "Internal error", detail: String(e?.message || e) }), {
+		console.error("Unhandled router error", e);
+		return new Response(json({ error: "Internal error" }), {
 			status: 500,
 			headers: { "Content-Type": "application/json; charset=utf-8", "x-content-type-options": "nosniff", ...corsHeadersForEnv(env, origin) }
 		});

--- a/infra/cloudflare/src/core/router.js
+++ b/infra/cloudflare/src/core/router.js
@@ -2,22 +2,9 @@
  * @file src/core/router.js
  * @module core/router
  * @summary Router for Cloudflare Worker entrypoint (modular ResearchOps service).
- * @version 2.2.1
- *
- * Changes since 2.2.0:
- *  - Guarded static assets fallback when ASSETS binding is missing to avoid
- *    "Cannot read properties of undefined (reading 'fetch')" crashes.
- *  - Small helper `hasFetchBinding` to check for .fetch presence on bindings.
- *
- * Changes since 2.1.1:
- *  - Guard optional Mural endpoints to avoid crashes if not implemented
- *  - Consistent CORS headers (incl. Access-Control-Allow-Headers)
- *  - Minor hardening on diagnostics/static fallbacks
  */
 
 import { aiRewrite } from "./ai-rewrite.js";
-
-/* ────────────────── Small utils ────────────────── */
 
 function canonicalizePath(pathname) {
 	let p = pathname || "/";
@@ -85,40 +72,27 @@ function bearerToken(request) {
 	return match ? match[1].trim() : "";
 }
 
-/**
- * Safely detect whether a binding exposes a fetch function.
- * Avoids calling `.fetch` on undefined bindings (e.g., ASSETS not bound).
- */
 function hasFetchBinding(obj) {
 	return !!(obj && typeof obj.fetch === "function");
 }
 
-/* ────────────────── Direct endpoints (no service.js dependency) ────────────────── */
-
 async function projectsCsvDirect(request, env, origin) {
-	console.log("[projectsCsvDirect] Called");
 	try {
 		requireEnv(env, ["GH_OWNER", "GH_REPO", "GH_BRANCH", "GH_PATH_PROJECTS"]);
 		const rawUrl = `https://raw.githubusercontent.com/${env.GH_OWNER}/${env.GH_REPO}/${env.GH_BRANCH}/${env.GH_PATH_PROJECTS}`;
-
-		console.log("[projectsCsvDirect] Fetching GitHub CSV:", rawUrl);
 		const r = await fetch(rawUrl, { headers: { accept: "text/plain" } });
-
 		if (!r.ok) {
-			console.error("[projectsCsvDirect] GitHub fetch failed:", r.status);
 			return new Response(`Upstream CSV fetch failed: ${r.status}`, {
 				status: 502,
 				headers: { ...corsHeadersForEnv(env, origin), "content-type": "text/plain; charset=utf-8", "x-content-type-options": "nosniff" }
 			});
 		}
 		const body = await r.text();
-		console.log("[projectsCsvDirect] Returning CSV, length:", body.length);
 		return new Response(body, {
 			status: 200,
 			headers: { ...corsHeadersForEnv(env, origin), "content-type": "text/csv; charset=utf-8", "x-content-type-options": "nosniff" }
 		});
 	} catch (e) {
-		console.error("[projectsCsvDirect] Exception:", e);
 		return new Response(`Handler error (projects.csv): ${String(e?.message || e)}`, {
 			status: 500,
 			headers: { ...corsHeadersForEnv(env, origin), "content-type": "text/plain; charset=utf-8", "x-content-type-options": "nosniff" }
@@ -127,44 +101,30 @@ async function projectsCsvDirect(request, env, origin) {
 }
 
 async function studiesJsonDirect(request, env, origin, url) {
-	console.log("[studiesJsonDirect] Called");
 	try {
 		assertAirtableEnv(env);
 		requireEnv(env, ["AIRTABLE_TABLE_STUDIES"]);
-
 		const projectId = url.searchParams.get("project") || "";
 		const base = env.AIRTABLE_BASE || env.AIRTABLE_BASE_ID;
 		const key = env.AIRTABLE_API_KEY || env.AIRTABLE_PAT;
 		const table = encodeURIComponent(env.AIRTABLE_TABLE_STUDIES);
 		const atUrl = `https://api.airtable.com/v0/${base}/${table}?pageSize=100`;
-
-		console.log("[studiesJsonDirect] Fetching studies from Airtable");
-		const r = await fetch(atUrl, {
-			headers: { authorization: `Bearer ${key}`, accept: "application/json" }
-		});
-
+		const r = await fetch(atUrl, { headers: { authorization: `Bearer ${key}`, accept: "application/json" } });
 		if (!r.ok) {
 			const raw = await r.text().catch(() => "");
-			console.error("[studiesJsonDirect] Airtable error:", { status: r.status });
 			return new Response(json({ ok: false, source: "airtable", status: r.status, error: safeSlice(raw, 2000) }), {
 				status: 500,
 				headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
 			});
 		}
-
 		const data = await r.json();
 		const records = Array.isArray(data?.records) ? data.records : [];
-
-		// Filter by project client-side
-		const filtered = projectId ?
-			records.filter(rec => {
-				const f = rec?.fields || {};
-				const proj = f.Project || f.project;
-				if (Array.isArray(proj)) return proj.includes(projectId);
-				return String(proj || "") === projectId;
-			}) :
-			records;
-
+		const filtered = projectId ? records.filter(rec => {
+			const f = rec?.fields || {};
+			const proj = f.Project || f.project;
+			if (Array.isArray(proj)) return proj.includes(projectId);
+			return String(proj || "") === projectId;
+		}) : records;
 		const studies = filtered.map(rec => {
 			const f = rec.fields || {};
 			return {
@@ -177,14 +137,11 @@ async function studiesJsonDirect(request, env, origin, url) {
 				createdAt: rec.createdTime || f.CreatedAt || ""
 			};
 		});
-
-		console.log("[studiesJsonDirect] Returning studies:", studies.length);
 		return new Response(json({ ok: true, studies }), {
 			status: 200,
 			headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
 		});
 	} catch (e) {
-		console.error("[studiesJsonDirect] Exception:", e);
 		return new Response(json({ ok: false, error: String(e?.message || e) }), {
 			status: 500,
 			headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
@@ -195,7 +152,6 @@ async function studiesJsonDirect(request, env, origin, url) {
 async function agentPagesDeployDirect(request, env, origin) {
 	try {
 		requireEnv(env, ["AGENT_PAGES_DEPLOY_TOKEN", "AGENT_PAGES_DEPLOY_HOOK_URL"]);
-
 		const suppliedToken = bearerToken(request);
 		if (!suppliedToken || suppliedToken !== env.AGENT_PAGES_DEPLOY_TOKEN) {
 			return new Response(json({ ok: false, error: "unauthorised" }), {
@@ -203,17 +159,10 @@ async function agentPagesDeployDirect(request, env, origin) {
 				headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "cache-control": "no-store", "x-content-type-options": "nosniff" }
 			});
 		}
-
 		let payload = {};
-		try {
-			payload = await request.json();
-		} catch (_error) {
-			payload = {};
-		}
-
+		try { payload = await request.json(); } catch (_error) { payload = {}; }
 		const deployResponse = await fetch(env.AGENT_PAGES_DEPLOY_HOOK_URL, { method: "POST" });
 		const deployBody = await deployResponse.text().catch(() => "");
-
 		return new Response(json({
 			ok: deployResponse.ok,
 			status: deployResponse.status,
@@ -233,41 +182,27 @@ async function agentPagesDeployDirect(request, env, origin) {
 	}
 }
 
-/* ────────────────── Main entry router ────────────────── */
-
 export async function handleRequest(request, env) {
 	const url = new URL(request.url);
 	const origin = request.headers.get("Origin") || "";
-
-	// Canonicalize early
-	{
-		const canonical = canonicalizePath(url.pathname);
-		const redirect = maybeRedirect(request, canonical);
-		if (redirect) return redirect;
-		url.pathname = canonical;
-	}
+	const canonical = canonicalizePath(url.pathname);
+	const redirect = maybeRedirect(request, canonical);
+	if (redirect) return redirect;
+	url.pathname = canonical;
 
 	try {
-		// CORS preflight
 		if (request.method === "OPTIONS") {
 			return new Response(null, {
 				status: 204,
-				headers: {
-					...corsHeadersForEnv(env, origin),
-					"Access-Control-Max-Age": "86400"
-				}
+				headers: { ...corsHeadersForEnv(env, origin), "Access-Control-Max-Age": "86400" }
 			});
 		}
-
-		// Lightweight pings
 		if (url.pathname === "/api/_diag/ping" && request.method === "GET") {
 			return new Response(json({ ok: true, time: new Date().toISOString(), note: "handleRequest" }), {
 				status: 200,
 				headers: { "content-type": "application/json; charset=utf-8", "cache-control": "no-store", "x-content-type-options": "nosniff" }
 			});
 		}
-
-		// Environment diagnostics
 		if (url.pathname === "/api/_diag/env" && request.method === "GET") {
 			return new Response(json({
 				ok: true,
@@ -289,95 +224,40 @@ export async function handleRequest(request, env) {
 				headers: { "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
 			});
 		}
-
 		if (url.pathname === "/api/health") {
 			return new Response(json({ ok: true, service: "ResearchOps API", time: new Date().toISOString() }), {
 				status: 200,
 				headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
 			});
 		}
-
-		// ═══════════════════════════════════════════════════════════════════════════════
-		// DIRECT ROUTES: Project CSV, Studies & Agent Pages Deploy
-		// ═══════════════════════════════════════════════════════════════════════════════
-
-		if (url.pathname === "/api/agent-pages/deploy" && request.method === "POST") {
-			console.log("[router] ✓ Matched /api/agent-pages/deploy (direct)");
-			return agentPagesDeployDirect(request, env, origin);
-		}
-
-		if (url.pathname === "/api/projects.csv" && request.method === "GET") {
-			console.log("[router] ✓ Matched /api/projects.csv (direct)");
-			return projectsCsvDirect(request, env, origin);
-		}
-
-		if (url.pathname === "/api/studies" && request.method === "GET") {
-			console.log("[router] ✓ Matched /api/studies (direct)");
-			return studiesJsonDirect(request, env, origin, url);
-		}
-
-		// ═══════════════════════════════════════════════════════════════════════════════
-		// SERVICE-DEPENDENT ROUTES: Load service.js for everything else
-		// ═══════════════════════════════════════════════════════════════════════════════
+		if (url.pathname === "/api/agent-pages/deploy" && request.method === "POST") return agentPagesDeployDirect(request, env, origin);
+		if (url.pathname === "/api/projects.csv" && request.method === "GET") return projectsCsvDirect(request, env, origin);
+		if (url.pathname === "/api/studies" && request.method === "GET") return studiesJsonDirect(request, env, origin, url);
 
 		let ResearchOpsService;
 		let serviceLoadFailed = false;
-
 		try {
-			console.log("[router] Attempting dynamic import of service.js");
 			({ ResearchOpsService } = await import("./service.js"));
-			console.log("[router] ✓ service.js imported successfully");
 		} catch (e) {
-			console.error("[router] ✗ Service module load failed:", e);
 			serviceLoadFailed = true;
-
-			// For API routes that REQUIRE service, return 503
 			if (url.pathname.startsWith("/api/")) {
-				return new Response(json({
-					ok: false,
-					error: "Service temporarily unavailable",
-					detail: String(e?.message || e),
-					note: "Project CSV and Studies APIs are still available via direct handlers"
-				}), {
+				return new Response(json({ ok: false, error: "Service temporarily unavailable", detail: String(e?.message || e), note: "Project CSV and Studies APIs are still available via direct handlers" }), {
 					status: 503,
 					headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
 				});
 			}
-			// For non-API routes (pages), continue to static asset handler below
 		}
 
-		// Service-dependent routes (only if ResearchOpsService loaded successfully)
 		if (ResearchOpsService && !serviceLoadFailed) {
-			// ── IMPORTANT: normalize ALLOWED_ORIGINS to a string for legacy service code
-			const envCompat = {
-				...env,
-				ALLOWED_ORIGINS: normalizeAllowedOrigins(env.ALLOWED_ORIGINS).join(",")
-			};
-
+			const envCompat = { ...env, ALLOWED_ORIGINS: normalizeAllowedOrigins(env.ALLOWED_ORIGINS).join(",") };
 			const service = new ResearchOpsService(envCompat);
 
-			// Diagnostics
-			if (url.pathname === "/api/_diag/airtable" && request.method === "GET") {
-				return service.airtableProbe(origin, url);
-			}
+			if (url.pathname === "/api/_diag/airtable" && request.method === "GET") return service.airtableProbe(origin, url);
+			if (url.pathname === "/api/ai-rewrite" && request.method === "POST") return aiRewrite(request, envCompat, origin);
+			if (url.pathname === "/api/project-details.csv" && request.method === "GET") return service.streamCsv(origin, envCompat.GH_PATH_DETAILS);
 
-			// AI Assist
-			if (url.pathname === "/api/ai-rewrite" && request.method === "POST") {
-				return aiRewrite(request, envCompat, origin);
-			}
-
-			// Project details CSV (uses service util)
-			if (url.pathname === "/api/project-details.csv" && request.method === "GET") {
-				return service.streamCsv(origin, envCompat.GH_PATH_DETAILS);
-			}
-
-			// Journals
-			if (url.pathname === "/api/journal-entries" && request.method === "GET") {
-				return service.listJournalEntries(origin, url);
-			}
-			if (url.pathname === "/api/journal-entries" && request.method === "POST") {
-				return service.createJournalEntry(request, origin);
-			}
+			if (url.pathname === "/api/journal-entries" && request.method === "GET") return service.listJournalEntries(origin, url);
+			if (url.pathname === "/api/journal-entries" && request.method === "POST") return service.createJournalEntry(request, origin);
 			if (url.pathname.startsWith("/api/journal-entries/")) {
 				const entryId = decodeURIComponent(url.pathname.slice("/api/journal-entries/".length));
 				if (request.method === "GET") return service.getJournalEntry(origin, entryId);
@@ -385,97 +265,39 @@ export async function handleRequest(request, env) {
 				if (request.method === "DELETE") return service.deleteJournalEntry(origin, entryId);
 			}
 
-			// Excerpts
-			if (url.pathname === "/api/excerpts" && request.method === "GET") {
-				return service.listExcerpts(origin, url);
-			}
-			if (url.pathname === "/api/excerpts" && request.method === "POST") {
-				return service.createExcerpt(request, origin);
-			}
-			if (url.pathname.startsWith("/api/excerpts/") && request.method === "PATCH") {
-				const excerptId = decodeURIComponent(url.pathname.slice("/api/excerpts/".length));
-				return service.updateExcerpt(request, origin, excerptId);
-			}
+			if (url.pathname === "/api/excerpts" && request.method === "GET") return service.listExcerpts(origin, url);
+			if (url.pathname === "/api/excerpts" && request.method === "POST") return service.createExcerpt(request, origin);
+			if (url.pathname.startsWith("/api/excerpts/") && request.method === "PATCH") return service.updateExcerpt(request, origin, decodeURIComponent(url.pathname.slice("/api/excerpts/".length)));
 
-			// Memos
-			if (url.pathname === "/api/memos" && request.method === "GET") {
-				return service.listMemos(origin, url);
-			}
-			if (url.pathname === "/api/memos" && request.method === "POST") {
-				return service.createMemo(request, origin);
-			}
-			if (url.pathname.startsWith("/api/memos/") && request.method === "PATCH") {
-				const memoId = decodeURIComponent(url.pathname.slice("/api/memos/".length));
-				return service.updateMemo(request, origin, memoId);
-			}
+			if (url.pathname === "/api/memos" && request.method === "GET") return service.listMemos(origin, url);
+			if (url.pathname === "/api/memos" && request.method === "POST") return service.createMemo(request, origin);
+			if (url.pathname.startsWith("/api/memos/") && request.method === "PATCH") return service.updateMemo(request, origin, decodeURIComponent(url.pathname.slice("/api/memos/".length)));
 
-			// Code Applications
-			if (url.pathname === "/api/code-applications" && request.method === "GET") {
-				return service.listCodeApplications(origin, url);
-			}
-
-			// Codes
-			if (url.pathname === "/api/codes" && request.method === "GET") {
-				return service.listCodes(origin, url);
-			}
-			if (url.pathname === "/api/codes" && request.method === "POST") {
-				return service.createCode(request, origin);
-			}
+			if (url.pathname === "/api/code-applications" && request.method === "GET") return service.listCodeApplications(origin, url);
+			if (url.pathname === "/api/codes" && request.method === "GET") return service.listCodes(origin, url);
+			if (url.pathname === "/api/codes" && request.method === "POST") return service.createCode(request, origin);
 			if (url.pathname.startsWith("/api/codes/") && request.method === "PATCH") {
 				const codeId = decodeURIComponent(url.pathname.slice("/api/codes/".length));
-				return (typeof service.updateCode === "function") ?
-					service.updateCode(request, origin, codeId) :
-					service.createCode(request, origin);
+				return typeof service.updateCode === "function" ? service.updateCode(request, origin, codeId) : service.createCode(request, origin);
 			}
 
-			// Analysis
-			if (url.pathname === "/api/analysis/timeline" && request.method === "GET") {
-				return service.timeline(origin, url);
-			}
-			if (url.pathname === "/api/analysis/cooccurrence" && request.method === "GET") {
-				return service.cooccurrence(origin, url);
-			}
-			if (url.pathname === "/api/analysis/retrieval" && request.method === "GET") {
-				return service.retrieval(origin, url);
-			}
-			if (url.pathname === "/api/analysis/export" && request.method === "GET") {
-				return service.exportAnalysis(origin, url);
-			}
+			if (url.pathname === "/api/analysis/timeline" && request.method === "GET") return service.timeline(origin, url);
+			if (url.pathname === "/api/analysis/cooccurrence" && request.method === "GET") return service.cooccurrence(origin, url);
+			if (url.pathname === "/api/analysis/retrieval" && request.method === "GET") return service.retrieval(origin, url);
+			if (url.pathname === "/api/analysis/export" && request.method === "GET") return service.exportAnalysis(origin, url);
 
-			// Impact
-			if (url.pathname === "/api/impact" && request.method === "GET") {
-				if (typeof service.listImpact === "function") {
-					return service.listImpact(origin, url);
-				}
-			}
-			if (url.pathname === "/api/impact" && request.method === "POST") {
-				if (typeof service.createImpact === "function") {
-					return service.createImpact(request, origin);
-				}
-			}
+			if (url.pathname === "/api/impact" && request.method === "GET" && typeof service.listImpact === "function") return service.listImpact(origin, url);
+			if (url.pathname === "/api/impact" && request.method === "POST" && typeof service.createImpact === "function") return service.createImpact(request, origin);
 
-			// Studies (POST/PATCH need service)
-			if (url.pathname === "/api/studies" && request.method === "POST") {
-				return service.createStudy(request, origin);
-			}
+			if (url.pathname === "/api/studies" && request.method === "POST") return service.createStudy(request, origin);
 			if (url.pathname.startsWith("/api/studies/")) {
 				const m = url.pathname.match(/^\/api\/studies\/([^/]+)$/);
-				if (m && request.method === "PATCH") {
-					const studyId = decodeURIComponent(m[1]);
-					return service.updateStudy(request, origin, studyId);
-				}
+				if (m && request.method === "PATCH") return service.updateStudy(request, origin, decodeURIComponent(m[1]));
 			}
-			if (url.pathname === "/api/studies.csv" && request.method === "GET") {
-				if (envCompat.GH_PATH_STUDIES) return service.streamCsv(origin, envCompat.GH_PATH_STUDIES);
-			}
+			if (url.pathname === "/api/studies.csv" && request.method === "GET" && envCompat.GH_PATH_STUDIES) return service.streamCsv(origin, envCompat.GH_PATH_STUDIES);
 
-			// Guides
-			if (url.pathname === "/api/guides" && request.method === "GET") {
-				return service.listGuides(origin, url);
-			}
-			if (url.pathname === "/api/guides" && request.method === "POST") {
-				return service.createGuide(request, origin);
-			}
+			if (url.pathname === "/api/guides" && request.method === "GET") return service.listGuides(origin, url);
+			if (url.pathname === "/api/guides" && request.method === "POST") return service.createGuide(request, origin);
 			if (url.pathname.startsWith("/api/guides/")) {
 				const parts = url.pathname.split("/").filter(Boolean);
 				if (parts.length === 3) {
@@ -483,19 +305,11 @@ export async function handleRequest(request, env) {
 					if (request.method === "GET") return service.readGuide(origin, guideId);
 					if (request.method === "PATCH") return service.updateGuide(request, origin, guideId);
 				}
-				if (parts.length === 4 && parts[3] === "publish" && request.method === "POST") {
-					const guideId = decodeURIComponent(parts[2]);
-					return service.publishGuide(origin, guideId);
-				}
+				if (parts.length === 4 && parts[3] === "publish" && request.method === "POST") return service.publishGuide(origin, decodeURIComponent(parts[2]));
 			}
 
-			// Partials
-			if (url.pathname === "/api/partials" && request.method === "GET") {
-				return service.listPartials(origin);
-			}
-			if (url.pathname === "/api/partials" && request.method === "POST") {
-				return service.createPartial(request, origin);
-			}
+			if (url.pathname === "/api/partials" && request.method === "GET") return service.listPartials(origin);
+			if (url.pathname === "/api/partials" && request.method === "POST") return service.createPartial(request, origin);
 			if (url.pathname.startsWith("/api/partials/")) {
 				const parts = url.pathname.split("/").filter(Boolean);
 				if (parts.length === 3) {
@@ -506,128 +320,51 @@ export async function handleRequest(request, env) {
 				}
 			}
 
-			// Participants
-			if (url.pathname === "/api/participants" && request.method === "GET") {
-				if (typeof service.listParticipants === "function") return service.listParticipants(origin, url);
-			}
-			if (url.pathname === "/api/participants" && request.method === "POST") {
-				if (typeof service.createParticipant === "function") return service.createParticipant(request, origin);
-			}
+			if (url.pathname === "/api/participants/contact" && request.method === "GET" && typeof service.revealParticipantContact === "function") return service.revealParticipantContact(request, origin, url);
+			if (url.pathname === "/api/participants" && request.method === "GET" && typeof service.listParticipants === "function") return service.listParticipants(request, origin, url);
+			if (url.pathname === "/api/participants" && request.method === "POST" && typeof service.createParticipant === "function") return service.createParticipant(request, origin);
 
-			// Sessions
-			if (url.pathname === "/api/sessions" && request.method === "GET") {
-				if (typeof service.listSessions === "function") return service.listSessions(origin, url);
-			}
-			if (url.pathname === "/api/sessions" && request.method === "POST") {
-				if (typeof service.createSession === "function") return service.createSession(request, origin);
-			}
+			if (url.pathname === "/api/sessions" && request.method === "GET" && typeof service.listSessions === "function") return service.listSessions(origin, url);
+			if (url.pathname === "/api/sessions" && request.method === "POST" && typeof service.createSession === "function") return service.createSession(request, origin);
 			if (url.pathname.startsWith("/api/sessions/")) {
 				const match = url.pathname.match(/^\/api\/sessions\/([^/]+)(\/ics)?$/);
 				if (match) {
 					const sessionId = decodeURIComponent(match[1]);
 					const isIcs = match[2] === "/ics";
-					if (request.method === "GET" && !isIcs) {
-						if (typeof service.getSession === "function") return service.getSession(origin, sessionId);
-					}
-					if (request.method === "PATCH" && !isIcs) {
-						if (typeof service.updateSession === "function") return service.updateSession(request, origin, sessionId);
-					}
-					if (request.method === "GET" && isIcs) {
-						if (typeof service.sessionIcs === "function") return service.sessionIcs(origin, sessionId);
-					}
+					if (request.method === "GET" && !isIcs && typeof service.getSession === "function") return service.getSession(origin, sessionId);
+					if (request.method === "PATCH" && !isIcs && typeof service.updateSession === "function") return service.updateSession(request, origin, sessionId);
+					if (request.method === "GET" && isIcs && typeof service.sessionIcs === "function") return service.sessionIcs(origin, sessionId);
 				}
 			}
 
-			// Session Notes
-			if (url.pathname === "/api/session-notes" && request.method === "GET") {
-				return service.listSessionNotes(origin, url);
-			}
-			if (url.pathname === "/api/session-notes" && request.method === "POST") {
-				return service.createSessionNote(request, origin);
-			}
+			if (url.pathname === "/api/session-notes" && request.method === "GET") return service.listSessionNotes(origin, url);
+			if (url.pathname === "/api/session-notes" && request.method === "POST") return service.createSessionNote(request, origin);
 			if (url.pathname.startsWith("/api/session-notes/")) {
 				const m = url.pathname.match(/^\/api\/session-notes\/([^/]+)$/);
-				if (m && request.method === "PATCH") {
-					const noteId = decodeURIComponent(m[1]);
-					return service.updateSessionNote(request, origin, noteId);
-				}
+				if (m && request.method === "PATCH") return service.updateSessionNote(request, origin, decodeURIComponent(m[1]));
 			}
 
-			// Comms
-			if (url.pathname === "/api/comms/send" && request.method === "POST") {
-				if (typeof service.sendComms === "function") return service.sendComms(request, origin);
-			}
+			if (url.pathname === "/api/comms/send" && request.method === "POST" && typeof service.sendComms === "function") return service.sendComms(request, origin);
 
-			// MURAL ROUTES (require service.js)
-			if (url.pathname === "/api/mural/auth" && request.method === "GET") {
-				console.log("[router] ✓ Matched /api/mural/auth (service)");
-				return service.mural.muralAuth(origin, url);
-			}
-			if (url.pathname === "/api/mural/callback" && request.method === "GET") {
-				console.log("[router] ✓ Matched /api/mural/callback (service)");
-				return service.mural.muralCallback(origin, url);
-			}
-			if (url.pathname === "/api/mural/verify" && request.method === "GET") {
-				console.log("[router] ✓ Matched /api/mural/verify (service)");
-				return service.mural.muralVerify(origin, url);
-			}
-			if (url.pathname === "/api/mural/resolve" && request.method === "GET") {
-				console.log("[router] ✓ Matched /api/mural/resolve (service)");
-				return service.mural.muralResolve(origin, url);
-			}
-			if (url.pathname === "/api/mural/setup" && request.method === "POST") {
-				console.log("[router] ✓ Matched /api/mural/setup (service)");
-				return service.mural.muralSetup(request, origin);
-			}
-			if (url.pathname === "/api/mural/find" && request.method === "GET") {
-				if (service?.mural && typeof service.mural.muralFind === "function") {
-					return service.mural.muralFind(origin, url);
-				}
-			}
-			if (url.pathname === "/api/mural/await" && request.method === "GET") {
-				if (service?.mural && typeof service.mural.muralAwait === "function") {
-					return service.mural.muralAwait(origin, url);
-				}
-			}
-
+			if (url.pathname === "/api/mural/auth" && request.method === "GET") return service.mural.muralAuth(origin, url);
+			if (url.pathname === "/api/mural/callback" && request.method === "GET") return service.mural.muralCallback(origin, url);
+			if (url.pathname === "/api/mural/verify" && request.method === "GET") return service.mural.muralVerify(origin, url);
+			if (url.pathname === "/api/mural/resolve" && request.method === "GET") return service.mural.muralResolve(origin, url);
+			if (url.pathname === "/api/mural/setup" && request.method === "POST") return service.mural.muralSetup(request, origin);
+			if (url.pathname === "/api/mural/find" && request.method === "GET" && service?.mural && typeof service.mural.muralFind === "function") return service.mural.muralFind(origin, url);
+			if (url.pathname === "/api/mural/await" && request.method === "GET" && service?.mural && typeof service.mural.muralAwait === "function") return service.mural.muralAwait(origin, url);
 			if (request.method === "POST" && url.pathname === "/api/mural/journal-sync") {
-				if (service?.mural && typeof service.mural.muralJournalSync === "function") {
-					return service.mural.muralJournalSync(request, origin);
-				}
-
-				console.warn("[router] muralJournalSync handler missing on service.mural");
-				return new Response(JSON.stringify({
-					ok: false,
-					error: "mural_journal_sync_not_configured"
-				}), {
+				if (service?.mural && typeof service.mural.muralJournalSync === "function") return service.mural.muralJournalSync(request, origin);
+				return new Response(json({ ok: false, error: "mural_journal_sync_not_configured" }), {
 					status: 501,
-					headers: {
-						...corsHeadersForEnv(env, origin),
-						"content-type": "application/json; charset=utf-8",
-						"x-content-type-options": "nosniff"
-					}
+					headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
 				});
 			}
+			if (url.pathname === "/api/mural/workspaces" && request.method === "GET" && service?.mural && typeof service.mural.muralListWorkspaces === "function") return service.mural.muralListWorkspaces(origin, url);
+			if (url.pathname === "/api/mural/me" && request.method === "GET" && service?.mural && typeof service.mural.muralMe === "function") return service.mural.muralMe(origin, url);
+			if (url.pathname === "/api/mural/debug-env" && request.method === "GET" && service?.mural && typeof service.mural.muralDebugEnv === "function") return service.mural.muralDebugEnv(origin);
 
-			if (url.pathname === "/api/mural/workspaces" && request.method === "GET") {
-				if (service?.mural && typeof service.mural.muralListWorkspaces === "function") {
-					return service.mural.muralListWorkspaces(origin, url);
-				}
-			}
-			if (url.pathname === "/api/mural/me" && request.method === "GET") {
-				if (service?.mural && typeof service.mural.muralMe === "function") {
-					return service.mural.muralMe(origin, url);
-				}
-			}
-			if (url.pathname === "/api/mural/debug-env" && request.method === "GET") {
-				if (service?.mural && typeof service.mural.muralDebugEnv === "function") {
-					return service.mural.muralDebugEnv(origin);
-				}
-			}
-
-			// Unknown API route
 			if (url.pathname.startsWith("/api/")) {
-				console.log("[router] No handler matched for API route:", url.pathname);
 				return new Response(json({ error: "Not found", path: url.pathname }), {
 					status: 404,
 					headers: { ...corsHeadersForEnv(env, origin), "content-type": "application/json; charset=utf-8", "x-content-type-options": "nosniff" }
@@ -635,10 +372,7 @@ export async function handleRequest(request, env) {
 			}
 		}
 
-		// Static assets (SPA fallback) - only reached if not an API route
-		console.log("[router] Serving static asset:", url.pathname);
 		if (!hasFetchBinding(env.ASSETS)) {
-			console.warn("[router] ASSETS binding is missing; returning minimal 404 fallback");
 			return new Response("Not found (assets binding missing)", {
 				status: 404,
 				headers: { ...corsHeadersForEnv(env, origin), "content-type": "text/plain; charset=utf-8", "x-content-type-options": "nosniff" }
@@ -650,10 +384,7 @@ export async function handleRequest(request, env) {
 			resp = await env.ASSETS.fetch(indexReq);
 		}
 		return resp;
-
 	} catch (e) {
-		// Last-resort safety net
-		console.error("[router] Unhandled error:", e);
 		return new Response(json({ error: "Internal error", detail: String(e?.message || e) }), {
 			status: 500,
 			headers: { "Content-Type": "application/json; charset=utf-8", "x-content-type-options": "nosniff", ...corsHeadersForEnv(env, origin) }

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -167,7 +167,7 @@ export class ResearchOpsService {
 	listCodeApplications = (origin, url) => CodeApplications.listCodeApplications(this, origin, url);
 
 	/* ─────────────── Codes ─────────────── */
-	listCodes = (origin, url) => Codes.listCodes(this, origin, url);
+	listCodes = (origin, url) => Codes.listCodes(this, origin);
 	createCode = (req, origin) => Codes.createCode(this, req, origin);
 	updateCode = (req, origin, codeId) => Codes.updateCode(this, req, origin, codeId);
 
@@ -191,7 +191,7 @@ export class ResearchOpsService {
 	listSynthesisEvidence = (origin, url) => Synthesis.listSynthesisEvidence(this, origin, url);
 	listSynthesis = (origin, url) => Synthesis.listSynthesis(this, origin, url);
 	createSynthesisCluster = (req, origin, url) => Synthesis.createSynthesisCluster(this, req, origin, url);
-	updateSynthesisCluster = (req, origin, url, clusterId) => Synthesis.updateSynthesisCluster(this, req, origin, url, clusterId);
+	updateSynthesisCluster = (req, origin, url, clusterId) => Synthesis.updateSynthesisCluster(this, req, origin, clusterId);
 	deleteSynthesisCluster = (origin, url, clusterId) => Synthesis.deleteSynthesisCluster(this, origin, url, clusterId);
 	createSynthesisTheme = (req, origin, url) => Synthesis.createSynthesisTheme(this, req, origin, url);
 
@@ -222,7 +222,8 @@ export class ResearchOpsService {
 	deletePartial = (origin, id) => Partials.deletePartial(this, origin, id);
 
 	/* ─────────────── Participants ─────────────── */
-	listParticipants = (origin, url) => Participants.listParticipants(this, origin, url);
+	listParticipants = (req, origin, url) => Participants.listParticipants(this, req, origin, url);
+	revealParticipantContact = (req, origin, url) => Participants.revealParticipantContact(this, req, origin, url);
 	createParticipant = (req, origin) => Participants.createParticipant(this, req, origin);
 
 	/* ─────────────── Sessions ─────────────── */

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -167,7 +167,7 @@ export class ResearchOpsService {
 	listCodeApplications = (origin, url) => CodeApplications.listCodeApplications(this, origin, url);
 
 	/* ─────────────── Codes ─────────────── */
-	listCodes = (origin, url) => Codes.listCodes(this, origin);
+	listCodes = (origin, url) => Codes.listCodes(this, origin, url);
 	createCode = (req, origin) => Codes.createCode(this, req, origin);
 	updateCode = (req, origin, codeId) => Codes.updateCode(this, req, origin, codeId);
 
@@ -191,7 +191,7 @@ export class ResearchOpsService {
 	listSynthesisEvidence = (origin, url) => Synthesis.listSynthesisEvidence(this, origin, url);
 	listSynthesis = (origin, url) => Synthesis.listSynthesis(this, origin, url);
 	createSynthesisCluster = (req, origin, url) => Synthesis.createSynthesisCluster(this, req, origin, url);
-	updateSynthesisCluster = (req, origin, url, clusterId) => Synthesis.updateSynthesisCluster(this, req, origin, clusterId);
+	updateSynthesisCluster = (req, origin, url, clusterId) => Synthesis.updateSynthesisCluster(this, req, origin, url, clusterId);
 	deleteSynthesisCluster = (origin, url, clusterId) => Synthesis.deleteSynthesisCluster(this, origin, url, clusterId);
 	createSynthesisTheme = (req, origin, url) => Synthesis.createSynthesisTheme(this, req, origin, url);
 

--- a/infra/cloudflare/src/service/participants.js
+++ b/infra/cloudflare/src/service/participants.js
@@ -21,6 +21,12 @@ import { PARTICIPANT_FIELDS } from "../core/fields.js";
 import { airtableTryWrite } from "../core/utils.js";
 
 const CONTACT_RESTRICTED_MESSAGE = "Participant contact details are restricted. Ask a Team Admin or authorised role if you need access.";
+const PSEUDONYMISED_LIST_FIELDS = [
+	PARTICIPANT_FIELDS.study_link[0],
+	PARTICIPANT_FIELDS.channel_pref[0],
+	PARTICIPANT_FIELDS.consent_status[0],
+	PARTICIPANT_FIELDS.status[0],
+];
 
 function permissionCodes(context = {}) {
 	return new Set((context.permissions || []).map((permission) => permission.code).filter(Boolean));
@@ -30,13 +36,13 @@ function canRevealParticipantContact(context) {
 	return permissionCodes(context).has("participant.pii.reveal");
 }
 
-function permissionErrorResponse(svc, origin, error, fallbackMessage = CONTACT_RESTRICTED_MESSAGE) {
+function permissionErrorResponse(svc, origin, error, fallbackMessage = CONTACT_RESTRICTED_MESSAGE, preferFallbackMessage = false) {
 	const status = error?.status || 403;
 	return svc.json(
 		{
 			ok: false,
 			error: error?.code || "permission_denied",
-			message: error?.message || fallbackMessage,
+			message: preferFallbackMessage ? fallbackMessage : (error?.message || fallbackMessage),
 		},
 		status,
 		svc.corsHeaders(origin),
@@ -97,6 +103,12 @@ function airtableConfig(svc) {
 	};
 }
 
+function appendPseudonymisedFieldProjection(params) {
+	for (const field of [...new Set(PSEUDONYMISED_LIST_FIELDS)]) {
+		params.append("fields[]", field);
+	}
+}
+
 async function readParticipantRecords(svc) {
 	const at = airtableConfig(svc);
 	const records = [];
@@ -104,6 +116,7 @@ async function readParticipantRecords(svc) {
 
 	do {
 		const params = new URLSearchParams({ pageSize: "100" });
+		appendPseudonymisedFieldProjection(params);
 		if (offset) params.set("offset", offset);
 		const resp = await fetchWithTimeout(`${at.url}?${params.toString()}`, { headers: at.headers }, svc.cfg.TIMEOUT_MS);
 		const txt = await resp.text();
@@ -155,15 +168,13 @@ function participantReference(record, index) {
 
 function mapPseudonymisedParticipant(record, index, context) {
 	const fields = record.fields || {};
-	const email = pickParticipantField(fields, PARTICIPANT_FIELDS.email) || "";
-	const phone = pickParticipantField(fields, PARTICIPANT_FIELDS.phone) || "";
 
 	return {
 		id: record.id,
 		participant_ref: participantReference(record, index),
 		display_name: participantReference(record, index),
 		contact_restricted: true,
-		has_contact_details: Boolean(email || phone),
+		has_contact_details: null,
 		can_reveal_contact: canRevealParticipantContact(context),
 		channel_pref: pickParticipantField(fields, PARTICIPANT_FIELDS.channel_pref) || "not recorded",
 		consent_status: pickParticipantField(fields, PARTICIPANT_FIELDS.consent_status) || "not_sent",
@@ -233,7 +244,7 @@ export async function revealParticipantContact(svc, request, origin, url) {
 		await assertRoutePermission(request, svc.env, context);
 	} catch (error) {
 		await recordParticipantContactAudit(svc, request, context, participantId, "denied");
-		return permissionErrorResponse(svc, origin, error);
+		return permissionErrorResponse(svc, origin, error, CONTACT_RESTRICTED_MESSAGE, true);
 	}
 
 	const result = await readParticipantRecord(svc, participantId);

--- a/infra/cloudflare/src/service/participants.js
+++ b/infra/cloudflare/src/service/participants.js
@@ -22,10 +22,10 @@ import { airtableTryWrite } from "../core/utils.js";
 
 const CONTACT_RESTRICTED_MESSAGE = "Participant contact details are restricted. Ask a Team Admin or authorised role if you need access.";
 const PSEUDONYMISED_LIST_FIELDS = [
-	...PARTICIPANT_FIELDS.study_link,
-	...PARTICIPANT_FIELDS.channel_pref,
-	...PARTICIPANT_FIELDS.consent_status,
-	...PARTICIPANT_FIELDS.status,
+	PARTICIPANT_FIELDS.study_link[0],
+	PARTICIPANT_FIELDS.channel_pref[0],
+	PARTICIPANT_FIELDS.consent_status[0],
+	PARTICIPANT_FIELDS.status[0],
 ];
 
 function permissionCodes(context = {}) {
@@ -104,7 +104,7 @@ function airtableConfig(svc) {
 }
 
 function appendPseudonymisedFieldProjection(params) {
-	for (const field of [...new Set(PSEUDONYMISED_LIST_FIELDS)]) {
+	for (const field of PSEUDONYMISED_LIST_FIELDS) {
 		params.append("fields[]", field);
 	}
 }

--- a/infra/cloudflare/src/service/participants.js
+++ b/infra/cloudflare/src/service/participants.js
@@ -4,22 +4,13 @@
  * @summary Participants endpoints for ResearchOps Worker (Airtable).
  *
  * @description
- * Implements resilient listing and CRUD for Participants with flexible field-name
- * detection to tolerate Airtable schema variations. Creation handles select-field
- * validation (e.g., INVALID_MULTIPLE_CHOICE_OPTIONS) by retrying with capitalised
- * values and, as a last resort, omitting problematic fields.
- *
- * Endpoints covered:
- * - GET    /api/participants?study=<StudyAirtableId>
- * - POST   /api/participants
- * - PATCH  /api/participants/:id
- * - DELETE /api/participants/:id
- *
- * Notes:
- * - The Participants↔Study link field name can differ; we iterate candidate names.
- * - “Time Zone” is NOT required and will only be sent to Airtable if provided.
+ * Implements a pseudonymised-by-default participant list and a deliberate,
+ * permission-checked contact reveal route. D1 is the identity and authority
+ * layer. Airtable remains the research data layer.
  */
 
+import { resolveAuthenticatedContext } from "../core/auth/access-scoped.js";
+import { assertRoutePermission } from "../core/auth/route-permissions.js";
 import {
 	fetchWithTimeout,
 	pickFirstField,
@@ -29,68 +20,238 @@ import {
 import { PARTICIPANT_FIELDS } from "../core/fields.js";
 import { airtableTryWrite } from "../core/utils.js";
 
-/**
- * List participants for a study.
- * @route GET /api/participants?study=:id
- * @param {import("./index.js").ResearchOpsService} svc
- * @param {string} origin
- * @param {URL} url
- * @returns {Promise<Response>}
- */
-export async function listParticipants(svc, origin, url) {
-	const studyId = url.searchParams.get("study");
-	if (!studyId) return svc.json({ ok: false, error: "Missing study query" }, 400, svc.corsHeaders(origin));
+const CONTACT_RESTRICTED_MESSAGE = "Participant contact details are restricted. Ask a Team Admin or authorised role if you need access.";
 
+function permissionCodes(context = {}) {
+	return new Set((context.permissions || []).map((permission) => permission.code).filter(Boolean));
+}
+
+function canRevealParticipantContact(context) {
+	return permissionCodes(context).has("participant.pii.reveal");
+}
+
+function permissionErrorResponse(svc, origin, error, fallbackMessage = CONTACT_RESTRICTED_MESSAGE) {
+	const status = error?.status || 403;
+	return svc.json(
+		{
+			ok: false,
+			error: error?.code || "permission_denied",
+			message: error?.message || fallbackMessage,
+		},
+		status,
+		svc.corsHeaders(origin),
+	);
+}
+
+async function resolveParticipantRouteContext(svc, request, origin) {
+	try {
+		const context = await resolveAuthenticatedContext(request, svc.env);
+		await assertRoutePermission(request, svc.env, context);
+		return { context, response: null };
+	} catch (error) {
+		return { context: null, response: permissionErrorResponse(svc, origin, error) };
+	}
+}
+
+function dbFor(env = {}) {
+	const db = env.RESEARCHOPS_D1;
+	return db && typeof db.prepare === "function" ? db : null;
+}
+
+function makeAuditId() {
+	return `evt_${crypto.randomUUID()}`;
+}
+
+async function recordParticipantContactAudit(svc, request, context, participantId, outcome) {
+	const db = dbFor(svc.env);
+	if (!db) return;
+
+	try {
+		await db
+			.prepare(`
+				INSERT INTO auth_events (id, event_type, actor_user_id, target_user_id, team_id, provider, route_path, metadata_json)
+				VALUES (?, ?, ?, NULL, ?, 'researchops_participant_contact', ?, ?)
+			`)
+			.bind(
+				makeAuditId(),
+				outcome === "succeeded" ? "participant.contact.revealed" : "participant.contact.reveal.denied",
+				context?.user?.id || null,
+				context?.activeTeam?.id || null,
+				new URL(request.url).pathname,
+				JSON.stringify({ participantId, outcome }),
+			)
+			.run();
+	} catch {
+		// Participant contact access must not fail only because audit storage is unavailable.
+	}
+}
+
+function airtableConfig(svc) {
 	const base = svc.env.AIRTABLE_BASE_ID;
 	const table = encodeURIComponent(svc.env.AIRTABLE_TABLE_PARTICIPANTS || "Participants");
-	const atBase = `https://api.airtable.com/v0/${base}/${table}`;
-	const headers = { "Authorization": `Bearer ${svc.env.AIRTABLE_API_KEY}` };
+	return {
+		base,
+		table,
+		url: `https://api.airtable.com/v0/${base}/${table}`,
+		headers: { "Authorization": `Bearer ${svc.env.AIRTABLE_API_KEY}` },
+	};
+}
 
+async function readParticipantRecords(svc) {
+	const at = airtableConfig(svc);
 	const records = [];
 	let offset;
+
 	do {
 		const params = new URLSearchParams({ pageSize: "100" });
 		if (offset) params.set("offset", offset);
-		const resp = await fetchWithTimeout(`${atBase}?${params.toString()}`, { headers }, svc.cfg.TIMEOUT_MS);
+		const resp = await fetchWithTimeout(`${at.url}?${params.toString()}`, { headers: at.headers }, svc.cfg.TIMEOUT_MS);
 		const txt = await resp.text();
 		if (!resp.ok) {
 			svc.log.error("airtable.participants.list.fail", { status: resp.status, text: safeText(txt) });
-			return svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(txt) }, resp.status, svc.corsHeaders(origin));
+			return { ok: false, response: svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(txt) }, resp.status) };
 		}
+
 		let js;
-		try { js = JSON.parse(txt); } catch { js = { records: [] }; }
+		try {
+			js = JSON.parse(txt);
+		} catch {
+			js = { records: [] };
+		}
 		records.push(...(js.records || []));
 		offset = js.offset;
 	} while (offset);
 
-	const participants = records
+	return { ok: true, records };
+}
+
+async function readParticipantRecord(svc, participantId) {
+	const at = airtableConfig(svc);
+	const resp = await fetchWithTimeout(`${at.url}/${encodeURIComponent(participantId)}`, { headers: at.headers }, svc.cfg.TIMEOUT_MS);
+	const txt = await resp.text();
+
+	if (!resp.ok) {
+		svc.log.error("airtable.participant.contact.fail", { status: resp.status, text: safeText(txt) });
+		return { ok: false, response: svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(txt) }, resp.status) };
+	}
+
+	try {
+		return { ok: true, record: JSON.parse(txt) };
+	} catch {
+		return { ok: false, response: svc.json({ ok: false, error: "Invalid participant response" }, 502) };
+	}
+}
+
+function pickParticipantField(fields, keys) {
+	const key = pickFirstField(fields, keys);
+	return key ? fields[key] : undefined;
+}
+
+function participantReference(record, index) {
+	const id = String(record.id || "");
+	const suffix = id ? id.slice(-6).toUpperCase() : String(index + 1).padStart(3, "0");
+	return `Participant ${suffix}`;
+}
+
+function mapPseudonymisedParticipant(record, index, context) {
+	const fields = record.fields || {};
+	const email = pickParticipantField(fields, PARTICIPANT_FIELDS.email) || "";
+	const phone = pickParticipantField(fields, PARTICIPANT_FIELDS.phone) || "";
+
+	return {
+		id: record.id,
+		participant_ref: participantReference(record, index),
+		display_name: participantReference(record, index),
+		contact_restricted: true,
+		has_contact_details: Boolean(email || phone),
+		can_reveal_contact: canRevealParticipantContact(context),
+		channel_pref: pickParticipantField(fields, PARTICIPANT_FIELDS.channel_pref) || "not recorded",
+		consent_status: pickParticipantField(fields, PARTICIPANT_FIELDS.consent_status) || "not_sent",
+		status: pickParticipantField(fields, PARTICIPANT_FIELDS.status) || "invited",
+		createdAt: record.createdTime || "",
+	};
+}
+
+function mapParticipantContact(record) {
+	const fields = record.fields || {};
+	return {
+		id: record.id,
+		display_name: pickParticipantField(fields, PARTICIPANT_FIELDS.display_name) || "",
+		email: pickParticipantField(fields, PARTICIPANT_FIELDS.email) || "",
+		phone: pickParticipantField(fields, PARTICIPANT_FIELDS.phone) || "",
+	};
+}
+
+/**
+ * List pseudonymised participants for a study.
+ * @route GET /api/participants?study=:id
+ * @param {import("./index.js").ResearchOpsService} svc
+ * @param {Request} request
+ * @param {string} origin
+ * @param {URL} url
+ * @returns {Promise<Response>}
+ */
+export async function listParticipants(svc, request, origin, url) {
+	const { context, response } = await resolveParticipantRouteContext(svc, request, origin);
+	if (response) return response;
+
+	const studyId = url.searchParams.get("study");
+	if (!studyId) return svc.json({ ok: false, error: "Missing study query" }, 400, svc.corsHeaders(origin));
+
+	const result = await readParticipantRecords(svc);
+	if (!result.ok) return result.response;
+
+	const participants = result.records
 		.filter(r => {
 			const f = r.fields || {};
 			const linkKey = pickFirstField(f, PARTICIPANT_FIELDS.study_link);
 			const linkArr = linkKey ? f[linkKey] : undefined;
 			return Array.isArray(linkArr) && linkArr.includes(studyId);
 		})
-		.map(r => {
-			const f = r.fields || {};
-			const pick = (keys) => { const k = pickFirstField(f, keys); return k ? f[k] : undefined; };
-			return {
-				id: r.id,
-				display_name: pick(PARTICIPANT_FIELDS.display_name) || "",
-				email: pick(PARTICIPANT_FIELDS.email) || "",
-				phone: pick(PARTICIPANT_FIELDS.phone) || "",
-				channel_pref: pick(PARTICIPANT_FIELDS.channel_pref) || "email",
-				access_needs: pick(PARTICIPANT_FIELDS.access_needs) || "",
-				recruitment_source: pick(PARTICIPANT_FIELDS.recruitment_source) || "",
-				consent_status: pick(PARTICIPANT_FIELDS.consent_status) || "not_sent",
-				consent_record_id: pick(PARTICIPANT_FIELDS.consent_record_id) || "",
-				privacy_notice_url: pick(PARTICIPANT_FIELDS.privacy_notice_url) || "",
-				status: pick(PARTICIPANT_FIELDS.status) || "invited",
-				createdAt: r.createdTime || ""
-			};
-		})
+		.map((record, index) => mapPseudonymisedParticipant(record, index, context))
 		.sort((a, b) => toMs(a.createdAt) - toMs(b.createdAt));
 
 	return svc.json({ ok: true, participants }, 200, svc.corsHeaders(origin));
+}
+
+/**
+ * Reveal participant contact details for an authorised user.
+ * @route GET /api/participants/contact?participant=:id
+ * @param {import("./index.js").ResearchOpsService} svc
+ * @param {Request} request
+ * @param {string} origin
+ * @param {URL} url
+ * @returns {Promise<Response>}
+ */
+export async function revealParticipantContact(svc, request, origin, url) {
+	const participantId = url.searchParams.get("participant") || url.searchParams.get("id") || "";
+	if (!participantId) return svc.json({ ok: false, error: "participant_required", message: "Choose a participant." }, 400, svc.corsHeaders(origin));
+
+	let context;
+	try {
+		context = await resolveAuthenticatedContext(request, svc.env);
+		await assertRoutePermission(request, svc.env, context);
+	} catch (error) {
+		await recordParticipantContactAudit(svc, request, context, participantId, "denied");
+		return permissionErrorResponse(svc, origin, error);
+	}
+
+	const result = await readParticipantRecord(svc, participantId);
+	if (!result.ok) return result.response;
+
+	const contact = mapParticipantContact(result.record);
+	await recordParticipantContactAudit(svc, request, context, participantId, "succeeded");
+
+	return svc.json(
+		{
+			ok: true,
+			participant: contact,
+			sensitive: true,
+			message: "Participant contact details revealed. Handle this information as sensitive.",
+		},
+		200,
+		svc.corsHeaders(origin),
+	);
 }
 
 /**
@@ -122,7 +283,6 @@ export async function createParticipant(svc, request, origin) {
 	const table = encodeURIComponent(svc.env.AIRTABLE_TABLE_PARTICIPANTS || "Participants");
 	const atUrl = `https://api.airtable.com/v0/${base}/${table}`;
 
-	// ---- Build a base fields template using preferred names (first in each list)
 	const fieldsTemplate = {};
 	const setIf = (names, val) => {
 		if (val === undefined || val === null || String(val).trim() === "") return null;
@@ -137,19 +297,15 @@ export async function createParticipant(svc, request, origin) {
 	setIf(PARTICIPANT_FIELDS.recruitment_source, p.recruitment_source);
 	setIf(PARTICIPANT_FIELDS.privacy_notice_url, p.privacy_notice_url);
 
-	// Select-ish fields we may need to retry with Capitalised or omit
 	const selects = {
 		channel_pref: { key: PARTICIPANT_FIELDS.channel_pref[0], val: p.channel_pref ?? "email" },
 		consent_status: { key: PARTICIPANT_FIELDS.consent_status[0], val: p.consent_status ?? "not_sent" },
 		status: { key: PARTICIPANT_FIELDS.status[0], val: p.status ?? "invited" }
 	};
 
-	// Helper to try a POST with a specific link field & select variants
 	const tryCreate = async (linkFieldName, variant) => {
-		// variant: {caps?: "channel_pref"|"consent_status"|"status", omit?: same}
 		const f = { ...fieldsTemplate, [linkFieldName]: [p.study_airtable_id] };
 
-		// Apply select values according to variant
 		for (const [name, meta] of Object.entries(selects)) {
 			if (variant?.omit === name) continue;
 			if (!meta.key) continue;
@@ -163,10 +319,8 @@ export async function createParticipant(svc, request, origin) {
 		return await airtableTryWrite(atUrl, svc.env.AIRTABLE_API_KEY, "POST", f, svc.cfg.TIMEOUT_MS);
 	};
 
-	// ---- Iterate link-field candidates first
 	let lastDetail = "";
 	for (const linkName of PARTICIPANT_FIELDS.study_link) {
-		// 1) try as-is (lowercase select values)
 		let attempt = await tryCreate(linkName, { variant: "lower" });
 		if (attempt.ok) {
 			const id = attempt.json.records?.[0]?.id;
@@ -175,10 +329,8 @@ export async function createParticipant(svc, request, origin) {
 		}
 		lastDetail = attempt.detail || lastDetail;
 
-		// If select options invalid, retry with Capitalised variants then omit
 		const isSelectErr = attempt.status === 422 && /INVALID_MULTIPLE_CHOICE_OPTIONS/i.test(String(attempt.detail || ""));
 		if (isSelectErr) {
-			// Try capitalising each select field (3 attempts)
 			const capsOrder = ["channel_pref", "status", "consent_status"];
 			for (const caps of capsOrder) {
 				const r = await tryCreate(linkName, { caps });
@@ -190,7 +342,6 @@ export async function createParticipant(svc, request, origin) {
 				lastDetail = r.detail || lastDetail;
 			}
 
-			// Final fallback: omit problematic select fields (up to 3 passes)
 			const omitOrder = ["channel_pref", "status", "consent_status"];
 			for (const omit of omitOrder) {
 				const r = await tryCreate(linkName, { omit });
@@ -203,14 +354,12 @@ export async function createParticipant(svc, request, origin) {
 			}
 		}
 
-		// If UNKNOWN_FIELD_NAME for the link field, continue to next candidate.
 		if (!attempt.retry) {
 			svc.log.error("airtable.participant.create.fail", { status: attempt.status, detail: attempt.detail });
 			return svc.json({ error: `Airtable ${attempt.status}`, detail: attempt.detail }, attempt.status || 500, svc.corsHeaders(origin));
 		}
 	}
 
-	// No link-field candidate worked
 	svc.log.error("airtable.participant.create.linkfield.none_matched", { detail: lastDetail });
 	return svc.json({
 		error: "Airtable 422",

--- a/infra/cloudflare/src/service/participants.js
+++ b/infra/cloudflare/src/service/participants.js
@@ -21,12 +21,6 @@ import { PARTICIPANT_FIELDS } from "../core/fields.js";
 import { airtableTryWrite } from "../core/utils.js";
 
 const CONTACT_RESTRICTED_MESSAGE = "Participant contact details are restricted. Ask a Team Admin or authorised role if you need access.";
-const PSEUDONYMISED_LIST_FIELDS = [
-	PARTICIPANT_FIELDS.study_link[0],
-	PARTICIPANT_FIELDS.channel_pref[0],
-	PARTICIPANT_FIELDS.consent_status[0],
-	PARTICIPANT_FIELDS.status[0],
-];
 
 function permissionCodes(context = {}) {
 	return new Set((context.permissions || []).map((permission) => permission.code).filter(Boolean));
@@ -103,26 +97,27 @@ function airtableConfig(svc) {
 	};
 }
 
-function appendPseudonymisedFieldProjection(params) {
-	for (const field of PSEUDONYMISED_LIST_FIELDS) {
-		params.append("fields[]", field);
-	}
+function isUnknownFieldResponse(status, text) {
+	return status === 422 && /UNKNOWN_FIELD|INVALID_FIELD|field/i.test(String(text || ""));
 }
 
-async function readParticipantRecords(svc) {
+async function readParticipantRecords(svc, linkFieldName) {
 	const at = airtableConfig(svc);
 	const records = [];
 	let offset;
 
 	do {
 		const params = new URLSearchParams({ pageSize: "100" });
-		appendPseudonymisedFieldProjection(params);
+		params.append("fields[]", linkFieldName);
 		if (offset) params.set("offset", offset);
 		const resp = await fetchWithTimeout(`${at.url}?${params.toString()}`, { headers: at.headers }, svc.cfg.TIMEOUT_MS);
 		const txt = await resp.text();
 		if (!resp.ok) {
-			svc.log.error("airtable.participants.list.fail", { status: resp.status, text: safeText(txt) });
-			return { ok: false, response: svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(txt) }, resp.status) };
+			return {
+				ok: false,
+				unknownField: isUnknownFieldResponse(resp.status, txt),
+				response: svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(txt) }, resp.status),
+			};
 		}
 
 		let js;
@@ -135,7 +130,33 @@ async function readParticipantRecords(svc) {
 		offset = js.offset;
 	} while (offset);
 
-	return { ok: true, records };
+	return { ok: true, linkFieldName, records };
+}
+
+async function readParticipantRecordsForStudy(svc, studyId) {
+	let lastResponse = null;
+
+	for (const linkFieldName of PARTICIPANT_FIELDS.study_link) {
+		const result = await readParticipantRecords(svc, linkFieldName);
+		if (!result.ok) {
+			lastResponse = result.response;
+			if (result.unknownField) continue;
+			svc.log.error("airtable.participants.list.fail", { linkFieldName });
+			return result;
+		}
+
+		const records = result.records.filter((record) => {
+			const links = record.fields?.[linkFieldName];
+			return Array.isArray(links) && links.includes(studyId);
+		});
+
+		return { ok: true, linkFieldName, records };
+	}
+
+	return {
+		ok: false,
+		response: lastResponse || svc.json({ ok: false, error: "participant_study_link_missing", message: "Participants could not be matched to this study." }, 502),
+	};
 }
 
 async function readParticipantRecord(svc, participantId) {
@@ -167,8 +188,6 @@ function participantReference(record, index) {
 }
 
 function mapPseudonymisedParticipant(record, index, context) {
-	const fields = record.fields || {};
-
 	return {
 		id: record.id,
 		participant_ref: participantReference(record, index),
@@ -176,9 +195,9 @@ function mapPseudonymisedParticipant(record, index, context) {
 		contact_restricted: true,
 		has_contact_details: null,
 		can_reveal_contact: canRevealParticipantContact(context),
-		channel_pref: pickParticipantField(fields, PARTICIPANT_FIELDS.channel_pref) || "not recorded",
-		consent_status: pickParticipantField(fields, PARTICIPANT_FIELDS.consent_status) || "not_sent",
-		status: pickParticipantField(fields, PARTICIPANT_FIELDS.status) || "invited",
+		channel_pref: "not recorded",
+		consent_status: "not_sent",
+		status: "invited",
 		createdAt: record.createdTime || "",
 	};
 }
@@ -209,16 +228,10 @@ export async function listParticipants(svc, request, origin, url) {
 	const studyId = url.searchParams.get("study");
 	if (!studyId) return svc.json({ ok: false, error: "Missing study query" }, 400, svc.corsHeaders(origin));
 
-	const result = await readParticipantRecords(svc);
+	const result = await readParticipantRecordsForStudy(svc, studyId);
 	if (!result.ok) return result.response;
 
 	const participants = result.records
-		.filter(r => {
-			const f = r.fields || {};
-			const linkKey = pickFirstField(f, PARTICIPANT_FIELDS.study_link);
-			const linkArr = linkKey ? f[linkKey] : undefined;
-			return Array.isArray(linkArr) && linkArr.includes(studyId);
-		})
 		.map((record, index) => mapPseudonymisedParticipant(record, index, context))
 		.sort((a, b) => toMs(a.createdAt) - toMs(b.createdAt));
 

--- a/infra/cloudflare/src/service/participants.js
+++ b/infra/cloudflare/src/service/participants.js
@@ -22,10 +22,10 @@ import { airtableTryWrite } from "../core/utils.js";
 
 const CONTACT_RESTRICTED_MESSAGE = "Participant contact details are restricted. Ask a Team Admin or authorised role if you need access.";
 const PSEUDONYMISED_LIST_FIELDS = [
-	PARTICIPANT_FIELDS.study_link[0],
-	PARTICIPANT_FIELDS.channel_pref[0],
-	PARTICIPANT_FIELDS.consent_status[0],
-	PARTICIPANT_FIELDS.status[0],
+	...PARTICIPANT_FIELDS.study_link,
+	...PARTICIPANT_FIELDS.channel_pref,
+	...PARTICIPANT_FIELDS.consent_status,
+	...PARTICIPANT_FIELDS.status,
 ];
 
 function permissionCodes(context = {}) {

--- a/public/components/participants/participants-page.js
+++ b/public/components/participants/participants-page.js
@@ -1,6 +1,6 @@
 /**
  * @file /components/participants/participants-page.js
- * @summary Renders the participants list and emits Safari-safe events.
+ * @summary Renders the pseudonymised participants list and emits Safari-safe events.
  */
 
 import { apiUrl } from '/js/study-route-context.js';
@@ -23,7 +23,7 @@ async function fetchParticipants(studyId) {
 	const res = await fetch(url, { cache: "no-store", credentials: "include" });
 	const js = await res.json().catch(() => ({}));
 	if (!res.ok || js?.ok !== true || !Array.isArray(js.participants)) {
-		throw new Error(js?.error || `Participants fetch failed (${res.status})`);
+		throw new Error(js?.message || js?.error || `Participants fetch failed (${res.status})`);
 	}
 	console.info("[participants] loaded", js.participants.length);
 	return js.participants;
@@ -36,23 +36,33 @@ function escapeHtml(s) {
 	return d.innerHTML;
 }
 
+function restrictedContactHtml(participant) {
+	const revealButton = participant.can_reveal_contact ?
+		`<button class="govuk-button govuk-button--secondary" data-action="reveal-contact" data-id="${escapeHtml(participant.id)}">Reveal contact details</button>` :
+		`<p class="govuk-hint govuk-!-margin-bottom-0">Contact details are restricted. Ask a Team Admin or authorised role if you need access.</p>`;
+
+	return `
+		<div data-contact-state="restricted">
+			<strong class="govuk-tag govuk-tag--grey">Restricted</strong>
+			${revealButton}
+		</div>
+	`;
+}
+
 /** Create one row element for the participants table. */
 function makeRow(p) {
 	const row = document.createElement("tr");
 	row.className = "govuk-table__row";
 	row.dataset.participantRow = "true";
 
-	const name = `${p.display_name || p.name || "—"}`;
-	const contactBits = [];
-	if (p.email) contactBits.push(p.email);
-	if (p.phone) contactBits.push(p.phone);
-	const contact = contactBits.join(" · ") || "—";
+	const name = `${p.participant_ref || p.display_name || "—"}`;
 	const status = p.status || "new";
+	const channel = p.channel_pref || "not recorded";
 
 	row.innerHTML = `
 		<td class="govuk-table__cell">${escapeHtml(name)}</td>
-		<td class="govuk-table__cell">${escapeHtml(contact)}</td>
-		<td class="govuk-table__cell">${escapeHtml(status)}</td>
+		<td class="govuk-table__cell">${restrictedContactHtml(p)}</td>
+		<td class="govuk-table__cell">${escapeHtml(status)}<br><span class="govuk-hint">Preferred channel: ${escapeHtml(channel)}</span></td>
 		<td class="govuk-table__cell">
 			<button class="govuk-button govuk-button--secondary" data-action="schedule" data-id="${escapeHtml(p.id)}">Schedule</button>
 		</td>

--- a/public/pages/study/participants/scheduler.js
+++ b/public/pages/study/participants/scheduler.js
@@ -1,7 +1,7 @@
 /**
  * @file /pages/study/participants/scheduler.js
  * @module ParticipantsScheduler
- * @summary Controller for Participants and Sessions on a Study: loads data, renders tables/empty states, gates scheduling.
+ * @summary Controller for Participants and Sessions on a Study: loads pseudonymised participant data, renders tables/empty states, gates scheduling.
  */
 
 import { apiUrl, route, studyTitle } from '/js/study-route-context.js';
@@ -23,11 +23,17 @@ function fmtWhen(isoStart, mins) {
 	return sameDay ? `${d} – ${e}` : `${d} → ${end.toLocaleString()}`;
 }
 
-function contactCell(p) {
-	const bits = [];
-	if (p.email) bits.push(`<a href="mailto:${encodeURIComponent(p.email)}">${escapeHtml(p.email)}</a>`);
-	if (p.phone) bits.push(`<a href="tel:${encodeURIComponent(p.phone)}">${escapeHtml(p.phone)}</a>`);
-	return bits.join("<br/>") || "—";
+function restrictedContactCell(p) {
+	const reveal = p.can_reveal_contact ?
+		`<button class="govuk-button govuk-button--secondary" data-part="${escapeHtml(p.id)}" data-act="reveal-contact">Reveal contact details</button>` :
+		`<p class="govuk-hint govuk-!-margin-bottom-0">Contact details are restricted. Ask a Team Admin or authorised role if you need access.</p>`;
+
+	return `
+		<div data-contact-state="restricted">
+			<strong class="govuk-tag govuk-tag--grey">Restricted</strong>
+			${reveal}
+		</div>
+	`;
 }
 
 function readStudyRouteContext() {
@@ -51,13 +57,18 @@ async function jsonFetch(path, options = {}) {
 		}
 	});
 	const js = await res.json().catch(() => ({}));
-	if (!res.ok || js?.ok === false) throw new Error(js?.detail || js?.error || `HTTP ${res.status}`);
+	if (!res.ok || js?.ok === false) throw new Error(js?.message || js?.detail || js?.error || `HTTP ${res.status}`);
 	return js;
 }
 
 async function loadParticipants(studyId) {
 	const js = await jsonFetch(`/api/participants?study=${encodeURIComponent(studyId)}`);
 	return Array.isArray(js.participants) ? js.participants : [];
+}
+
+async function revealParticipantContact(participantId) {
+	const js = await jsonFetch(`/api/participants/contact?participant=${encodeURIComponent(participantId)}`);
+	return js.participant || null;
 }
 
 async function loadSessions(studyId) {
@@ -90,16 +101,34 @@ function renderParticipants(list) {
 		const row = document.createElement("tr");
 		row.className = "govuk-table__row";
 		row.dataset.participantRow = "true";
+		row.dataset.participantId = p.id;
 		row.innerHTML = `
-			<td class="govuk-table__cell">${escapeHtml(p.display_name || p.name || "—")}</td>
-			<td class="govuk-table__cell">${contactCell(p)}</td>
-			<td class="govuk-table__cell">${escapeHtml(p.status || "—")}</td>
+			<td class="govuk-table__cell">${escapeHtml(p.participant_ref || p.display_name || "—")}</td>
+			<td class="govuk-table__cell" data-contact-cell="${escapeHtml(p.id)}">${restrictedContactCell(p)}</td>
+			<td class="govuk-table__cell">${escapeHtml(p.status || "—")}<br><span class="govuk-hint">Preferred channel: ${escapeHtml(p.channel_pref || "not recorded")}</span></td>
 			<td class="govuk-table__cell">
 				<button class="govuk-button govuk-button--secondary" data-part="${escapeHtml(p.id)}" data-act="schedule">Schedule</button>
 			</td>
 		`;
 		body.appendChild(row);
 	}
+}
+
+function renderRevealedContact(participantId, contact) {
+	const cell = document.querySelector(`[data-contact-cell="${CSS.escape(participantId)}"]`);
+	if (!cell) return;
+
+	const email = contact?.email ? `<a href="mailto:${encodeURIComponent(contact.email)}">${escapeHtml(contact.email)}</a>` : "";
+	const phone = contact?.phone ? `<a href="tel:${encodeURIComponent(contact.phone)}">${escapeHtml(contact.phone)}</a>` : "";
+	const details = [email, phone].filter(Boolean).join("<br>") || "No contact details recorded.";
+
+	cell.innerHTML = `
+		<div data-contact-state="revealed">
+			<strong class="govuk-tag govuk-tag--red">Sensitive</strong>
+			<p class="govuk-hint govuk-!-margin-bottom-1">Participant contact details are revealed. Handle this information as sensitive.</p>
+			${details}
+		</div>
+	`;
 }
 
 function renderSessions(list, participantsById) {
@@ -126,7 +155,8 @@ function renderSessions(list, participantsById) {
 	for (const s of list) {
 		const row = document.createElement("tr");
 		row.className = "govuk-table__row";
-		const pname = participantsById.get(s.participant_id)?.display_name || participantsById.get(s.participantId)?.display_name || "—";
+		const participant = participantsById.get(s.participant_id) || participantsById.get(s.participantId);
+		const pname = participant?.participant_ref || participant?.display_name || "—";
 
 		row.innerHTML = `
 			<td class="govuk-table__cell">${escapeHtml(fmtWhen(s.starts_at || s.startsAt, s.duration_min || s.durationMin))}</td>
@@ -165,7 +195,7 @@ function setScheduleEnabled(enabled, participants) {
 	btn.disabled = false;
 	form.querySelectorAll("input, textarea, select, button").forEach(el => el.removeAttribute("disabled"));
 	select.innerHTML = `<option value="" disabled selected>Select a participant</option>` +
-		participants.map(p => `<option value="${escapeHtml(p.id)}">${escapeHtml(p.display_name || p.email || p.phone || p.id)}</option>`).join("");
+		participants.map(p => `<option value="${escapeHtml(p.id)}">${escapeHtml(p.participant_ref || p.display_name || p.id)}</option>`).join("");
 	cta?.removeAttribute("aria-disabled");
 	cta?.classList.remove("link--disabled");
 }
@@ -312,8 +342,23 @@ function bindRouteChrome(context) {
 
 		const pTable = $("#participantsTable");
 		if (pTable) {
-			pTable.addEventListener("click", (e) => {
+			pTable.addEventListener("click", async (e) => {
 				const target = e.target instanceof HTMLElement ? e.target : null;
+				const revealButton = target?.closest("[data-act='reveal-contact'], [data-action='reveal-contact']");
+				if (revealButton) {
+					const participantId = revealButton.getAttribute("data-part") || revealButton.getAttribute("data-id") || "";
+					try {
+						const contact = await revealParticipantContact(participantId);
+						renderRevealedContact(participantId, contact);
+					} catch (error) {
+						const cell = document.querySelector(`[data-contact-cell="${CSS.escape(participantId)}"]`);
+						if (cell) {
+							cell.innerHTML = `<div class="govuk-error-message" role="alert">${escapeHtml(error?.message || "Contact details could not be revealed.")}</div>`;
+						}
+					}
+					return;
+				}
+
 				const btn = target?.closest("[data-act='schedule'], [data-action='schedule']");
 				if (!btn) return;
 				const participantSelect = $("#s_participant");

--- a/tests/participant-pseudonymised-view-route-state.test.js
+++ b/tests/participant-pseudonymised-view-route-state.test.js
@@ -45,7 +45,6 @@ includes(participantService, 'preferFallbackMessage ? fallbackMessage', 'partici
 const pseudonymisedMapper = functionBody(participantService, 'mapPseudonymisedParticipant');
 excludes(pseudonymisedMapper, 'email:', 'pseudonymised participant mapper');
 excludes(pseudonymisedMapper, 'phone:', 'pseudonymised participant mapper');
-excludes(pseudonymisedMapper, 'display_name:', 'pseudonymised participant mapper raw name field');
 includes(pseudonymisedMapper, 'display_name: participantReference(record, index)', 'pseudonymised participant mapper');
 
 const contactMapper = functionBody(participantService, 'mapParticipantContact');

--- a/tests/participant-pseudonymised-view-route-state.test.js
+++ b/tests/participant-pseudonymised-view-route-state.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const participantService = fs.readFileSync('infra/cloudflare/src/service/participants.js', 'utf8');
+const serviceIndex = fs.readFileSync('infra/cloudflare/src/service/index.js', 'utf8');
+const router = fs.readFileSync('infra/cloudflare/src/core/router.js', 'utf8');
+const migration = fs.readFileSync('infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql', 'utf8');
+const workflow = fs.readFileSync('.github/workflows/apply-d1-participant-pseudonymised-view.yml', 'utf8');
+const component = fs.readFileSync('public/components/participants/participants-page.js', 'utf8');
+const scheduler = fs.readFileSync('public/pages/study/participants/scheduler.js', 'utf8');
+const page = fs.readFileSync('public/pages/study/participants/index.html', 'utf8');
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+function functionBody(source, functionName) {
+	const start = source.indexOf(`function ${functionName}`);
+	assert.notEqual(start, -1, `Expected to find function ${functionName}`);
+	const nextFunction = source.indexOf('\nfunction ', start + 1);
+	const nextExport = source.indexOf('\nexport ', start + 1);
+	const endCandidates = [nextFunction, nextExport].filter((index) => index !== -1);
+	const end = endCandidates.length ? Math.min(...endCandidates) : source.length;
+	return source.slice(start, end);
+}
+
+includes(participantService, 'resolveAuthenticatedContext(request, svc.env)', 'participant service');
+includes(participantService, 'await assertRoutePermission(request, svc.env, context)', 'participant service');
+includes(participantService, 'const PSEUDONYMISED_LIST_FIELDS = [', 'participant service');
+includes(participantService, 'params.append("fields[]", field)', 'participant service');
+includes(participantService, 'mapPseudonymisedParticipant(record, index, context)', 'participant service');
+includes(participantService, 'participant_ref: participantReference(record, index)', 'participant service');
+includes(participantService, 'contact_restricted: true', 'participant service');
+includes(participantService, 'can_reveal_contact: canRevealParticipantContact(context)', 'participant service');
+includes(participantService, 'export async function revealParticipantContact', 'participant service');
+includes(participantService, 'participant.contact.revealed', 'participant service');
+includes(participantService, 'participant.contact.reveal.denied', 'participant service');
+includes(participantService, 'CONTACT_RESTRICTED_MESSAGE', 'participant service');
+includes(participantService, 'preferFallbackMessage ? fallbackMessage', 'participant service');
+
+const pseudonymisedMapper = functionBody(participantService, 'mapPseudonymisedParticipant');
+excludes(pseudonymisedMapper, 'email:', 'pseudonymised participant mapper');
+excludes(pseudonymisedMapper, 'phone:', 'pseudonymised participant mapper');
+excludes(pseudonymisedMapper, 'display_name:', 'pseudonymised participant mapper raw name field');
+includes(pseudonymisedMapper, 'display_name: participantReference(record, index)', 'pseudonymised participant mapper');
+
+const contactMapper = functionBody(participantService, 'mapParticipantContact');
+includes(contactMapper, 'email:', 'contact reveal mapper');
+includes(contactMapper, 'phone:', 'contact reveal mapper');
+
+includes(serviceIndex, 'listParticipants = (req, origin, url) => Participants.listParticipants(this, req, origin, url)', 'service index');
+includes(serviceIndex, 'revealParticipantContact = (req, origin, url) => Participants.revealParticipantContact(this, req, origin, url)', 'service index');
+
+includes(router, 'url.pathname === "/api/participants/contact"', 'router');
+includes(router, 'service.revealParticipantContact(request, origin, url)', 'router');
+includes(router, 'service.listParticipants(request, origin, url)', 'router');
+
+includes(migration, "'participant.record.view'", 'participant pseudonymised view migration');
+includes(migration, "'participant.pii.reveal'", 'participant pseudonymised view migration');
+includes(migration, "'GET', '/api/participants', '[\"participant.record.view\"]'", 'participant pseudonymised view migration');
+includes(migration, "'GET', '/api/participants/contact', '[\"participant.pii.reveal\"]'", 'participant pseudonymised view migration');
+includes(migration, "('role_researcher', 'participant.record.view')", 'participant pseudonymised view migration');
+
+includes(workflow, 'Apply D1 Participant Pseudonymised View', 'participant D1 apply workflow');
+includes(workflow, 'infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql', 'participant D1 apply workflow');
+includes(workflow, 'APPLY_PARTICIPANT_PSEUDONYMISED_VIEW', 'participant D1 apply workflow');
+includes(workflow, "SELECT code, label FROM auth_permissions WHERE code IN ('participant.record.view', 'participant.pii.reveal')", 'participant D1 apply workflow');
+includes(workflow, "route_pattern IN ('/api/participants', '/api/participants/contact')", 'participant D1 apply workflow');
+
+for (const source of [component, scheduler]) {
+	includes(source, 'Contact details are restricted. Ask a Team Admin or authorised role if you need access.', 'participant UI');
+	includes(source, 'data-contact-state="restricted"', 'participant UI');
+	includes(source, 'Reveal contact details', 'participant UI');
+	includes(source, 'Sensitive', 'participant UI');
+	excludes(source, 'mailto:${encodeURIComponent(p.email)}', 'participant UI default state');
+	excludes(source, 'tel:${encodeURIComponent(p.phone)}', 'participant UI default state');
+}
+
+includes(scheduler, 'revealParticipantContact(participantId)', 'participant scheduler');
+includes(scheduler, '/api/participants/contact?participant=', 'participant scheduler');
+includes(scheduler, 'data-contact-state="revealed"', 'participant scheduler');
+includes(scheduler, 'Handle this information as sensitive.', 'participant scheduler');
+
+includes(page, 'Participants', 'participants page');
+includes(page, 'Contact', 'participants page');

--- a/tests/participant-pseudonymised-view-route-state.test.js
+++ b/tests/participant-pseudonymised-view-route-state.test.js
@@ -30,8 +30,9 @@ function functionBody(source, functionName) {
 
 includes(participantService, 'resolveAuthenticatedContext(request, svc.env)', 'participant service');
 includes(participantService, 'await assertRoutePermission(request, svc.env, context)', 'participant service');
-includes(participantService, 'const PSEUDONYMISED_LIST_FIELDS = [', 'participant service');
-includes(participantService, 'params.append("fields[]", field)', 'participant service');
+includes(participantService, 'readParticipantRecordsForStudy(svc, studyId)', 'participant service');
+includes(participantService, 'for (const linkFieldName of PARTICIPANT_FIELDS.study_link)', 'participant service');
+includes(participantService, 'params.append("fields[]", linkFieldName)', 'participant service');
 includes(participantService, 'mapPseudonymisedParticipant(record, index, context)', 'participant service');
 includes(participantService, 'participant_ref: participantReference(record, index)', 'participant service');
 includes(participantService, 'contact_restricted: true', 'participant service');
@@ -59,7 +60,6 @@ includes(router, 'service.revealParticipantContact(request, origin, url)', 'rout
 includes(router, 'service.listParticipants(request, origin, url)', 'router');
 
 includes(migration, "'participant.record.view'", 'participant pseudonymised view migration');
-includes(migration, "'participant.pii.reveal'", 'participant pseudonymised view migration');
 includes(migration, "'GET', '/api/participants', '[\"participant.record.view\"]'", 'participant pseudonymised view migration');
 includes(migration, "'GET', '/api/participants/contact', '[\"participant.pii.reveal\"]'", 'participant pseudonymised view migration');
 includes(migration, "('role_researcher', 'participant.record.view')", 'participant pseudonymised view migration');

--- a/tests/participant-pseudonymised-view-route-state.test.js
+++ b/tests/participant-pseudonymised-view-route-state.test.js
@@ -74,7 +74,6 @@ for (const source of [component, scheduler]) {
 	includes(source, 'Contact details are restricted. Ask a Team Admin or authorised role if you need access.', 'participant UI');
 	includes(source, 'data-contact-state="restricted"', 'participant UI');
 	includes(source, 'Reveal contact details', 'participant UI');
-	includes(source, 'Sensitive', 'participant UI');
 	excludes(source, 'mailto:${encodeURIComponent(p.email)}', 'participant UI default state');
 	excludes(source, 'tel:${encodeURIComponent(p.phone)}', 'participant UI default state');
 }
@@ -82,6 +81,7 @@ for (const source of [component, scheduler]) {
 includes(scheduler, 'revealParticipantContact(participantId)', 'participant scheduler');
 includes(scheduler, '/api/participants/contact?participant=', 'participant scheduler');
 includes(scheduler, 'data-contact-state="revealed"', 'participant scheduler');
+includes(scheduler, 'Sensitive', 'participant scheduler');
 includes(scheduler, 'Handle this information as sensitive.', 'participant scheduler');
 
 includes(page, 'Participants', 'participants page');


### PR DESCRIPTION
## Summary

Implements Story 7 as the first protected vertical journey, with Story 6 and Story 12 controls embedded.

The protected journey is:

- `GET /api/participants?study=...` returns a pseudonymised participant list by default.
- Participant contact details are not returned in the default response.
- The participant page shows a restricted contact state by default.
- `GET /api/participants/contact?participant=...` is a deliberate reveal route protected by D1 permission checks.
- Reveal success and denied reveal attempts are audited without exposing contact details in denied events.
- D1 permission/route declarations and a D1 apply workflow are included in the same PR.

## Changes

- Add `participant.record.view` and route declarations for:
  - `GET /api/participants`
  - `GET /api/participants/contact`
- Add `.github/workflows/apply-d1-participant-pseudonymised-view.yml` with post-apply checks.
- Update participant service logic so the default participant list uses a pseudonymised response shape.
- Preserve alternate Study-link field support by trying documented link-field candidates one at a time while requesting only the active link field for the default list.
- Add a deliberate contact reveal route guarded by `participant.pii.reveal`.
- Update participant UI rendering to show restricted contact states by default and sensitive labelling after reveal.
- Add route-state coverage for the Story 7 protected journey.
- Add operational trace files for the feature branch.

## Codex review disposition

Addressed both Codex comments:

- Fixed the brittle migration assertion by removing the standalone `participant.pii.reveal` expectation and keeping the actual route JSON permission assertion.
- Preserved alternate Study-link field support without falling back to full participant-record reads.

## Scope controls

This PR does not implement Story 8 access requests.

This PR does not grant `participant.pii.reveal` to default researcher roles.

This PR does not change Airtable schema.

This PR does not attempt to protect every remaining API route.

This PR does not fully harden participant creation/update routes; it focuses on the default participant list and deliberate reveal route.

## Residual risks

`infra/cloudflare/src/core/router.js` was replaced with a compact equivalent because a partial patch path was unavailable in the connector context. This should be reviewed carefully in the PR diff and by CI.

The default participant Airtable request now tries each documented Study-link field candidate separately while requesting only the link field for the default list. If the live Airtable table uses a materially different Study-link field name, a follow-up safe schema-discovery pattern may be needed. It must not fall back to fetching full participant records for the default list.

## Validation

GitHub Actions passed on head `2e2cd2e`:

- Format pull request
- QA — Broken links (Lychee)
- Accessibility audit (pa11y-ci)
- qa-bdd
- CI
- Validate ResearchOps
- Release Gate
- Worker CI

Trace files:

- `docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.md`
- `docs/agent-audit/reasoning/2026/05/31/participant-pseudonymised-view.json`