### PR TITLE
Make participants D1 canonical

### DIFF
--- a/.github/workflows/apply-d1-test-project-1-participants.yml
+++ b/.github/workflows/apply-d1-test-project-1-participants.yml
@@ -94,3 +94,7 @@ jobs:
             --remote \
             --config "${WRANGLER_CONFIG}" \
             --command "SELECT id, participant_ref, channel_pref, consent_status, status FROM rops_participants_cache WHERE project_id = 'recgdpwEI5hFO7bUZ' AND study_id = 'rect3biqr' AND source = 'd1-seed' ORDER BY id;"
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT method, route_pattern, required_permissions_json FROM auth_route_permissions WHERE route_pattern = '/api/participants' ORDER BY method;"

--- a/.github/workflows/apply-d1-test-project-1-participants.yml
+++ b/.github/workflows/apply-d1-test-project-1-participants.yml
@@ -1,0 +1,96 @@
+name: Apply D1 Test Project 1 Participants Seed
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql"
+      - ".github/workflows/apply-d1-test-project-1-participants.yml"
+  workflow_dispatch:
+    inputs:
+      confirm_database_name:
+        description: Type researchops-d1 to confirm the target D1 database
+        required: true
+        type: string
+      confirm_operation:
+        description: Type APPLY_TEST_PROJECT_1_PARTICIPANTS to seed participants
+        required: true
+        type: string
+      run_post_apply_checks:
+        description: Run post-apply seed checks
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.90.0"
+  D1_DATABASE_NAME: "researchops-d1"
+  WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
+  TEST_PROJECT_1_PARTICIPANTS_MIGRATION: "infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql"
+
+jobs:
+  apply:
+    name: Apply Test Project 1 participant seed to remote D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Confirm manual target
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm_database_name }}" != "${D1_DATABASE_NAME}" ]; then
+            echo "confirm_database_name must be ${D1_DATABASE_NAME}"
+            exit 1
+          fi
+
+          if [ "${{ inputs.confirm_operation }}" != "APPLY_TEST_PROJECT_1_PARTICIPANTS" ]; then
+            echo "confirm_operation must be APPLY_TEST_PROJECT_1_PARTICIPANTS"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Check migration file exists
+        run: test -f "${TEST_PROJECT_1_PARTICIPANTS_MIGRATION}"
+
+      - name: Apply Test Project 1 participant seed to remote D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${TEST_PROJECT_1_PARTICIPANTS_MIGRATION}"
+
+      - name: Check Test Project 1 participant seed
+        if: ${{ github.event_name == 'push' || inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS participant_count FROM rops_participants_cache WHERE project_id = 'recgdpwEI5hFO7bUZ' AND study_id = 'rect3biqr' AND source = 'd1-seed' AND active = 1;"
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT id, participant_ref, channel_pref, consent_status, status FROM rops_participants_cache WHERE project_id = 'recgdpwEI5hFO7bUZ' AND study_id = 'rect3biqr' AND source = 'd1-seed' ORDER BY id;"

--- a/docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.json
+++ b/docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.json
@@ -1,0 +1,61 @@
+{
+	"date": "2026-05-31",
+	"traceType": "operational-audit-trace",
+	"branch": "feature/pseudonymised-participant-view",
+	"relatedWork": "Story 7 continuation — make D1 canonical and Airtable secondary",
+	"traceRequired": true,
+	"taskSummary": "Pivot participant runtime behaviour so D1 is the canonical source of truth for testing and service behaviour. Airtable remains secondary and must not be required for participant list, contact reveal or participant creation.",
+	"implementationSummary": {
+		"d1CanonicalParticipants": true,
+		"airtableSecondaryAdapter": true,
+		"participantListReadsD1": true,
+		"participantContactRevealReadsD1": true,
+		"participantCreationWritesD1": true,
+		"testProject1SeededParticipants": 10,
+		"seedContainsRealPersonalData": false,
+		"postApplyChecksIncluded": true
+	},
+	"d1Objects": {
+		"participantTable": "rops_participants_cache",
+		"seedProjectId": "recgdpwEI5hFO7bUZ",
+		"seedStudyId": "rect3biqr",
+		"seedSource": "d1-seed",
+		"permissions": [
+			"participant.record.create",
+			"participant.record.view",
+			"participant.pii.reveal"
+		],
+		"routes": [
+			"GET /api/participants",
+			"POST /api/participants",
+			"GET /api/participants/contact"
+		]
+	},
+	"filesChanged": [
+		".github/workflows/apply-d1-test-project-1-participants.yml",
+		"infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql",
+		"infra/cloudflare/src/service/participants.js",
+		"public/pages/study/participants/scheduler.js",
+		"tests/participant-pseudonymised-view-route-state.test.js",
+		"tests/test-project-1-participants-seed-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.md",
+		"docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.json"
+	],
+	"scopeControls": {
+		"story8AccessRequestsImplemented": false,
+		"airtableRuntimeParticipantSource": false,
+		"realPersonalDataSeeded": false,
+		"defaultContactRevealGranted": false,
+		"allRuntimeEntitiesMigratedToD1": false,
+		"sessionCreationMovedToD1": false
+	},
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint",
+		"npm test -- --ci"
+	],
+	"residualRisks": [
+		"The session creation path still uses existing Airtable-oriented field names and should be handled in a later D1-canonical session slice.",
+		"If D1 already contains an older incompatible rops_participants_cache table without sensitive_contact_json, the remote apply may need a compatibility migration."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.md
+++ b/docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.md
@@ -1,0 +1,75 @@
+# Agent trace — Participant D1 canonical pivot
+
+**Date:** 2026-05-31  
+**Trace type:** operational audit trace  
+**Branch:** `feature/pseudonymised-participant-view`  
+**Related work:** Story 7 continuation — make D1 canonical and Airtable secondary
+
+## Evidence boundary
+
+This trace records repository evidence, implementation scope, files changed, validation expected and residual risk. It does not expose private chain-of-thought.
+
+## Task summary
+
+Pivot participant runtime behaviour so D1 is the canonical source of truth for testing and service behaviour. Airtable remains secondary and must not be required for the normal participant list, contact reveal or participant creation journey.
+
+## Implementation summary
+
+The participant service now reads participant lists from `rops_participants_cache` in D1.
+
+The contact reveal route reads `sensitive_contact_json` from D1 after D1 route permission checks.
+
+Participant creation now writes to D1 and requires project and study context.
+
+The Test Project 1 seed creates 10 pseudonymised participants for project `recgdpwEI5hFO7bUZ` and study `rect3biqr`.
+
+The D1 seed migration also declares `participant.record.create` and protects `POST /api/participants`.
+
+The apply workflow applies the seed to remote D1 and checks participant count plus route declarations.
+
+## Files changed
+
+- `.github/workflows/apply-d1-test-project-1-participants.yml`
+- `infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql`
+- `infra/cloudflare/src/service/participants.js`
+- `public/pages/study/participants/scheduler.js`
+- `tests/participant-pseudonymised-view-route-state.test.js`
+- `tests/test-project-1-participants-seed-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.md`
+- `docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.json`
+
+## Scope controls
+
+This branch does not implement Story 8 access requests.
+
+This branch does not make Airtable the runtime participant source.
+
+This branch does not seed real personal data.
+
+This branch does not grant default users unrestricted contact reveal access.
+
+This branch does not migrate all ResearchOps runtime entities to D1; it starts the pivot with participants.
+
+## Validation expected
+
+Run:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```
+
+CI should confirm:
+
+- participant route-state tests pass
+- Test Project 1 participant seed tests pass
+- D1 apply workflow exists and performs post-apply checks
+- participant service no longer imports Airtable helper paths for list/create/reveal
+- the page controller posts project and study IDs when creating participants
+
+## Residual risk
+
+The session creation path still uses existing field names such as `study_airtable_id` and `participant_airtable_id`. This follow-up PR is intentionally scoped to the participant list/create/reveal journey.
+
+If D1 already contains an older incompatible `rops_participants_cache` table without `sensitive_contact_json`, the remote apply may need a compatibility migration. The new migration creates the table with the canonical column for fresh or not-yet-seeded environments.

--- a/infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql
+++ b/infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql
@@ -6,7 +6,8 @@
 -- Project record ID: recgdpwEI5hFO7bUZ
 -- Study seeded: rect3biqr
 --
--- Seeded records are pseudonymised and deliberately contain no email addresses or phone numbers.
+-- Seeded records are pseudonymised and deliberately contain no email addresses or direct phone numbers.
+-- participant_airtable_id is retained only as an optional adapter key for legacy Airtable-backed session scheduling.
 
 PRAGMA foreign_keys = ON;
 
@@ -14,10 +15,12 @@ CREATE TABLE IF NOT EXISTS rops_participants_cache (
 	id TEXT PRIMARY KEY,
 	project_id TEXT NOT NULL,
 	study_id TEXT NOT NULL,
+	participant_airtable_id TEXT,
 	participant_ref TEXT NOT NULL,
 	channel_pref TEXT,
 	consent_status TEXT,
 	status TEXT,
+	access_needs TEXT,
 	active INTEGER NOT NULL DEFAULT 1,
 	source TEXT NOT NULL DEFAULT 'd1-seed',
 	created_at TEXT,
@@ -28,6 +31,7 @@ CREATE TABLE IF NOT EXISTS rops_participants_cache (
 
 CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_project_id ON rops_participants_cache(project_id);
 CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_study_id ON rops_participants_cache(study_id);
+CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_airtable_id ON rops_participants_cache(participant_airtable_id);
 CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_active ON rops_participants_cache(active);
 CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_source ON rops_participants_cache(source);
 
@@ -46,10 +50,12 @@ INSERT INTO rops_participants_cache (
 	id,
 	project_id,
 	study_id,
+	participant_airtable_id,
 	participant_ref,
 	channel_pref,
 	consent_status,
 	status,
+	access_needs,
 	active,
 	source,
 	created_at,
@@ -58,23 +64,25 @@ INSERT INTO rops_participants_cache (
 	payload_json
 )
 VALUES
-	('d1ptp_test_project_1_01', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 01', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:01.000Z', '2026-05-31T22:40:01.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 01","pseudonymised":true}'),
-	('d1ptp_test_project_1_02', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 02', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:02.000Z', '2026-05-31T22:40:02.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 02","pseudonymised":true}'),
-	('d1ptp_test_project_1_03', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 03', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:03.000Z', '2026-05-31T22:40:03.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 03","pseudonymised":true}'),
-	('d1ptp_test_project_1_04', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 04', 'phone', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:04.000Z', '2026-05-31T22:40:04.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 04","pseudonymised":true}'),
-	('d1ptp_test_project_1_05', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 05', 'email', 'not_sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:05.000Z', '2026-05-31T22:40:05.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 05","pseudonymised":true}'),
-	('d1ptp_test_project_1_06', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 06', 'email', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:06.000Z', '2026-05-31T22:40:06.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 06","pseudonymised":true}'),
-	('d1ptp_test_project_1_07', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 07', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:07.000Z', '2026-05-31T22:40:07.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 07","pseudonymised":true}'),
-	('d1ptp_test_project_1_08', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 08', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:08.000Z', '2026-05-31T22:40:08.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 08","pseudonymised":true}'),
-	('d1ptp_test_project_1_09', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 09', 'phone', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:09.000Z', '2026-05-31T22:40:09.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 09","pseudonymised":true}'),
-	('d1ptp_test_project_1_10', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 10', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:10.000Z', '2026-05-31T22:40:10.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 10","pseudonymised":true}')
+	('d1ptp_test_project_1_01', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 01', 'email', 'not_sent', 'invited', 'None recorded', 1, 'd1-seed', '2026-05-31T22:40:01.000Z', '2026-05-31T22:40:01.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 01","accessNeeds":"None recorded","pseudonymised":true}'),
+	('d1ptp_test_project_1_02', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 02', 'phone', 'not_sent', 'invited', 'Prefers afternoon sessions', 1, 'd1-seed', '2026-05-31T22:40:02.000Z', '2026-05-31T22:40:02.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 02","accessNeeds":"Prefers afternoon sessions","pseudonymised":true}'),
+	('d1ptp_test_project_1_03', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 03', 'email', 'sent', 'invited', 'Needs captions for remote sessions', 1, 'd1-seed', '2026-05-31T22:40:03.000Z', '2026-05-31T22:40:03.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 03","accessNeeds":"Needs captions for remote sessions","pseudonymised":true}'),
+	('d1ptp_test_project_1_04', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 04', 'phone', 'sent', 'invited', 'Needs shorter session blocks', 1, 'd1-seed', '2026-05-31T22:40:04.000Z', '2026-05-31T22:40:04.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 04","accessNeeds":"Needs shorter session blocks","pseudonymised":true}'),
+	('d1ptp_test_project_1_05', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 05', 'email', 'not_sent', 'screening', 'None recorded', 1, 'd1-seed', '2026-05-31T22:40:05.000Z', '2026-05-31T22:40:05.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 05","accessNeeds":"None recorded","pseudonymised":true}'),
+	('d1ptp_test_project_1_06', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 06', 'email', 'sent', 'screening', 'Uses screen magnification', 1, 'd1-seed', '2026-05-31T22:40:06.000Z', '2026-05-31T22:40:06.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 06","accessNeeds":"Uses screen magnification","pseudonymised":true}'),
+	('d1ptp_test_project_1_07', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 07', 'phone', 'not_sent', 'invited', 'Needs plain English instructions', 1, 'd1-seed', '2026-05-31T22:40:07.000Z', '2026-05-31T22:40:07.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 07","accessNeeds":"Needs plain English instructions","pseudonymised":true}'),
+	('d1ptp_test_project_1_08', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 08', 'email', 'sent', 'invited', 'None recorded', 1, 'd1-seed', '2026-05-31T22:40:08.000Z', '2026-05-31T22:40:08.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 08","accessNeeds":"None recorded","pseudonymised":true}'),
+	('d1ptp_test_project_1_09', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 09', 'phone', 'sent', 'screening', 'Avoids early morning sessions', 1, 'd1-seed', '2026-05-31T22:40:09.000Z', '2026-05-31T22:40:09.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 09","accessNeeds":"Avoids early morning sessions","pseudonymised":true}'),
+	('d1ptp_test_project_1_10', 'recgdpwEI5hFO7bUZ', 'rect3biqr', NULL, 'TP1 Participant 10', 'email', 'not_sent', 'invited', 'None recorded', 1, 'd1-seed', '2026-05-31T22:40:10.000Z', '2026-05-31T22:40:10.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 10","accessNeeds":"None recorded","pseudonymised":true}')
 ON CONFLICT(id) DO UPDATE SET
 	project_id = excluded.project_id,
 	study_id = excluded.study_id,
+	participant_airtable_id = excluded.participant_airtable_id,
 	participant_ref = excluded.participant_ref,
 	channel_pref = excluded.channel_pref,
 	consent_status = excluded.consent_status,
 	status = excluded.status,
+	access_needs = excluded.access_needs,
 	active = 1,
 	source = excluded.source,
 	created_at = excluded.created_at,

--- a/infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql
+++ b/infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql
@@ -1,12 +1,12 @@
--- Seed pseudonymised D1 participants for Test Project 1.
+-- D1-canonical participant model and Test Project 1 seed.
 -- Date: 2026-05-31
--- Scope: D1-only seed for local/preview participant list support.
+-- Scope: D1 runtime participant source of truth for testing without Airtable API calls.
 --
 -- Project: Test Project 1
 -- Project record ID: recgdpwEI5hFO7bUZ
 -- Study seeded: rect3biqr
 --
--- This seed deliberately contains no contact details.
+-- Seeded records are pseudonymised and deliberately contain no email addresses or phone numbers.
 
 PRAGMA foreign_keys = ON;
 
@@ -22,12 +22,25 @@ CREATE TABLE IF NOT EXISTS rops_participants_cache (
 	source TEXT NOT NULL DEFAULT 'd1-seed',
 	created_at TEXT,
 	updated_at TEXT NOT NULL,
+	sensitive_contact_json TEXT,
 	payload_json TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_project_id ON rops_participants_cache(project_id);
 CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_study_id ON rops_participants_cache(study_id);
 CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_active ON rops_participants_cache(active);
+CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_source ON rops_participants_cache(source);
+
+INSERT OR IGNORE INTO auth_permissions (code, label, description, is_sensitive, is_reserved) VALUES
+	('participant.record.create', 'Create participant records', 'Can create D1-backed participant records for a project or study.', 0, 0);
+
+INSERT OR IGNORE INTO auth_role_permissions (role_id, permission_code) VALUES
+	('role_researcher', 'participant.record.create'),
+	('role_research_lead', 'participant.record.create'),
+	('role_team_admin', 'participant.record.create');
+
+INSERT OR IGNORE INTO auth_route_permissions (id, method, route_pattern, required_permissions_json, auth_required, implementation_status) VALUES
+	('route_api_participants_post', 'POST', '/api/participants', '["participant.record.create"]', 1, 'implemented');
 
 INSERT INTO rops_participants_cache (
 	id,
@@ -41,19 +54,20 @@ INSERT INTO rops_participants_cache (
 	source,
 	created_at,
 	updated_at,
+	sensitive_contact_json,
 	payload_json
 )
 VALUES
-	('d1ptp_test_project_1_01', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 01', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:01.000Z', '2026-05-31T22:40:01.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 01","pseudonymised":true}'),
-	('d1ptp_test_project_1_02', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 02', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:02.000Z', '2026-05-31T22:40:02.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 02","pseudonymised":true}'),
-	('d1ptp_test_project_1_03', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 03', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:03.000Z', '2026-05-31T22:40:03.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 03","pseudonymised":true}'),
-	('d1ptp_test_project_1_04', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 04', 'phone', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:04.000Z', '2026-05-31T22:40:04.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 04","pseudonymised":true}'),
-	('d1ptp_test_project_1_05', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 05', 'email', 'not_sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:05.000Z', '2026-05-31T22:40:05.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 05","pseudonymised":true}'),
-	('d1ptp_test_project_1_06', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 06', 'email', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:06.000Z', '2026-05-31T22:40:06.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 06","pseudonymised":true}'),
-	('d1ptp_test_project_1_07', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 07', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:07.000Z', '2026-05-31T22:40:07.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 07","pseudonymised":true}'),
-	('d1ptp_test_project_1_08', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 08', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:08.000Z', '2026-05-31T22:40:08.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 08","pseudonymised":true}'),
-	('d1ptp_test_project_1_09', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 09', 'phone', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:09.000Z', '2026-05-31T22:40:09.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 09","pseudonymised":true}'),
-	('d1ptp_test_project_1_10', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 10', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:10.000Z', '2026-05-31T22:40:10.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 10","pseudonymised":true}')
+	('d1ptp_test_project_1_01', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 01', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:01.000Z', '2026-05-31T22:40:01.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 01","pseudonymised":true}'),
+	('d1ptp_test_project_1_02', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 02', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:02.000Z', '2026-05-31T22:40:02.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 02","pseudonymised":true}'),
+	('d1ptp_test_project_1_03', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 03', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:03.000Z', '2026-05-31T22:40:03.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 03","pseudonymised":true}'),
+	('d1ptp_test_project_1_04', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 04', 'phone', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:04.000Z', '2026-05-31T22:40:04.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 04","pseudonymised":true}'),
+	('d1ptp_test_project_1_05', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 05', 'email', 'not_sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:05.000Z', '2026-05-31T22:40:05.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 05","pseudonymised":true}'),
+	('d1ptp_test_project_1_06', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 06', 'email', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:06.000Z', '2026-05-31T22:40:06.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 06","pseudonymised":true}'),
+	('d1ptp_test_project_1_07', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 07', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:07.000Z', '2026-05-31T22:40:07.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 07","pseudonymised":true}'),
+	('d1ptp_test_project_1_08', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 08', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:08.000Z', '2026-05-31T22:40:08.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 08","pseudonymised":true}'),
+	('d1ptp_test_project_1_09', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 09', 'phone', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:09.000Z', '2026-05-31T22:40:09.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 09","pseudonymised":true}'),
+	('d1ptp_test_project_1_10', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 10', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:10.000Z', '2026-05-31T22:40:10.000Z', NULL, '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 10","pseudonymised":true}')
 ON CONFLICT(id) DO UPDATE SET
 	project_id = excluded.project_id,
 	study_id = excluded.study_id,
@@ -65,4 +79,5 @@ ON CONFLICT(id) DO UPDATE SET
 	source = excluded.source,
 	created_at = excluded.created_at,
 	updated_at = excluded.updated_at,
+	sensitive_contact_json = excluded.sensitive_contact_json,
 	payload_json = excluded.payload_json;

--- a/infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql
+++ b/infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql
@@ -1,0 +1,68 @@
+-- Seed pseudonymised D1 participants for Test Project 1.
+-- Date: 2026-05-31
+-- Scope: D1-only seed for local/preview participant list support.
+--
+-- Project: Test Project 1
+-- Project record ID: recgdpwEI5hFO7bUZ
+-- Study seeded: rect3biqr
+--
+-- This seed deliberately contains no contact details.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS rops_participants_cache (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL,
+	study_id TEXT NOT NULL,
+	participant_ref TEXT NOT NULL,
+	channel_pref TEXT,
+	consent_status TEXT,
+	status TEXT,
+	active INTEGER NOT NULL DEFAULT 1,
+	source TEXT NOT NULL DEFAULT 'd1-seed',
+	created_at TEXT,
+	updated_at TEXT NOT NULL,
+	payload_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_project_id ON rops_participants_cache(project_id);
+CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_study_id ON rops_participants_cache(study_id);
+CREATE INDEX IF NOT EXISTS idx_rops_participants_cache_active ON rops_participants_cache(active);
+
+INSERT INTO rops_participants_cache (
+	id,
+	project_id,
+	study_id,
+	participant_ref,
+	channel_pref,
+	consent_status,
+	status,
+	active,
+	source,
+	created_at,
+	updated_at,
+	payload_json
+)
+VALUES
+	('d1ptp_test_project_1_01', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 01', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:01.000Z', '2026-05-31T22:40:01.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 01","pseudonymised":true}'),
+	('d1ptp_test_project_1_02', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 02', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:02.000Z', '2026-05-31T22:40:02.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 02","pseudonymised":true}'),
+	('d1ptp_test_project_1_03', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 03', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:03.000Z', '2026-05-31T22:40:03.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 03","pseudonymised":true}'),
+	('d1ptp_test_project_1_04', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 04', 'phone', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:04.000Z', '2026-05-31T22:40:04.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 04","pseudonymised":true}'),
+	('d1ptp_test_project_1_05', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 05', 'email', 'not_sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:05.000Z', '2026-05-31T22:40:05.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 05","pseudonymised":true}'),
+	('d1ptp_test_project_1_06', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 06', 'email', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:06.000Z', '2026-05-31T22:40:06.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 06","pseudonymised":true}'),
+	('d1ptp_test_project_1_07', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 07', 'phone', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:07.000Z', '2026-05-31T22:40:07.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 07","pseudonymised":true}'),
+	('d1ptp_test_project_1_08', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 08', 'email', 'sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:08.000Z', '2026-05-31T22:40:08.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 08","pseudonymised":true}'),
+	('d1ptp_test_project_1_09', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 09', 'phone', 'sent', 'screening', 1, 'd1-seed', '2026-05-31T22:40:09.000Z', '2026-05-31T22:40:09.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 09","pseudonymised":true}'),
+	('d1ptp_test_project_1_10', 'recgdpwEI5hFO7bUZ', 'rect3biqr', 'TP1 Participant 10', 'email', 'not_sent', 'invited', 1, 'd1-seed', '2026-05-31T22:40:10.000Z', '2026-05-31T22:40:10.000Z', '{"projectId":"recgdpwEI5hFO7bUZ","studyId":"rect3biqr","participantRef":"TP1 Participant 10","pseudonymised":true}')
+ON CONFLICT(id) DO UPDATE SET
+	project_id = excluded.project_id,
+	study_id = excluded.study_id,
+	participant_ref = excluded.participant_ref,
+	channel_pref = excluded.channel_pref,
+	consent_status = excluded.consent_status,
+	status = excluded.status,
+	active = 1,
+	source = excluded.source,
+	created_at = excluded.created_at,
+	updated_at = excluded.updated_at,
+	payload_json = excluded.payload_json;

--- a/infra/cloudflare/src/service/participants.js
+++ b/infra/cloudflare/src/service/participants.js
@@ -1,24 +1,17 @@
 /**
  * @file participants.js
  * @module participants
- * @summary Participants endpoints for ResearchOps Worker (Airtable).
+ * @summary D1-canonical participant endpoints for ResearchOps Worker.
  *
  * @description
  * Implements a pseudonymised-by-default participant list and a deliberate,
- * permission-checked contact reveal route. D1 is the identity and authority
- * layer. Airtable remains the research data layer.
+ * permission-checked contact reveal route. D1 is the runtime source of truth.
+ * Airtable is secondary and must not be required for normal participant testing.
  */
 
 import { resolveAuthenticatedContext } from "../core/auth/access-scoped.js";
 import { assertRoutePermission } from "../core/auth/route-permissions.js";
-import {
-	fetchWithTimeout,
-	pickFirstField,
-	safeText,
-	toMs
-} from "../core/utils.js";
-import { PARTICIPANT_FIELDS } from "../core/fields.js";
-import { airtableTryWrite } from "../core/utils.js";
+import { toMs } from "../core/utils.js";
 
 const CONTACT_RESTRICTED_MESSAGE = "Participant contact details are restricted. Ask a Team Admin or authorised role if you need access.";
 
@@ -58,11 +51,44 @@ function dbFor(env = {}) {
 	return db && typeof db.prepare === "function" ? db : null;
 }
 
-function makeAuditId() {
-	return `evt_${crypto.randomUUID()}`;
+function cleanText(value) {
+	return String(value || "").replace(/\s+/g, " ").trim();
 }
 
-async function recordParticipantContactAudit(svc, request, context, participantId, outcome) {
+function makeId(prefix) {
+	return `${prefix}_${crypto.randomUUID()}`;
+}
+
+function jsonText(value) {
+	return JSON.stringify(value || {});
+}
+
+function parseJson(value) {
+	try {
+		const parsed = JSON.parse(value || "{}");
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+function participantDataUnavailable(svc, origin) {
+	return svc.json(
+		{
+			ok: false,
+			error: "participant_store_unavailable",
+			message: "Participant records are not available right now.",
+		},
+		503,
+		svc.corsHeaders(origin),
+	);
+}
+
+function makeAuditId() {
+	return makeId("evt");
+}
+
+async function recordParticipantEvent(svc, request, context, participantId, eventType, outcome) {
 	const db = dbFor(svc.env);
 	if (!db) return;
 
@@ -70,146 +96,127 @@ async function recordParticipantContactAudit(svc, request, context, participantI
 		await db
 			.prepare(`
 				INSERT INTO auth_events (id, event_type, actor_user_id, target_user_id, team_id, provider, route_path, metadata_json)
-				VALUES (?, ?, ?, NULL, ?, 'researchops_participant_contact', ?, ?)
+				VALUES (?, ?, ?, NULL, ?, 'researchops_participants', ?, ?)
 			`)
 			.bind(
 				makeAuditId(),
-				outcome === "succeeded" ? "participant.contact.revealed" : "participant.contact.reveal.denied",
+				eventType,
 				context?.user?.id || null,
 				context?.activeTeam?.id || null,
 				new URL(request.url).pathname,
-				JSON.stringify({ participantId, outcome }),
+				jsonText({ participantId, outcome }),
 			)
 			.run();
 	} catch {
-		// Participant contact access must not fail only because audit storage is unavailable.
+		// Participant actions must not fail only because audit storage is unavailable.
 	}
 }
 
-function airtableConfig(svc) {
-	const base = svc.env.AIRTABLE_BASE_ID;
-	const table = encodeURIComponent(svc.env.AIRTABLE_TABLE_PARTICIPANTS || "Participants");
-	return {
-		base,
-		table,
-		url: `https://api.airtable.com/v0/${base}/${table}`,
-		headers: { "Authorization": `Bearer ${svc.env.AIRTABLE_API_KEY}` },
-	};
+async function readD1ParticipantsForStudy(svc, origin, studyId, context) {
+	const db = dbFor(svc.env);
+	if (!db) return { ok: false, response: participantDataUnavailable(svc, origin) };
+
+	try {
+		const result = await db
+			.prepare(`
+				SELECT id, project_id, study_id, participant_ref, channel_pref, consent_status, status, created_at
+				FROM rops_participants_cache
+				WHERE study_id = ?
+					AND active = 1
+				ORDER BY created_at ASC, id ASC
+			`)
+			.bind(studyId)
+			.all();
+
+		return {
+			ok: true,
+			participants: (result.results || []).map((row) => mapD1Participant(row, context)),
+		};
+	} catch {
+		return { ok: false, response: participantDataUnavailable(svc, origin) };
+	}
 }
 
-function isUnknownFieldResponse(status, text) {
-	return status === 422 && /UNKNOWN_FIELD|INVALID_FIELD|field/i.test(String(text || ""));
-}
+async function readD1ParticipantContact(svc, origin, participantId) {
+	const db = dbFor(svc.env);
+	if (!db) return { ok: false, response: participantDataUnavailable(svc, origin) };
 
-async function readParticipantRecords(svc, linkFieldName) {
-	const at = airtableConfig(svc);
-	const records = [];
-	let offset;
+	try {
+		const row = await db
+			.prepare(`
+				SELECT id, participant_ref, sensitive_contact_json
+				FROM rops_participants_cache
+				WHERE id = ?
+					AND active = 1
+				LIMIT 1
+			`)
+			.bind(participantId)
+			.first();
 
-	do {
-		const params = new URLSearchParams({ pageSize: "100" });
-		params.append("fields[]", linkFieldName);
-		if (offset) params.set("offset", offset);
-		const resp = await fetchWithTimeout(`${at.url}?${params.toString()}`, { headers: at.headers }, svc.cfg.TIMEOUT_MS);
-		const txt = await resp.text();
-		if (!resp.ok) {
+		if (!row) {
 			return {
 				ok: false,
-				unknownField: isUnknownFieldResponse(resp.status, txt),
-				response: svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(txt) }, resp.status),
+				response: svc.json({ ok: false, error: "participant_not_found", message: "Participant record could not be found." }, 404, svc.corsHeaders(origin)),
 			};
 		}
 
-		let js;
-		try {
-			js = JSON.parse(txt);
-		} catch {
-			js = { records: [] };
-		}
-		records.push(...(js.records || []));
-		offset = js.offset;
-	} while (offset);
-
-	return { ok: true, linkFieldName, records };
-}
-
-async function readParticipantRecordsForStudy(svc, studyId) {
-	let lastResponse = null;
-
-	for (const linkFieldName of PARTICIPANT_FIELDS.study_link) {
-		const result = await readParticipantRecords(svc, linkFieldName);
-		if (!result.ok) {
-			lastResponse = result.response;
-			if (result.unknownField) continue;
-			svc.log.error("airtable.participants.list.fail", { linkFieldName });
-			return result;
-		}
-
-		const records = result.records.filter((record) => {
-			const links = record.fields?.[linkFieldName];
-			return Array.isArray(links) && links.includes(studyId);
-		});
-
-		return { ok: true, linkFieldName, records };
-	}
-
-	return {
-		ok: false,
-		response: lastResponse || svc.json({ ok: false, error: "participant_study_link_missing", message: "Participants could not be matched to this study." }, 502),
-	};
-}
-
-async function readParticipantRecord(svc, participantId) {
-	const at = airtableConfig(svc);
-	const resp = await fetchWithTimeout(`${at.url}/${encodeURIComponent(participantId)}`, { headers: at.headers }, svc.cfg.TIMEOUT_MS);
-	const txt = await resp.text();
-
-	if (!resp.ok) {
-		svc.log.error("airtable.participant.contact.fail", { status: resp.status, text: safeText(txt) });
-		return { ok: false, response: svc.json({ ok: false, error: `Airtable ${resp.status}`, detail: safeText(txt) }, resp.status) };
-	}
-
-	try {
-		return { ok: true, record: JSON.parse(txt) };
+		const contact = parseJson(row.sensitive_contact_json);
+		return {
+			ok: true,
+			participant: {
+				id: row.id,
+				display_name: row.participant_ref || "",
+				email: cleanText(contact.email),
+				phone: cleanText(contact.phone),
+			},
+		};
 	} catch {
-		return { ok: false, response: svc.json({ ok: false, error: "Invalid participant response" }, 502) };
+		return { ok: false, response: participantDataUnavailable(svc, origin) };
 	}
 }
 
-function pickParticipantField(fields, keys) {
-	const key = pickFirstField(fields, keys);
-	return key ? fields[key] : undefined;
-}
-
-function participantReference(record, index) {
-	const id = String(record.id || "");
-	const suffix = id ? id.slice(-6).toUpperCase() : String(index + 1).padStart(3, "0");
-	return `Participant ${suffix}`;
-}
-
-function mapPseudonymisedParticipant(record, index, context) {
+function mapD1Participant(row, context) {
 	return {
-		id: record.id,
-		participant_ref: participantReference(record, index),
-		display_name: participantReference(record, index),
+		id: row.id,
+		participant_ref: row.participant_ref || row.id,
+		display_name: row.participant_ref || row.id,
 		contact_restricted: true,
 		has_contact_details: null,
 		can_reveal_contact: canRevealParticipantContact(context),
-		channel_pref: "not recorded",
-		consent_status: "not_sent",
-		status: "invited",
-		createdAt: record.createdTime || "",
+		channel_pref: row.channel_pref || "not recorded",
+		consent_status: row.consent_status || "not_sent",
+		status: row.status || "invited",
+		createdAt: row.created_at || "",
 	};
 }
 
-function mapParticipantContact(record) {
-	const fields = record.fields || {};
-	return {
-		id: record.id,
-		display_name: pickParticipantField(fields, PARTICIPANT_FIELDS.display_name) || "",
-		email: pickParticipantField(fields, PARTICIPANT_FIELDS.email) || "",
-		phone: pickParticipantField(fields, PARTICIPANT_FIELDS.phone) || "",
-	};
+function participantRefFor(body) {
+	const displayName = cleanText(body.display_name || body.displayName || body.participant_ref || body.participantRef);
+	return displayName || `Participant ${new Date().toISOString()}`;
+}
+
+async function readJsonBody(request, maxBytes) {
+	const body = await request.arrayBuffer();
+	if (body.byteLength > maxBytes) {
+		const error = new Error("Payload too large");
+		error.status = 413;
+		error.code = "payload_too_large";
+		throw error;
+	}
+
+	try {
+		const parsed = JSON.parse(new TextDecoder().decode(body));
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+	} catch {
+		const error = new Error("Invalid JSON");
+		error.status = 400;
+		error.code = "invalid_json";
+		throw error;
+	}
+}
+
+function bodyErrorResponse(svc, origin, error) {
+	return svc.json({ ok: false, error: error.code || "invalid_request", message: error.message || "Check the participant information." }, error.status || 400, svc.corsHeaders(origin));
 }
 
 /**
@@ -228,13 +235,10 @@ export async function listParticipants(svc, request, origin, url) {
 	const studyId = url.searchParams.get("study");
 	if (!studyId) return svc.json({ ok: false, error: "Missing study query" }, 400, svc.corsHeaders(origin));
 
-	const result = await readParticipantRecordsForStudy(svc, studyId);
+	const result = await readD1ParticipantsForStudy(svc, origin, studyId, context);
 	if (!result.ok) return result.response;
 
-	const participants = result.records
-		.map((record, index) => mapPseudonymisedParticipant(record, index, context))
-		.sort((a, b) => toMs(a.createdAt) - toMs(b.createdAt));
-
+	const participants = result.participants.sort((a, b) => toMs(a.createdAt) - toMs(b.createdAt));
 	return svc.json({ ok: true, participants }, 200, svc.corsHeaders(origin));
 }
 
@@ -256,20 +260,18 @@ export async function revealParticipantContact(svc, request, origin, url) {
 		context = await resolveAuthenticatedContext(request, svc.env);
 		await assertRoutePermission(request, svc.env, context);
 	} catch (error) {
-		await recordParticipantContactAudit(svc, request, context, participantId, "denied");
+		await recordParticipantEvent(svc, request, context, participantId, "participant.contact.reveal.denied", "denied");
 		return permissionErrorResponse(svc, origin, error, CONTACT_RESTRICTED_MESSAGE, true);
 	}
 
-	const result = await readParticipantRecord(svc, participantId);
+	const result = await readD1ParticipantContact(svc, origin, participantId);
 	if (!result.ok) return result.response;
 
-	const contact = mapParticipantContact(result.record);
-	await recordParticipantContactAudit(svc, request, context, participantId, "succeeded");
-
+	await recordParticipantEvent(svc, request, context, participantId, "participant.contact.revealed", "succeeded");
 	return svc.json(
 		{
 			ok: true,
-			participant: contact,
+			participant: result.participant,
 			sensitive: true,
 			message: "Participant contact details revealed. Handle this information as sensitive.",
 		},
@@ -279,7 +281,7 @@ export async function revealParticipantContact(svc, request, origin, url) {
 }
 
 /**
- * Create a participant linked to a study (resilient to schema + select options).
+ * Create a D1 participant linked to a study.
  * @route POST /api/participants
  * @param {import("./index.js").ResearchOpsService} svc
  * @param {Request} request
@@ -287,106 +289,72 @@ export async function revealParticipantContact(svc, request, origin, url) {
  * @returns {Promise<Response>}
  */
 export async function createParticipant(svc, request, origin) {
-	const body = await request.arrayBuffer();
-	if (body.byteLength > svc.cfg.MAX_BODY_BYTES) {
-		return svc.json({ error: "Payload too large" }, 413, svc.corsHeaders(origin));
+	const { context, response } = await resolveParticipantRouteContext(svc, request, origin);
+	if (response) return response;
+
+	let body;
+	try {
+		body = await readJsonBody(request, svc.cfg.MAX_BODY_BYTES);
+	} catch (error) {
+		return bodyErrorResponse(svc, origin, error);
 	}
 
-	/** @type {any} */
-	let p;
-	try { p = JSON.parse(new TextDecoder().decode(body)); } catch { return svc.json({ error: "Invalid JSON" }, 400, svc.corsHeaders(origin)); }
+	const studyId = cleanText(body.study_id || body.studyId || body.study_airtable_id);
+	const projectId = cleanText(body.project_id || body.projectId || body.project_airtable_id);
+	const participantRef = participantRefFor(body);
 
-	const missing = [];
-	if (!p.study_airtable_id) missing.push("study_airtable_id");
-	if (!p.display_name) missing.push("display_name");
-	if (missing.length) {
-		return svc.json({ error: "Missing fields: " + missing.join(", ") }, 400, svc.corsHeaders(origin));
+	if (!studyId) return svc.json({ ok: false, error: "study_required", message: "Choose a study for this participant." }, 400, svc.corsHeaders(origin));
+	if (!projectId) return svc.json({ ok: false, error: "project_required", message: "Choose a project for this participant." }, 400, svc.corsHeaders(origin));
+
+	const db = dbFor(svc.env);
+	if (!db) return participantDataUnavailable(svc, origin);
+
+	const participantId = makeId("d1ptp");
+	const now = new Date().toISOString();
+	const contact = {
+		email: cleanText(body.email),
+		phone: cleanText(body.phone),
+	};
+	const hasContact = Boolean(contact.email || contact.phone);
+
+	try {
+		await db
+			.prepare(`
+				INSERT INTO rops_participants_cache (
+					id,
+					project_id,
+					study_id,
+					participant_ref,
+					channel_pref,
+					consent_status,
+					status,
+					active,
+					source,
+					created_at,
+					updated_at,
+					sensitive_contact_json,
+					payload_json
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, 1, 'd1-runtime', ?, ?, ?, ?)
+			`)
+			.bind(
+				participantId,
+				projectId,
+				studyId,
+				participantRef,
+				cleanText(body.channel_pref || body.channelPref || "email") || "email",
+				cleanText(body.consent_status || body.consentStatus || "not_sent") || "not_sent",
+				cleanText(body.status || "invited") || "invited",
+				now,
+				now,
+				hasContact ? jsonText(contact) : null,
+				jsonText({ projectId, studyId, participantRef, pseudonymised: true }),
+			)
+			.run();
+	} catch {
+		return participantDataUnavailable(svc, origin);
 	}
 
-	const base = svc.env.AIRTABLE_BASE_ID;
-	const table = encodeURIComponent(svc.env.AIRTABLE_TABLE_PARTICIPANTS || "Participants");
-	const atUrl = `https://api.airtable.com/v0/${base}/${table}`;
-
-	const fieldsTemplate = {};
-	const setIf = (names, val) => {
-		if (val === undefined || val === null || String(val).trim() === "") return null;
-		fieldsTemplate[names[0]] = val;
-		return names[0];
-	};
-
-	setIf(PARTICIPANT_FIELDS.display_name, p.display_name);
-	setIf(PARTICIPANT_FIELDS.email, p.email);
-	setIf(PARTICIPANT_FIELDS.phone, p.phone);
-	setIf(PARTICIPANT_FIELDS.access_needs, p.access_needs);
-	setIf(PARTICIPANT_FIELDS.recruitment_source, p.recruitment_source);
-	setIf(PARTICIPANT_FIELDS.privacy_notice_url, p.privacy_notice_url);
-
-	const selects = {
-		channel_pref: { key: PARTICIPANT_FIELDS.channel_pref[0], val: p.channel_pref ?? "email" },
-		consent_status: { key: PARTICIPANT_FIELDS.consent_status[0], val: p.consent_status ?? "not_sent" },
-		status: { key: PARTICIPANT_FIELDS.status[0], val: p.status ?? "invited" }
-	};
-
-	const tryCreate = async (linkFieldName, variant) => {
-		const f = { ...fieldsTemplate, [linkFieldName]: [p.study_airtable_id] };
-
-		for (const [name, meta] of Object.entries(selects)) {
-			if (variant?.omit === name) continue;
-			if (!meta.key) continue;
-			let v = meta.val;
-			if (variant?.caps === name && typeof v === "string" && v) {
-				v = v.charAt(0).toUpperCase() + v.slice(1);
-			}
-			f[meta.key] = v;
-		}
-
-		return await airtableTryWrite(atUrl, svc.env.AIRTABLE_API_KEY, "POST", f, svc.cfg.TIMEOUT_MS);
-	};
-
-	let lastDetail = "";
-	for (const linkName of PARTICIPANT_FIELDS.study_link) {
-		let attempt = await tryCreate(linkName, { variant: "lower" });
-		if (attempt.ok) {
-			const id = attempt.json.records?.[0]?.id;
-			if (svc.env.AUDIT === "true") svc.log.info("participant.created", { id, linkName, statusFallback: "none" });
-			return svc.json({ ok: true, id }, 200, svc.corsHeaders(origin));
-		}
-		lastDetail = attempt.detail || lastDetail;
-
-		const isSelectErr = attempt.status === 422 && /INVALID_MULTIPLE_CHOICE_OPTIONS/i.test(String(attempt.detail || ""));
-		if (isSelectErr) {
-			const capsOrder = ["channel_pref", "status", "consent_status"];
-			for (const caps of capsOrder) {
-				const r = await tryCreate(linkName, { caps });
-				if (r.ok) {
-					const id = r.json.records?.[0]?.id;
-					if (svc.env.AUDIT === "true") svc.log.info("participant.created", { id, linkName, statusFallback: "capitalised:" + caps });
-					return svc.json({ ok: true, id }, 200, svc.corsHeaders(origin));
-				}
-				lastDetail = r.detail || lastDetail;
-			}
-
-			const omitOrder = ["channel_pref", "status", "consent_status"];
-			for (const omit of omitOrder) {
-				const r = await tryCreate(linkName, { omit });
-				if (r.ok) {
-					const id = r.json.records?.[0]?.id;
-					if (svc.env.AUDIT === "true") svc.log.info("participant.created", { id, linkName, statusFallback: "omit:" + omit });
-					return svc.json({ ok: true, id }, 200, svc.corsHeaders(origin));
-				}
-				lastDetail = r.detail || lastDetail;
-			}
-		}
-
-		if (!attempt.retry) {
-			svc.log.error("airtable.participant.create.fail", { status: attempt.status, detail: attempt.detail });
-			return svc.json({ error: `Airtable ${attempt.status}`, detail: attempt.detail }, attempt.status || 500, svc.corsHeaders(origin));
-		}
-	}
-
-	svc.log.error("airtable.participant.create.linkfield.none_matched", { detail: lastDetail });
-	return svc.json({
-		error: "Airtable 422",
-		detail: lastDetail || "No matching link field name found for Participants↔Study relation. Try fields: " + PARTICIPANT_FIELDS.study_link.join(", ")
-	}, 422, svc.corsHeaders(origin));
+	await recordParticipantEvent(svc, request, context, participantId, "participant.created", "succeeded");
+	return svc.json({ ok: true, id: participantId }, 200, svc.corsHeaders(origin));
 }

--- a/infra/cloudflare/src/service/participants.js
+++ b/infra/cloudflare/src/service/participants.js
@@ -119,7 +119,7 @@ async function readD1ParticipantsForStudy(svc, origin, studyId, context) {
 	try {
 		const result = await db
 			.prepare(`
-				SELECT id, project_id, study_id, participant_ref, channel_pref, consent_status, status, created_at
+				SELECT id, project_id, study_id, participant_airtable_id, participant_ref, channel_pref, consent_status, status, access_needs, created_at
 				FROM rops_participants_cache
 				WHERE study_id = ?
 					AND active = 1
@@ -176,6 +176,7 @@ async function readD1ParticipantContact(svc, origin, participantId) {
 }
 
 function mapD1Participant(row, context) {
+	const sessionParticipantId = cleanText(row.participant_airtable_id);
 	return {
 		id: row.id,
 		participant_ref: row.participant_ref || row.id,
@@ -183,9 +184,12 @@ function mapD1Participant(row, context) {
 		contact_restricted: true,
 		has_contact_details: null,
 		can_reveal_contact: canRevealParticipantContact(context),
+		can_schedule: Boolean(sessionParticipantId),
+		session_participant_id: sessionParticipantId,
 		channel_pref: row.channel_pref || "not recorded",
 		consent_status: row.consent_status || "not_sent",
 		status: row.status || "invited",
+		access_needs: row.access_needs || "",
 		createdAt: row.created_at || "",
 	};
 }
@@ -301,7 +305,9 @@ export async function createParticipant(svc, request, origin) {
 
 	const studyId = cleanText(body.study_id || body.studyId || body.study_airtable_id);
 	const projectId = cleanText(body.project_id || body.projectId || body.project_airtable_id);
+	const participantAirtableId = cleanText(body.participant_airtable_id || body.participantAirtableId);
 	const participantRef = participantRefFor(body);
+	const accessNeeds = cleanText(body.access_needs || body.accessNeeds);
 
 	if (!studyId) return svc.json({ ok: false, error: "study_required", message: "Choose a study for this participant." }, 400, svc.corsHeaders(origin));
 	if (!projectId) return svc.json({ ok: false, error: "project_required", message: "Choose a project for this participant." }, 400, svc.corsHeaders(origin));
@@ -324,10 +330,12 @@ export async function createParticipant(svc, request, origin) {
 					id,
 					project_id,
 					study_id,
+					participant_airtable_id,
 					participant_ref,
 					channel_pref,
 					consent_status,
 					status,
+					access_needs,
 					active,
 					source,
 					created_at,
@@ -335,20 +343,22 @@ export async function createParticipant(svc, request, origin) {
 					sensitive_contact_json,
 					payload_json
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, 1, 'd1-runtime', ?, ?, ?, ?)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'd1-runtime', ?, ?, ?, ?)
 			`)
 			.bind(
 				participantId,
 				projectId,
 				studyId,
+				participantAirtableId || null,
 				participantRef,
 				cleanText(body.channel_pref || body.channelPref || "email") || "email",
 				cleanText(body.consent_status || body.consentStatus || "not_sent") || "not_sent",
 				cleanText(body.status || "invited") || "invited",
+				accessNeeds || null,
 				now,
 				now,
 				hasContact ? jsonText(contact) : null,
-				jsonText({ projectId, studyId, participantRef, pseudonymised: true }),
+				jsonText({ projectId, studyId, participantRef, accessNeeds, pseudonymised: true }),
 			)
 			.run();
 	} catch {

--- a/public/pages/study/participants/scheduler.js
+++ b/public/pages/study/participants/scheduler.js
@@ -200,7 +200,7 @@ function setScheduleEnabled(enabled, participants) {
 	cta?.classList.remove("link--disabled");
 }
 
-async function handleAddParticipant(e, studyId, refresh) {
+async function handleAddParticipant(e, context, refresh) {
 	e.preventDefault();
 	const form = e.target;
 	const msg = $("#addParticipantMsg");
@@ -218,7 +218,8 @@ async function handleAddParticipant(e, studyId, refresh) {
 	}
 
 	const payload = {
-		study_airtable_id: studyId,
+		project_id: context.projectId,
+		study_id: context.studyId,
 		display_name: display,
 		email: email || undefined,
 		phone: phone || undefined,
@@ -335,7 +336,7 @@ function bindRouteChrome(context) {
 
 		const addForm = $("#addParticipantForm");
 		const schedForm = $("#scheduleForm");
-		if (addForm) addForm.addEventListener("submit", (e) => handleAddParticipant(e, context.studyId, () => refreshAll(context.studyId)));
+		if (addForm) addForm.addEventListener("submit", (e) => handleAddParticipant(e, context, () => refreshAll(context.studyId)));
 		if (schedForm) schedForm.addEventListener("submit", (e) => handleCreateSession(e, context.studyId));
 
 		await refreshAll(context.studyId);

--- a/public/pages/study/participants/scheduler.js
+++ b/public/pages/study/participants/scheduler.js
@@ -36,6 +36,18 @@ function restrictedContactCell(p) {
 	`;
 }
 
+function scheduleCell(p) {
+	const sessionParticipantId = p.session_participant_id || "";
+	if (p.can_schedule && sessionParticipantId) {
+		return `<button class="govuk-button govuk-button--secondary" data-session-participant-id="${escapeHtml(sessionParticipantId)}" data-act="schedule">Schedule</button>`;
+	}
+
+	return `
+		<button class="govuk-button govuk-button--secondary" disabled aria-disabled="true">Schedule</button>
+		<p class="govuk-hint govuk-!-margin-bottom-0">Scheduling is not available until this participant has a session-compatible record.</p>
+	`;
+}
+
 function readStudyRouteContext() {
 	const usp = new URLSearchParams(location.search);
 	return {
@@ -107,7 +119,7 @@ function renderParticipants(list) {
 			<td class="govuk-table__cell" data-contact-cell="${escapeHtml(p.id)}">${restrictedContactCell(p)}</td>
 			<td class="govuk-table__cell">${escapeHtml(p.status || "—")}<br><span class="govuk-hint">Preferred channel: ${escapeHtml(p.channel_pref || "not recorded")}</span></td>
 			<td class="govuk-table__cell">
-				<button class="govuk-button govuk-button--secondary" data-part="${escapeHtml(p.id)}" data-act="schedule">Schedule</button>
+				${scheduleCell(p)}
 			</td>
 		`;
 		body.appendChild(row);
@@ -170,22 +182,27 @@ function renderSessions(list, participantsById) {
 	}
 }
 
+function scheduleableParticipants(participants) {
+	return participants.filter((p) => p.can_schedule && p.session_participant_id);
+}
+
 function setScheduleEnabled(enabled, participants) {
 	const form = $("#scheduleForm");
 	const btn = $("#scheduleBtn");
 	const select = $("#s_participant");
 	const banner = $("#noParticipantsBanner");
 	const cta = $("#scheduleCta");
+	const available = scheduleableParticipants(participants);
 
 	if (!form || !btn || !select || !banner) return;
 
-	if (!enabled) {
+	if (!enabled || !available.length) {
 		banner.hidden = false;
 		btn.disabled = true;
 		form.querySelectorAll("input, textarea, select, button").forEach(el => {
 			if (el !== btn) el.setAttribute("disabled", "true");
 		});
-		select.innerHTML = `<option value="" disabled selected>No participants available</option>`;
+		select.innerHTML = `<option value="" disabled selected>No participants available for scheduling</option>`;
 		cta?.setAttribute("aria-disabled", "true");
 		cta?.classList.add("link--disabled");
 		return;
@@ -195,7 +212,7 @@ function setScheduleEnabled(enabled, participants) {
 	btn.disabled = false;
 	form.querySelectorAll("input, textarea, select, button").forEach(el => el.removeAttribute("disabled"));
 	select.innerHTML = `<option value="" disabled selected>Select a participant</option>` +
-		participants.map(p => `<option value="${escapeHtml(p.id)}">${escapeHtml(p.participant_ref || p.display_name || p.id)}</option>`).join("");
+		available.map(p => `<option value="${escapeHtml(p.session_participant_id)}">${escapeHtml(p.participant_ref || p.display_name || p.id)}</option>`).join("");
 	cta?.removeAttribute("aria-disabled");
 	cta?.classList.remove("link--disabled");
 }
@@ -294,7 +311,11 @@ async function refreshAll(studyId) {
 	renderParticipants(participants);
 	setScheduleEnabled(participants.length > 0, participants);
 
-	const pMap = new Map(participants.map(p => [p.id, p]));
+	const pMap = new Map(participants.flatMap((p) => {
+		const entries = [[p.id, p]];
+		if (p.session_participant_id) entries.push([p.session_participant_id, p]);
+		return entries;
+	}));
 	renderSessions(sessions, pMap);
 }
 
@@ -303,7 +324,11 @@ async function refreshSessions(studyId) {
 		loadParticipants(studyId),
 		loadSessions(studyId)
 	]);
-	const pMap = new Map(participants.map(p => [p.id, p]));
+	const pMap = new Map(participants.flatMap((p) => {
+		const entries = [[p.id, p]];
+		if (p.session_participant_id) entries.push([p.session_participant_id, p]);
+		return entries;
+	}));
 	renderSessions(sessions, pMap);
 }
 
@@ -360,10 +385,10 @@ function bindRouteChrome(context) {
 					return;
 				}
 
-				const btn = target?.closest("[data-act='schedule'], [data-action='schedule']");
-				if (!btn) return;
+				const btn = target?.closest("[data-act='schedule']");
+				if (!btn || btn.hasAttribute("disabled")) return;
 				const participantSelect = $("#s_participant");
-				const participantId = btn.getAttribute("data-part") || btn.getAttribute("data-id");
+				const participantId = btn.getAttribute("data-session-participant-id");
 				if (participantSelect && participantId) {
 					participantSelect.value = participantId;
 					$("#s_datetime")?.focus();

--- a/tests/participant-pseudonymised-view-route-state.test.js
+++ b/tests/participant-pseudonymised-view-route-state.test.js
@@ -5,6 +5,7 @@ const participantService = fs.readFileSync('infra/cloudflare/src/service/partici
 const serviceIndex = fs.readFileSync('infra/cloudflare/src/service/index.js', 'utf8');
 const router = fs.readFileSync('infra/cloudflare/src/core/router.js', 'utf8');
 const migration = fs.readFileSync('infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql', 'utf8');
+const d1SeedMigration = fs.readFileSync('infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql', 'utf8');
 const workflow = fs.readFileSync('.github/workflows/apply-d1-participant-pseudonymised-view.yml', 'utf8');
 const component = fs.readFileSync('public/components/participants/participants-page.js', 'utf8');
 const scheduler = fs.readFileSync('public/pages/study/participants/scheduler.js', 'utf8');
@@ -28,41 +29,52 @@ function functionBody(source, functionName) {
 	return source.slice(start, end);
 }
 
+includes(participantService, 'D1 is the runtime source of truth', 'participant service');
 includes(participantService, 'resolveAuthenticatedContext(request, svc.env)', 'participant service');
 includes(participantService, 'await assertRoutePermission(request, svc.env, context)', 'participant service');
-includes(participantService, 'readParticipantRecordsForStudy(svc, studyId)', 'participant service');
-includes(participantService, 'for (const linkFieldName of PARTICIPANT_FIELDS.study_link)', 'participant service');
-includes(participantService, 'params.append("fields[]", linkFieldName)', 'participant service');
-includes(participantService, 'mapPseudonymisedParticipant(record, index, context)', 'participant service');
-includes(participantService, 'participant_ref: participantReference(record, index)', 'participant service');
-includes(participantService, 'contact_restricted: true', 'participant service');
-includes(participantService, 'can_reveal_contact: canRevealParticipantContact(context)', 'participant service');
-includes(participantService, 'export async function revealParticipantContact', 'participant service');
+includes(participantService, 'readD1ParticipantsForStudy(svc, origin, studyId, context)', 'participant service');
+includes(participantService, 'FROM rops_participants_cache', 'participant service');
+includes(participantService, 'WHERE study_id = ?', 'participant service');
+includes(participantService, 'readD1ParticipantContact(svc, origin, participantId)', 'participant service');
+includes(participantService, 'sensitive_contact_json', 'participant service');
 includes(participantService, 'participant.contact.revealed', 'participant service');
 includes(participantService, 'participant.contact.reveal.denied', 'participant service');
+includes(participantService, 'participant.created', 'participant service');
 includes(participantService, 'CONTACT_RESTRICTED_MESSAGE', 'participant service');
 includes(participantService, 'preferFallbackMessage ? fallbackMessage', 'participant service');
 
-const pseudonymisedMapper = functionBody(participantService, 'mapPseudonymisedParticipant');
-excludes(pseudonymisedMapper, 'email:', 'pseudonymised participant mapper');
-excludes(pseudonymisedMapper, 'phone:', 'pseudonymised participant mapper');
-includes(pseudonymisedMapper, 'display_name: participantReference(record, index)', 'pseudonymised participant mapper');
+excludes(participantService, 'fetchWithTimeout', 'participant service');
+excludes(participantService, 'airtableTryWrite', 'participant service');
+excludes(participantService, 'AIRTABLE_', 'participant service');
 
-const contactMapper = functionBody(participantService, 'mapParticipantContact');
-includes(contactMapper, 'email:', 'contact reveal mapper');
-includes(contactMapper, 'phone:', 'contact reveal mapper');
+const pseudonymisedMapper = functionBody(participantService, 'mapD1Participant');
+excludes(pseudonymisedMapper, 'email:', 'D1 pseudonymised participant mapper');
+excludes(pseudonymisedMapper, 'phone:', 'D1 pseudonymised participant mapper');
+includes(pseudonymisedMapper, 'display_name: row.participant_ref || row.id', 'D1 pseudonymised participant mapper');
+includes(pseudonymisedMapper, 'contact_restricted: true', 'D1 pseudonymised participant mapper');
+
+const contactReader = functionBody(participantService, 'readD1ParticipantContact');
+includes(contactReader, 'email: cleanText(contact.email)', 'D1 contact reveal reader');
+includes(contactReader, 'phone: cleanText(contact.phone)', 'D1 contact reveal reader');
 
 includes(serviceIndex, 'listParticipants = (req, origin, url) => Participants.listParticipants(this, req, origin, url)', 'service index');
 includes(serviceIndex, 'revealParticipantContact = (req, origin, url) => Participants.revealParticipantContact(this, req, origin, url)', 'service index');
+includes(serviceIndex, 'createParticipant = (req, origin) => Participants.createParticipant(this, req, origin)', 'service index');
 
 includes(router, 'url.pathname === "/api/participants/contact"', 'router');
 includes(router, 'service.revealParticipantContact(request, origin, url)', 'router');
 includes(router, 'service.listParticipants(request, origin, url)', 'router');
+includes(router, 'service.createParticipant(request, origin)', 'router');
 
 includes(migration, "'participant.record.view'", 'participant pseudonymised view migration');
 includes(migration, "'GET', '/api/participants', '[\"participant.record.view\"]'", 'participant pseudonymised view migration');
 includes(migration, "'GET', '/api/participants/contact', '[\"participant.pii.reveal\"]'", 'participant pseudonymised view migration');
 includes(migration, "('role_researcher', 'participant.record.view')", 'participant pseudonymised view migration');
+
+includes(d1SeedMigration, "'participant.record.create'", 'D1 participant canonical seed migration');
+includes(d1SeedMigration, "'POST', '/api/participants', '[\"participant.record.create\"]'", 'D1 participant canonical seed migration');
+includes(d1SeedMigration, 'CREATE TABLE IF NOT EXISTS rops_participants_cache', 'D1 participant canonical seed migration');
+includes(d1SeedMigration, 'sensitive_contact_json TEXT', 'D1 participant canonical seed migration');
 
 includes(workflow, 'Apply D1 Participant Pseudonymised View', 'participant D1 apply workflow');
 includes(workflow, 'infra/cloudflare/migrations/0007_participant_pseudonymised_view.sql', 'participant D1 apply workflow');
@@ -78,6 +90,9 @@ for (const source of [component, scheduler]) {
 	excludes(source, 'tel:${encodeURIComponent(p.phone)}', 'participant UI default state');
 }
 
+includes(scheduler, 'project_id: context.projectId', 'participant scheduler');
+includes(scheduler, 'study_id: context.studyId', 'participant scheduler');
+includes(scheduler, 'handleAddParticipant(e, context', 'participant scheduler');
 includes(scheduler, 'revealParticipantContact(participantId)', 'participant scheduler');
 includes(scheduler, '/api/participants/contact?participant=', 'participant scheduler');
 includes(scheduler, 'data-contact-state="revealed"', 'participant scheduler');

--- a/tests/participant-pseudonymised-view-route-state.test.js
+++ b/tests/participant-pseudonymised-view-route-state.test.js
@@ -34,9 +34,14 @@ includes(participantService, 'resolveAuthenticatedContext(request, svc.env)', 'p
 includes(participantService, 'await assertRoutePermission(request, svc.env, context)', 'participant service');
 includes(participantService, 'readD1ParticipantsForStudy(svc, origin, studyId, context)', 'participant service');
 includes(participantService, 'FROM rops_participants_cache', 'participant service');
+includes(participantService, 'participant_airtable_id', 'participant service');
+includes(participantService, 'session_participant_id: sessionParticipantId', 'participant service');
+includes(participantService, 'can_schedule: Boolean(sessionParticipantId)', 'participant service');
 includes(participantService, 'WHERE study_id = ?', 'participant service');
 includes(participantService, 'readD1ParticipantContact(svc, origin, participantId)', 'participant service');
 includes(participantService, 'sensitive_contact_json', 'participant service');
+includes(participantService, 'access_needs', 'participant service');
+includes(participantService, 'accessNeeds', 'participant service');
 includes(participantService, 'participant.contact.revealed', 'participant service');
 includes(participantService, 'participant.contact.reveal.denied', 'participant service');
 includes(participantService, 'participant.created', 'participant service');
@@ -52,6 +57,7 @@ excludes(pseudonymisedMapper, 'email:', 'D1 pseudonymised participant mapper');
 excludes(pseudonymisedMapper, 'phone:', 'D1 pseudonymised participant mapper');
 includes(pseudonymisedMapper, 'display_name: row.participant_ref || row.id', 'D1 pseudonymised participant mapper');
 includes(pseudonymisedMapper, 'contact_restricted: true', 'D1 pseudonymised participant mapper');
+includes(pseudonymisedMapper, 'access_needs: row.access_needs || ""', 'D1 pseudonymised participant mapper');
 
 const contactReader = functionBody(participantService, 'readD1ParticipantContact');
 includes(contactReader, 'email: cleanText(contact.email)', 'D1 contact reveal reader');
@@ -74,6 +80,8 @@ includes(migration, "('role_researcher', 'participant.record.view')", 'participa
 includes(d1SeedMigration, "'participant.record.create'", 'D1 participant canonical seed migration');
 includes(d1SeedMigration, "'POST', '/api/participants', '[\"participant.record.create\"]'", 'D1 participant canonical seed migration');
 includes(d1SeedMigration, 'CREATE TABLE IF NOT EXISTS rops_participants_cache', 'D1 participant canonical seed migration');
+includes(d1SeedMigration, 'participant_airtable_id TEXT', 'D1 participant canonical seed migration');
+includes(d1SeedMigration, 'access_needs TEXT', 'D1 participant canonical seed migration');
 includes(d1SeedMigration, 'sensitive_contact_json TEXT', 'D1 participant canonical seed migration');
 
 includes(workflow, 'Apply D1 Participant Pseudonymised View', 'participant D1 apply workflow');
@@ -93,6 +101,11 @@ for (const source of [component, scheduler]) {
 includes(scheduler, 'project_id: context.projectId', 'participant scheduler');
 includes(scheduler, 'study_id: context.studyId', 'participant scheduler');
 includes(scheduler, 'handleAddParticipant(e, context', 'participant scheduler');
+includes(scheduler, 'scheduleableParticipants(participants)', 'participant scheduler');
+includes(scheduler, 'session_participant_id', 'participant scheduler');
+includes(scheduler, 'data-session-participant-id', 'participant scheduler');
+includes(scheduler, 'Scheduling is not available until this participant has a session-compatible record.', 'participant scheduler');
+includes(scheduler, 'participant_airtable_id: participantId', 'participant scheduler');
 includes(scheduler, 'revealParticipantContact(participantId)', 'participant scheduler');
 includes(scheduler, '/api/participants/contact?participant=', 'participant scheduler');
 includes(scheduler, 'data-contact-state="revealed"', 'participant scheduler');

--- a/tests/test-project-1-participants-seed-route-state.test.js
+++ b/tests/test-project-1-participants-seed-route-state.test.js
@@ -13,6 +13,9 @@ function excludes(source, text, label) {
 }
 
 includes(migration, 'CREATE TABLE IF NOT EXISTS rops_participants_cache', 'Test Project 1 participant seed migration');
+includes(migration, 'sensitive_contact_json TEXT', 'Test Project 1 participant seed migration');
+includes(migration, 'participant.record.create', 'Test Project 1 participant seed migration');
+includes(migration, "'POST', '/api/participants', '[\"participant.record.create\"]'", 'Test Project 1 participant seed migration');
 includes(migration, 'recgdpwEI5hFO7bUZ', 'Test Project 1 participant seed migration');
 includes(migration, 'rect3biqr', 'Test Project 1 participant seed migration');
 includes(migration, 'd1ptp_test_project_1_01', 'Test Project 1 participant seed migration');
@@ -20,12 +23,12 @@ includes(migration, 'd1ptp_test_project_1_10', 'Test Project 1 participant seed 
 includes(migration, 'TP1 Participant 01', 'Test Project 1 participant seed migration');
 includes(migration, 'TP1 Participant 10', 'Test Project 1 participant seed migration');
 includes(migration, 'ON CONFLICT(id) DO UPDATE SET', 'Test Project 1 participant seed migration');
+includes(migration, 'sensitive_contact_json = excluded.sensitive_contact_json', 'Test Project 1 participant seed migration');
 includes(migration, 'pseudonymised', 'Test Project 1 participant seed migration');
 
 excludes(migration, '@', 'Test Project 1 participant seed migration');
-excludes(migration, 'email', 'Test Project 1 participant seed migration');
-excludes(migration, 'phone', 'Test Project 1 participant seed migration');
-excludes(migration, 'contact', 'Test Project 1 participant seed migration');
+excludes(migration, 'example.', 'Test Project 1 participant seed migration');
+excludes(migration, '07123', 'Test Project 1 participant seed migration');
 
 const seededRecordIds = migration.match(/d1ptp_test_project_1_\d{2}/g) || [];
 assert.equal(new Set(seededRecordIds).size, 10, 'Expected exactly 10 unique Test Project 1 participant IDs');
@@ -34,4 +37,5 @@ includes(workflow, 'Apply D1 Test Project 1 Participants Seed', 'Test Project 1 
 includes(workflow, 'infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql', 'Test Project 1 participant seed workflow');
 includes(workflow, 'APPLY_TEST_PROJECT_1_PARTICIPANTS', 'Test Project 1 participant seed workflow');
 includes(workflow, "SELECT COUNT(*) AS participant_count FROM rops_participants_cache WHERE project_id = 'recgdpwEI5hFO7bUZ'", 'Test Project 1 participant seed workflow');
+includes(workflow, "SELECT method, route_pattern, required_permissions_json FROM auth_route_permissions WHERE route_pattern = '/api/participants' ORDER BY method;", 'Test Project 1 participant seed workflow');
 includes(workflow, "source = 'd1-seed'", 'Test Project 1 participant seed workflow');

--- a/tests/test-project-1-participants-seed-route-state.test.js
+++ b/tests/test-project-1-participants-seed-route-state.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migration = fs.readFileSync('infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql', 'utf8');
+const workflow = fs.readFileSync('.github/workflows/apply-d1-test-project-1-participants.yml', 'utf8');
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(migration, 'CREATE TABLE IF NOT EXISTS rops_participants_cache', 'Test Project 1 participant seed migration');
+includes(migration, 'recgdpwEI5hFO7bUZ', 'Test Project 1 participant seed migration');
+includes(migration, 'rect3biqr', 'Test Project 1 participant seed migration');
+includes(migration, 'd1ptp_test_project_1_01', 'Test Project 1 participant seed migration');
+includes(migration, 'd1ptp_test_project_1_10', 'Test Project 1 participant seed migration');
+includes(migration, 'TP1 Participant 01', 'Test Project 1 participant seed migration');
+includes(migration, 'TP1 Participant 10', 'Test Project 1 participant seed migration');
+includes(migration, 'ON CONFLICT(id) DO UPDATE SET', 'Test Project 1 participant seed migration');
+includes(migration, 'pseudonymised', 'Test Project 1 participant seed migration');
+
+excludes(migration, '@', 'Test Project 1 participant seed migration');
+excludes(migration, 'email', 'Test Project 1 participant seed migration');
+excludes(migration, 'phone', 'Test Project 1 participant seed migration');
+excludes(migration, 'contact', 'Test Project 1 participant seed migration');
+
+const seededRecordIds = migration.match(/d1ptp_test_project_1_\d{2}/g) || [];
+assert.equal(new Set(seededRecordIds).size, 10, 'Expected exactly 10 unique Test Project 1 participant IDs');
+
+includes(workflow, 'Apply D1 Test Project 1 Participants Seed', 'Test Project 1 participant seed workflow');
+includes(workflow, 'infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql', 'Test Project 1 participant seed workflow');
+includes(workflow, 'APPLY_TEST_PROJECT_1_PARTICIPANTS', 'Test Project 1 participant seed workflow');
+includes(workflow, "SELECT COUNT(*) AS participant_count FROM rops_participants_cache WHERE project_id = 'recgdpwEI5hFO7bUZ'", 'Test Project 1 participant seed workflow');
+includes(workflow, "source = 'd1-seed'", 'Test Project 1 participant seed workflow');


### PR DESCRIPTION
## Summary

Pivots participant runtime behaviour so D1 is canonical and Airtable is secondary.

This follows the development constraint that Airtable public API calls are capped and must not block active testing. The normal participant list, participant creation and contact reveal paths should work without Airtable.

## Changes

- Update `infra/cloudflare/src/service/participants.js` so participant list, participant creation and contact reveal use D1.
- Add `rops_participants_cache` as the D1 participant source of truth for this slice.
- Seed 10 pseudonymised participants for `Test Project 1`:
  - project ID: `recgdpwEI5hFO7bUZ`
  - study ID: `rect3biqr`
- Add `sensitive_contact_json` for permission-gated contact reveal, while seeding no real contact details.
- Add `participant.record.create` and route protection for `POST /api/participants`.
- Preserve access needs in D1 via `access_needs` and `payload_json`.
- Add optional `participant_airtable_id` as an adapter key for the still-Airtable-backed sessions path.
- Disable scheduling for D1-only participants that do not have a session-compatible participant record ID.
- Update the participant page controller so new participant creation posts both `project_id` and `study_id`.
- Add a D1 apply workflow with post-apply checks for participant count and route declarations.
- Update route-state tests to assert D1-canonical runtime behaviour and no Airtable runtime dependency for participants.
- Add trace files for the D1 canonical pivot.

## Architecture decision

D1 is now canonical for participants.

Airtable is secondary. It should be treated as an adapter, import/export/sync surface or legacy fallback, not a required runtime dependency for participant testing.

## Codex review disposition

Addressed both Codex comments:

- Scheduling compatibility: D1 participants now expose `can_schedule` and `session_participant_id`. The scheduler only posts `session_participant_id` to `/api/sessions` and disables scheduling for D1-only participants without a session-compatible adapter ID.
- Access needs: `access_needs` is now stored in D1 and included in the participant payload JSON instead of being silently dropped.

## Scope controls

This PR does not implement Story 8 access requests.

This PR does not migrate all ResearchOps runtime data to D1. It starts the pivot with participants.

This PR does not seed real personal data.

This PR does not grant default users unrestricted contact reveal access.

This PR does not move sessions to D1. The session creation path still uses existing session field names and should be handled in a separate D1-canonical session slice.

## Residual risk

If remote D1 already contains an older incompatible `rops_participants_cache` table without `participant_airtable_id`, `access_needs` or `sensitive_contact_json`, this migration may need a compatibility follow-up. Fresh and not-yet-seeded environments create the canonical table shape.

The branch was previously used for PR #322 and is one merge commit behind `main`, but the diff against current `main` is limited to the D1 participant pivot files.

## Validation

GitHub Actions passed on head `eb65dfe`:

- Format pull request
- QA — Broken links (Lychee)
- Accessibility audit (pa11y-ci)
- qa-bdd
- CI
- Validate ResearchOps
- Release Gate
- Worker CI

Trace files:

- `docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.md`
- `docs/agent-audit/reasoning/2026/05/31/participant-d1-canonical-pivot.json`