### PR TITLE
Show project participants on dashboard

### DIFF
--- a/public/js/project-dashboard.js
+++ b/public/js/project-dashboard.js
@@ -183,6 +183,27 @@ async function loadStudies(projectId) {
 	}));
 }
 
+async function loadParticipantsForStudy(study) {
+	if (!study?.id) return [];
+	const response = await fetchWithTimeout(apiUrl(`/api/participants?study=${encodeURIComponent(study.id)}&ts=${Date.now()}`), {
+		cache: "no-store",
+		credentials: "include",
+	}, 15000);
+	const json = await readJsonResponse(response, "Participants");
+	const participants = Array.isArray(json.participants) ? json.participants : [];
+	const studyTitle = study.title?.trim() || study.method?.trim() || computeStudyTitle(study);
+	return participants.map((participant) => ({
+		...participant,
+		studyId: study.id,
+		studyTitle,
+	}));
+}
+
+async function loadParticipantsForStudies(studies = []) {
+	const results = await Promise.all(studies.map((study) => loadParticipantsForStudy(study)));
+	return results.flat();
+}
+
 function computeStudyTitle({ description = "", method = "", createdAt = "" } = {}) {
 	if (description.trim()) return description.trim().slice(0, 80);
 	const date = createdAt ? new Date(createdAt) : new Date();
@@ -293,6 +314,54 @@ ${description ? `<p class="govuk-body-s rops-study-description">${escapeHtml(des
 ${status ? `<strong class="govuk-tag ${studyStatusTagClass(status)}">${escapeHtml(status)}</strong>` : ""}
 </li>`;
 	}).join("");
+}
+
+function participantPlanningPanel() {
+	const heading = Array.from(document.querySelectorAll("#planning h3")).find((element) => element.textContent.trim() === "Participants");
+	return heading?.parentElement || null;
+}
+
+function renderParticipantsSummary(project, participants = []) {
+	const panel = participantPlanningPanel();
+	if (!panel) return;
+
+	const projectId = encodeURIComponent(projectIdFromUrl(project));
+	const summary = participants.length === 1 ? "1 participant" : `${participants.length} participants`;
+	const participantList = participants.length ? `
+<ul class="govuk-list govuk-list--spaced rops-divided-list" id="participants-list">
+${participants.map((participant) => {
+		const reference = escapeHtml(participant.participant_ref || participant.display_name || participant.id || "Participant");
+		const status = participant.status ? `<br><span class="govuk-hint">Status: ${escapeHtml(participant.status)}</span>` : "";
+		const study = participant.studyTitle ? `<br><span class="govuk-hint">Study: ${escapeHtml(participant.studyTitle)}</span>` : "";
+		return `<li><strong>${reference}</strong>${status}${study}</li>`;
+	}).join("")}
+</ul>` : "<p class=\"govuk-body-s\">No participants yet.</p>";
+
+	panel.innerHTML = `
+<h3 class="govuk-heading-s">Participants</h3>
+<p class="govuk-body-s" id="participants-summary-status">${escapeHtml(summary)} linked to this project.</p>
+${participantList}
+<p class="govuk-body-s">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
+<div class="govuk-button-group">
+<a href="/pages/project-dashboard/participants/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="add-participant-link">Add participant</a>
+<a href="/pages/project-dashboard/participants/import/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="import-participants-link">Bulk upload participants via CSV</a>
+</div>`;
+}
+
+function renderParticipantsLoadError(project, error) {
+	const panel = participantPlanningPanel();
+	if (!panel) return;
+	const projectId = encodeURIComponent(projectIdFromUrl(project));
+	const reason = escapeHtml(String(error?.message || error || "Unknown error"));
+	panel.innerHTML = `
+<h3 class="govuk-heading-s">Participants</h3>
+<p class="govuk-body-s" role="alert"><strong>Could not load participants</strong><br>Participant records could not be loaded for this project.</p>
+<p class="govuk-body-s"><strong>Technical detail:</strong> <code>${reason}</code></p>
+<p class="govuk-body-s">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
+<div class="govuk-button-group">
+<a href="/pages/project-dashboard/participants/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="add-participant-link">Add participant</a>
+<a href="/pages/project-dashboard/participants/import/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="import-participants-link">Bulk upload participants via CSV</a>
+</div>`;
 }
 
 function renderStudiesLoadError(error) {
@@ -461,9 +530,17 @@ function renderProjectLoadError(error, requestedProjectId) {
 		try {
 			const studies = await loadStudies(project.id || requestedProjectId);
 			renderStudies(project, studies);
+			try {
+				const participants = await loadParticipantsForStudies(studies);
+				renderParticipantsSummary(project, participants);
+			} catch (participantError) {
+				console.error("[project-dashboard] participants load failed", participantError);
+				renderParticipantsLoadError(project, participantError);
+			}
 		} catch (studyError) {
 			console.error("[project-dashboard] studies load failed", studyError);
 			renderStudiesLoadError(studyError);
+			renderParticipantsSummary(project, []);
 		}
 		initProjectActions();
 	} catch (error) {

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -8,7 +8,7 @@
 	
 	<meta name="project:name" content="">
 	<link rel="modulepreload" href="/js/project-dashboard-context.js">
-	<link rel="modulepreload" href="/js/project-dashboard.js?v=project-dashboard-d1-first-20260526">
+	<link rel="modulepreload" href="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601">
 	<link rel="stylesheet" href="/css/project-dashboard.css?v=project-dashboard-govuk-existing-model-20260525" media="screen">
 
 	<script type="module" src="/components/layout.js" defer></script>
@@ -414,9 +414,9 @@
 							</form>
 						</div>
 					</div>
-					<div>
+					<div id="participants-dashboard-panel">
 						<h3 class="govuk-heading-s">Participants</h3>
-						<p class="govuk-body-s">No participants yet.</p>
+						<p class="govuk-body-s" id="participants-summary-status">Loading participants…</p>
 						<p class="govuk-body-s">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
 						<div class="govuk-button-group">
 							
@@ -513,7 +513,7 @@
 	<x-include src="/partials/footer.html"></x-include>
 	
 	<script type="module" src="/js/project-dashboard-context.js"></script>
-	<script type="module" src="/js/project-dashboard.js?v=project-dashboard-d1-first-20260526"></script>
+	<script type="module" src="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601"></script>
 	<script type="module" src="/components/mural-integration.js?v=project-dashboard-mural-optional-20260526"></script>
 	<script type="module" src="/components/project-dashboard-mural-state.js?v=inert-20260525"></script>
 

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -4,7 +4,7 @@
 {% block head %}
 	<meta name="project:name" content="">
 	<link rel="modulepreload" href="/js/project-dashboard-context.js">
-	<link rel="modulepreload" href="/js/project-dashboard.js?v=project-dashboard-d1-first-20260526">
+	<link rel="modulepreload" href="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601">
 	<link rel="stylesheet" href="/css/project-dashboard.css?v=project-dashboard-govuk-existing-model-20260525" media="screen">
 {% endblock %}
 
@@ -286,9 +286,9 @@
 							</form>
 						</div>
 					</div>
-					<div>
+					<div id="participants-dashboard-panel">
 						<h3 class="govuk-heading-s">Participants</h3>
-						<p class="govuk-body-s">No participants yet.</p>
+						<p class="govuk-body-s" id="participants-summary-status">Loading participants…</p>
 						<p class="govuk-body-s">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
 						<div class="govuk-button-group">
 							{{ govukButton({ text: "Add participant", href: "/pages/project-dashboard/participants/?pid=", classes: "govuk-button--secondary", attributes: { id: "add-participant-link" } }) }}
@@ -328,7 +328,7 @@
 
 {% block scripts %}
 	<script type="module" src="/js/project-dashboard-context.js"></script>
-	<script type="module" src="/js/project-dashboard.js?v=project-dashboard-d1-first-20260526"></script>
+	<script type="module" src="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601"></script>
 	<script type="module" src="/components/mural-integration.js?v=project-dashboard-mural-optional-20260526"></script>
 	<script type="module" src="/components/project-dashboard-mural-state.js?v=inert-20260525"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Fixes the project dashboard participant summary so seeded participants are visible on the dashboard.

The screenshot showed `No participants yet` because the project dashboard template hard-coded that text and `public/js/project-dashboard.js` only loaded project details and studies. It never queried the participant endpoint.

## Changes

- Update `src/govuk/templates/pages/project-dashboard.njk` so the source template owns the participant panel.
- Include the corresponding generated `public/pages/project-dashboard/index.html` change because `public/` is the deployed Cloudflare Pages output.
- Add a stable `participants-dashboard-panel` container.
- Change the initial participant state from `No participants yet` to `Loading participants…`.
- Bump the project-dashboard script cache key in the source template and generated page.
- Update `public/js/project-dashboard.js` so the dashboard loads participants for each loaded study via `GET /api/participants?study=...` and renders a project-level participant summary.
- Keep participant display pseudonymised: participant reference, status and study title only.

## Codex review disposition

Addressed the Codex comment by including the regenerated/served `public/pages/project-dashboard/index.html` change alongside the source template change.

## Scope controls

This does not expose participant contact details.

This does not change the participant schema.

This does not migrate sessions.

This keeps the source template and generated Pages output aligned.

## Validation

Not run locally in this connector context. Ready for GitHub Actions and review.