### PR TITLE
Improve participant page guidance and grouping

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.json
+++ b/docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.json
@@ -1,0 +1,34 @@
+{
+	"date": "2026-06-01",
+	"traceType": "operational-audit-trace",
+	"branch": "fix/participant-page-guidance-and-grouping",
+	"base": "merged PR #326",
+	"task": "Improve the project dashboard participant creation page after team critique.",
+	"scopeControls": [
+		"No participant D1 data model changes.",
+		"No new participant API routes.",
+		"No change to pseudonymised-by-default participant lists."
+	],
+	"teamConsultation": {
+		"researchOperations": "Explain what happens after a participant record is created.",
+		"userResearch": "Use operational workflow language connected to recruitment, consent, withdrawal and sessions.",
+		"privacy": "Explain why real names and contact details are captured and how participant references remain the default display label.",
+		"security": "Make the authorised-role boundary visible for names, contact details and support needs.",
+		"interactionDesign": "Group the form into Study, Participant identity, Contact details, and Access or support needs.",
+		"contentDesign": "Use clearer optional-field wording and change Preferred contact channel to Preferred contact method.",
+		"accessibility": "Keep GOV.UK macros and add structured explanatory content with GOV.UK Details and Inset Text."
+	},
+	"filesChanged": [
+		"public/partials/header.html",
+		"src/govuk/templates/pages/project-dashboard-participants.njk",
+		"tests/govuk-page-chrome-navigation-route-state.test.js",
+		"tests/participant-pseudonymised-view-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.md",
+		"docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.json"
+	],
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint",
+		"npm test -- --ci"
+	]
+}

--- a/docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.md
+++ b/docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.md
@@ -1,0 +1,47 @@
+# Agent trace — Participant page guidance and grouping
+
+**Date:** 2026-06-01  
+**Trace type:** operational audit trace  
+**Branch:** `fix/participant-page-guidance-and-grouping`  
+**Base:** merged PR #326
+
+## Scope
+
+Improve the project dashboard participant creation page after team critique.
+
+This branch does not change the participant data model or D1 canonical behaviour from PR #326.
+
+## Team consultation summary
+
+Research Operations needs the page to explain what happens after a participant is created. The form now tells users that creating a record links the participant to the selected study, but does not send an email, create a consent request or schedule a session.
+
+User Research needs the page to explain the workflow in operational language. The lead paragraph now focuses on managing recruitment, consent, withdrawal and sessions.
+
+Privacy needs the page to explain why real names and contact details are captured and how the default pseudonymised display works. The page now says participant lists continue to show the participant reference by default.
+
+Security needs the page to make the permission boundary visible. The page now states that real names, contact details and support needs are restricted to authorised project roles.
+
+Interaction Design needs clearer grouping. The form is now grouped under Study, Participant identity, Contact details, and Access or support needs.
+
+Content Design needs clearer labels and optional-field wording. The page now uses Participant reference (optional), Email address (optional), Phone number (optional), Preferred contact method, and Access or support needs (optional).
+
+Accessibility needs clearer structure and GOV.UK components. The page keeps GOV.UK macros and adds GOV.UK Details and Inset Text content to explain the workflow.
+
+## Files changed
+
+- `public/partials/header.html`
+- `src/govuk/templates/pages/project-dashboard-participants.njk`
+- `tests/govuk-page-chrome-navigation-route-state.test.js`
+- `tests/participant-pseudonymised-view-route-state.test.js`
+
+## Validation expectation
+
+The render workflow should regenerate `public/pages/project-dashboard/participants/index.html` from the updated Nunjucks source.
+
+Expected checks:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```

--- a/public/pages/project-dashboard/participants/index.html
+++ b/public/pages/project-dashboard/participants/index.html
@@ -52,10 +52,34 @@
 					<p id="project-eyebrow" class="govuk-caption-l">Project</p>
 					<h1 class="govuk-heading-l">Add participant</h1>
 					<p class="govuk-body-l">
-						Add participants through a study-specific workflow so recruitment, consent, withdrawal and sessions remain
-						traceable.
+						Add a participant to a study so the team can manage recruitment, consent, withdrawal and sessions.
 					</p>
 				</div>
+
+				<div class="govuk-inset-text">
+					<h2 class="govuk-heading-m">How participant details are used</h2>
+					<p class="govuk-body">
+						This prototype models how production ResearchOps will capture sensitive participant details. Real names and
+						contact details are used for recruitment, consent and withdrawal operations.
+					</p>
+					<p class="govuk-body">
+						Participant lists continue to show the participant reference by default. Real names, contact details and
+						support needs are restricted to authorised project roles.
+					</p>
+				</div>
+
+				<details class="govuk-details">
+					<summary class="govuk-details__summary">
+						<span class="govuk-details__summary-text">What happens next</span>
+					</summary>
+					<div class="govuk-details__text">
+						<p class="govuk-body">ResearchOps creates a participant record and links it to the selected study.</p>
+						<p class="govuk-body">
+							This does not send an email, create a consent request or schedule a session. Those actions happen
+							separately from the study participants area.
+						</p>
+					</div>
+				</details>
 
 				<div
 					class="govuk-error-summary"
@@ -80,6 +104,8 @@
 				<form id="add-participant-form" novalidate>
 					<input id="project-id" name="project_id" type="hidden" value="" />
 
+					<h2 class="govuk-heading-m">Study</h2>
+
 					<div class="govuk-form-group">
 						<label class="govuk-label" for="study-select">Study</label>
 
@@ -95,6 +121,8 @@
 							<option value="">Choose a study</option>
 						</select>
 					</div>
+
+					<h2 class="govuk-heading-m">Participant identity</h2>
 
 					<div class="govuk-form-group">
 						<label class="govuk-label" for="participant-first-name">First name</label>
@@ -118,10 +146,7 @@
 					<div class="govuk-form-group">
 						<label class="govuk-label" for="participant-family-name">Family name</label>
 
-						<div id="participant-family-name-hint" class="govuk-hint">
-							Enter the participant’s real family name. The participant list will continue to show a participant
-							reference by default.
-						</div>
+						<div id="participant-family-name-hint" class="govuk-hint">Enter the participant’s real family name.</div>
 
 						<input
 							class="govuk-input govuk-!-width-two-thirds"
@@ -135,10 +160,11 @@
 					</div>
 
 					<div class="govuk-form-group">
-						<label class="govuk-label" for="participant-ref">Participant reference</label>
+						<label class="govuk-label" for="participant-ref">Participant reference (optional)</label>
 
 						<div id="participant-ref-hint" class="govuk-hint">
-							Use a study reference such as TP1 Participant 11. Leave blank to let ResearchOps create one.
+							This is the label shown by default in participant lists. Do not use a real name here. Leave blank to let
+							ResearchOps create one.
 						</div>
 
 						<input
@@ -151,8 +177,10 @@
 						/>
 					</div>
 
+					<h2 class="govuk-heading-m">Contact details</h2>
+
 					<div class="govuk-form-group">
-						<label class="govuk-label" for="participant-email">Email address</label>
+						<label class="govuk-label" for="participant-email">Email address (optional)</label>
 
 						<input
 							class="govuk-input govuk-!-width-two-thirds"
@@ -164,7 +192,7 @@
 					</div>
 
 					<div class="govuk-form-group">
-						<label class="govuk-label" for="participant-phone">Phone number</label>
+						<label class="govuk-label" for="participant-phone">Phone number (optional)</label>
 
 						<input
 							class="govuk-input govuk-!-width-two-thirds"
@@ -176,7 +204,7 @@
 					</div>
 
 					<div class="govuk-form-group">
-						<label class="govuk-label" for="participant-channel">Preferred contact channel</label>
+						<label class="govuk-label" for="participant-channel">Preferred contact method</label>
 
 						<select class="govuk-select" id="participant-channel" name="channel_pref">
 							<option value="email" selected>Email</option>
@@ -187,11 +215,14 @@
 						</select>
 					</div>
 
+					<h2 class="govuk-heading-m">Access or support needs</h2>
+
 					<div class="govuk-form-group">
-						<label class="govuk-label" for="participant-access-needs">Access needs</label>
+						<label class="govuk-label" for="participant-access-needs">Access or support needs (optional)</label>
 
 						<div id="participant-access-needs-hint" class="govuk-hint">
-							Only record support needs needed to run the research safely and accessibly.
+							Only include adjustments or support needs needed to plan and run the session. Do not record medical
+							history or unnecessary personal details.
 						</div>
 
 						<textarea
@@ -216,7 +247,7 @@
 							data-module="govuk-button"
 							id="cancel-participant"
 						>
-							Cancel
+							Cancel and return to project dashboard
 						</a>
 					</div>
 

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -62,7 +62,7 @@
 <div class="govuk-phase-banner govuk-width-container" role="note" aria-label="Service phase">
 	<p class="govuk-phase-banner__content">
 		<strong class="govuk-tag govuk-phase-banner__content__tag">Prototype</strong>
-		<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant personal data.</span>
+		<span class="govuk-phase-banner__text">This is a ResearchOps prototype. Do not enter real participant data in this prototype.</span>
 	</p>
 </div>
 

--- a/src/govuk/templates/pages/project-dashboard-participants.njk
+++ b/src/govuk/templates/pages/project-dashboard-participants.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/researchops.njk" %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
@@ -50,8 +51,17 @@
 	<div class="dashboard-hero">
 		<p id="project-eyebrow" class="govuk-caption-l">Project</p>
 		<h1 class="govuk-heading-l">Add participant</h1>
-		<p class="govuk-body-l">Add participants through a study-specific workflow so recruitment, consent, withdrawal and sessions remain traceable.</p>
+		<p class="govuk-body-l">Add a participant to a study so the team can manage recruitment, consent, withdrawal and sessions.</p>
 	</div>
+
+	{{ govukInsetText({
+		html: '<h2 class="govuk-heading-m">How participant details are used</h2><p class="govuk-body">This prototype models how production ResearchOps will capture sensitive participant details. Real names and contact details are used for recruitment, consent and withdrawal operations.</p><p class="govuk-body">Participant lists continue to show the participant reference by default. Real names, contact details and support needs are restricted to authorised project roles.</p>'
+	}) }}
+
+	{{ govukDetails({
+		summaryText: "What happens next",
+		html: '<p class="govuk-body">ResearchOps creates a participant record and links it to the selected study.</p><p class="govuk-body">This does not send an email, create a consent request or schedule a session. Those actions happen separately from the study participants area.</p>'
+	}) }}
 
 	{{ govukErrorSummary({
 		attributes: {
@@ -73,6 +83,7 @@
 	<form id="add-participant-form" novalidate>
 		<input id="project-id" name="project_id" type="hidden" value="">
 
+		<h2 class="govuk-heading-m">Study</h2>
 		{{ govukSelect({
 			id: "study-select",
 			name: "study_id",
@@ -94,6 +105,7 @@
 			}
 		}) }}
 
+		<h2 class="govuk-heading-m">Participant identity</h2>
 		{{ govukInput({
 			id: "participant-first-name",
 			name: "first_name",
@@ -118,7 +130,7 @@
 				text: "Family name"
 			},
 			hint: {
-				text: "Enter the participant’s real family name. The participant list will continue to show a participant reference by default."
+				text: "Enter the participant’s real family name."
 			},
 			autocomplete: "family-name",
 			attributes: {
@@ -131,21 +143,22 @@
 			name: "participant_ref",
 			classes: "govuk-!-width-two-thirds",
 			label: {
-				text: "Participant reference"
+				text: "Participant reference (optional)"
 			},
 			hint: {
-				text: "Use a study reference such as TP1 Participant 11. Leave blank to let ResearchOps create one."
+				text: "This is the label shown by default in participant lists. Do not use a real name here. Leave blank to let ResearchOps create one."
 			},
 			autocomplete: "off"
 		}) }}
 
+		<h2 class="govuk-heading-m">Contact details</h2>
 		{{ govukInput({
 			id: "participant-email",
 			name: "email",
 			type: "email",
 			classes: "govuk-!-width-two-thirds",
 			label: {
-				text: "Email address"
+				text: "Email address (optional)"
 			},
 			autocomplete: "email"
 		}) }}
@@ -156,7 +169,7 @@
 			type: "tel",
 			classes: "govuk-!-width-two-thirds",
 			label: {
-				text: "Phone number"
+				text: "Phone number (optional)"
 			},
 			autocomplete: "tel"
 		}) }}
@@ -165,7 +178,7 @@
 			id: "participant-channel",
 			name: "channel_pref",
 			label: {
-				text: "Preferred contact channel"
+				text: "Preferred contact method"
 			},
 			items: [
 				{
@@ -184,6 +197,7 @@
 			]
 		}) }}
 
+		<h2 class="govuk-heading-m">Access or support needs</h2>
 		{{ govukTextarea({
 			id: "participant-access-needs",
 			name: "access_needs",
@@ -194,10 +208,10 @@
 				classes: ""
 			},
 			label: {
-				text: "Access needs"
+				text: "Access or support needs (optional)"
 			},
 			hint: {
-				text: "Only record support needs needed to run the research safely and accessibly."
+				text: "Only include adjustments or support needs needed to plan and run the session. Do not record medical history or unnecessary personal details."
 			}
 		}) }}
 
@@ -210,7 +224,7 @@
 				}
 			}) }}
 			{{ govukButton({
-				text: "Cancel",
+				text: "Cancel and return to project dashboard",
 				href: "/pages/projects/",
 				classes: "govuk-button--secondary",
 				attributes: {

--- a/tests/govuk-page-chrome-navigation-route-state.test.js
+++ b/tests/govuk-page-chrome-navigation-route-state.test.js
@@ -91,7 +91,7 @@ includes(headerPartial, "data-nav=\"Home\"", "shared header partial");
 includes(headerPartial, "data-nav=\"Start Research Project\"", "shared header partial");
 includes(headerPartial, "data-nav=\"Projects\"", "shared header partial");
 includes(headerPartial, "class=\"govuk-phase-banner govuk-width-container\"", "shared header partial");
-includes(headerPartial, "Do not enter real participant personal data", "shared header partial");
+includes(headerPartial, "Do not enter real participant data in this prototype", "shared header partial");
 includes(headerPartial, "ensurePageChromeStylesheet", "shared header partial");
 includes(headerPartial, "ensureMainContentTarget", "shared header partial");
 includes(headerPartial, "initServiceNavigation", "shared header partial");

--- a/tests/participant-pseudonymised-view-route-state.test.js
+++ b/tests/participant-pseudonymised-view-route-state.test.js
@@ -129,11 +129,18 @@ includes(scheduler, 'Sensitive', 'participant scheduler');
 includes(scheduler, 'Handle this information as sensitive.', 'participant scheduler');
 
 includes(projectParticipantSource, 'from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs', 'project participant source');
+includes(projectParticipantSource, 'from "govuk/components/details/macro.njk" import govukDetails', 'project participant source');
 includes(projectParticipantSource, 'from "govuk/components/error-summary/macro.njk" import govukErrorSummary', 'project participant source');
 includes(projectParticipantSource, 'from "govuk/components/input/macro.njk" import govukInput', 'project participant source');
 includes(projectParticipantSource, 'from "govuk/components/select/macro.njk" import govukSelect', 'project participant source');
 includes(projectParticipantSource, 'from "govuk/components/textarea/macro.njk" import govukTextarea', 'project participant source');
 includes(projectParticipantSource, 'from "govuk/components/inset-text/macro.njk" import govukInsetText', 'project participant source');
+includes(projectParticipantSource, 'How participant details are used', 'project participant source');
+includes(projectParticipantSource, 'What happens next', 'project participant source');
+includes(projectParticipantSource, 'Participant reference (optional)', 'project participant source');
+includes(projectParticipantSource, 'Preferred contact method', 'project participant source');
+includes(projectParticipantSource, 'Access or support needs (optional)', 'project participant source');
+includes(projectParticipantSource, 'Do not record medical history or unnecessary personal details.', 'project participant source');
 includes(projectParticipantSource, 'typeof: "schema:BreadcrumbList"', 'project participant breadcrumb source');
 
 includes(projectParticipantPage, 'id="participant-first-name"', 'project participant page');


### PR DESCRIPTION
## Summary

- Clarifies the prototype banner so it no longer conflicts with the participant form.
- Improves the add-participant page lead copy.
- Adds guidance explaining how participant details are used and who can see sensitive details.
- Adds a “What happens next” details section.
- Groups the form into Study, Participant identity, Contact details, and Access or support needs.
- Renames “Preferred contact channel” to “Preferred contact method”.
- Marks optional fields explicitly.
- Strengthens the participant reference and support-needs hints.
- Updates route-state tests for the new guidance and banner copy.

## Scope

This PR does not change the D1 participant data model, participant API, or the pseudonymised-by-default participant list behaviour from PR #326.

## Trace

- `docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.md`
- `docs/agent-audit/reasoning/2026/06/01/participant-page-guidance-and-grouping.json`

## Validation

Expected checks:

```bash
npm run validate
npm run lint
npm test -- --ci
```

The GOV.UK render workflow should regenerate the static participant page from the updated Nunjucks template.