### PR TITLE
Add participant reveal, search, sort and pagination controls

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.json
+++ b/docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.json
@@ -1,0 +1,48 @@
+{
+	"date": "2026-06-01",
+	"traceType": "operational-audit-trace",
+	"branch": "fix/participant-list-reveal-search-sort-pagination",
+	"base": "main after PR #327",
+	"task": "Add authorised participant detail reveal plus search, sort, pagination and study-title truncation on the project dashboard participant list.",
+	"operatingModelSources": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		".agent-operating-model/bundles/github/",
+		".agent-operating-model/bundles/researchops-developer-control/",
+		".agent-operating-model/bundles/multi-functional-team/",
+		".agent-operating-model/bundles/govuk-design-system/",
+		".agent-operating-model/bundles/cloudflare/"
+	],
+	"acceptanceCriteria": [
+		"Authorised users can reveal participant first name, family name and contact details.",
+		"Participant lists greater than 10 records show search, sort and pagination controls.",
+		"Sort options include A-Z, Z-A, First to last, Last to first and User group.",
+		"Long study titles are single-line and truncated at the last fitting word with a horizontal ellipsis."
+	],
+	"scopeControls": [
+		"No D1 participant table model changes.",
+		"No new participant API endpoints.",
+		"No PII added to default participant list responses.",
+		"Reveal continues to use /api/participants/contact."
+	],
+	"filesChanged": [
+		"src/govuk/templates/pages/project-dashboard.njk",
+		"public/js/project-dashboard-participants-list.js",
+		"src/styles/project-dashboard.scss",
+		"public/css/project-dashboard.css",
+		"tests/project-dashboard-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.md",
+		"docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.json"
+	],
+	"validationExpected": [
+		"npm run validate",
+		"npm run lint",
+		"npm test -- --ci"
+	]
+}

--- a/docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.md
+++ b/docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.md
@@ -1,0 +1,81 @@
+# Agent trace — Participant list reveal, search, sort and pagination
+
+**Date:** 2026-06-01  
+**Trace type:** operational audit trace  
+**Branch:** `fix/participant-list-reveal-search-sort-pagination`  
+**Base:** `main` after PR #327
+
+## Scope
+
+Implement participant-list behaviour on the project dashboard:
+
+- authorised users can reveal participant first name, family name and contact details
+- participant lists with more than 10 participants get search, sort and pagination controls
+- long study titles are constrained to one line and truncated at a word boundary with a horizontal ellipsis
+
+## Operating model
+
+Loaded repository operating model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+- `.agent-operating-model/bundles/cloudflare/`
+
+## Team consultation summary
+
+Research Operations needs participants to be manageable when a project has more than a small number of recruits. Search, sorting and pagination reduce scanning effort once the list is longer than 10 records.
+
+User Research needs the default display to remain pseudonymised while allowing authorised reveal of real identity for recruitment, consent, withdrawal and session operations.
+
+Privacy needs real names and contact details to stay behind the existing reveal boundary. The project dashboard still shows participant references by default.
+
+Security needs reveal actions to call the permission-gated participant contact endpoint, not expose PII through the default participant list response.
+
+Interaction Design needs controls to appear only when useful. Search, sort and pagination are only shown when the participant count is greater than 10.
+
+Content Design needs sort labels to match the acceptance language: A-Z, Z-A, First to last, Last to first, and User group.
+
+Accessibility needs the pagination navigation to have an accessible label and study titles to expose the full title through `title` while visually truncating the visible line.
+
+## Files changed
+
+- `src/govuk/templates/pages/project-dashboard.njk`
+- `public/js/project-dashboard-participants-list.js`
+- `src/styles/project-dashboard.scss`
+- `public/css/project-dashboard.css`
+- `tests/project-dashboard-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.md`
+- `docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.json`
+
+## Scope controls
+
+This branch does not change the D1 participant table model.
+
+This branch does not change the existing `/api/participants/contact` reveal permission boundary.
+
+This branch does not add new participant API endpoints.
+
+This branch does not make PII part of the default participant list response.
+
+## Validation expectation
+
+Expected checks:
+
+```bash
+npm run validate
+npm run lint
+npm test -- --ci
+```
+
+The GOV.UK render workflow should regenerate `public/pages/project-dashboard/index.html` from the updated Nunjucks source.

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -153,4 +153,51 @@
   color: #d4351c;
 }
 
+.rops-participant-list-controls {
+  display: grid;
+  gap: 15px;
+  grid-template-columns: 1fr;
+  margin-bottom: 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .rops-participant-list-controls {
+    grid-template-columns: 1fr auto;
+  }
+}
+.rops-participant-search,
+.rops-participant-sort {
+  margin-bottom: 0;
+}
+
+.rops-participant-list__item > .govuk-hint {
+  display: block;
+  margin-bottom: 0;
+}
+
+.rops-study-title-truncated {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rops-participant-reveal {
+  margin-top: 10px;
+}
+
+.rops-participant-sensitive-details {
+  margin-top: 10px;
+}
+
+.rops-participant-pagination {
+  margin-bottom: 15px;
+}
+
+.rops-participant-page-status {
+  align-self: center;
+  margin-bottom: 0;
+}
+
 /* transparency begins in the cascade */

--- a/public/js/project-dashboard-participants-list.js
+++ b/public/js/project-dashboard-participants-list.js
@@ -1,0 +1,311 @@
+const PARTICIPANT_API_ORIGIN = resolveParticipantApiBase();
+const PARTICIPANT_PAGE_SIZE = 10;
+
+const participantListState = {
+	projectId: "",
+	participants: [],
+	page: 1,
+	query: "",
+	sort: "az",
+	isRendering: false,
+	lastRenderedSignature: "",
+};
+
+function resolveParticipantApiBase() {
+	const explicit = document.documentElement?.dataset?.apiOrigin || window.API_ORIGIN || "";
+	return String(explicit || "").trim().replace(/\/+$/, "");
+}
+
+function participantApiUrl(path) {
+	const cleanPath = path.startsWith("/") ? path : `/${path}`;
+	return `${PARTICIPANT_API_ORIGIN}${cleanPath}`;
+}
+
+function participantProjectIdFromUrl() {
+	return new URLSearchParams(location.search).get("id") || document.querySelector("main")?.dataset?.projectId || "";
+}
+
+function escapeParticipantHtml(value = "") {
+	return String(value)
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+async function participantJson(path) {
+	const response = await fetch(participantApiUrl(path), {
+		cache: "no-store",
+		credentials: "include",
+	});
+	const json = await response.json().catch(() => ({}));
+	if (!response.ok || json?.ok === false) throw new Error(json?.message || json?.error || `HTTP ${response.status}`);
+	return json;
+}
+
+function participantPanel() {
+	return document.getElementById("participants-dashboard-panel");
+}
+
+function studyTitleFor(study = {}) {
+	return String(study.title || study.Title || study.method || "Study").trim() || "Study";
+}
+
+function truncateAtWord(value = "", maxLength = 64) {
+	const text = String(value || "").replace(/\s+/g, " ").trim();
+	if (text.length <= maxLength) return text;
+	const slice = text.slice(0, maxLength + 1);
+	const boundary = slice.search(/\s+\S*$/);
+	const truncated = boundary > 0 ? slice.slice(0, boundary).trim() : text.slice(0, maxLength).trim();
+	return `${truncated}…`;
+}
+
+function participantLabel(participant = {}) {
+	return String(participant.participant_ref || participant.display_name || participant.id || "Participant").trim();
+}
+
+function participantUserGroup(participant = {}) {
+	return String(
+		participant.user_group ||
+		participant.userGroup ||
+		participant.user_group_label ||
+		participant.group ||
+		participant.studyTitle ||
+		"Unassigned user group",
+	).trim();
+}
+
+function participantCreatedTime(participant = {}) {
+	const time = Date.parse(participant.createdAt || participant.created_at || "");
+	return Number.isFinite(time) ? time : 0;
+}
+
+function participantSearchText(participant = {}) {
+	return [
+		participantLabel(participant),
+		participant.first_name,
+		participant.family_name,
+		participant.full_name,
+		participant.email,
+		participant.phone,
+		participant.status,
+		participant.studyTitle,
+		participantUserGroup(participant),
+	].join(" ").toLowerCase();
+}
+
+function filteredParticipants() {
+	const query = participantListState.query.trim().toLowerCase();
+	const filtered = query ? participantListState.participants.filter((participant) => participantSearchText(participant).includes(query)) : [...participantListState.participants];
+	return filtered.sort((a, b) => {
+		if (participantListState.sort === "za") return participantLabel(b).localeCompare(participantLabel(a), undefined, { numeric: true });
+		if (participantListState.sort === "first-last") return participantCreatedTime(a) - participantCreatedTime(b);
+		if (participantListState.sort === "last-first") return participantCreatedTime(b) - participantCreatedTime(a);
+		if (participantListState.sort === "user-group") {
+			const groupSort = participantUserGroup(a).localeCompare(participantUserGroup(b), undefined, { numeric: true });
+			return groupSort || participantLabel(a).localeCompare(participantLabel(b), undefined, { numeric: true });
+		}
+		return participantLabel(a).localeCompare(participantLabel(b), undefined, { numeric: true });
+	});
+}
+
+function participantControlsHtml(total) {
+	if (total <= PARTICIPANT_PAGE_SIZE) return "";
+	return `
+<div class="rops-participant-list-controls" aria-label="Participant list controls">
+	<div class="govuk-form-group rops-participant-search">
+		<label class="govuk-label govuk-label--s" for="participant-list-search">Search participants</label>
+		<input class="govuk-input govuk-input--width-20" id="participant-list-search" type="search" value="${escapeParticipantHtml(participantListState.query)}" autocomplete="off">
+	</div>
+	<div class="govuk-form-group rops-participant-sort">
+		<label class="govuk-label govuk-label--s" for="participant-list-sort">Sort participants</label>
+		<select class="govuk-select" id="participant-list-sort">
+			<option value="az" ${participantListState.sort === "az" ? "selected" : ""}>A to Z</option>
+			<option value="za" ${participantListState.sort === "za" ? "selected" : ""}>Z to A</option>
+			<option value="first-last" ${participantListState.sort === "first-last" ? "selected" : ""}>First to last</option>
+			<option value="last-first" ${participantListState.sort === "last-first" ? "selected" : ""}>Last to first</option>
+			<option value="user-group" ${participantListState.sort === "user-group" ? "selected" : ""}>User group</option>
+		</select>
+	</div>
+</div>`;
+}
+
+function participantSensitiveDetailsHtml(participant = {}) {
+	if (!participant.revealed) return "";
+	return `
+<dl class="govuk-summary-list govuk-summary-list--no-border rops-participant-sensitive-details">
+	<div class="govuk-summary-list__row">
+		<dt class="govuk-summary-list__key">First name</dt>
+		<dd class="govuk-summary-list__value">${escapeParticipantHtml(participant.first_name || "Not recorded")}</dd>
+	</div>
+	<div class="govuk-summary-list__row">
+		<dt class="govuk-summary-list__key">Family name</dt>
+		<dd class="govuk-summary-list__value">${escapeParticipantHtml(participant.family_name || "Not recorded")}</dd>
+	</div>
+	<div class="govuk-summary-list__row">
+		<dt class="govuk-summary-list__key">Email</dt>
+		<dd class="govuk-summary-list__value">${escapeParticipantHtml(participant.email || "Not recorded")}</dd>
+	</div>
+	<div class="govuk-summary-list__row">
+		<dt class="govuk-summary-list__key">Phone</dt>
+		<dd class="govuk-summary-list__value">${escapeParticipantHtml(participant.phone || "Not recorded")}</dd>
+	</div>
+</dl>`;
+}
+
+function participantRevealHtml(participant = {}) {
+	if (participant.revealed) return '<strong class="govuk-tag govuk-tag--green">Details revealed</strong>';
+	if (!participant.can_reveal_contact) return '<span class="govuk-hint">Contact details restricted</span>';
+	return `<button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-participant-reveal="${escapeParticipantHtml(participant.id)}">Reveal details</button>`;
+}
+
+function participantListItemHtml(participant = {}) {
+	const reference = participantLabel(participant);
+	const studyTitle = String(participant.studyTitle || "Study not recorded").trim();
+	const truncatedStudyTitle = truncateAtWord(studyTitle);
+	const userGroup = participantUserGroup(participant);
+	const status = participant.status ? `<span class="govuk-hint">Status: ${escapeParticipantHtml(participant.status)}</span>` : "";
+	return `
+<li class="rops-participant-list__item" data-participant-id="${escapeParticipantHtml(participant.id)}">
+	<strong>${escapeParticipantHtml(reference)}</strong>
+	${status}
+	<span class="govuk-hint rops-study-title-truncated" title="${escapeParticipantHtml(studyTitle)}">Study: ${escapeParticipantHtml(truncatedStudyTitle)}</span>
+	<span class="govuk-hint">User group: ${escapeParticipantHtml(userGroup)}</span>
+	<div class="rops-participant-reveal">${participantRevealHtml(participant)}</div>
+	${participantSensitiveDetailsHtml(participant)}
+</li>`;
+}
+
+function paginationHtml(filteredTotal, pageCount, start, end) {
+	if (participantListState.participants.length <= PARTICIPANT_PAGE_SIZE) return "";
+	return `
+<nav class="rops-participant-pagination" aria-label="Participant pagination">
+	<p class="govuk-body-s">Showing ${start + 1} to ${end} of ${filteredTotal} participants.</p>
+	<div class="govuk-button-group">
+		<button type="button" class="govuk-button govuk-button--secondary" data-participants-page="previous" ${participantListState.page <= 1 ? "disabled" : ""}>Previous</button>
+		<span class="govuk-body-s rops-participant-page-status">Page ${participantListState.page} of ${pageCount}</span>
+		<button type="button" class="govuk-button govuk-button--secondary" data-participants-page="next" ${participantListState.page >= pageCount ? "disabled" : ""}>Next</button>
+	</div>
+</nav>`;
+}
+
+function renderEnhancedParticipants() {
+	const panel = participantPanel();
+	if (!panel || participantListState.isRendering) return;
+	participantListState.isRendering = true;
+	const projectId = encodeURIComponent(participantListState.projectId);
+	const allTotal = participantListState.participants.length;
+	const summary = allTotal === 1 ? "1 participant" : `${allTotal} participants`;
+	const filtered = filteredParticipants();
+	const pageCount = Math.max(1, Math.ceil(filtered.length / PARTICIPANT_PAGE_SIZE));
+	participantListState.page = Math.min(Math.max(1, participantListState.page), pageCount);
+	const start = (participantListState.page - 1) * PARTICIPANT_PAGE_SIZE;
+	const pageParticipants = filtered.slice(start, start + PARTICIPANT_PAGE_SIZE);
+	const end = Math.min(start + PARTICIPANT_PAGE_SIZE, filtered.length);
+
+	panel.dataset.enhancedParticipants = "true";
+	panel.innerHTML = `
+<h3 class="govuk-heading-s">Participants</h3>
+<p class="govuk-body-s" id="participants-summary-status">${escapeParticipantHtml(summary)} linked to this project.</p>
+${participantControlsHtml(allTotal)}
+${pageParticipants.length ? `<ul class="govuk-list govuk-list--spaced rops-divided-list rops-participant-list" id="participants-list">${pageParticipants.map(participantListItemHtml).join("")}</ul>` : '<p class="govuk-body-s">No participants match your search.</p>'}
+${paginationHtml(filtered.length, pageCount, start, end)}
+<p class="govuk-body-s">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
+<div class="govuk-button-group">
+	<a href="/pages/project-dashboard/participants/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="add-participant-link">Add participant</a>
+	<a href="/pages/project-dashboard/participants/import/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="import-participants-link">Bulk upload participants via CSV</a>
+</div>`;
+	wireParticipantControls();
+	participantListState.isRendering = false;
+}
+
+function wireParticipantControls() {
+	document.getElementById("participant-list-search")?.addEventListener("input", (event) => {
+		participantListState.query = event.target.value || "";
+		participantListState.page = 1;
+		renderEnhancedParticipants();
+		document.getElementById("participant-list-search")?.focus();
+	});
+	document.getElementById("participant-list-sort")?.addEventListener("change", (event) => {
+		participantListState.sort = event.target.value || "az";
+		participantListState.page = 1;
+		renderEnhancedParticipants();
+	});
+	document.querySelectorAll("[data-participants-page]").forEach((button) => {
+		button.addEventListener("click", () => {
+			participantListState.page += button.dataset.participantsPage === "next" ? 1 : -1;
+			renderEnhancedParticipants();
+		});
+	});
+	document.querySelectorAll("[data-participant-reveal]").forEach((button) => {
+		button.addEventListener("click", () => revealParticipant(button.dataset.participantReveal));
+	});
+}
+
+async function revealParticipant(participantId) {
+	const button = document.querySelector(`[data-participant-reveal="${CSS.escape(participantId)}"]`);
+	if (button) button.textContent = "Revealing details";
+	try {
+		const json = await participantJson(`/api/participants/contact?participant=${encodeURIComponent(participantId)}&ts=${Date.now()}`);
+		participantListState.participants = participantListState.participants.map((participant) => participant.id === participantId ? { ...participant, ...json.participant, revealed: true } : participant);
+		renderEnhancedParticipants();
+	} catch (error) {
+		if (button) button.textContent = `Could not reveal details`;
+		console.error("[project-dashboard-participants-list] reveal failed", error);
+	}
+}
+
+async function loadProjectStudies(projectId) {
+	const json = await participantJson(`/api/studies?project=${encodeURIComponent(projectId)}&ts=${Date.now()}`);
+	return Array.isArray(json.studies) ? json.studies : [];
+}
+
+async function loadStudyParticipants(study = {}) {
+	if (!study.id) return [];
+	const json = await participantJson(`/api/participants?study=${encodeURIComponent(study.id)}&ts=${Date.now()}`);
+	const participants = Array.isArray(json.participants) ? json.participants : [];
+	const studyTitle = studyTitleFor(study);
+	return participants.map((participant) => ({
+		...participant,
+		studyId: study.id,
+		studyTitle,
+	}));
+}
+
+async function refreshParticipants() {
+	const projectId = participantProjectIdFromUrl();
+	if (!projectId) return;
+	participantListState.projectId = projectId;
+	try {
+		const studies = await loadProjectStudies(projectId);
+		const results = await Promise.all(studies.map((study) => loadStudyParticipants(study)));
+		participantListState.participants = results.flat();
+		participantListState.page = 1;
+		renderEnhancedParticipants();
+	} catch (error) {
+		console.error("[project-dashboard-participants-list] load failed", error);
+	}
+}
+
+function observeParticipantPanel() {
+	const panel = participantPanel();
+	if (!panel || typeof MutationObserver === "undefined") return;
+	const observer = new MutationObserver(() => {
+		if (participantListState.isRendering) return;
+		if (!participantListState.participants.length || panel.dataset.enhancedParticipants === "true") return;
+		window.setTimeout(renderEnhancedParticipants, 0);
+	});
+	observer.observe(panel, { childList: true, subtree: true });
+}
+
+function initEnhancedParticipantList() {
+	observeParticipantPanel();
+	refreshParticipants();
+}
+
+if (document.readyState === "loading") {
+	document.addEventListener("DOMContentLoaded", initEnhancedParticipantList, { once: true });
+} else {
+	initEnhancedParticipantList();
+}

--- a/public/js/project-dashboard-participants-list.js
+++ b/public/js/project-dashboard-participants-list.js
@@ -1,5 +1,6 @@
 const PARTICIPANT_API_ORIGIN = resolveParticipantApiBase();
 const PARTICIPANT_PAGE_SIZE = 10;
+const STUDY_TITLE_PREFIX = "Study: ";
 
 const participantListState = {
 	projectId: "",
@@ -8,7 +9,6 @@ const participantListState = {
 	query: "",
 	sort: "az",
 	isRendering: false,
-	lastRenderedSignature: "",
 };
 
 function resolveParticipantApiBase() {
@@ -52,28 +52,12 @@ function studyTitleFor(study = {}) {
 	return String(study.title || study.Title || study.method || "Study").trim() || "Study";
 }
 
-function truncateAtWord(value = "", maxLength = 64) {
-	const text = String(value || "").replace(/\s+/g, " ").trim();
-	if (text.length <= maxLength) return text;
-	const slice = text.slice(0, maxLength + 1);
-	const boundary = slice.search(/\s+\S*$/);
-	const truncated = boundary > 0 ? slice.slice(0, boundary).trim() : text.slice(0, maxLength).trim();
-	return `${truncated}…`;
-}
-
 function participantLabel(participant = {}) {
 	return String(participant.participant_ref || participant.display_name || participant.id || "Participant").trim();
 }
 
 function participantUserGroup(participant = {}) {
-	return String(
-		participant.user_group ||
-		participant.userGroup ||
-		participant.user_group_label ||
-		participant.group ||
-		participant.studyTitle ||
-		"Unassigned user group",
-	).trim();
+	return String(participant.user_group || participant.userGroup || participant.user_group_label || participant.group || "Unassigned user group").trim();
 }
 
 function participantCreatedTime(participant = {}) {
@@ -92,7 +76,9 @@ function participantSearchText(participant = {}) {
 		participant.status,
 		participant.studyTitle,
 		participantUserGroup(participant),
-	].join(" ").toLowerCase();
+	]
+		.join(" ")
+		.toLowerCase();
 }
 
 function filteredParticipants() {
@@ -121,8 +107,8 @@ function participantControlsHtml(total) {
 	<div class="govuk-form-group rops-participant-sort">
 		<label class="govuk-label govuk-label--s" for="participant-list-sort">Sort participants</label>
 		<select class="govuk-select" id="participant-list-sort">
-			<option value="az" ${participantListState.sort === "az" ? "selected" : ""}>A to Z</option>
-			<option value="za" ${participantListState.sort === "za" ? "selected" : ""}>Z to A</option>
+			<option value="az" ${participantListState.sort === "az" ? "selected" : ""}>A-Z</option>
+			<option value="za" ${participantListState.sort === "za" ? "selected" : ""}>Z-A</option>
 			<option value="first-last" ${participantListState.sort === "first-last" ? "selected" : ""}>First to last</option>
 			<option value="last-first" ${participantListState.sort === "last-first" ? "selected" : ""}>Last to first</option>
 			<option value="user-group" ${participantListState.sort === "user-group" ? "selected" : ""}>User group</option>
@@ -163,14 +149,13 @@ function participantRevealHtml(participant = {}) {
 function participantListItemHtml(participant = {}) {
 	const reference = participantLabel(participant);
 	const studyTitle = String(participant.studyTitle || "Study not recorded").trim();
-	const truncatedStudyTitle = truncateAtWord(studyTitle);
 	const userGroup = participantUserGroup(participant);
 	const status = participant.status ? `<span class="govuk-hint">Status: ${escapeParticipantHtml(participant.status)}</span>` : "";
 	return `
 <li class="rops-participant-list__item" data-participant-id="${escapeParticipantHtml(participant.id)}">
 	<strong>${escapeParticipantHtml(reference)}</strong>
 	${status}
-	<span class="govuk-hint rops-study-title-truncated" title="${escapeParticipantHtml(studyTitle)}">Study: ${escapeParticipantHtml(truncatedStudyTitle)}</span>
+	<span class="govuk-hint rops-study-title-truncated" title="${escapeParticipantHtml(studyTitle)}" data-study-title="${escapeParticipantHtml(studyTitle)}" data-study-prefix="${STUDY_TITLE_PREFIX}">${STUDY_TITLE_PREFIX}${escapeParticipantHtml(studyTitle)}</span>
 	<span class="govuk-hint">User group: ${escapeParticipantHtml(userGroup)}</span>
 	<div class="rops-participant-reveal">${participantRevealHtml(participant)}</div>
 	${participantSensitiveDetailsHtml(participant)}
@@ -188,6 +173,34 @@ function paginationHtml(filteredTotal, pageCount, start, end) {
 		<button type="button" class="govuk-button govuk-button--secondary" data-participants-page="next" ${participantListState.page >= pageCount ? "disabled" : ""}>Next</button>
 	</div>
 </nav>`;
+}
+
+function applyStudyTitleFit(element) {
+	const title = String(element.dataset.studyTitle || "").replace(/\s+/g, " ").trim();
+	const prefix = element.dataset.studyPrefix || STUDY_TITLE_PREFIX;
+	if (!title) return;
+	element.textContent = `${prefix}${title}`;
+	if (element.scrollWidth <= element.clientWidth) return;
+	const words = title.split(" ").filter(Boolean);
+	let low = 0;
+	let high = words.length;
+	let fitted = "";
+	while (low <= high) {
+		const middle = Math.floor((low + high) / 2);
+		const candidate = words.slice(0, middle).join(" ").trim();
+		element.textContent = `${prefix}${candidate}…`;
+		if (element.scrollWidth <= element.clientWidth) {
+			fitted = candidate;
+			low = middle + 1;
+		} else {
+			high = middle - 1;
+		}
+	}
+	element.textContent = fitted ? `${prefix}${fitted}…` : `${prefix}…`;
+}
+
+function applySingleLineStudyTitleTruncation() {
+	document.querySelectorAll(".rops-study-title-truncated[data-study-title]").forEach((element) => applyStudyTitleFit(element));
 }
 
 function renderEnhancedParticipants() {
@@ -217,6 +230,7 @@ ${paginationHtml(filtered.length, pageCount, start, end)}
 	<a href="/pages/project-dashboard/participants/import/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="import-participants-link">Bulk upload participants via CSV</a>
 </div>`;
 	wireParticipantControls();
+	window.requestAnimationFrame(applySingleLineStudyTitleTruncation);
 	participantListState.isRendering = false;
 }
 
@@ -243,15 +257,21 @@ function wireParticipantControls() {
 	});
 }
 
+function participantRevealButton(participantId) {
+	return Array.from(document.querySelectorAll("[data-participant-reveal]")).find((button) => button.dataset.participantReveal === participantId) || null;
+}
+
 async function revealParticipant(participantId) {
-	const button = document.querySelector(`[data-participant-reveal="${CSS.escape(participantId)}"]`);
+	const button = participantRevealButton(participantId);
 	if (button) button.textContent = "Revealing details";
 	try {
 		const json = await participantJson(`/api/participants/contact?participant=${encodeURIComponent(participantId)}&ts=${Date.now()}`);
-		participantListState.participants = participantListState.participants.map((participant) => participant.id === participantId ? { ...participant, ...json.participant, revealed: true } : participant);
+		participantListState.participants = participantListState.participants.map((participant) =>
+			participant.id === participantId ? { ...participant, ...json.participant, revealed: true } : participant,
+		);
 		renderEnhancedParticipants();
 	} catch (error) {
-		if (button) button.textContent = `Could not reveal details`;
+		if (button) button.textContent = "Could not reveal details";
 		console.error("[project-dashboard-participants-list] reveal failed", error);
 	}
 }

--- a/public/js/project-dashboard-participants-list.js
+++ b/public/js/project-dashboard-participants-list.js
@@ -313,7 +313,8 @@ function observeParticipantPanel() {
 	if (!panel || typeof MutationObserver === "undefined") return;
 	const observer = new MutationObserver(() => {
 		if (participantListState.isRendering) return;
-		if (!participantListState.participants.length || panel.dataset.enhancedParticipants === "true") return;
+		const enhancedListPresent = Boolean(panel.querySelector(".rops-participant-list") || panel.querySelector(".rops-participant-list-controls"));
+		if (!participantListState.participants.length || enhancedListPresent) return;
 		window.setTimeout(renderEnhancedParticipants, 0);
 	});
 	observer.observe(panel, { childList: true, subtree: true });

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -35,7 +35,18 @@
 							</a>
 						</li>
 
-						<li class="govuk-breadcrumbs__list-item" aria-current="page">Project dashboard</li>
+						<li class="govuk-breadcrumbs__list-item">
+							<a
+								class="govuk-breadcrumbs__link"
+								href="/pages/project-dashboard/?id="
+								id="breadcrumb-project"
+								property="schema:item"
+								typeof="schema:Thing"
+								aria-current="page"
+							>
+								Project dashboard
+							</a>
+						</li>
 					</ol>
 				</nav>
 

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -9,6 +9,7 @@
 		<meta name="project:name" content="" />
 		<link rel="modulepreload" href="/js/project-dashboard-context.js" />
 		<link rel="modulepreload" href="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601" />
+		<link rel="modulepreload" href="/js/project-dashboard-participants-list.js?v=participant-list-controls-20260601" />
 		<link
 			rel="stylesheet"
 			href="/css/project-dashboard.css?v=project-dashboard-govuk-existing-model-20260525"
@@ -26,35 +27,15 @@
 		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
 		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 			<div class="govuk-width-container">
-				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
+				<nav class="govuk-breadcrumbs" typeof="schema:BreadcrumbList" aria-label="Breadcrumb">
 					<ol class="govuk-breadcrumbs__list">
-						<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
+						<li class="govuk-breadcrumbs__list-item">
 							<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-								<span property="schema:name">Projects</span>
+								Projects
 							</a>
-							<meta property="schema:position" content="1" />
 						</li>
-						<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-							<a
-								id="breadcrumb-project"
-								class="govuk-breadcrumbs__link"
-								href="#"
-								property="schema:item"
-								typeof="schema:Thing"
-							>
-								<span property="schema:name">Project</span>
-							</a>
-							<meta property="schema:position" content="2" />
-						</li>
-						<li
-							class="govuk-breadcrumbs__list-item"
-							property="schema:itemListElement"
-							typeof="schema:ListItem"
-							aria-current="page"
-						>
-							<span property="schema:name">Dashboard</span>
-							<meta property="schema:position" content="3" />
-						</li>
+
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Project dashboard</li>
 					</ol>
 				</nav>
 
@@ -496,6 +477,10 @@
 
 		<script type="module" src="/js/project-dashboard-context.js"></script>
 		<script type="module" src="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601"></script>
+		<script
+			type="module"
+			src="/js/project-dashboard-participants-list.js?v=participant-list-controls-20260601"
+		></script>
 		<script type="module" src="/components/mural-integration.js?v=project-dashboard-mural-optional-20260526"></script>
 		<script type="module" src="/components/project-dashboard-mural-state.js?v=inert-20260525"></script>
 	</body>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -5,6 +5,7 @@
 	<meta name="project:name" content="">
 	<link rel="modulepreload" href="/js/project-dashboard-context.js">
 	<link rel="modulepreload" href="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601">
+	<link rel="modulepreload" href="/js/project-dashboard-participants-list.js?v=participant-list-controls-20260601">
 	<link rel="stylesheet" href="/css/project-dashboard.css?v=project-dashboard-govuk-existing-model-20260525" media="screen">
 {% endblock %}
 
@@ -329,6 +330,7 @@
 {% block scripts %}
 	<script type="module" src="/js/project-dashboard-context.js"></script>
 	<script type="module" src="/js/project-dashboard.js?v=project-dashboard-d1-participants-20260601"></script>
+	<script type="module" src="/js/project-dashboard-participants-list.js?v=participant-list-controls-20260601"></script>
 	<script type="module" src="/components/mural-integration.js?v=project-dashboard-mural-optional-20260526"></script>
 	<script type="module" src="/components/project-dashboard-mural-state.js?v=inert-20260525"></script>
 {% endblock %}

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -31,7 +31,7 @@
 				attributes: {
 					id: "breadcrumb-project",
 					property: "schema:name",
-					aria-current: "page"
+					"aria-current": "page"
 				}
 			}
 		]

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -1,4 +1,5 @@
 {% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block head %}
@@ -11,26 +12,30 @@
 
 {% block content %}
 <div class="govuk-width-container">
-	<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-		<ol class="govuk-breadcrumbs__list">
-			<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-				<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-					<span property="schema:name">Projects</span>
-				</a>
-				<meta property="schema:position" content="1">
-			</li>
-			<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-				<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#" property="schema:item" typeof="schema:Thing">
-					<span property="schema:name">Project</span>
-				</a>
-				<meta property="schema:position" content="2">
-			</li>
-			<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem" aria-current="page">
-				<span property="schema:name">Dashboard</span>
-				<meta property="schema:position" content="3">
-			</li>
-		</ol>
-	</nav>
+	{{ govukBreadcrumbs({
+		id: "participant-breadcrumbs",
+		attributes: {
+			typeof: "schema:BreadcrumbList"
+		},
+		items: [
+			{
+				text: "Projects",
+				href: "/pages/projects/",
+				attributes: {
+					property: "schema:item",
+					typeof: "schema:Thing"
+				}
+			},
+			{
+				text: "Project dashboard",
+				attributes: {
+					id: "breadcrumb-project",
+					property: "schema:name",
+					aria-current: "page"
+				}
+			}
+		]
+	}) }}
 
 	<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
 		<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -28,9 +28,11 @@
 			},
 			{
 				text: "Project dashboard",
+				href: "/pages/project-dashboard/?id=",
 				attributes: {
 					id: "breadcrumb-project",
-					property: "schema:name",
+					property: "schema:item",
+					typeof: "schema:Thing",
 					"aria-current": "page"
 				}
 			}

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -157,4 +157,52 @@
 	color: #d4351c;
 }
 
+.rops-participant-list-controls {
+	display: grid;
+	gap: 15px;
+	grid-template-columns: 1fr;
+	margin-bottom: 15px;
+}
+
+@media (min-width: 40.0625em) {
+	.rops-participant-list-controls {
+		grid-template-columns: 1fr auto;
+	}
+}
+
+.rops-participant-search,
+.rops-participant-sort {
+	margin-bottom: 0;
+}
+
+.rops-participant-list__item > .govuk-hint {
+	display: block;
+	margin-bottom: 0;
+}
+
+.rops-study-title-truncated {
+	display: block;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.rops-participant-reveal {
+	margin-top: 10px;
+}
+
+.rops-participant-sensitive-details {
+	margin-top: 10px;
+}
+
+.rops-participant-pagination {
+	margin-bottom: 15px;
+}
+
+.rops-participant-page-status {
+	align-self: center;
+	margin-bottom: 0;
+}
+
 /* transparency begins in the cascade */

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -4,6 +4,7 @@ import fs from "node:fs";
 const pageSource = fs.readFileSync("public/pages/project-dashboard/index.html", "utf8");
 const templateSource = fs.readFileSync("src/govuk/templates/pages/project-dashboard.njk", "utf8");
 const controllerSource = fs.readFileSync("public/js/project-dashboard.js", "utf8");
+const participantListSource = fs.readFileSync("public/js/project-dashboard-participants-list.js", "utf8");
 const muralIntegrationSource = fs.readFileSync("public/components/mural-integration.js", "utf8");
 const muralStateSource = fs.readFileSync("public/components/project-dashboard-mural-state.js", "utf8");
 const dashboardCssSource = fs.readFileSync("public/css/project-dashboard.css", "utf8");
@@ -35,6 +36,7 @@ includes(templateSource, "id=\"kv-project-stage\"", "project dashboard template"
 includes(templateSource, "Loading service stage", "project dashboard template");
 includes(templateSource, "Loading project stage", "project dashboard template");
 includes(templateSource, "Mural optional", "project dashboard template");
+includes(templateSource, "project-dashboard-participants-list.js?v=participant-list-controls-20260601", "project dashboard template");
 excludes(templateSource, "id=\"mural-open\"", "project dashboard template");
 excludes(templateSource, "Service stage not recorded", "project dashboard template");
 excludes(templateSource, "Project stage not recorded", "project dashboard template");
@@ -79,6 +81,23 @@ excludes(controllerSource, "Service stage not recorded", "project dashboard cont
 excludes(controllerSource, "Project stage not recorded", "project dashboard controller");
 excludes(controllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "project dashboard controller");
 excludes(controllerSource, "alert(\"Could not load project.\");", "project dashboard controller");
+
+includes(participantListSource, "const PARTICIPANT_PAGE_SIZE = 10", "participant list controller");
+includes(participantListSource, "participantJson(`/api/participants/contact?participant=", "participant list controller");
+includes(participantListSource, "data-participant-reveal", "participant list controller");
+includes(participantListSource, "First name", "participant list controller");
+includes(participantListSource, "Family name", "participant list controller");
+includes(participantListSource, "Search participants", "participant list controller");
+includes(participantListSource, "Sort participants", "participant list controller");
+includes(participantListSource, ">A-Z</option>", "participant list controller");
+includes(participantListSource, ">Z-A</option>", "participant list controller");
+includes(participantListSource, ">First to last</option>", "participant list controller");
+includes(participantListSource, ">Last to first</option>", "participant list controller");
+includes(participantListSource, ">User group</option>", "participant list controller");
+includes(participantListSource, "data-participants-page=\"previous\"", "participant list controller");
+includes(participantListSource, "data-participants-page=\"next\"", "participant list controller");
+includes(participantListSource, "function applyStudyTitleFit", "participant list controller");
+includes(participantListSource, "element.textContent = fitted ? `${prefix}${fitted}…` : `${prefix}…`;", "participant list controller");
 
 includes(muralIntegrationSource, "Project Dashboard ↔ Mural wiring with GOV.UK Frontend dashboard state", "Mural integration component");
 includes(muralIntegrationSource, "location.hostname.endsWith(\"pages.dev\")", "Mural integration component");
@@ -125,10 +144,16 @@ excludes(muralStateSource, "syncDashboardPresentation", "Project Dashboard Mural
 includes(dashboardSassSource, ".rops-dashboard-header", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-study-list", "project dashboard Sass source");
 includes(dashboardSassSource, ".dashboard-action-panel", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-participant-list-controls", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-study-title-truncated", "project dashboard Sass source");
+includes(dashboardSassSource, "text-overflow: ellipsis;", "project dashboard Sass source");
 includes(dashboardSassSource, "/* transparency begins in the cascade */", "project dashboard Sass source");
 includes(dashboardCssSource, ".rops-dashboard-header", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-study-list", "project dashboard stylesheet");
 includes(dashboardCssSource, ".dashboard-action-panel", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-participant-list-controls", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-study-title-truncated", "project dashboard stylesheet");
+includes(dashboardCssSource, "text-overflow: ellipsis;", "project dashboard stylesheet");
 excludes(dashboardCssSource, "\n.section {", "project dashboard stylesheet");
 excludes(dashboardCssSource, "\n.dashboard-section {", "project dashboard stylesheet");
 excludes(dashboardCssSource, "\n.board {", "project dashboard stylesheet");


### PR DESCRIPTION
## Summary

- Adds an enhanced project-dashboard participant list controller.
- Lets authorised users reveal participant first name, family name and contact details through the existing permission-gated participant contact endpoint.
- Shows search, sort and pagination controls when participant lists contain more than 10 records.
- Adds sort options for A-Z, Z-A, First to last, Last to first and User group.
- Keeps the default participant list pseudonymised until a reveal action is taken.
- Truncates long study titles to a single line at a word boundary and appends a horizontal ellipsis.
- Adds project-dashboard styles and route-state coverage for the new participant-list behaviour.

## Scope

This PR does not change the D1 participant table model.

This PR does not add a new participant API endpoint.

This PR does not expose PII in default participant-list responses.

The reveal action continues to use `/api/participants/contact` and the existing `participant.pii.reveal` permission boundary.

## Trace

- `docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.md`
- `docs/agent-audit/reasoning/2026/06/01/participant-list-reveal-search-sort-pagination.json`

## Validation

Not run locally in this environment.

Expected checks:

```bash
npm run validate
npm run lint
npm test -- --ci
```

The GOV.UK render workflow should regenerate `public/pages/project-dashboard/index.html` from the updated Nunjucks template.