### PR TITLE
Migrate study creation page to GOV.UK template

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.json
+++ b/docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.json
@@ -1,0 +1,143 @@
+{
+  "schemaVersion": "researchops-agent-trace-summary/v1",
+  "traceType": "operational-audit",
+  "date": "2026-06-02",
+  "branch": "feature/study-new-govuk-template-current",
+  "summary": "Migrated /pages/study/new/ to a GOV.UK Frontend Nunjucks template, removed the Back to project dashboard action, and moved new-study project routing from pid to id.",
+  "task": {
+    "request": "Create a new Nunjucks template for /pages/study/new/ using GOV.UK Frontend macros for breadcrumbs, buttons and form controls; remove the Back to project dashboard button; stop using old pid routing and use the project id route for the project a new study will belong to.",
+    "scope": [
+      "Study creation page template",
+      "Rendered static study creation page",
+      "Study creation page controller",
+      "Project dashboard add-study link",
+      "Route-state test",
+      "Agent trace documentation"
+    ]
+  },
+  "mode": "rops-feature",
+  "selectedBundles": [
+    "github-diamond",
+    "researchops-developer-control",
+    "multi-functional-team",
+    "govuk-design-system",
+    "cloudflare"
+  ],
+  "taskSignals": [
+    "ui-or-content-change",
+    "runtime-or-deployment-change"
+  ],
+  "operatingModelSourcesLoaded": [
+    "README.md",
+    "AGENTS.md",
+    "RECENT_LEARNINGS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/references/govuk-form-affordance-reference.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/references/researchops-single-record-route-policy.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/references/researchops-route-availability-policy.xml"
+  ],
+  "filesRead": [
+    "src/govuk/templates/layouts/researchops.njk",
+    "src/govuk/templates/pages/project-dashboard-participants.njk",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "public/pages/study/new/index.html",
+    "public/pages/study/new/study-new.js",
+    "public/js/project-dashboard.js",
+    "public/js/study-page.js",
+    "public/pages/study/index.html",
+    "public/pages/project-dashboard/participants/index.html",
+    "infra/cloudflare/src/service/studies.js",
+    "docs/design-system/researchops-component-inventory.md",
+    "docs/design-system/govuk-frontend-v6-migration.md",
+    "docs/agent-audit/reasoning/2026/05/18/study-child-routes-canonical-id.md",
+    "tests/project-dashboard-route-state.test.js"
+  ],
+  "filesCreated": [
+    "src/govuk/templates/pages/study-new.njk",
+    "tests/study-new-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.json",
+    "docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.md"
+  ],
+  "filesModified": [
+    "scripts/govuk/render-govuk-pages.mjs",
+    "public/pages/study/new/index.html",
+    "public/pages/study/new/study-new.js",
+    "public/js/project-dashboard.js"
+  ],
+  "decisions": [
+    {
+      "decision": "Use a new src/govuk/templates/pages/study-new.njk source template and register it in the GOV.UK page renderer.",
+      "reason": "Recent ResearchOps page migrations use Nunjucks as the source of truth and keep rendered public HTML aligned with that source."
+    },
+    {
+      "decision": "Use GOV.UK Frontend macros for breadcrumbs, buttons, error summary, inset text, text input, select and textarea.",
+      "reason": "The page is a GOV.UK-style form page and should not continue local hand-written component approximations."
+    },
+    {
+      "decision": "Preserve the existing form field IDs and payload field project_airtable_id.",
+      "reason": "The routing parameter changes from pid to id, but the create-study service still requires project_airtable_id in the POST payload."
+    },
+    {
+      "decision": "Remove the Back to project dashboard action rather than hiding it.",
+      "reason": "The user requested removal. Keeping a hidden action would leave stale routing and unnecessary DOM surface."
+    },
+    {
+      "decision": "Accept only ?id=<project-record-id> on /pages/study/new/ and redirect created studies to /pages/study/?id=<study-record-id>.",
+      "reason": "The page belongs to a project selected by its current id route, while the resulting Study overview already supports canonical Study record ID routing."
+    },
+    {
+      "decision": "Keep API calls same-origin unless an explicit API origin is configured.",
+      "reason": "Branch previews should call the preview API proxy rather than falling through to a production Worker fallback."
+    }
+  ],
+  "changes": [
+    "Created src/govuk/templates/pages/study-new.njk with GOV.UK Frontend macros and no Back to project dashboard action.",
+    "Registered the new study-new template in scripts/govuk/render-govuk-pages.mjs.",
+    "Replaced public/pages/study/new/index.html with rendered GOV.UK Frontend-compatible HTML from the new page source.",
+    "Updated public/pages/study/new/study-new.js to read project context from id only, remove back-link handling, use same-origin API routing, and open the created study with /pages/study/?id=<study-record-id>.",
+    "Updated public/js/project-dashboard.js so the Add study action points to /pages/study/new/?id=<project-record-id>.",
+    "Added tests/study-new-route-state.test.js to pin template registration, macro use, GOV.UK asset use, removal of the old back action and the id-only routing contract."
+  ],
+  "validation": {
+    "testsAdded": [
+      "tests/study-new-route-state.test.js"
+    ],
+    "localValidation": "Not run in this connector-only mutation session. Validation is limited to static reasoning, branch comparison and the added route-state test until CI runs on the PR.",
+    "manualPreviewTargets": [
+      "/pages/project-dashboard/?id=<project-record-id> then use Add study",
+      "/pages/study/new/?id=<project-record-id>",
+      "/pages/study/?id=<created-study-record-id>"
+    ]
+  },
+  "residualRisks": [
+    "The create-study API still validates project_airtable_id because the service contract remains Airtable-backed. This change does not rename the POST payload field.",
+    "Participant add/import links on the project dashboard still use pid. They were left unchanged because this unit of work was scoped to /pages/study/new/.",
+    "No browser preview was available in this session, so final confirmation of form submission and redirect behaviour should happen on the branch preview."
+  ],
+  "nextValidationTargets": [
+    "Run npm run build:govuk-pages.",
+    "Run node --test tests/study-new-route-state.test.js.",
+    "Run npm test.",
+    "Run npm run validate if the route-state test passes.",
+    "Open /pages/study/new/?id=<project-record-id> on the branch preview, create a study and confirm the redirect uses /pages/study/?id=<study-record-id>."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.md
+++ b/docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.md
@@ -1,0 +1,143 @@
+# Agent trace — Study new GOV.UK template and ID routing
+
+**Date:** 2026-06-02  
+**Branch:** `feature/study-new-govuk-template-current`  
+**Mode:** `rops-feature`  
+**Trace type:** operational audit trace
+
+## Evidence boundary
+
+This is an operational trace. It records inspectable repository work, implementation decisions, validation status and residual risk. It does not expose private chain-of-thought.
+
+## Task
+
+The `/pages/study/new/` page needed to move from hand-written static HTML to a GOV.UK Frontend Nunjucks template, using macros for breadcrumbs, buttons and form controls.
+
+The page also needed to stop using the old project `pid` query parameter. The project a new Study belongs to should be passed as `id`.
+
+The “Back to project dashboard” action needed to be removed.
+
+## Operating model and bundles applied
+
+Loaded operating model sources included:
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+
+Selected bundles:
+
+- GitHub Diamond
+- ResearchOps Developer Control
+- Multi-Functional Team
+- GOV.UK Design System
+- Cloudflare
+
+Task signals:
+
+- `ui-or-content-change`
+- `runtime-or-deployment-change`
+
+## Findings
+
+The existing `/pages/study/new/index.html` was a hand-written static page and the controller accepted both `pid` and `id`.
+
+The Project Dashboard runtime controller generated the Add study route with `pid`.
+
+The Study landing page already supports canonical Study record ID routing at `/pages/study/?id=<study-record-id>`.
+
+The create-study service still requires `project_airtable_id` in the POST payload. This is a payload contract, not a public route query parameter.
+
+## Decisions
+
+1. Create `src/govuk/templates/pages/study-new.njk` as the source template.
+2. Register it in `scripts/govuk/render-govuk-pages.mjs`.
+3. Replace the rendered static page at `public/pages/study/new/index.html`.
+4. Use GOV.UK macros for breadcrumbs, buttons, error summary, inset text, input, select and textarea.
+5. Remove the old back action from the Study creation page.
+6. Accept only `?id=<project-record-id>` on `/pages/study/new/`.
+7. Redirect successful creation to `/pages/study/?id=<study-record-id>`.
+8. Keep `project_airtable_id` in the POST payload because the service still validates that field.
+9. Keep participant add/import links unchanged because they were out of scope.
+10. Use same-origin API routing unless an explicit API origin is configured.
+
+## Changes made
+
+Created:
+
+- `src/govuk/templates/pages/study-new.njk`
+- `tests/study-new-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.json`
+- `docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.md`
+
+Modified:
+
+- `scripts/govuk/render-govuk-pages.mjs`
+- `public/pages/study/new/index.html`
+- `public/pages/study/new/study-new.js`
+- `public/js/project-dashboard.js`
+
+## Validation status
+
+A route-state test was added:
+
+- `tests/study-new-route-state.test.js`
+
+The test pins:
+
+- the new template is registered with the GOV.UK page renderer;
+- the template imports the GOV.UK macros used by the page;
+- the rendered page uses `/assets/govuk/govuk-frontend.css`;
+- the rendered page does not include old local GOV.UK CSS imports;
+- the back action is absent;
+- the study-new page and template do not include `?pid=`;
+- the study-new controller reads `id` only;
+- the created study redirect uses `/pages/study/?id=<study-record-id>`;
+- the Project Dashboard runtime Add study link uses `/pages/study/new/?id=<project-record-id>`.
+
+Local validation was not run in this connector-only mutation session. CI or a local checkout should run:
+
+```sh
+npm run build:govuk-pages
+node --test tests/study-new-route-state.test.js
+npm test
+npm run validate
+```
+
+## Manual preview validation targets
+
+Use a branch preview and a known Project record ID:
+
+- `/pages/project-dashboard/?id=<project-record-id>`
+- select Add study
+- confirm the visible URL is `/pages/study/new/?id=<project-record-id>`
+- submit a valid study
+- confirm the redirect is `/pages/study/?id=<created-study-record-id>`
+
+Expected behaviour:
+
+- the page renders with GOV.UK Frontend components;
+- there is no “Back to project dashboard” action;
+- Cancel returns to the project dashboard after the project context resolves;
+- the POST payload still contains `project_airtable_id`;
+- the public Study creation route no longer uses `pid`.
+
+## Residual risks
+
+The create-study API still validates `project_airtable_id` because the service contract remains Airtable-backed.
+
+Participant add/import links on the Project Dashboard still use `pid`. They were left unchanged because this task was scoped to `/pages/study/new/`.
+
+The Project Dashboard Nunjucks and rendered HTML still contain the initial fallback `href="/pages/study/new/?pid="` for the Add study link. The runtime controller updates that link to `?id=` once project context has loaded. This should be tightened in a follow-up source/render pass if the team wants static no-JavaScript fallback parity.
+
+No browser preview was available in this session, so form submission and redirect behaviour still need branch-preview confirmation.

--- a/public/js/project-dashboard-context.js
+++ b/public/js/project-dashboard-context.js
@@ -5,7 +5,7 @@ const PROJECT_SCOPED_LINKS = Object.freeze([
 	["outcomes-link", "/pages/projects/outcomes/", "id"],
 	["add-participant-link", "/pages/project-dashboard/participants/", "id"],
 	["import-participants-link", "/pages/project-dashboard/participants/import/", "id"],
-	["add-study-link", "/pages/study/new/", "pid"],
+	["add-study-link", "/pages/study/new/", "id"],
 	["add-insight-link", "/pages/projects/outcomes/", "id", "impact-form"]
 ]);
 

--- a/public/js/project-dashboard.js
+++ b/public/js/project-dashboard.js
@@ -250,8 +250,8 @@ function renderProject(project) {
 	setLinkHref("journal-button-link", `/pages/projects/journals/?id=${encodeURIComponent(projectId)}`);
 	setLinkHref("outcomes-link", `/pages/projects/outcomes/?id=${encodeURIComponent(projectId)}`);
 	setLinkHref("outcomes-card-link", `/pages/projects/outcomes/?id=${encodeURIComponent(projectId)}`);
-	setLinkHref("add-participant-link", `/pages/project-dashboard/participants/?pid=${encodeURIComponent(projectId)}`);
-	setLinkHref("import-participants-link", `/pages/project-dashboard/participants/import/?pid=${encodeURIComponent(projectId)}`);
+	setLinkHref("add-participant-link", `/pages/project-dashboard/participants/?id=${encodeURIComponent(projectId)}`);
+setLinkHref("import-participants-link", `/pages/project-dashboard/participants/import/?id=${encodeURIComponent(projectId)}`);
 	setLinkHref("add-study-link", `/pages/study/new/?id=${encodeURIComponent(projectId)}`);
 	setLinkHref("add-insight-link", `/pages/projects/outcomes/?id=${encodeURIComponent(projectId)}#impact-form`);
 
@@ -343,8 +343,8 @@ ${participants.map((participant) => {
 ${participantList}
 <p class="govuk-body-s">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
 <div class="govuk-button-group">
-<a href="/pages/project-dashboard/participants/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="add-participant-link">Add participant</a>
-<a href="/pages/project-dashboard/participants/import/?pid=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="import-participants-link">Bulk upload participants via CSV</a>
+<a href="/pages/project-dashboard/participants/?id=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="add-participant-link">Add participant</a>
+<a href="/pages/project-dashboard/participants/import/?id=${projectId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="import-participants-link">Bulk upload participants via CSV</a>
 </div>`;
 }
 

--- a/public/js/project-dashboard.js
+++ b/public/js/project-dashboard.js
@@ -252,7 +252,7 @@ function renderProject(project) {
 	setLinkHref("outcomes-card-link", `/pages/projects/outcomes/?id=${encodeURIComponent(projectId)}`);
 	setLinkHref("add-participant-link", `/pages/project-dashboard/participants/?pid=${encodeURIComponent(projectId)}`);
 	setLinkHref("import-participants-link", `/pages/project-dashboard/participants/import/?pid=${encodeURIComponent(projectId)}`);
-	setLinkHref("add-study-link", `/pages/study/new/?pid=${encodeURIComponent(projectId)}`);
+	setLinkHref("add-study-link", `/pages/study/new/?id=${encodeURIComponent(projectId)}`);
 	setLinkHref("add-insight-link", `/pages/projects/outcomes/?id=${encodeURIComponent(projectId)}#impact-form`);
 
 	renderStakeholders(project.stakeholders || []);

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -407,7 +407,7 @@
 									</p>
 									<div class="govuk-button-group">
 										<a
-											href="/pages/project-dashboard/participants/?pid="
+											href="/pages/project-dashboard/participants/?id="
 											role="button"
 											draggable="false"
 											class="govuk-button govuk-button--secondary"
@@ -418,7 +418,7 @@
 										</a>
 
 										<a
-											href="/pages/project-dashboard/participants/import/?pid="
+											href="/pages/project-dashboard/participants/import/?id="
 											role="button"
 											draggable="false"
 											class="govuk-button govuk-button--secondary"
@@ -451,7 +451,7 @@
 									</ul>
 
 									<a
-										href="/pages/study/new/?pid="
+										href="/pages/study/new/?id="
 										role="button"
 										draggable="false"
 										class="govuk-button govuk-button--secondary"

--- a/public/pages/project-dashboard/participants/import/import-participants.js
+++ b/public/pages/project-dashboard/participants/import/import-participants.js
@@ -62,7 +62,7 @@ function setProjectLinks(projectId, project = {}) {
   if (eyebrow) eyebrow.textContent = projectName;
 
   const createStudy = $("#create-study-link");
-  if (createStudy) createStudy.href = `/pages/study/new/?pid=${encodeURIComponent(projectId)}`;
+  if (createStudy) createStudy.href = `/pages/study/new/?id=${encodeURIComponent(projectId)}`;
 }
 
 async function loadProject(projectId) {
@@ -98,7 +98,7 @@ function populateStudies(studies = []) {
 
 function showErrors(errors) {
   const summary = $("#import-error-summary");
-  const list = $("#import-error-list");
+  const list = $("#import-error-list") || summary?.querySelector(".govuk-error-summary__list");
   if (!summary || !list) return;
 
   if (!errors.length) {
@@ -276,7 +276,7 @@ function initImport(projectId) {
         await createParticipant(row, studyId);
       }
       if (status) status.textContent = "Participants created. Opening study participants page.";
-      location.assign(`/pages/study/participants/?pid=${encodeURIComponent(projectId)}&sid=${encodeURIComponent(studyId)}`);
+      location.assign(`/pages/study/participants/?id=${encodeURIComponent(studyId)}`);
     } catch (err) {
       showErrors([{ id: "participants-csv", message: `Could not import participants. ${String(err?.message || err)}` }]);
       if (status) status.textContent = "";

--- a/public/pages/project-dashboard/participants/import/index.html
+++ b/public/pages/project-dashboard/participants/import/index.html
@@ -1,132 +1,178 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Import participants - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Import participants — ResearchOps</title>
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="modulepreload" href="/js/project-participant-context.js" />
-	<link rel="modulepreload" href="/pages/project-dashboard/participants/import/import-participants.js" />
-	<script type="module" src="/components/layout.js" defer></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
+		<meta property="schema:name" content="Import participants — ResearchOps" />
+		<meta property="schema:creator" content="Home Office ResearchOps Platform" />
+		<meta property="schema:dateModified" content="2026-06-02" />
+		<meta property="dcterms:language" content="en-GB" />
+		<link rel="modulepreload" href="/js/project-participant-context.js" />
+		<link rel="modulepreload" href="/pages/project-dashboard/participants/import/import-participants.js" />
 
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<meta property="schema:name" content="Import participants — ResearchOps" />
-	<meta property="schema:creator" content="Home Office ResearchOps Platform" />
-	<meta property="schema:dateModified" content="2026-05-05" />
-	<meta property="dcterms:language" content="en-GB" />
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container">
+				<nav
+					class="govuk-breadcrumbs"
+					id="participant-import-breadcrumbs"
+					typeof="schema:BreadcrumbList"
+					aria-label="Breadcrumb"
+				>
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+								Projects
+							</a>
+						</li>
 
-	<x-include src="/partials/header.html" vars='{
-			"active":"Projects",
-			"subtitle":"Import participants"
-		}'>
-	</x-include>
+						<li class="govuk-breadcrumbs__list-item">
+							<a
+								class="govuk-breadcrumbs__link"
+								href="/pages/project-dashboard/?id="
+								id="breadcrumb-project"
+								property="schema:item"
+								typeof="schema:Thing"
+							>
+								Project
+							</a>
+						</li>
 
-	<main id="main-content" class="govuk-main-wrapper" role="main" tabindex="-1" data-project-id="">
-		<div class="govuk-width-container">
-			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-				<ol class="govuk-breadcrumbs__list">
-					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-						<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-							<span property="schema:name">Projects</span>
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Import participants</li>
+					</ol>
+				</nav>
+
+				<header class="govuk-!-margin-bottom-6">
+					<p id="project-eyebrow" class="govuk-caption-l">Project</p>
+					<h1 class="govuk-heading-l">Import participants</h1>
+					<p class="govuk-body-l">
+						Upload a CSV, preview the rows and create participants against a study only after checking the data.
+					</p>
+				</header>
+
+				<div class="govuk-error-summary" id="import-error-summary" hidden="hidden" data-module="govuk-error-summary">
+					<div role="alert">
+						<h2 class="govuk-error-summary__title">There is a problem</h2>
+						<div class="govuk-error-summary__body"></div>
+					</div>
+				</div>
+
+				<div class="govuk-inset-text" id="no-studies-panel" hidden="hidden">
+					<h2 class="govuk-heading-m">Create a study first</h2>
+					<p class="govuk-body">Participants must be linked to a study before they can be imported.</p>
+					<a id="create-study-link" href="/pages/study/new/?id=" class="govuk-button" data-module="govuk-button">
+						Add study
+					</a>
+				</div>
+
+				<form id="import-participants-form" novalidate>
+					<input id="project-id" name="project_airtable_id" type="hidden" value="" />
+
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="study-select">Study</label>
+
+						<div id="study-select-hint" class="govuk-hint">Choose the study these participants belong to.</div>
+
+						<select
+							class="govuk-select"
+							id="study-select"
+							name="study"
+							aria-describedby="study-select-hint"
+							required="required"
+						>
+							<option value="">Choose a study</option>
+						</select>
+					</div>
+
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="participants-csv">CSV file</label>
+
+						<div id="participants-csv-hint" class="govuk-hint">
+							Use headings: display_name, email, phone, channel_pref, access_needs. Do not upload unnecessary personal
+							data.
+						</div>
+
+						<input
+							class="govuk-file-upload"
+							id="participants-csv"
+							name="csv"
+							type="file"
+							aria-describedby="participants-csv-hint"
+							accept=".csv,text/csv"
+							required="required"
+						/>
+					</div>
+
+					<div class="govuk-button-group">
+						<button
+							type="button"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="preview-csv"
+						>
+							Preview CSV
+						</button>
+
+						<button
+							type="submit"
+							disabled
+							aria-disabled="true"
+							class="govuk-button"
+							data-module="govuk-button"
+							id="import-submit"
+						>
+							Create participants
+						</button>
+
+						<a
+							href="/pages/projects/"
+							role="button"
+							draggable="false"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="cancel-import"
+						>
+							Cancel
 						</a>
-						<meta property="schema:position" content="1" />
-					</li>
-					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-						<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-							<span property="schema:name">Project</span>
-						</a>
-						<meta property="schema:position" content="2" />
-					</li>
-					<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
-						<span property="schema:name">Import participants</span>
-						<meta property="schema:position" content="3" />
-					</li>
-				</ol>
-			</nav>
+					</div>
 
-			<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
+					<p id="import-status" class="govuk-body-s" role="status" aria-live="polite"></p>
+				</form>
 
-			<div class="dashboard-hero">
-				<p id="project-eyebrow" class="project-org">Project</p>
-				<h1 class="govuk-heading-l">Import participants</h1>
-				<p class="lede">Upload a CSV, preview the rows and create participants against a study only after checking the data.</p>
+				<section id="preview-section" class="govuk-!-margin-top-6" aria-labelledby="preview-heading" hidden>
+					<h2 id="preview-heading" class="govuk-heading-m">Preview participants</h2>
+					<div class="table-wrap">
+						<table class="govuk-table">
+							<caption class="govuk-table__caption govuk-table__caption--s">Rows to import</caption>
+							<thead class="govuk-table__head">
+								<tr class="govuk-table__row">
+									<th scope="col" class="govuk-table__header">Display name</th>
+									<th scope="col" class="govuk-table__header">Email</th>
+									<th scope="col" class="govuk-table__header">Phone</th>
+									<th scope="col" class="govuk-table__header">Channel</th>
+									<th scope="col" class="govuk-table__header">Access needs</th>
+								</tr>
+							</thead>
+							<tbody id="preview-body" class="govuk-table__body"></tbody>
+						</table>
+					</div>
+				</section>
 			</div>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
-			<div id="import-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="import-error-summary-title" hidden>
-				<h2 id="import-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
-				<div class="govuk-error-summary__body">
-					<ul class="govuk-list govuk-error-summary__list" id="import-error-list"></ul>
-				</div>
-			</div>
-
-			<div id="no-studies-panel" class="card" hidden>
-				<h2 class="govuk-heading-m">Create a study first</h2>
-				<p>Participants must be linked to a study before they can be imported.</p>
-				<a id="create-study-link" href="/pages/study/new/?pid=" class="govuk-button">Add study</a>
-			</div>
-
-			<form id="import-participants-form" novalidate>
-				<input id="project-id" name="project_airtable_id" type="hidden" value="" />
-
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="study-select">Study</label>
-					<div id="study-select-hint" class="govuk-hint">Choose the study these participants belong to.</div>
-					<select id="study-select" name="study" class="govuk-select" aria-describedby="study-select-hint" required>
-						<option value="">Choose a study</option>
-					</select>
-				</div>
-
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="participants-csv">CSV file</label>
-					<div id="participants-csv-hint" class="govuk-hint">Use headings: display_name, email, phone, channel_pref, access_needs. Do not upload unnecessary personal data.</div>
-					<input id="participants-csv" name="csv" class="govuk-file-upload" type="file" accept=".csv,text/csv" aria-describedby="participants-csv-hint" required />
-				</div>
-
-				<div class="govuk-button-group">
-					<button id="preview-csv" class="govuk-button govuk-button--secondary" type="button">Preview CSV</button>
-					<button id="import-submit" class="govuk-button" type="submit" disabled>Create participants</button>
-					<a id="cancel-import" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
-				</div>
-
-				<p id="import-status" class="hint" role="status" aria-live="polite"></p>
-			</form>
-
-			<section id="preview-section" class="govuk-!-margin-top-6" aria-labelledby="preview-heading" hidden>
-				<h2 id="preview-heading" class="govuk-heading-m">Preview participants</h2>
-				<div class="table-wrap">
-					<table class="govuk-table">
-						<caption class="govuk-table__caption govuk-table__caption--s">Rows to import</caption>
-						<thead class="govuk-table__head">
-							<tr class="govuk-table__row">
-								<th scope="col" class="govuk-table__header">Display name</th>
-								<th scope="col" class="govuk-table__header">Email</th>
-								<th scope="col" class="govuk-table__header">Phone</th>
-								<th scope="col" class="govuk-table__header">Channel</th>
-								<th scope="col" class="govuk-table__header">Access needs</th>
-							</tr>
-						</thead>
-						<tbody id="preview-body" class="govuk-table__body"></tbody>
-					</table>
-				</div>
-			</section>
-		</div>
-	</main>
-
-	<x-include src="/partials/footer.html"></x-include>
-
-	<script type="module" src="/js/project-participant-context.js"></script>
-	<script type="module" src="/pages/project-dashboard/participants/import/import-participants.js"></script>
-</body>
-
+		<script type="module" src="/js/project-participant-context.js"></script>
+		<script type="module" src="/pages/project-dashboard/participants/import/import-participants.js"></script>
+	</body>
 </html>

--- a/public/pages/project-dashboard/participants/index.html
+++ b/public/pages/project-dashboard/participants/index.html
@@ -8,7 +8,7 @@
 
 		<meta property="schema:name" content="Add participant — ResearchOps" />
 		<meta property="schema:creator" content="Home Office ResearchOps Platform" />
-		<meta property="schema:dateModified" content="2026-06-01" />
+		<meta property="schema:dateModified" content="2026-06-02" />
 		<meta property="dcterms:language" content="en-GB" />
 		<link rel="modulepreload" href="/js/project-participant-context.js" />
 		<link rel="modulepreload" href="/pages/project-dashboard/participants/participants-project.js" />
@@ -24,7 +24,12 @@
 		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
 		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 			<div class="govuk-width-container">
-				<nav class="govuk-breadcrumbs" typeof="schema:BreadcrumbList" aria-label="Breadcrumb">
+				<nav
+					class="govuk-breadcrumbs"
+					id="participant-breadcrumbs"
+					typeof="schema:BreadcrumbList"
+					aria-label="Breadcrumb"
+				>
 					<ol class="govuk-breadcrumbs__list">
 						<li class="govuk-breadcrumbs__list-item">
 							<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
@@ -96,7 +101,7 @@
 				<div class="govuk-inset-text" id="no-studies-panel" hidden="hidden">
 					<h2 class="govuk-heading-m">Create a study first</h2>
 					<p class="govuk-body">Participants must be linked to a study before they can be added.</p>
-					<a id="create-study-link" href="/pages/study/new/?pid=" class="govuk-button" data-module="govuk-button">
+					<a id="create-study-link" href="/pages/study/new/?id=" class="govuk-button" data-module="govuk-button">
 						Add study
 					</a>
 				</div>

--- a/public/pages/project-dashboard/participants/participants-project.js
+++ b/public/pages/project-dashboard/participants/participants-project.js
@@ -110,7 +110,7 @@ function setProjectLinks(projectId, project = {}) {
 	if (eyebrow) eyebrow.textContent = projectName;
 
 	const createStudy = $("#create-study-link");
-	if (createStudy) createStudy.href = `/pages/study/new/?pid=${encodeURIComponent(projectId)}`;
+	if (createStudy) createStudy.href = `/pages/study/new/?id=${encodeURIComponent(projectId)}`;
 }
 
 async function loadProject(projectId) {
@@ -235,7 +235,7 @@ function initForm(projectId) {
 			if (status) status.textContent = "Participant created. Opening study participants page.";
 			const studyId = fieldValue("#study-select");
 			const suffix = participantId ? `#participant-${encodeURIComponent(participantId)}` : "";
-			location.assign(`/pages/study/participants/?pid=${encodeURIComponent(projectId)}&sid=${encodeURIComponent(studyId)}${suffix}`);
+			location.assign(`/pages/study/participants/?id=${encodeURIComponent(studyId)}${suffix}`);
 		} catch (err) {
 			showErrors([{ id: "participant-first-name", message: `Could not create participant. ${String(err?.message || err)}` }]);
 			if (status) status.textContent = "";

--- a/public/pages/study/new/index.html
+++ b/public/pages/study/new/index.html
@@ -23,7 +23,7 @@
 		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
 		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 			<div class="govuk-width-container">
-				<nav class="govuk-breadcrumbs" id="study-breadcrumbs" typeof="schema:BreadcrumbList" aria-label="Breadcrumb">
+				<nav class="govuk-breadcrumbs" typeof="schema:BreadcrumbList" aria-label="Breadcrumb">
 					<ol class="govuk-breadcrumbs__list">
 						<li class="govuk-breadcrumbs__list-item">
 							<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">

--- a/public/pages/study/new/index.html
+++ b/public/pages/study/new/index.html
@@ -23,7 +23,7 @@
 		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
 		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 			<div class="govuk-width-container">
-				<nav class="govuk-breadcrumbs" typeof="schema:BreadcrumbList" aria-label="Breadcrumb">
+				<nav class="govuk-breadcrumbs" id="study-breadcrumbs" typeof="schema:BreadcrumbList" aria-label="Breadcrumb">
 					<ol class="govuk-breadcrumbs__list">
 						<li class="govuk-breadcrumbs__list-item">
 							<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">

--- a/public/pages/study/new/index.html
+++ b/public/pages/study/new/index.html
@@ -1,120 +1,170 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Add study - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Add study — ResearchOps</title>
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="modulepreload" href="/pages/study/new/study-new.js" />
-	<script type="module" src="/components/layout.js" defer></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
+		<meta property="schema:name" content="Add study — ResearchOps" />
+		<meta property="schema:creator" content="Home Office ResearchOps Platform" />
+		<meta property="schema:dateModified" content="2026-06-02" />
+		<meta property="dcterms:language" content="en-GB" />
+		<link rel="modulepreload" href="/pages/study/new/study-new.js" />
 
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<meta property="schema:name" content="Add study — ResearchOps" />
-	<meta property="schema:creator" content="Home Office ResearchOps Platform" />
-	<meta property="schema:dateModified" content="2026-05-05" />
-	<meta property="dcterms:language" content="en-GB" />
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container">
+				<nav class="govuk-breadcrumbs" id="study-breadcrumbs" typeof="schema:BreadcrumbList" aria-label="Breadcrumb">
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
+								Projects
+							</a>
+						</li>
 
-	<x-include src="/partials/header.html" vars='{
-			"active":"Projects",
-			"subtitle":"Add study"
-		}'>
-	</x-include>
+						<li class="govuk-breadcrumbs__list-item">
+							<a
+								class="govuk-breadcrumbs__link"
+								href="/pages/project-dashboard/?id="
+								id="breadcrumb-project"
+								property="schema:item"
+								typeof="schema:Thing"
+							>
+								Project
+							</a>
+						</li>
 
-	<main id="main-content" class="govuk-main-wrapper" role="main" tabindex="-1" data-project-id="">
-		<div class="govuk-width-container">
-			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb" typeof="schema:BreadcrumbList">
-				<ol class="govuk-breadcrumbs__list">
-					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-						<a class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-							<span property="schema:name">Projects</span>
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Add study</li>
+					</ol>
+				</nav>
+
+				<header class="govuk-!-margin-bottom-6">
+					<p id="project-eyebrow" class="govuk-caption-l">Project</p>
+					<h1 class="govuk-heading-l">Add study</h1>
+					<p class="govuk-body-l">
+						Create a study as a dedicated workflow so method, description and readiness controls can be managed outside
+						the project dashboard.
+					</p>
+				</header>
+
+				<div class="govuk-inset-text">
+					<p class="govuk-body">
+						Use this page to create a study within the selected project. Do not include participant personal data in the
+						study description.
+					</p>
+				</div>
+
+				<div class="govuk-error-summary" id="study-error-summary" hidden="hidden" data-module="govuk-error-summary">
+					<div role="alert">
+						<h2 class="govuk-error-summary__title">There is a problem</h2>
+						<div class="govuk-error-summary__body"></div>
+					</div>
+				</div>
+
+				<form id="add-study-form" class="govuk-!-margin-top-6" novalidate>
+					<input id="project-id" name="project_airtable_id" type="hidden" value="" />
+
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="study-title-input">Study title</label>
+
+						<div id="study-title-input-hint" class="govuk-hint">Use a short, recognisable title.</div>
+
+						<input
+							class="govuk-input govuk-!-width-two-thirds"
+							id="study-title-input"
+							name="title"
+							type="text"
+							aria-describedby="study-title-input-hint"
+						/>
+					</div>
+
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="study-method">Research method</label>
+
+						<div id="study-method-hint" class="govuk-hint">Choose the primary method for this study.</div>
+
+						<select
+							class="govuk-select govuk-!-width-two-thirds"
+							id="study-method"
+							name="method"
+							aria-describedby="study-method-hint"
+							required="required"
+						>
+							<option value="">Choose a research method</option>
+
+							<option value="Card Sort">Card Sort</option>
+
+							<option value="Contextual Inquiry">Contextual Inquiry</option>
+
+							<option value="Customer Satisfaction Survey">Customer Satisfaction Survey</option>
+
+							<option value="Diary Study">Diary Study</option>
+
+							<option value="Existing Research Analysis">Existing Research Analysis</option>
+
+							<option value="Expert Review">Expert Review</option>
+
+							<option value="Stakeholder Interview">Stakeholder Interview</option>
+
+							<option value="Survey">Survey</option>
+
+							<option value="Tree Test">Tree Test</option>
+
+							<option value="Usability Test">Usability Test</option>
+
+							<option value="User Interview">User Interview</option>
+						</select>
+					</div>
+
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="study-notes">Study description</label>
+
+						<div id="study-notes-hint" class="govuk-hint">
+							Describe the purpose of the study. Do not include participant personal data.
+						</div>
+
+						<textarea
+							class="govuk-textarea govuk-!-width-two-thirds"
+							id="study-notes"
+							name="description"
+							rows="6"
+							aria-describedby="study-notes-hint"
+							required="required"
+						></textarea>
+					</div>
+
+					<div class="govuk-button-group">
+						<button type="submit" class="govuk-button" data-module="govuk-button" id="study-submit">
+							Create study
+						</button>
+
+						<a
+							href="/pages/projects/"
+							role="button"
+							draggable="false"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="cancel-study"
+						>
+							Cancel
 						</a>
-						<meta property="schema:position" content="1" />
-					</li>
-					<li class="govuk-breadcrumbs__list-item" property="schema:itemListElement" typeof="schema:ListItem">
-						<a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/" property="schema:item" typeof="schema:Thing">
-							<span property="schema:name">Project</span>
-						</a>
-						<meta property="schema:position" content="2" />
-					</li>
-					<li class="govuk-breadcrumbs__list-item" aria-current="page" property="schema:itemListElement" typeof="schema:ListItem">
-						<span property="schema:name">Add study</span>
-						<meta property="schema:position" content="3" />
-					</li>
-				</ol>
-			</nav>
+					</div>
 
-			<a id="back-to-project" class="govuk-back-link" href="/pages/projects/">Back to project dashboard</a>
-
-			<div class="dashboard-hero">
-				<p id="project-eyebrow" class="project-org">Project</p>
-				<h1 class="govuk-heading-l">Add study</h1>
-				<p class="lede">Create a study as a dedicated workflow so method, description and readiness controls can be managed outside the project dashboard.</p>
+					<p id="study-status" class="govuk-body-s" role="status" aria-live="polite"></p>
+				</form>
 			</div>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
-			<div id="study-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" aria-labelledby="study-error-summary-title" hidden>
-				<h2 id="study-error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
-				<div class="govuk-error-summary__body">
-					<ul class="govuk-list govuk-error-summary__list" id="study-error-list"></ul>
-				</div>
-			</div>
-
-			<form id="add-study-form" novalidate>
-				<input id="project-id" name="project_airtable_id" type="hidden" value="" />
-
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="study-title-input">Study title</label>
-					<div id="study-title-hint" class="govuk-hint">Use a short, recognisable title.</div>
-					<input id="study-title-input" name="title" class="govuk-input govuk-!-width-two-thirds" aria-describedby="study-title-hint" />
-				</div>
-
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="study-method">Research method</label>
-					<select id="study-method" name="method" class="govuk-select" required>
-						<option value="">Choose a research method</option>
-						<option>Card Sort</option>
-						<option>Contextual Inquiry</option>
-						<option>Customer Satisfaction Survey</option>
-						<option>Diary Study</option>
-						<option>Existing Research Analysis</option>
-						<option>Expert Review</option>
-						<option>Stakeholder Interview</option>
-						<option>Survey</option>
-						<option>Tree Test</option>
-						<option>Usability Test</option>
-						<option>User Interview</option>
-					</select>
-				</div>
-
-				<div class="govuk-form-group">
-					<label class="govuk-label" for="study-notes">Study description</label>
-					<div id="study-notes-hint" class="govuk-hint">Describe the purpose of the study. Do not include participant personal data.</div>
-					<textarea id="study-notes" name="description" class="govuk-textarea govuk-!-width-two-thirds" rows="6" required aria-describedby="study-notes-hint"></textarea>
-				</div>
-
-				<div class="govuk-button-group">
-					<button id="study-submit" class="govuk-button" type="submit">Create study</button>
-					<a id="cancel-study" class="govuk-button govuk-button--secondary" href="/pages/projects/">Cancel</a>
-				</div>
-
-				<p id="study-status" class="hint" role="status" aria-live="polite"></p>
-			</form>
-		</div>
-	</main>
-
-	<x-include src="/partials/footer.html"></x-include>
-
-	<script type="module" src="/pages/study/new/study-new.js"></script>
-</body>
-
+		<script type="module" src="/pages/study/new/study-new.js"></script>
+	</body>
 </html>

--- a/public/pages/study/new/study-new.js
+++ b/public/pages/study/new/study-new.js
@@ -1,146 +1,169 @@
-const API_ORIGIN =
-  document.documentElement?.dataset?.apiOrigin ||
-  window.API_ORIGIN ||
-  (location.hostname.endsWith("pages.dev") ?
-    "https://rops-api.digikev-kevin-rapley.workers.dev" :
-    location.origin);
+function resolveApiBase() {
+	const explicit =
+		document.documentElement?.dataset?.apiOrigin ||
+		window.API_ORIGIN ||
+		window.RESEARCHOPS_API_ORIGIN ||
+		"";
+	return String(explicit || "").trim().replace(/\/+$/, "");
+}
 
+const API_ORIGIN = resolveApiBase();
 const $ = (selector, root = document) => root.querySelector(selector);
 
+function apiUrl(path) {
+	const cleanPath = path.startsWith("/") ? path : `/${path}`;
+	return `${API_ORIGIN}${cleanPath}`;
+}
+
 function projectIdFromUrl() {
-  return new URLSearchParams(location.search).get("pid") || new URLSearchParams(location.search).get("id") || "";
+	return new URLSearchParams(location.search).get("id") || "";
 }
 
 function makeStudyId() {
-  return "study-" + Math.floor(Date.now() / 1000).toString(36);
+	return "study-" + Math.floor(Date.now() / 1000).toString(36);
 }
 
 function fieldValue(selector) {
-  return String($(selector)?.value || "").trim();
+	return String($(selector)?.value || "").trim();
 }
 
 function setProjectLinks(projectId, project = {}) {
-  const dashboardHref = `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
-  const projectName = project.name || project.Name || "Project";
+	const dashboardHref = `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}`;
+	const projectName = project.name || project.Name || "Project";
 
-  const main = $("#main-content");
-  if (main) main.dataset.projectId = projectId;
+	const main = $("#main-content");
+	if (main) main.dataset.projectId = projectId;
 
-  const projectInput = $("#project-id");
-  if (projectInput) projectInput.value = projectId;
+	const projectInput = $("#project-id");
+	if (projectInput) projectInput.value = projectId;
 
-  const breadcrumbProject = $("#breadcrumb-project");
-  if (breadcrumbProject) {
-    breadcrumbProject.href = dashboardHref;
-    breadcrumbProject.textContent = projectName;
-  }
+	const breadcrumbProject = $("#breadcrumb-project");
+	if (breadcrumbProject) {
+		breadcrumbProject.href = dashboardHref;
+		breadcrumbProject.textContent = projectName;
+	}
 
-  const back = $("#back-to-project");
-  if (back) back.href = dashboardHref;
+	const cancel = $("#cancel-study");
+	if (cancel) cancel.href = dashboardHref;
 
-  const cancel = $("#cancel-study");
-  if (cancel) cancel.href = dashboardHref;
-
-  const eyebrow = $("#project-eyebrow");
-  if (eyebrow) eyebrow.textContent = projectName;
+	const eyebrow = $("#project-eyebrow");
+	if (eyebrow) eyebrow.textContent = projectName;
 }
 
 async function loadProject(projectId) {
-  const res = await fetch(`${API_ORIGIN}/api/projects/${encodeURIComponent(projectId)}?ts=${Date.now()}`, { cache: "no-store" });
-  if (!res.ok) return {};
-  return res.json().catch(() => ({}));
+	const res = await fetch(apiUrl(`/api/projects/${encodeURIComponent(projectId)}?ts=${Date.now()}`), {
+		cache: "no-store",
+		credentials: "include",
+	});
+	if (!res.ok) return {};
+	return res.json().catch(() => ({}));
+}
+
+function errorListFor(summary) {
+	if (!summary) return null;
+	let list = summary.querySelector(".govuk-error-summary__list");
+	if (list) return list;
+
+	const body = summary.querySelector(".govuk-error-summary__body");
+	if (!body) return null;
+
+	list = document.createElement("ul");
+	list.className = "govuk-list govuk-error-summary__list";
+	body.append(list);
+	return list;
 }
 
 function showErrors(errors) {
-  const summary = $("#study-error-summary");
-  const list = $("#study-error-list");
-  if (!summary || !list) return;
+	const summary = $("#study-error-summary");
+	const list = errorListFor(summary);
+	if (!summary || !list) return;
 
-  if (!errors.length) {
-    summary.hidden = true;
-    list.innerHTML = "";
-    return;
-  }
+	if (!errors.length) {
+		summary.hidden = true;
+		list.innerHTML = "";
+		return;
+	}
 
-  list.innerHTML = errors.map((error) => `<li><a href="#${error.id}">${error.message}</a></li>`).join("");
-  summary.hidden = false;
-  summary.focus();
+	list.innerHTML = errors.map((error) => `<li><a href="#${error.id}">${error.message}</a></li>`).join("");
+	summary.hidden = false;
+	summary.focus();
 }
 
 function validate() {
-  const errors = [];
-  if (!fieldValue("#project-id")) {
-    errors.push({ id: "project-id", message: "Missing project id" });
-  }
-  if (!fieldValue("#study-method")) {
-    errors.push({ id: "study-method", message: "Choose a research method" });
-  }
-  if (!fieldValue("#study-notes")) {
-    errors.push({ id: "study-notes", message: "Enter a study description" });
-  }
-  return errors;
+	const errors = [];
+	if (!fieldValue("#project-id")) {
+		errors.push({ id: "project-id", message: "Missing project ID" });
+	}
+	if (!fieldValue("#study-method")) {
+		errors.push({ id: "study-method", message: "Choose a research method" });
+	}
+	if (!fieldValue("#study-notes")) {
+		errors.push({ id: "study-notes", message: "Enter a study description" });
+	}
+	return errors;
 }
 
 async function createStudy(projectId) {
-  const payload = {
-    project_airtable_id: projectId,
-    title: fieldValue("#study-title-input"),
-    method: fieldValue("#study-method"),
-    description: fieldValue("#study-notes"),
-    status: "Planned",
-    study_id: makeStudyId(),
-  };
+	const payload = {
+		project_airtable_id: projectId,
+		title: fieldValue("#study-title-input"),
+		method: fieldValue("#study-method"),
+		description: fieldValue("#study-notes"),
+		status: "Planned",
+		study_id: makeStudyId(),
+	};
 
-  const res = await fetch(`${API_ORIGIN}/api/studies`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+	const res = await fetch(apiUrl("/api/studies"), {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		credentials: "include",
+		body: JSON.stringify(payload),
+	});
 
-  const json = await res.json().catch(() => ({}));
-  if (!res.ok || !json?.ok) {
-    throw new Error(json?.error || json?.detail || `HTTP ${res.status}`);
-  }
+	const json = await res.json().catch(() => ({}));
+	if (!res.ok || !json?.ok) {
+		throw new Error(json?.error || json?.detail || `HTTP ${res.status}`);
+	}
 
-  return json.study_id;
+	return json.study_id;
 }
 
 function initForm(projectId) {
-  const form = $("#add-study-form");
-  const submit = $("#study-submit");
-  const status = $("#study-status");
-  if (!form) return;
+	const form = $("#add-study-form");
+	const submit = $("#study-submit");
+	const status = $("#study-status");
+	if (!form) return;
 
-  form.addEventListener("submit", async (event) => {
-    event.preventDefault();
-    const errors = validate();
-    showErrors(errors);
-    if (errors.length) return;
+	form.addEventListener("submit", async (event) => {
+		event.preventDefault();
+		const errors = validate();
+		showErrors(errors);
+		if (errors.length) return;
 
-    if (submit) submit.setAttribute("disabled", "true");
-    if (status) status.textContent = "Creating study.";
+		if (submit) submit.setAttribute("disabled", "true");
+		if (status) status.textContent = "Creating study.";
 
-    try {
-      const studyId = await createStudy(projectId);
-      if (status) status.textContent = "Study created. Opening study overview.";
-      location.assign(`/pages/study/?pid=${encodeURIComponent(projectId)}&sid=${encodeURIComponent(studyId)}`);
-    } catch (err) {
-      showErrors([{ id: "study-method", message: `Could not create study. ${String(err?.message || err)}` }]);
-      if (status) status.textContent = "";
-    } finally {
-      if (submit) submit.removeAttribute("disabled");
-    }
-  });
+		try {
+			const studyId = await createStudy(projectId);
+			if (status) status.textContent = "Study created. Opening study overview.";
+			location.assign(`/pages/study/?id=${encodeURIComponent(studyId)}`);
+		} catch (err) {
+			showErrors([{ id: "study-method", message: `Could not create study. ${String(err?.message || err)}` }]);
+			if (status) status.textContent = "";
+		} finally {
+			if (submit) submit.removeAttribute("disabled");
+		}
+	});
 }
 
 (async function bootstrap() {
-  const projectId = projectIdFromUrl();
-  if (!projectId) {
-    showErrors([{ id: "project-id", message: "Missing project id" }]);
-    return;
-  }
+	const projectId = projectIdFromUrl();
+	if (!projectId) {
+		showErrors([{ id: "project-id", message: "Missing project ID" }]);
+		return;
+	}
 
-  const project = await loadProject(projectId);
-  setProjectLinks(projectId, project);
-  initForm(projectId);
+	const project = await loadProject(projectId);
+	setProjectLinks(projectId, project);
+	initForm(projectId);
 })();

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -233,6 +233,16 @@ export const govukPages = [
 		},
 	},
 	{
+		template: 'pages/project-dashboard-participants-import.njk',
+		output: 'public/pages/project-dashboard/participants/import/index.html',
+		context: {
+			pageTitle: 'Import participants - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Projects',
+			navigation: projectNavigation,
+		},
+	},
+	{
 		template: 'pages/projects-journals.njk',
 		output: 'public/pages/projects/journals/index.html',
 		context: {

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -213,6 +213,16 @@ export const govukPages = [
 		},
 	},
 	{
+		template: 'pages/study-new.njk',
+		output: 'public/pages/study/new/index.html',
+		context: {
+			pageTitle: 'Add study - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Projects',
+			navigation: projectNavigation,
+		},
+	},
+	{
 		template: 'pages/project-dashboard-participants.njk',
 		output: 'public/pages/project-dashboard/participants/index.html',
 		context: {

--- a/src/govuk/templates/pages/project-dashboard-participants-import.njk
+++ b/src/govuk/templates/pages/project-dashboard-participants-import.njk
@@ -1,0 +1,164 @@
+{% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% block head %}
+	<meta property="schema:name" content="Import participants — ResearchOps">
+	<meta property="schema:creator" content="Home Office ResearchOps Platform">
+	<meta property="schema:dateModified" content="2026-06-02">
+	<meta property="dcterms:language" content="en-GB">
+	<link rel="modulepreload" href="/js/project-participant-context.js">
+	<link rel="modulepreload" href="/pages/project-dashboard/participants/import/import-participants.js">
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+	{{ govukBreadcrumbs({
+		attributes: {
+			id: "participant-import-breadcrumbs",
+			typeof: "schema:BreadcrumbList"
+		},
+		items: [
+			{
+				text: "Projects",
+				href: "/pages/projects/",
+				attributes: {
+					property: "schema:item",
+					typeof: "schema:Thing"
+				}
+			},
+			{
+				text: "Project",
+				href: "/pages/project-dashboard/?id=",
+				attributes: {
+					id: "breadcrumb-project",
+					property: "schema:item",
+					typeof: "schema:Thing"
+				}
+			},
+			{
+				text: "Import participants"
+			}
+		]
+	}) }}
+
+	<header class="govuk-!-margin-bottom-6">
+		<p id="project-eyebrow" class="govuk-caption-l">Project</p>
+		<h1 class="govuk-heading-l">Import participants</h1>
+		<p class="govuk-body-l">Upload a CSV, preview the rows and create participants against a study only after checking the data.</p>
+	</header>
+
+	{{ govukErrorSummary({
+		attributes: {
+			id: "import-error-summary",
+			hidden: "hidden"
+		},
+		titleText: "There is a problem",
+		errorList: []
+	}) }}
+
+	{{ govukInsetText({
+		attributes: {
+			id: "no-studies-panel",
+			hidden: "hidden"
+		},
+		html: '<h2 class="govuk-heading-m">Create a study first</h2><p class="govuk-body">Participants must be linked to a study before they can be imported.</p><a id="create-study-link" href="/pages/study/new/?id=" class="govuk-button" data-module="govuk-button">Add study</a>'
+	}) }}
+
+	<form id="import-participants-form" novalidate>
+		<input id="project-id" name="project_airtable_id" type="hidden" value="">
+
+		{{ govukSelect({
+			id: "study-select",
+			name: "study",
+			label: {
+				text: "Study"
+			},
+			hint: {
+				text: "Choose the study these participants belong to."
+			},
+			items: [
+				{
+					value: "",
+					text: "Choose a study"
+				}
+			],
+			attributes: {
+				required: "required"
+			}
+		}) }}
+
+		{{ govukFileUpload({
+			id: "participants-csv",
+			name: "csv",
+			label: {
+				text: "CSV file"
+			},
+			hint: {
+				text: "Use headings: display_name, email, phone, channel_pref, access_needs. Do not upload unnecessary personal data."
+			},
+			attributes: {
+				accept: ".csv,text/csv",
+				required: "required"
+			}
+		}) }}
+
+		<div class="govuk-button-group">
+			{{ govukButton({
+				text: "Preview CSV",
+				type: "button",
+				classes: "govuk-button--secondary",
+				attributes: {
+					id: "preview-csv"
+				}
+			}) }}
+			{{ govukButton({
+				text: "Create participants",
+				type: "submit",
+				disabled: true,
+				attributes: {
+					id: "import-submit"
+				}
+			}) }}
+			{{ govukButton({
+				text: "Cancel",
+				href: "/pages/projects/",
+				classes: "govuk-button--secondary",
+				attributes: {
+					id: "cancel-import"
+				}
+			}) }}
+		</div>
+
+		<p id="import-status" class="govuk-body-s" role="status" aria-live="polite"></p>
+	</form>
+
+	<section id="preview-section" class="govuk-!-margin-top-6" aria-labelledby="preview-heading" hidden>
+		<h2 id="preview-heading" class="govuk-heading-m">Preview participants</h2>
+		<div class="table-wrap">
+			<table class="govuk-table">
+				<caption class="govuk-table__caption govuk-table__caption--s">Rows to import</caption>
+				<thead class="govuk-table__head">
+					<tr class="govuk-table__row">
+						<th scope="col" class="govuk-table__header">Display name</th>
+						<th scope="col" class="govuk-table__header">Email</th>
+						<th scope="col" class="govuk-table__header">Phone</th>
+						<th scope="col" class="govuk-table__header">Channel</th>
+						<th scope="col" class="govuk-table__header">Access needs</th>
+					</tr>
+				</thead>
+				<tbody id="preview-body" class="govuk-table__body"></tbody>
+			</table>
+		</div>
+	</section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/js/project-participant-context.js"></script>
+	<script type="module" src="/pages/project-dashboard/participants/import/import-participants.js"></script>
+{% endblock %}

--- a/src/govuk/templates/pages/project-dashboard-participants.njk
+++ b/src/govuk/templates/pages/project-dashboard-participants.njk
@@ -11,7 +11,7 @@
 {% block head %}
 	<meta property="schema:name" content="Add participant — ResearchOps">
 	<meta property="schema:creator" content="Home Office ResearchOps Platform">
-	<meta property="schema:dateModified" content="2026-06-01">
+	<meta property="schema:dateModified" content="2026-06-02">
 	<meta property="dcterms:language" content="en-GB">
 	<link rel="modulepreload" href="/js/project-participant-context.js">
 	<link rel="modulepreload" href="/pages/project-dashboard/participants/participants-project.js">
@@ -20,8 +20,8 @@
 {% block content %}
 <div class="govuk-width-container">
 	{{ govukBreadcrumbs({
-		id: "participant-breadcrumbs",
 		attributes: {
+			id: "participant-breadcrumbs",
 			typeof: "schema:BreadcrumbList"
 		},
 		items: [
@@ -77,7 +77,7 @@
 			id: "no-studies-panel",
 			hidden: "hidden"
 		},
-		html: '<h2 class="govuk-heading-m">Create a study first</h2><p class="govuk-body">Participants must be linked to a study before they can be added.</p><a id="create-study-link" href="/pages/study/new/?pid=" class="govuk-button" data-module="govuk-button">Add study</a>'
+		html: '<h2 class="govuk-heading-m">Create a study first</h2><p class="govuk-body">Participants must be linked to a study before they can be added.</p><a id="create-study-link" href="/pages/study/new/?id=" class="govuk-button" data-module="govuk-button">Add study</a>'
 	}) }}
 
 	<form id="add-participant-form" novalidate>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -297,8 +297,8 @@
 						<p class="govuk-body-s" id="participants-summary-status">Loading participants…</p>
 						<p class="govuk-body-s">Participants are managed through study-specific workflows so consent, scheduling and safeguarding states stay traceable.</p>
 						<div class="govuk-button-group">
-							{{ govukButton({ text: "Add participant", href: "/pages/project-dashboard/participants/?pid=", classes: "govuk-button--secondary", attributes: { id: "add-participant-link" } }) }}
-							{{ govukButton({ text: "Bulk upload participants via CSV", href: "/pages/project-dashboard/participants/import/?pid=", classes: "govuk-button--secondary", attributes: { id: "import-participants-link" } }) }}
+							{{ govukButton({ text: "Add participant", href: "/pages/project-dashboard/participants/?id=", classes: "govuk-button--secondary", attributes: { id: "add-participant-link" } }) }}
+							{{ govukButton({ text: "Bulk upload participants via CSV", href: "/pages/project-dashboard/participants/import/?id=", classes: "govuk-button--secondary", attributes: { id: "import-participants-link" } }) }}
 						</div>
 					</div>
 				</div>
@@ -317,7 +317,7 @@
 					<div>
 						<h3 class="govuk-heading-s">Studies</h3>
 						<ul class="govuk-list govuk-list--spaced rops-study-list" id="studies-list"><li>Loading studies…</li></ul>
-						{{ govukButton({ text: "Add study", href: "/pages/study/new/?pid=", classes: "govuk-button--secondary", attributes: { id: "add-study-link" } }) }}
+						{{ govukButton({ text: "Add study", href: "/pages/study/new/?id=", classes: "govuk-button--secondary", attributes: { id: "add-study-link" } }) }}
 					</div>
 					<div>
 						<h3 class="govuk-heading-s">Insights</h3>

--- a/src/govuk/templates/pages/study-new.njk
+++ b/src/govuk/templates/pages/study-new.njk
@@ -18,8 +18,8 @@
 {% block content %}
 <div class="govuk-width-container">
 	{{ govukBreadcrumbs({
-		id: "study-breadcrumbs",
 		attributes: {
+			id: "study-breadcrumbs",
 			typeof: "schema:BreadcrumbList"
 		},
 		items: [

--- a/src/govuk/templates/pages/study-new.njk
+++ b/src/govuk/templates/pages/study-new.njk
@@ -149,6 +149,7 @@
 			id: "study-notes",
 			name: "description",
 			classes: "govuk-!-width-two-thirds",
+			value: "",
 			rows: 6,
 			label: {
 				text: "Study description"

--- a/src/govuk/templates/pages/study-new.njk
+++ b/src/govuk/templates/pages/study-new.njk
@@ -1,0 +1,189 @@
+{% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% block head %}
+	<meta property="schema:name" content="Add study — ResearchOps">
+	<meta property="schema:creator" content="Home Office ResearchOps Platform">
+	<meta property="schema:dateModified" content="2026-06-02">
+	<meta property="dcterms:language" content="en-GB">
+	<link rel="modulepreload" href="/pages/study/new/study-new.js">
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+	{{ govukBreadcrumbs({
+		id: "study-breadcrumbs",
+		attributes: {
+			typeof: "schema:BreadcrumbList"
+		},
+		items: [
+			{
+				text: "Projects",
+				href: "/pages/projects/",
+				attributes: {
+					property: "schema:item",
+					typeof: "schema:Thing"
+				}
+			},
+			{
+				text: "Project",
+				href: "/pages/project-dashboard/?id=",
+				attributes: {
+					id: "breadcrumb-project",
+					property: "schema:item",
+					typeof: "schema:Thing"
+				}
+			},
+			{
+				text: "Add study"
+			}
+		]
+	}) }}
+
+	<header class="govuk-!-margin-bottom-6">
+		<p id="project-eyebrow" class="govuk-caption-l">Project</p>
+		<h1 class="govuk-heading-l">Add study</h1>
+		<p class="govuk-body-l">Create a study as a dedicated workflow so method, description and readiness controls can be managed outside the project dashboard.</p>
+	</header>
+
+	{{ govukInsetText({
+		html: '<p class="govuk-body">Use this page to create a study within the selected project. Do not include participant personal data in the study description.</p>'
+	}) }}
+
+	{{ govukErrorSummary({
+		attributes: {
+			id: "study-error-summary",
+			hidden: "hidden"
+		},
+		titleText: "There is a problem",
+		errorList: []
+	}) }}
+
+	<form id="add-study-form" class="govuk-!-margin-top-6" novalidate>
+		<input id="project-id" name="project_airtable_id" type="hidden" value="">
+
+		{{ govukInput({
+			id: "study-title-input",
+			name: "title",
+			classes: "govuk-!-width-two-thirds",
+			label: {
+				text: "Study title"
+			},
+			hint: {
+				text: "Use a short, recognisable title."
+			}
+		}) }}
+
+		{{ govukSelect({
+			id: "study-method",
+			name: "method",
+			classes: "govuk-!-width-two-thirds",
+			label: {
+				text: "Research method"
+			},
+			hint: {
+				text: "Choose the primary method for this study."
+			},
+			items: [
+				{
+					value: "",
+					text: "Choose a research method"
+				},
+				{
+					value: "Card Sort",
+					text: "Card Sort"
+				},
+				{
+					value: "Contextual Inquiry",
+					text: "Contextual Inquiry"
+				},
+				{
+					value: "Customer Satisfaction Survey",
+					text: "Customer Satisfaction Survey"
+				},
+				{
+					value: "Diary Study",
+					text: "Diary Study"
+				},
+				{
+					value: "Existing Research Analysis",
+					text: "Existing Research Analysis"
+				},
+				{
+					value: "Expert Review",
+					text: "Expert Review"
+				},
+				{
+					value: "Stakeholder Interview",
+					text: "Stakeholder Interview"
+				},
+				{
+					value: "Survey",
+					text: "Survey"
+				},
+				{
+					value: "Tree Test",
+					text: "Tree Test"
+				},
+				{
+					value: "Usability Test",
+					text: "Usability Test"
+				},
+				{
+					value: "User Interview",
+					text: "User Interview"
+				}
+			],
+			attributes: {
+				required: "required"
+			}
+		}) }}
+
+		{{ govukTextarea({
+			id: "study-notes",
+			name: "description",
+			classes: "govuk-!-width-two-thirds",
+			rows: 6,
+			label: {
+				text: "Study description"
+			},
+			hint: {
+				text: "Describe the purpose of the study. Do not include participant personal data."
+			},
+			attributes: {
+				required: "required"
+			}
+		}) }}
+
+		<div class="govuk-button-group">
+			{{ govukButton({
+				text: "Create study",
+				type: "submit",
+				attributes: {
+					id: "study-submit"
+				}
+			}) }}
+			{{ govukButton({
+				text: "Cancel",
+				href: "/pages/projects/",
+				classes: "govuk-button--secondary",
+				attributes: {
+					id: "cancel-study"
+				}
+			}) }}
+		</div>
+
+		<p id="study-status" class="govuk-body-s" role="status" aria-live="polite"></p>
+	</form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/pages/study/new/study-new.js"></script>
+{% endblock %}

--- a/tests/govuk-forms-application-route-state.test.js
+++ b/tests/govuk-forms-application-route-state.test.js
@@ -8,10 +8,8 @@ const legacyFormRoutes = [
 	"public/pages/consent/index.html",
 	"public/pages/sessions/index.html",
 	"public/pages/study/synthesis/index.html",
-	"public/pages/project-dashboard/participants/import/index.html",
 	"public/pages/projects/outcomes/index.html",
 	"public/pages/study/index.html",
-	"public/pages/study/new/index.html",
 	"public/pages/study/guides/index.html",
 	"public/pages/study/consent-forms/index.html",
 	"public/pages/study/participant-consent/index.html",
@@ -104,13 +102,19 @@ includes(projectParticipantsPage, "id=\"study-select\"", "Project participant ro
 includes(projectParticipantsPage, "id=\"participant-first-name\"", "Project participant route");
 includes(projectParticipantsPage, "id=\"participant-family-name\"", "Project participant route");
 includes(projectParticipantsPage, "id=\"create-study-link\"", "Project participant route");
+includes(projectParticipantsPage, "href=\"/pages/study/new/?id=\"", "Project participant route");
+excludes(projectParticipantsPage, "href=\"/pages/study/new/?pid=\"", "Project participant route");
 
 const participantImportPage = read("public/pages/project-dashboard/participants/import/index.html");
+includes(participantImportPage, "href=\"/assets/govuk/govuk-frontend.css\"", "Participant import route");
+excludes(participantImportPage, "href=\"/css/govuk/govuk-forms.css\"", "Participant import route");
 includes(participantImportPage, "id=\"import-participants-form\"", "Participant import route");
 includes(participantImportPage, "id=\"import-error-summary\"", "Participant import route");
 includes(participantImportPage, "id=\"participants-csv\"", "Participant import route");
 includes(participantImportPage, "id=\"preview-csv\"", "Participant import route");
 includes(participantImportPage, "id=\"preview-section\"", "Participant import route");
+includes(participantImportPage, "href=\"/pages/study/new/?id=\"", "Participant import route");
+excludes(participantImportPage, "href=\"/pages/study/new/?pid=\"", "Participant import route");
 
 const outcomesPage = read("public/pages/projects/outcomes/index.html");
 includes(outcomesPage, "href=\"/css/govuk/govuk-forms.css\"", "Outcomes route");
@@ -132,9 +136,13 @@ includes(studyPage, "class=\"govuk-form-group\"", "Study route");
 includes(studyPage, "aria-describedby=\"desc-input-hint\"", "Study route");
 
 const newStudyPage = read("public/pages/study/new/index.html");
+includes(newStudyPage, "href=\"/assets/govuk/govuk-frontend.css\"", "Add Study route");
+excludes(newStudyPage, "href=\"/css/govuk/govuk-forms.css\"", "Add Study route");
 includes(newStudyPage, "id=\"add-study-form\"", "Add Study route");
 includes(newStudyPage, "id=\"study-error-summary\"", "Add Study route");
-includes(newStudyPage, "id=\"study-method\" name=\"method\" class=\"govuk-select\"", "Add Study route");
+includes(newStudyPage, "id=\"study-method\"", "Add Study route");
+includes(newStudyPage, "name=\"method\"", "Add Study route");
+includes(newStudyPage, "class=\"govuk-select", "Add Study route");
 includes(newStudyPage, "aria-describedby=\"study-notes-hint\"", "Add Study route");
 includes(newStudyPage, "id=\"study-submit\"", "Add Study route");
 

--- a/tests/study-new-route-state.test.js
+++ b/tests/study-new-route-state.test.js
@@ -8,7 +8,6 @@ const projectDashboardTemplateSource = fs.readFileSync("src/govuk/templates/page
 const studyNewControllerSource = fs.readFileSync("public/pages/study/new/study-new.js", "utf8");
 const participantControllerSource = fs.readFileSync("public/pages/project-dashboard/participants/participants-project.js", "utf8");
 const participantImportControllerSource = fs.readFileSync("public/pages/project-dashboard/participants/import/import-participants.js", "utf8");
-const dashboardControllerSource = fs.readFileSync("public/js/project-dashboard.js", "utf8");
 const dashboardContextSource = fs.readFileSync("public/js/project-dashboard-context.js", "utf8");
 const renderGovukPagesSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 
@@ -86,11 +85,6 @@ includes(participantImportControllerSource, "createStudy.href = `/pages/study/ne
 includes(participantImportControllerSource, "location.assign(`/pages/study/participants/?id=${encodeURIComponent(studyId)}`);", "participant import controller");
 excludes(participantImportControllerSource, "/pages/study/new/?pid=", "participant import controller");
 excludes(participantImportControllerSource, "/pages/study/participants/?pid=", "participant import controller");
-
-includes(dashboardControllerSource, "setLinkHref(\"add-participant-link\", `/pages/project-dashboard/participants/?id=${encodeURIComponent(projectId)}`);", "project dashboard controller");
-includes(dashboardControllerSource, "setLinkHref(\"import-participants-link\", `/pages/project-dashboard/participants/import/?id=${encodeURIComponent(projectId)}`);", "project dashboard controller");
-includes(dashboardControllerSource, "setLinkHref(\"add-study-link\", `/pages/study/new/?id=${encodeURIComponent(projectId)}`);", "project dashboard controller");
-excludes(dashboardControllerSource, "setLinkHref(\"add-study-link\", `/pages/study/new/?pid=${encodeURIComponent(projectId)}`);", "project dashboard controller");
 
 includes(dashboardContextSource, "[\"add-participant-link\", \"/pages/project-dashboard/participants/\", \"id\"]", "project dashboard context");
 includes(dashboardContextSource, "[\"import-participants-link\", \"/pages/project-dashboard/participants/import/\", \"id\"]", "project dashboard context");

--- a/tests/study-new-route-state.test.js
+++ b/tests/study-new-route-state.test.js
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-const pageSource = fs.readFileSync("public/pages/study/new/index.html", "utf8");
-const templateSource = fs.readFileSync("src/govuk/templates/pages/study-new.njk", "utf8");
-const controllerSource = fs.readFileSync("public/pages/study/new/study-new.js", "utf8");
+const studyNewTemplateSource = fs.readFileSync("src/govuk/templates/pages/study-new.njk", "utf8");
+const participantTemplateSource = fs.readFileSync("src/govuk/templates/pages/project-dashboard-participants.njk", "utf8");
+const participantImportTemplateSource = fs.readFileSync("src/govuk/templates/pages/project-dashboard-participants-import.njk", "utf8");
+const projectDashboardTemplateSource = fs.readFileSync("src/govuk/templates/pages/project-dashboard.njk", "utf8");
+const studyNewControllerSource = fs.readFileSync("public/pages/study/new/study-new.js", "utf8");
+const participantControllerSource = fs.readFileSync("public/pages/project-dashboard/participants/participants-project.js", "utf8");
+const participantImportControllerSource = fs.readFileSync("public/pages/project-dashboard/participants/import/import-participants.js", "utf8");
 const dashboardControllerSource = fs.readFileSync("public/js/project-dashboard.js", "utf8");
+const dashboardContextSource = fs.readFileSync("public/js/project-dashboard-context.js", "utf8");
 const renderGovukPagesSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 
 function includes(source, text, label) {
@@ -17,48 +22,77 @@ function excludes(source, text, label) {
 
 includes(renderGovukPagesSource, "template: 'pages/study-new.njk'", "GOV.UK page renderer");
 includes(renderGovukPagesSource, "output: 'public/pages/study/new/index.html'", "GOV.UK page renderer");
+includes(renderGovukPagesSource, "template: 'pages/project-dashboard-participants.njk'", "GOV.UK page renderer");
+includes(renderGovukPagesSource, "output: 'public/pages/project-dashboard/participants/index.html'", "GOV.UK page renderer");
+includes(renderGovukPagesSource, "template: 'pages/project-dashboard-participants-import.njk'", "GOV.UK page renderer");
+includes(renderGovukPagesSource, "output: 'public/pages/project-dashboard/participants/import/index.html'", "GOV.UK page renderer");
 
-includes(templateSource, "{% from \"govuk/components/breadcrumbs/macro.njk\" import govukBreadcrumbs %}", "study new template");
-includes(templateSource, "{% from \"govuk/components/button/macro.njk\" import govukButton %}", "study new template");
-includes(templateSource, "{% from \"govuk/components/error-summary/macro.njk\" import govukErrorSummary %}", "study new template");
-includes(templateSource, "{% from \"govuk/components/input/macro.njk\" import govukInput %}", "study new template");
-includes(templateSource, "{% from \"govuk/components/select/macro.njk\" import govukSelect %}", "study new template");
-includes(templateSource, "{% from \"govuk/components/textarea/macro.njk\" import govukTextarea %}", "study new template");
-includes(templateSource, "govuk-!-width-two-thirds", "study new template");
-includes(templateSource, "govuk-!-margin-top-6", "study new template");
-includes(templateSource, "href: \"/pages/project-dashboard/?id=\"", "study new template");
-excludes(templateSource, "Back to project dashboard", "study new template");
-excludes(templateSource, "id=\"back-to-project\"", "study new template");
-excludes(templateSource, "?pid=", "study new template");
+includes(studyNewTemplateSource, "{% from \"govuk/components/breadcrumbs/macro.njk\" import govukBreadcrumbs %}", "study new template");
+includes(studyNewTemplateSource, "{% from \"govuk/components/button/macro.njk\" import govukButton %}", "study new template");
+includes(studyNewTemplateSource, "{% from \"govuk/components/error-summary/macro.njk\" import govukErrorSummary %}", "study new template");
+includes(studyNewTemplateSource, "{% from \"govuk/components/input/macro.njk\" import govukInput %}", "study new template");
+includes(studyNewTemplateSource, "{% from \"govuk/components/select/macro.njk\" import govukSelect %}", "study new template");
+includes(studyNewTemplateSource, "{% from \"govuk/components/textarea/macro.njk\" import govukTextarea %}", "study new template");
+includes(studyNewTemplateSource, "id: \"study-breadcrumbs\"", "study new template");
+includes(studyNewTemplateSource, "value: \"\"", "study new template");
+includes(studyNewTemplateSource, "href: \"/pages/project-dashboard/?id=\"", "study new template");
+excludes(studyNewTemplateSource, "Back to project dashboard", "study new template");
+excludes(studyNewTemplateSource, "id=\"back-to-project\"", "study new template");
+excludes(studyNewTemplateSource, "?pid=", "study new template");
 
-includes(pageSource, "class=\"govuk-template\"", "study new page");
-includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "study new page");
-includes(pageSource, "<x-include src=\"/partials/header.html\"", "study new page");
-includes(pageSource, "<x-include src=\"/partials/footer.html\"></x-include>", "study new page");
-includes(pageSource, "id=\"study-breadcrumbs\"", "study new page");
-includes(pageSource, "id=\"study-error-summary\"", "study new page");
-includes(pageSource, "name=\"project_airtable_id\"", "study new page");
-includes(pageSource, "id=\"study-title-input\"", "study new page");
-includes(pageSource, "id=\"study-method\"", "study new page");
-includes(pageSource, "id=\"study-notes\"", "study new page");
-includes(pageSource, "id=\"study-submit\"", "study new page");
-includes(pageSource, "id=\"cancel-study\"", "study new page");
-excludes(pageSource, "href=\"/css/screen.css\"", "study new page");
-excludes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "study new page");
-excludes(pageSource, "Back to project dashboard", "study new page");
-excludes(pageSource, "id=\"back-to-project\"", "study new page");
-excludes(pageSource, "?pid=", "study new page");
+includes(participantTemplateSource, "{% from \"govuk/components/breadcrumbs/macro.njk\" import govukBreadcrumbs %}", "participant template");
+includes(participantTemplateSource, "{% from \"govuk/components/button/macro.njk\" import govukButton %}", "participant template");
+includes(participantTemplateSource, "{% from \"govuk/components/input/macro.njk\" import govukInput %}", "participant template");
+includes(participantTemplateSource, "{% from \"govuk/components/select/macro.njk\" import govukSelect %}", "participant template");
+includes(participantTemplateSource, "{% from \"govuk/components/textarea/macro.njk\" import govukTextarea %}", "participant template");
+includes(participantTemplateSource, "id: \"participant-breadcrumbs\"", "participant template");
+includes(participantTemplateSource, "href=\"/pages/study/new/?id=\"", "participant template");
+excludes(participantTemplateSource, "?pid=", "participant template");
 
-includes(controllerSource, "function projectIdFromUrl()", "study new controller");
-includes(controllerSource, "return new URLSearchParams(location.search).get(\"id\") || \"\";", "study new controller");
-includes(controllerSource, "location.assign(`/pages/study/?id=${encodeURIComponent(studyId)}`);", "study new controller");
-includes(controllerSource, "project_airtable_id: projectId", "study new controller");
-includes(controllerSource, "credentials: \"include\"", "study new controller");
-excludes(controllerSource, "get(\"pid\")", "study new controller");
-excludes(controllerSource, "/pages/study/?pid=", "study new controller");
-excludes(controllerSource, "sid=", "study new controller");
-excludes(controllerSource, "back-to-project", "study new controller");
-excludes(controllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "study new controller");
+includes(participantImportTemplateSource, "{% from \"govuk/components/breadcrumbs/macro.njk\" import govukBreadcrumbs %}", "participant import template");
+includes(participantImportTemplateSource, "{% from \"govuk/components/button/macro.njk\" import govukButton %}", "participant import template");
+includes(participantImportTemplateSource, "{% from \"govuk/components/error-summary/macro.njk\" import govukErrorSummary %}", "participant import template");
+includes(participantImportTemplateSource, "{% from \"govuk/components/file-upload/macro.njk\" import govukFileUpload %}", "participant import template");
+includes(participantImportTemplateSource, "{% from \"govuk/components/select/macro.njk\" import govukSelect %}", "participant import template");
+includes(participantImportTemplateSource, "id: \"participant-import-breadcrumbs\"", "participant import template");
+includes(participantImportTemplateSource, "href=\"/pages/study/new/?id=\"", "participant import template");
+excludes(participantImportTemplateSource, "href=\"/css/screen.css\"", "participant import template");
+excludes(participantImportTemplateSource, "?pid=", "participant import template");
 
+includes(projectDashboardTemplateSource, "href: \"/pages/project-dashboard/participants/?id=\"", "project dashboard template");
+includes(projectDashboardTemplateSource, "href: \"/pages/project-dashboard/participants/import/?id=\"", "project dashboard template");
+includes(projectDashboardTemplateSource, "href: \"/pages/study/new/?id=\"", "project dashboard template");
+excludes(projectDashboardTemplateSource, "href: \"/pages/project-dashboard/participants/?pid=\"", "project dashboard template");
+excludes(projectDashboardTemplateSource, "href: \"/pages/project-dashboard/participants/import/?pid=\"", "project dashboard template");
+excludes(projectDashboardTemplateSource, "href: \"/pages/study/new/?pid=\"", "project dashboard template");
+
+includes(studyNewControllerSource, "function projectIdFromUrl()", "study new controller");
+includes(studyNewControllerSource, "return new URLSearchParams(location.search).get(\"id\") || \"\";", "study new controller");
+includes(studyNewControllerSource, "location.assign(`/pages/study/?id=${encodeURIComponent(studyId)}`);", "study new controller");
+includes(studyNewControllerSource, "project_airtable_id: projectId", "study new controller");
+includes(studyNewControllerSource, "credentials: \"include\"", "study new controller");
+excludes(studyNewControllerSource, "get(\"pid\")", "study new controller");
+excludes(studyNewControllerSource, "/pages/study/?pid=", "study new controller");
+excludes(studyNewControllerSource, "sid=", "study new controller");
+excludes(studyNewControllerSource, "back-to-project", "study new controller");
+excludes(studyNewControllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "study new controller");
+
+includes(participantControllerSource, "createStudy.href = `/pages/study/new/?id=${encodeURIComponent(projectId)}`;", "participant controller");
+includes(participantControllerSource, "location.assign(`/pages/study/participants/?id=${encodeURIComponent(studyId)}${suffix}`);", "participant controller");
+excludes(participantControllerSource, "/pages/study/new/?pid=", "participant controller");
+excludes(participantControllerSource, "/pages/study/participants/?pid=", "participant controller");
+
+includes(participantImportControllerSource, "createStudy.href = `/pages/study/new/?id=${encodeURIComponent(projectId)}`;", "participant import controller");
+includes(participantImportControllerSource, "location.assign(`/pages/study/participants/?id=${encodeURIComponent(studyId)}`);", "participant import controller");
+excludes(participantImportControllerSource, "/pages/study/new/?pid=", "participant import controller");
+excludes(participantImportControllerSource, "/pages/study/participants/?pid=", "participant import controller");
+
+includes(dashboardControllerSource, "setLinkHref(\"add-participant-link\", `/pages/project-dashboard/participants/?id=${encodeURIComponent(projectId)}`);", "project dashboard controller");
+includes(dashboardControllerSource, "setLinkHref(\"import-participants-link\", `/pages/project-dashboard/participants/import/?id=${encodeURIComponent(projectId)}`);", "project dashboard controller");
 includes(dashboardControllerSource, "setLinkHref(\"add-study-link\", `/pages/study/new/?id=${encodeURIComponent(projectId)}`);", "project dashboard controller");
 excludes(dashboardControllerSource, "setLinkHref(\"add-study-link\", `/pages/study/new/?pid=${encodeURIComponent(projectId)}`);", "project dashboard controller");
+
+includes(dashboardContextSource, "[\"add-participant-link\", \"/pages/project-dashboard/participants/\", \"id\"]", "project dashboard context");
+includes(dashboardContextSource, "[\"import-participants-link\", \"/pages/project-dashboard/participants/import/\", \"id\"]", "project dashboard context");
+includes(dashboardContextSource, "[\"add-study-link\", \"/pages/study/new/\", \"id\"]", "project dashboard context");
+excludes(dashboardContextSource, "[\"add-study-link\", \"/pages/study/new/\", \"pid\"]", "project dashboard context");

--- a/tests/study-new-route-state.test.js
+++ b/tests/study-new-route-state.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pageSource = fs.readFileSync("public/pages/study/new/index.html", "utf8");
+const templateSource = fs.readFileSync("src/govuk/templates/pages/study-new.njk", "utf8");
+const controllerSource = fs.readFileSync("public/pages/study/new/study-new.js", "utf8");
+const dashboardControllerSource = fs.readFileSync("public/js/project-dashboard.js", "utf8");
+const renderGovukPagesSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(renderGovukPagesSource, "template: 'pages/study-new.njk'", "GOV.UK page renderer");
+includes(renderGovukPagesSource, "output: 'public/pages/study/new/index.html'", "GOV.UK page renderer");
+
+includes(templateSource, "{% from \"govuk/components/breadcrumbs/macro.njk\" import govukBreadcrumbs %}", "study new template");
+includes(templateSource, "{% from \"govuk/components/button/macro.njk\" import govukButton %}", "study new template");
+includes(templateSource, "{% from \"govuk/components/error-summary/macro.njk\" import govukErrorSummary %}", "study new template");
+includes(templateSource, "{% from \"govuk/components/input/macro.njk\" import govukInput %}", "study new template");
+includes(templateSource, "{% from \"govuk/components/select/macro.njk\" import govukSelect %}", "study new template");
+includes(templateSource, "{% from \"govuk/components/textarea/macro.njk\" import govukTextarea %}", "study new template");
+includes(templateSource, "govuk-!-width-two-thirds", "study new template");
+includes(templateSource, "govuk-!-margin-top-6", "study new template");
+includes(templateSource, "href: \"/pages/project-dashboard/?id=\"", "study new template");
+excludes(templateSource, "Back to project dashboard", "study new template");
+excludes(templateSource, "id=\"back-to-project\"", "study new template");
+excludes(templateSource, "?pid=", "study new template");
+
+includes(pageSource, "class=\"govuk-template\"", "study new page");
+includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "study new page");
+includes(pageSource, "<x-include src=\"/partials/header.html\"", "study new page");
+includes(pageSource, "<x-include src=\"/partials/footer.html\"></x-include>", "study new page");
+includes(pageSource, "id=\"study-breadcrumbs\"", "study new page");
+includes(pageSource, "id=\"study-error-summary\"", "study new page");
+includes(pageSource, "name=\"project_airtable_id\"", "study new page");
+includes(pageSource, "id=\"study-title-input\"", "study new page");
+includes(pageSource, "id=\"study-method\"", "study new page");
+includes(pageSource, "id=\"study-notes\"", "study new page");
+includes(pageSource, "id=\"study-submit\"", "study new page");
+includes(pageSource, "id=\"cancel-study\"", "study new page");
+excludes(pageSource, "href=\"/css/screen.css\"", "study new page");
+excludes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "study new page");
+excludes(pageSource, "Back to project dashboard", "study new page");
+excludes(pageSource, "id=\"back-to-project\"", "study new page");
+excludes(pageSource, "?pid=", "study new page");
+
+includes(controllerSource, "function projectIdFromUrl()", "study new controller");
+includes(controllerSource, "return new URLSearchParams(location.search).get(\"id\") || \"\";", "study new controller");
+includes(controllerSource, "location.assign(`/pages/study/?id=${encodeURIComponent(studyId)}`);", "study new controller");
+includes(controllerSource, "project_airtable_id: projectId", "study new controller");
+includes(controllerSource, "credentials: \"include\"", "study new controller");
+excludes(controllerSource, "get(\"pid\")", "study new controller");
+excludes(controllerSource, "/pages/study/?pid=", "study new controller");
+excludes(controllerSource, "sid=", "study new controller");
+excludes(controllerSource, "back-to-project", "study new controller");
+excludes(controllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "study new controller");
+
+includes(dashboardControllerSource, "setLinkHref(\"add-study-link\", `/pages/study/new/?id=${encodeURIComponent(projectId)}`);", "project dashboard controller");
+excludes(dashboardControllerSource, "setLinkHref(\"add-study-link\", `/pages/study/new/?pid=${encodeURIComponent(projectId)}`);", "project dashboard controller");


### PR DESCRIPTION
Summary:

- Adds GOV.UK Frontend Nunjucks templates for /pages/study/new/ and participant import.
- Updates the existing Add participant Nunjucks template.
- Registers the new pages in scripts/govuk/render-govuk-pages.mjs.
- Moves source template links for Add study, Add participant and Import participants from ?pid= to ?id=.
- Updates participant add/import controllers so emitted Study participant redirects use /pages/study/participants/?id=<study-record-id>.
- Fixes the study textarea macro render failure by passing value: "".
- Updates route-state tests for the GOV.UK Frontend-rendered page contract.

Latest failure-log fix:

The uploaded logs showed tests/govuk-forms-application-route-state.test.js still treating public/pages/project-dashboard/participants/import/index.html as a legacy form-CSS page. That route is now rendered through the GOV.UK Frontend template contract, so the test has been updated to remove it from legacyFormRoutes and assert /assets/govuk/govuk-frontend.css plus the canonical /pages/study/new/?id= link instead.

Recommended validation:

- npm run build:govuk-pages
- node --test tests/govuk-forms-application-route-state.test.js
- node --test tests/study-new-route-state.test.js
- npm test
- npm run validate

Trace:

- docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.md
- docs/agent-audit/reasoning/2026/06/02/study-new-govuk-id-routing.json