### PR TITLE
Cache bust outcomes page scripts

### DIFF
--- a/public/pages/projects/outcomes/index.html
+++ b/public/pages/projects/outcomes/index.html
@@ -11,12 +11,9 @@
 		<meta property="schema:dateModified" content="2026-06-02" />
 		<meta property="dcterms:language" content="en-GB" />
 		<link rel="stylesheet" href="/css/outcomes.css?v=20260603-form-interactions" media="screen" />
-		<link rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions?v=20260603-form-interactions" />
-		<link rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions?v=20260603-form-interactions" />
-		<link
-			rel="modulepreload"
-			href="/components/impact-tracker.js?v=20260603-form-interactions?v=20260603-form-interactions"
-		/>
+		<link rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions" />
+		<link rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions" />
+		<link rel="modulepreload" href="/components/impact-tracker.js?v=20260603-form-interactions" />
 
 		<script type="module" src="/components/layout.js" defer></script>
 		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
@@ -804,8 +801,8 @@
 		</main>
 		<x-include src="/partials/footer.html"></x-include>
 
-		<script type="module" src="/js/project-context.js?v=20260603-form-interactions"></script>
-		<script type="module" src="/js/outcomes-page.js?v=20260603-form-interactions"></script>
-		<script type="module" src="/components/impact-tracker.js?v=20260603-form-interactions"></script>
+		<script type="module" src="/js/project-context.js"></script>
+		<script type="module" src="/js/outcomes-page.js"></script>
+		<script type="module" src="/components/impact-tracker.js"></script>
 	</body>
 </html>

--- a/public/pages/projects/outcomes/index.html
+++ b/public/pages/projects/outcomes/index.html
@@ -11,9 +11,9 @@
 		<meta property="schema:dateModified" content="2026-06-02" />
 		<meta property="dcterms:language" content="en-GB" />
 		<link rel="stylesheet" href="/css/outcomes.css" media="screen" />
-		<link rel="modulepreload" href="/js/project-context.js" />
-		<link rel="modulepreload" href="/js/outcomes-page.js" />
-		<link rel="modulepreload" href="/components/impact-tracker.js" />
+		<link rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions" />
+		<link rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions" />
+		<link rel="modulepreload" href="/components/impact-tracker.js?v=20260603-form-interactions" />
 
 		<script type="module" src="/components/layout.js" defer></script>
 		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
@@ -801,8 +801,8 @@
 		</main>
 		<x-include src="/partials/footer.html"></x-include>
 
-		<script type="module" src="/js/project-context.js"></script>
-		<script type="module" src="/js/outcomes-page.js"></script>
-		<script type="module" src="/components/impact-tracker.js"></script>
+		<script type="module" src="/js/project-context.js?v=20260603-form-interactions"></script>
+		<script type="module" src="/js/outcomes-page.js?v=20260603-form-interactions"></script>
+		<script type="module" src="/components/impact-tracker.js?v=20260603-form-interactions"></script>
 	</body>
 </html>

--- a/public/pages/projects/outcomes/index.html
+++ b/public/pages/projects/outcomes/index.html
@@ -10,10 +10,13 @@
 		<meta property="schema:creator" content="Home Office ResearchOps Platform" />
 		<meta property="schema:dateModified" content="2026-06-02" />
 		<meta property="dcterms:language" content="en-GB" />
-		<link rel="stylesheet" href="/css/outcomes.css" media="screen" />
-		<link rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions" />
-		<link rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions" />
-		<link rel="modulepreload" href="/components/impact-tracker.js?v=20260603-form-interactions" />
+		<link rel="stylesheet" href="/css/outcomes.css?v=20260603-form-interactions" media="screen" />
+		<link rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions?v=20260603-form-interactions" />
+		<link rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions?v=20260603-form-interactions" />
+		<link
+			rel="modulepreload"
+			href="/components/impact-tracker.js?v=20260603-form-interactions?v=20260603-form-interactions"
+		/>
 
 		<script type="module" src="/components/layout.js" defer></script>
 		<script type="module" src="/js/govuk-frontend-init.js" defer></script>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -16,6 +16,9 @@ const env = new nunjucks.Environment(
 	},
 );
 
+const outcomesScriptVersion = '20260603-form-interactions';
+const outcomesScriptPaths = ['/js/project-context.js', '/js/outcomes-page.js', '/components/impact-tracker.js'];
+
 function escapeHtmlAttribute(value) {
 	return String(value)
 		.replaceAll('&', '&amp;')
@@ -46,6 +49,14 @@ async function formatRenderedHtml(html) {
 		tabWidth: 2,
 		htmlWhitespaceSensitivity: 'ignore',
 	});
+}
+
+function cacheBustOutcomesPageScripts(html, page) {
+	if (page.output !== 'public/pages/projects/outcomes/index.html') return html;
+
+	return outcomesScriptPaths.reduce((nextHtml, scriptPath) => {
+		return nextHtml.replaceAll(scriptPath, `${scriptPath}?v=${outcomesScriptVersion}`);
+	}, html);
 }
 
 env.addFilter('govukAttributes', govukAttributes);
@@ -266,7 +277,7 @@ export const govukPages = [
 
 export async function renderGovukPage(page) {
 	const outputPath = resolve(root, page.output);
-	const rawHtml = env.render(page.template, page.context);
+	const rawHtml = cacheBustOutcomesPageScripts(env.render(page.template, page.context), page);
 	const html = await formatRenderedHtml(rawHtml);
 	await mkdir(dirname(outputPath), { recursive: true });
 	await writeFile(outputPath, html.endsWith('\n') ? html : `${html}\n`, 'utf8');

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -16,9 +16,6 @@ const env = new nunjucks.Environment(
 	},
 );
 
-const outcomesScriptVersion = '20260603-form-interactions';
-const outcomesScriptPaths = ['/js/project-context.js', '/js/outcomes-page.js', '/components/impact-tracker.js'];
-
 function escapeHtmlAttribute(value) {
 	return String(value)
 		.replaceAll('&', '&amp;')
@@ -49,14 +46,6 @@ async function formatRenderedHtml(html) {
 		tabWidth: 2,
 		htmlWhitespaceSensitivity: 'ignore',
 	});
-}
-
-function cacheBustOutcomesPageScripts(html, page) {
-	if (page.output !== 'public/pages/projects/outcomes/index.html') return html;
-
-	return outcomesScriptPaths.reduce((nextHtml, scriptPath) => {
-		return nextHtml.replaceAll(scriptPath, `${scriptPath}?v=${outcomesScriptVersion}`);
-	}, html);
 }
 
 env.addFilter('govukAttributes', govukAttributes);
@@ -277,7 +266,7 @@ export const govukPages = [
 
 export async function renderGovukPage(page) {
 	const outputPath = resolve(root, page.output);
-	const rawHtml = cacheBustOutcomesPageScripts(env.render(page.template, page.context), page);
+	const rawHtml = env.render(page.template, page.context);
 	const html = await formatRenderedHtml(rawHtml);
 	await mkdir(dirname(outputPath), { recursive: true });
 	await writeFile(outputPath, html.endsWith('\n') ? html : `${html}\n`, 'utf8');

--- a/src/govuk/templates/pages/projects-outcomes.njk
+++ b/src/govuk/templates/pages/projects-outcomes.njk
@@ -48,10 +48,10 @@
 	<meta property="schema:creator" content="Home Office ResearchOps Platform">
 	<meta property="schema:dateModified" content="2026-06-02">
 	<meta property="dcterms:language" content="en-GB">
-	<link rel="stylesheet" href="/css/outcomes.css" media="screen">
-	<link rel="modulepreload" href="/js/project-context.js">
-	<link rel="modulepreload" href="/js/outcomes-page.js">
-	<link rel="modulepreload" href="/components/impact-tracker.js">
+	<link rel="stylesheet" href="/css/outcomes.css?v=20260603-form-interactions" media="screen">
+	<link rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions" />
+	<link rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions" />
+	<link rel="modulepreload" href="/components/impact-tracker.js?v=20260603-form-interactions" />
 {% endblock %}
 
 {% block content %}

--- a/tests/outcomes-page-route-state.test.js
+++ b/tests/outcomes-page-route-state.test.js
@@ -9,6 +9,7 @@ const packageSource = fs.readFileSync('package.json', 'utf8');
 const generatedCssTargetsSource = fs.readFileSync('scripts/styles/generated-css-targets.mjs', 'utf8');
 const controllerSource = fs.readFileSync('public/js/outcomes-page.js', 'utf8');
 const impactTrackerSource = fs.readFileSync('public/components/impact-tracker.js', 'utf8');
+const rendererSource = fs.readFileSync('scripts/govuk/render-govuk-pages.mjs', 'utf8');
 
 function includes(source, text, label) {
 	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -20,10 +21,10 @@ function excludes(source, text, label) {
 
 includes(pageSource, 'href="/assets/govuk/govuk-frontend.css"', 'outcomes page');
 includes(pageSource, 'href="/css/outcomes.css"', 'outcomes page');
-includes(pageSource, 'rel="modulepreload" href="/js/outcomes-page.js"', 'outcomes page');
+includes(pageSource, 'rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions"', 'outcomes page');
 includes(pageSource, 'src="/components/layout.js" defer', 'outcomes page');
-includes(pageSource, 'src="/components/impact-tracker.js"', 'outcomes page');
-includes(pageSource, 'src="/js/outcomes-page.js"', 'outcomes page');
+includes(pageSource, 'src="/components/impact-tracker.js?v=20260603-form-interactions"', 'outcomes page');
+includes(pageSource, 'src="/js/outcomes-page.js?v=20260603-form-interactions"', 'outcomes page');
 includes(pageSource, 'class="outcomes-hero"', 'outcomes page');
 includes(pageSource, 'class="outcomes-tracker"', 'outcomes page');
 includes(pageSource, 'class="outcomes-form"', 'outcomes page');
@@ -71,12 +72,17 @@ includes(stylesheetSource, '.outcomes-table-wrap', 'outcomes stylesheet');
 includes(stylesheetSource, '.impact-record-action-cell', 'outcomes stylesheet');
 includes(stylesheetSource, '/* transparency begins in the cascade */', 'outcomes stylesheet');
 
+includes(rendererSource, 'outcomesScriptVersion', 'GOV.UK renderer');
+includes(rendererSource, 'cacheBustOutcomesPageScripts', 'GOV.UK renderer');
+includes(rendererSource, '20260603-form-interactions', 'GOV.UK renderer');
+
 includes(controllerSource, 'function initOutcomesPage', 'outcomes controller');
 includes(controllerSource, 'URLSearchParams', 'outcomes controller');
 includes(controllerSource, 'impact-tracker', 'outcomes controller');
 includes(controllerSource, 'breadcrumb-project', 'outcomes controller');
 includes(controllerSource, 'data-guidance-key', 'outcomes controller');
 includes(controllerSource, 'showValidationErrors', 'outcomes controller');
+includes(controllerSource, 'clearDynamicErrorDescriptions', 'outcomes controller');
 includes(controllerSource, 'setAttribute(\'novalidate\'', 'outcomes controller');
 includes(controllerSource, 'removeAttribute(\'required\')', 'outcomes controller');
 excludes(controllerSource, 'alert(', 'outcomes controller');


### PR DESCRIPTION
## Summary

Adds explicit cache busting for the outcomes page scripts so the browser requests the latest interaction fixes instead of reusing cached JavaScript.

This updates the GOV.UK page renderer so `/pages/projects/outcomes/` renders versioned URLs for:

- `/js/project-context.js?v=20260603-form-interactions`
- `/js/outcomes-page.js?v=20260603-form-interactions`
- `/components/impact-tracker.js?v=20260603-form-interactions`

It also updates the route-state test to require the versioned outcomes script URLs and pin the renderer helper.

## Why

Users were still seeing stale behaviour after the interaction fixes were merged, including validation and copy-reference behaviour. The script path did not change, so browser/cache-layer reuse could continue serving old JavaScript.

## Validation

Not run locally in this connector-only session.

Expected checks:

- `npm run build`
- `node --test tests/outcomes-page-route-state.test.js`
- `npm test`
- `npm run validate`