### PR TITLE
Fix outcomes cache-busting route-state regression

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.json
+++ b/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "researchops-agent-trace-summary/v1",
+  "traceType": "operational-audit",
+  "date": "2026-06-03",
+  "branch": "fix/outcomes-cache-busting-route-state",
+  "summary": "Fixed breaking main tests caused by PR #341 by adding the missing GOV.UK renderer cache-busting helper and aligning the outcomes route-state stylesheet assertion with the versioned static artefact.",
+  "task": {
+    "request": "Familiarise with ResearchOps operating-model bundles and docs. Fix breaking tests on main after merge of PR #341 and open a fix PR.",
+    "scope": [
+      "Repository operating-model bootstrap",
+      "PR #341 patch review",
+      "Outcomes GOV.UK renderer repair",
+      "Outcomes route-state assertion repair",
+      "Trace documentation",
+      "Fix pull request"
+    ]
+  },
+  "selectedBundles": [
+    "github-diamond",
+    "researchops-developer-control",
+    "multi-functional-team",
+    "govuk-design-system"
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "operatingModelFilesLoaded": [
+    "README.md",
+    "AGENTS.md",
+    "RECENT_LEARNINGS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml"
+  ],
+  "filesInspected": [
+    "public/pages/projects/outcomes/index.html",
+    "src/govuk/templates/pages/projects-outcomes.njk",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "tests/outcomes-page-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/02/impact-record-workflow.md",
+    "docs/agent-audit/reasoning/2026/06/02/impact-record-workflow.json",
+    "docs/agent-audit/reasoning/2026/06/03/impact-record-workflow-ci-repair.md",
+    "docs/agent-audit/reasoning/2026/06/03/impact-record-workflow-ci-repair.json"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md",
+    "docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.json"
+  ],
+  "filesModified": [
+    "scripts/govuk/render-govuk-pages.mjs",
+    "tests/outcomes-page-route-state.test.js"
+  ],
+  "diagnosis": "PR #341 changed the outcomes route-state test to expect versioned footer script URLs and renderer helper symbols, but the merged code only changed the template/static head links and the test. scripts/govuk/render-govuk-pages.mjs did not contain outcomesScriptVersion or cacheBustOutcomesPageScripts, so the test could fail on main.",
+  "decisions": [
+    {
+      "decision": "Fix the renderer rather than weakening the test.",
+      "reason": "The test was asserting a valid source-of-truth contract: rendering the outcomes page should consistently produce cache-busted script URLs."
+    },
+    {
+      "decision": "Scope cache busting to the outcomes page only.",
+      "reason": "The regression is limited to PR #341's outcomes-page cache-busting change, so broad GOV.UK page rendering behaviour should not be changed."
+    },
+    {
+      "decision": "Pin the versioned outcomes CSS URL in the route-state test.",
+      "reason": "PR #341 already committed the versioned stylesheet URL. The route-state assertion should match that deployed contract."
+    }
+  ],
+  "validation": {
+    "localValidation": "Not run. A local checkout could not be created in this connector session because git clone could not resolve github.com.",
+    "connectorVerification": [
+      "Confirmed scripts/govuk/render-govuk-pages.mjs contains outcomesScriptVersion.",
+      "Confirmed scripts/govuk/render-govuk-pages.mjs contains cacheBustOutcomesPageScripts.",
+      "Confirmed renderGovukPage applies cacheBustOutcomesPageScripts before formatting and writing output.",
+      "Confirmed tests/outcomes-page-route-state.test.js pins the versioned outcomes stylesheet, script modulepreload and footer script URLs."
+    ],
+    "requiredChecks": [
+      "npm run build",
+      "node --test tests/outcomes-page-route-state.test.js",
+      "npm test",
+      "npm run validate"
+    ]
+  },
+  "residualRisk": [
+    "The PR should not be considered fully validated until normal PR checks complete.",
+    "The Render GOV.UK pages workflow may commit regenerated static HTML after the PR opens because the renderer changed."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md
+++ b/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md
@@ -83,9 +83,12 @@ The fix keeps the PR #341 cache-busting intent and restores source-of-truth beha
 - `/js/outcomes-page.js`
 - `/components/impact-tracker.js`
 
+The route-state test now pins the already-committed versioned outcomes CSS URL explicitly, matching PR #341's cache-busting scope.
+
 ## Files modified
 
 - `scripts/govuk/render-govuk-pages.mjs`
+- `tests/outcomes-page-route-state.test.js`
 - `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md`
 - `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.json`
 
@@ -98,6 +101,7 @@ Connector verification completed:
 - Confirmed the fix branch renderer contains `outcomesScriptVersion`.
 - Confirmed the fix branch renderer contains `cacheBustOutcomesPageScripts`.
 - Confirmed `renderGovukPage` passes `env.render(page.template, page.context)` through `cacheBustOutcomesPageScripts` before formatting and writing output.
+- Confirmed the outcomes route-state test pins the versioned outcomes stylesheet, script modulepreload and footer script URLs.
 
 Required CI and local follow-up checks:
 

--- a/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md
+++ b/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md
@@ -1,0 +1,113 @@
+# Agent trace — Outcomes cache-busting route-state fix
+
+**Date:** 2026-06-03  
+**Branch:** `fix/outcomes-cache-busting-route-state`  
+**Trace type:** operational audit trace  
+**Task:** Fix breaking tests on `main` after merge of PR #341.
+
+## Evidence boundary
+
+This trace records observable repository files, tool actions, implementation decisions, validation status and residual risk. It does not expose private chain-of-thought.
+
+## Operating model loaded
+
+Loaded files:
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/github/prompt.spec.yaml`
+- `.agent-operating-model/bundles/github/prompt.body.xml`
+- `.agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml`
+- `.agent-operating-model/bundles/researchops-developer-control/prompt.body.xml`
+- `.agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml`
+- `.agent-operating-model/bundles/multi-functional-team/prompt.body.xml`
+- `.agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml`
+- `.agent-operating-model/bundles/govuk-design-system/prompt.body.xml`
+
+Selected bundles:
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `govuk-design-system`
+
+Skipped bundles:
+
+- `cloudflare`
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+Cloudflare was not selected because this fix changes the GOV.UK renderer and route-state contract only. It does not change Pages, Worker, Wrangler, D1, KV, deployment workflow or routing configuration.
+
+## Files inspected
+
+- PR #341 metadata and patch
+- `public/pages/projects/outcomes/index.html`
+- `src/govuk/templates/pages/projects-outcomes.njk`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `tests/outcomes-page-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/02/impact-record-workflow.md`
+- `docs/agent-audit/reasoning/2026/06/02/impact-record-workflow.json`
+- `docs/agent-audit/reasoning/2026/06/03/impact-record-workflow-ci-repair.md`
+- `docs/agent-audit/reasoning/2026/06/03/impact-record-workflow-ci-repair.json`
+
+## Diagnosis
+
+PR #341 updated `tests/outcomes-page-route-state.test.js` so the outcomes route-state test expected two things:
+
+1. footer script URLs for the outcomes page to include `?v=20260603-form-interactions`;
+2. the GOV.UK renderer to contain an `outcomesScriptVersion` and `cacheBustOutcomesPageScripts` helper.
+
+The merged PR versioned the page head stylesheet and modulepreload links, but it did not update `scripts/govuk/render-govuk-pages.mjs`. The committed `public/pages/projects/outcomes/index.html` footer scripts therefore still rendered as unversioned `src` URLs. Main could fail before functional code is reached because the route-state test now asserted renderer symbols that did not exist.
+
+## Implementation decision
+
+The fix keeps the PR #341 cache-busting intent and restores source-of-truth behaviour in the renderer rather than weakening the test.
+
+`renderGovukPage` now routes rendered outcomes HTML through `cacheBustOutcomesPageScripts` before Prettier formats and writes the static page. The helper only applies to `public/pages/projects/outcomes/index.html`, preserves other GOV.UK pages, and versions both `href` and `src` references for:
+
+- `/js/project-context.js`
+- `/js/outcomes-page.js`
+- `/components/impact-tracker.js`
+
+## Files modified
+
+- `scripts/govuk/render-govuk-pages.mjs`
+- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md`
+- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.json`
+
+## Validation status
+
+Local validation was not run. A local checkout could not be created in this connector session because `git clone` could not resolve `github.com`.
+
+Connector verification completed:
+
+- Confirmed the fix branch renderer contains `outcomesScriptVersion`.
+- Confirmed the fix branch renderer contains `cacheBustOutcomesPageScripts`.
+- Confirmed `renderGovukPage` passes `env.render(page.template, page.context)` through `cacheBustOutcomesPageScripts` before formatting and writing output.
+
+Required CI and local follow-up checks:
+
+```sh
+npm run build
+node --test tests/outcomes-page-route-state.test.js
+npm test
+npm run validate
+```
+
+## Residual risk
+
+The PR should not be treated as fully validated until the normal PR checks complete. The Render GOV.UK pages workflow may also commit regenerated static HTML after the PR is opened because the renderer changed.

--- a/public/pages/projects/outcomes/index.html
+++ b/public/pages/projects/outcomes/index.html
@@ -801,8 +801,8 @@
 		</main>
 		<x-include src="/partials/footer.html"></x-include>
 
-		<script type="module" src="/js/project-context.js"></script>
-		<script type="module" src="/js/outcomes-page.js"></script>
-		<script type="module" src="/components/impact-tracker.js"></script>
+		<script type="module" src="/js/project-context.js?v=20260603-form-interactions"></script>
+		<script type="module" src="/js/outcomes-page.js?v=20260603-form-interactions"></script>
+		<script type="module" src="/components/impact-tracker.js?v=20260603-form-interactions"></script>
 	</body>
 </html>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -51,6 +51,28 @@ async function formatRenderedHtml(html) {
 env.addFilter('govukAttributes', govukAttributes);
 env.addGlobal('govukAttributes', govukAttributes);
 
+export const outcomesScriptVersion = '20260603-form-interactions';
+
+const outcomesPageOutput = 'public/pages/projects/outcomes/index.html';
+const outcomesPageScriptPaths = ['/js/project-context.js', '/js/outcomes-page.js', '/components/impact-tracker.js'];
+const outcomesPageScriptUrlAttributes = ['href', 'src'];
+
+export function cacheBustOutcomesPageScripts(html, page) {
+	if (page.output !== outcomesPageOutput) return html;
+
+	let updatedHtml = html;
+	for (const scriptPath of outcomesPageScriptPaths) {
+		for (const attribute of outcomesPageScriptUrlAttributes) {
+			updatedHtml = updatedHtml.replaceAll(
+				`${attribute}="${scriptPath}"`,
+				`${attribute}="${scriptPath}?v=${outcomesScriptVersion}"`,
+			);
+		}
+	}
+
+	return updatedHtml;
+}
+
 const navigation = [
 	{
 		text: 'Home',
@@ -266,7 +288,7 @@ export const govukPages = [
 
 export async function renderGovukPage(page) {
 	const outputPath = resolve(root, page.output);
-	const rawHtml = env.render(page.template, page.context);
+	const rawHtml = cacheBustOutcomesPageScripts(env.render(page.template, page.context), page);
 	const html = await formatRenderedHtml(rawHtml);
 	await mkdir(dirname(outputPath), { recursive: true });
 	await writeFile(outputPath, html.endsWith('\n') ? html : `${html}\n`, 'utf8');

--- a/tests/outcomes-page-route-state.test.js
+++ b/tests/outcomes-page-route-state.test.js
@@ -20,7 +20,7 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, 'href="/assets/govuk/govuk-frontend.css"', 'outcomes page');
-includes(pageSource, 'href="/css/outcomes.css"', 'outcomes page');
+includes(pageSource, 'href="/css/outcomes.css?v=20260603-form-interactions"', 'outcomes page');
 includes(pageSource, 'rel="modulepreload" href="/js/outcomes-page.js?v=20260603-form-interactions"', 'outcomes page');
 includes(pageSource, 'src="/components/layout.js" defer', 'outcomes page');
 includes(pageSource, 'src="/components/impact-tracker.js?v=20260603-form-interactions"', 'outcomes page');


### PR DESCRIPTION
## Summary

Fixes the breaking `main` tests introduced by the merge of PR #341.

PR #341 updated the outcomes route-state test to expect versioned outcomes footer scripts and renderer helper symbols, but the merged code did not add the matching renderer implementation. This PR restores the source-of-truth contract in the GOV.UK renderer.

Changes:

- Adds `outcomesScriptVersion` and `cacheBustOutcomesPageScripts` to `scripts/govuk/render-govuk-pages.mjs`.
- Applies outcomes script cache-busting during `renderGovukPage()` before Prettier formats and writes the static page.
- Keeps the helper scoped to `public/pages/projects/outcomes/index.html`.
- Pins the outcomes route-state stylesheet assertion to the already-versioned PR #341 CSS URL.
- Adds the required `fix/` branch trace artefacts.

## Why

The route-state test on `main` now asserts renderer behaviour that PR #341 did not implement. The intended behaviour is valid, so this fixes the renderer rather than weakening the test.

## Validation

Local validation was not run because this connector session could not create a local checkout: `git clone` failed DNS resolution for `github.com`.

Connector verification completed:

- Confirmed the fix branch renderer contains `outcomesScriptVersion`.
- Confirmed the fix branch renderer contains `cacheBustOutcomesPageScripts`.
- Confirmed `renderGovukPage()` passes rendered outcomes HTML through the cache-busting helper before formatting and writing output.
- Confirmed `tests/outcomes-page-route-state.test.js` pins the versioned outcomes stylesheet, modulepreload and footer script URLs.

Expected checks:

```sh
npm run build
node --test tests/outcomes-page-route-state.test.js
npm test
npm run validate
```

## Trace

- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.md`
- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-route-state-fix.json`

## Notes

The Render GOV.UK pages workflow may commit regenerated `public/pages/projects/outcomes/index.html` after this PR opens because the renderer changed.