### PR TITLE
Fix outcomes breadcrumb route-state cache-busting assertion

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.json
+++ b/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": "researchops-agent-trace-summary/v1",
+  "traceType": "operational-audit",
+  "date": "2026-06-03",
+  "branch": "fix/outcomes-cache-busting-breadcrumb-test",
+  "summary": "Fixed the remaining main-branch failure after PR #342 by aligning the breadcrumb/back-link route-state test with the now-versioned outcomes project-context asset URLs.",
+  "task": {
+    "request": "The tests are still failing on the main branch after merging the fix PR.",
+    "scope": [
+      "Inspect failing release gate artifact",
+      "Identify remaining route-state assertion drift",
+      "Update breadcrumb/back-link route-state test",
+      "Add trace documentation",
+      "Open fix pull request"
+    ]
+  },
+  "selectedBundles": [
+    "github-diamond",
+    "researchops-developer-control",
+    "multi-functional-team",
+    "govuk-design-system"
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "operatingModelFilesLoaded": [
+    "README.md",
+    "AGENTS.md",
+    "RECENT_LEARNINGS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml"
+  ],
+  "filesInspected": [
+    "release-gate artifact from PR #342",
+    "public/pages/projects/outcomes/index.html",
+    "tests/outcomes-page-route-state.test.js",
+    "tests/govuk-breadcrumb-back-link-route-state.test.js"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.md",
+    "docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.json"
+  ],
+  "filesModified": [
+    "tests/govuk-breadcrumb-back-link-route-state.test.js"
+  ],
+  "failureEvidence": {
+    "source": "PR #342 release-gate artifact",
+    "failedCommands": [
+      "validate",
+      "unit-tests"
+    ],
+    "failingTest": "tests/govuk-breadcrumb-back-link-route-state.test.js",
+    "assertion": "Expected Outcomes route to include: rel=\"modulepreload\" href=\"/js/project-context.js\""
+  },
+  "diagnosis": "PR #342 correctly rendered the outcomes page with versioned project-context.js URLs, and tests/outcomes-page-route-state.test.js was aligned to that contract. A second route-state test still pinned the old unversioned outcomes project-context.js URLs, causing main to continue failing.",
+  "decisions": [
+    {
+      "decision": "Update the breadcrumb/back-link route-state test rather than changing rendered page output.",
+      "reason": "The rendered versioned outcomes asset URLs are the intended cache-busting contract from PR #341 and PR #342."
+    },
+    {
+      "decision": "Keep journals assertions unversioned.",
+      "reason": "The outcomes cache-busting helper is intentionally scoped to the outcomes page only. Journals did not receive this cache-busting contract."
+    }
+  ],
+  "validation": {
+    "localValidation": "Not run. A local checkout could not be created in this connector session because git clone could not resolve github.com.",
+    "connectorVerification": [
+      "Confirmed the PR #342 release-gate artifact shows the remaining breadcrumb/back-link route-state assertion failure.",
+      "Confirmed public/pages/projects/outcomes/index.html on main contains versioned project-context.js modulepreload and footer script URLs.",
+      "Confirmed tests/govuk-breadcrumb-back-link-route-state.test.js now expects versioned outcomes project-context.js URLs.",
+      "Confirmed journals route assertions remain unversioned."
+    ],
+    "requiredChecks": [
+      "node --test tests/govuk-breadcrumb-back-link-route-state.test.js",
+      "node --test tests/outcomes-page-route-state.test.js",
+      "npm test",
+      "npm run validate"
+    ]
+  },
+  "residualRisk": [
+    "The PR should not be considered fully validated until normal PR checks complete."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.md
+++ b/docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.md
@@ -1,0 +1,110 @@
+# Agent trace — Outcomes cache-busting breadcrumb route-state fix
+
+**Date:** 2026-06-03  
+**Branch:** `fix/outcomes-cache-busting-breadcrumb-test`  
+**Trace type:** operational audit trace  
+**Task:** Fix remaining failing `main` tests after PR #342 was merged.
+
+## Evidence boundary
+
+This trace records observable repository files, tool actions, implementation decisions, validation status and residual risk. It does not expose private chain-of-thought.
+
+## Operating model loaded
+
+Loaded files:
+
+- `README.md`
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/github/prompt.spec.yaml`
+- `.agent-operating-model/bundles/github/prompt.body.xml`
+- `.agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml`
+- `.agent-operating-model/bundles/researchops-developer-control/prompt.body.xml`
+- `.agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml`
+- `.agent-operating-model/bundles/multi-functional-team/prompt.body.xml`
+- `.agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml`
+- `.agent-operating-model/bundles/govuk-design-system/prompt.body.xml`
+
+Selected bundles:
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `govuk-design-system`
+
+Skipped bundles:
+
+- `cloudflare`
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+Cloudflare was not selected because this fix changes a route-state test assertion only. It does not change Pages, Worker, Wrangler, D1, KV, deployment workflow or routing configuration.
+
+## Failure evidence
+
+The release gate artifact from PR #342 showed `validate` and `unit-tests` failing. The concrete failing assertion was:
+
+```text
+AssertionError [ERR_ASSERTION]: Expected Outcomes route to include: rel="modulepreload" href="/js/project-context.js"
+```
+
+The failing test was `tests/govuk-breadcrumb-back-link-route-state.test.js`.
+
+## Diagnosis
+
+PR #342 correctly regenerated `public/pages/projects/outcomes/index.html` so the outcomes page now contains:
+
+```html
+<link rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions" />
+<script type="module" src="/js/project-context.js?v=20260603-form-interactions"></script>
+```
+
+`tests/outcomes-page-route-state.test.js` was aligned with that versioned contract, but `tests/govuk-breadcrumb-back-link-route-state.test.js` still asserted the older unversioned project-context URLs for the outcomes route.
+
+## Implementation decision
+
+The test was updated to keep the breadcrumb and project-context coverage while matching the current outcomes cache-busting contract.
+
+Only the outcomes assertions changed. Journals remain pinned to unversioned `project-context.js`, because the cache-busting helper is intentionally scoped to the outcomes page.
+
+## Files modified
+
+- `tests/govuk-breadcrumb-back-link-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.md`
+- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.json`
+
+## Validation status
+
+Local validation was not run. A local checkout could not be created in this connector session because `git clone` could not resolve `github.com`.
+
+Connector verification completed:
+
+- Confirmed the failing assertion from the PR #342 release gate artifact.
+- Confirmed `public/pages/projects/outcomes/index.html` on `main` contains versioned outcomes `project-context.js` modulepreload and footer script URLs.
+- Confirmed `tests/govuk-breadcrumb-back-link-route-state.test.js` now expects versioned outcomes `project-context.js` URLs.
+- Confirmed journals assertions remain unversioned.
+
+Required CI and local follow-up checks:
+
+```sh
+node --test tests/govuk-breadcrumb-back-link-route-state.test.js
+node --test tests/outcomes-page-route-state.test.js
+npm test
+npm run validate
+```
+
+## Residual risk
+
+The PR should not be treated as fully validated until the normal PR checks complete on the branch head.

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -124,8 +124,8 @@ includes(studyPage, "id=\"back-to-project\"", "Study route");
 includes(studyPage, ">Back to Project</a>", "Study route");
 
 const outcomesPage = fs.readFileSync("public/pages/projects/outcomes/index.html", "utf8");
-includes(outcomesPage, "rel=\"modulepreload\" href=\"/js/project-context.js\"", "Outcomes route");
-includes(outcomesPage, "src=\"/js/project-context.js\"", "Outcomes route");
+includes(outcomesPage, "rel=\"modulepreload\" href=\"/js/project-context.js?v=20260603-form-interactions\"", "Outcomes route");
+includes(outcomesPage, "src=\"/js/project-context.js?v=20260603-form-interactions\"", "Outcomes route");
 includes(outcomesPage, "id=\"breadcrumb-project\"", "Outcomes route");
 excludes(outcomesPage, "id=\"back-to-project\"", "Outcomes route");
 excludes(outcomesPage, ">Back to Project</a>", "Outcomes route");


### PR DESCRIPTION
## Summary

Fixes the remaining failing `main` tests after PR #342 was merged.

The rendered outcomes page now correctly cache-busts `project-context.js` as:

- `rel="modulepreload" href="/js/project-context.js?v=20260603-form-interactions"`
- `src="/js/project-context.js?v=20260603-form-interactions"`

`tests/outcomes-page-route-state.test.js` was already aligned with that contract, but `tests/govuk-breadcrumb-back-link-route-state.test.js` still asserted the old unversioned outcomes URLs. This PR updates only the outcomes assertions in that breadcrumb/back-link test. Journals remain pinned to unversioned `project-context.js`, because cache busting is scoped to the outcomes page.

## Failure evidence

From the PR #342 release-gate artifact:

```text
AssertionError [ERR_ASSERTION]: Expected Outcomes route to include: rel="modulepreload" href="/js/project-context.js"
```

Failing test:

```text
tests/govuk-breadcrumb-back-link-route-state.test.js
```

## Validation

Local validation was not run because this connector session could not create a local checkout: `git clone` failed DNS resolution for `github.com`.

Connector verification completed:

- Confirmed the release-gate artifact shows the remaining breadcrumb/back-link route-state assertion failure.
- Confirmed `public/pages/projects/outcomes/index.html` on `main` contains versioned `project-context.js` modulepreload and footer script URLs.
- Confirmed `tests/govuk-breadcrumb-back-link-route-state.test.js` now expects those versioned outcomes URLs.
- Confirmed journals assertions remain unversioned.

Expected checks:

```sh
node --test tests/govuk-breadcrumb-back-link-route-state.test.js
node --test tests/outcomes-page-route-state.test.js
npm test
npm run validate
```

## Trace

- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.md`
- `docs/agent-audit/reasoning/2026/06/03/outcomes-cache-busting-breadcrumb-test-fix.json`