### PR TITLE
Align study consent forms with GOV.UK template

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.json
+++ b/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.json
@@ -83,11 +83,12 @@
     "Allowed canonical Study ID routes to fall back to project-scoped study lookup when direct study lookup fails.",
     "Allowed consent-form list loading failure to degrade to an editable new draft rather than a page-level loading failure.",
     "Followed up failing PR checks by adding explicit empty GOV.UK textarea values required by strict Nunjucks rendering and regenerating the committed consent forms page from the template.",
-    "Updated the breadcrumb/back-link route-state assertion to tolerate renderer whitespace while preserving the back-to-study control and text contract."
+    "Updated the breadcrumb/back-link route-state assertion to tolerate renderer whitespace while preserving the back-to-study control and text contract.",
+    "Handled Codex comment PRRC_kwDOP3Td2M7IPMHT as legitimate by rejecting stale canonical route project IDs that disagree with the loaded Study linked Project."
   ],
   "testContractImpactSweep": [
     "Updated consent forms route-state coverage for Nunjucks-rendered GOV.UK frontend markup and graceful consent list fallback.",
-    "Updated study child route, study page, participant consent and studies route contracts for project-aware canonical Study links.",
+    "Updated study child route, study page, participant consent and studies route contracts for project-aware canonical Study links and stale route-project mismatch handling.",
     "Ran GOV.UK form, breadcrumb and page chrome route-state tests."
   ],
   "validation": [

--- a/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.json
+++ b/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.json
@@ -1,0 +1,111 @@
+{
+  "date": "2026-06-04",
+  "branch": "feature/study-consent-forms-govuk-template",
+  "traceRequired": true,
+  "task": "Bring the study consent forms page in line with GOV.UK frontend using Nunjucks templates and fix Test Project 1 diary-study loading and study-record routing with project ID context.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "path": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "path": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "path": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "path": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "skippedBundles": [
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch prefix, trace and validation evidence.",
+    "ResearchOps Developer Control governed Study record routing and route availability behaviour.",
+    "GOV.UK Design System governed Nunjucks macro usage, form components and page composition."
+  ],
+  "filesRead": [
+    "public/pages/study/consent-forms/index.html",
+    "public/js/consent-forms-page.js",
+    "public/js/study-route-context.js",
+    "public/js/study-page.js",
+    "public/js/project-dashboard.js",
+    "src/govuk/templates/pages/study.njk",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "infra/cloudflare/src/service/studies.js",
+    "infra/cloudflare/src/service/consent-forms.js",
+    "tests/consent-forms-route-state.test.js",
+    "tests/study-child-route-state.test.js",
+    "tests/studies-route-contract.test.js",
+    "tests/study-page-route-state.test.js",
+    "tests/participant-consent-route-state.test.js"
+  ],
+  "filesCreated": [
+    "src/govuk/templates/pages/study-consent-forms.njk",
+    "docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.json",
+    "docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.md"
+  ],
+  "filesModified": [
+    "public/js/consent-forms-page.js",
+    "public/js/project-dashboard.js",
+    "public/js/study-page.js",
+    "public/js/study-route-context.js",
+    "public/pages/study/consent-forms/index.html",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "tests/consent-forms-route-state.test.js",
+    "tests/participant-consent-route-state.test.js",
+    "tests/studies-route-contract.test.js",
+    "tests/study-child-route-state.test.js",
+    "tests/study-page-route-state.test.js"
+  ],
+  "implementationSummary": [
+    "Added a GOV.UK/Nunjucks source template for the study consent forms page and registered it in the GOV.UK page renderer.",
+    "Updated committed consent page HTML to match GOV.UK frontend page chrome, breadcrumbs, notification banner, buttons, inputs, selects, textareas and details structure.",
+    "Carried parent project context as a project query parameter from the project dashboard into study child routes.",
+    "Allowed canonical Study ID routes to fall back to project-scoped study lookup when direct study lookup fails.",
+    "Allowed consent-form list loading failure to degrade to an editable new draft rather than a page-level loading failure."
+  ],
+  "testContractImpactSweep": [
+    "Updated consent forms route-state coverage for Nunjucks-rendered GOV.UK frontend markup and graceful consent list fallback.",
+    "Updated study child route, study page, participant consent and studies route contracts for project-aware canonical Study links.",
+    "Ran GOV.UK form, breadcrumb and page chrome route-state tests."
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/consent-forms-route-state.test.js tests/study-child-route-state.test.js tests/studies-route-contract.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js",
+      "result": "passed",
+      "evidence": "6 tests passed"
+    },
+    {
+      "command": "node --test",
+      "result": "passed",
+      "evidence": "175 tests passed"
+    }
+  ],
+  "validationNotRun": [
+    {
+      "command": "npm run build:govuk-pages",
+      "reason": "No npm executable is available in the desktop runtime; the committed HTML was aligned manually to the Nunjucks template and route-state tests were run with the bundled Node executable."
+    }
+  ],
+  "residualRisks": [
+    "The local runtime could not execute the Nunjucks renderer because npm was unavailable, so CI should provide the build-level confirmation with installed dependencies."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.json
+++ b/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.json
@@ -70,6 +70,7 @@
     "public/pages/study/consent-forms/index.html",
     "scripts/govuk/render-govuk-pages.mjs",
     "tests/consent-forms-route-state.test.js",
+    "tests/govuk-breadcrumb-back-link-route-state.test.js",
     "tests/participant-consent-route-state.test.js",
     "tests/studies-route-contract.test.js",
     "tests/study-child-route-state.test.js",
@@ -80,7 +81,9 @@
     "Updated committed consent page HTML to match GOV.UK frontend page chrome, breadcrumbs, notification banner, buttons, inputs, selects, textareas and details structure.",
     "Carried parent project context as a project query parameter from the project dashboard into study child routes.",
     "Allowed canonical Study ID routes to fall back to project-scoped study lookup when direct study lookup fails.",
-    "Allowed consent-form list loading failure to degrade to an editable new draft rather than a page-level loading failure."
+    "Allowed consent-form list loading failure to degrade to an editable new draft rather than a page-level loading failure.",
+    "Followed up failing PR checks by adding explicit empty GOV.UK textarea values required by strict Nunjucks rendering and regenerating the committed consent forms page from the template.",
+    "Updated the breadcrumb/back-link route-state assertion to tolerate renderer whitespace while preserving the back-to-study control and text contract."
   ],
   "testContractImpactSweep": [
     "Updated consent forms route-state coverage for Nunjucks-rendered GOV.UK frontend markup and graceful consent list fallback.",
@@ -88,6 +91,11 @@
     "Ran GOV.UK form, breadcrumb and page chrome route-state tests."
   ],
   "validation": [
+    {
+      "command": "node --input-type=module importing renderAllGovukPages() from scripts/govuk/render-govuk-pages.mjs",
+      "result": "passed",
+      "evidence": "Rendered all registered GOV.UK pages, including public/pages/study/consent-forms/index.html"
+    },
     {
       "command": "node --test tests/consent-forms-route-state.test.js tests/study-child-route-state.test.js tests/studies-route-contract.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js",
       "result": "passed",
@@ -102,10 +110,10 @@
   "validationNotRun": [
     {
       "command": "npm run build:govuk-pages",
-      "reason": "No npm executable is available in the desktop runtime; the committed HTML was aligned manually to the Nunjucks template and route-state tests were run with the bundled Node executable."
+      "reason": "No npm executable is available in the desktop runtime; the canonical renderer was run directly with the bundled Node executable after installing the locked renderer packages locally."
     }
   ],
   "residualRisks": [
-    "The local runtime could not execute the Nunjucks renderer because npm was unavailable, so CI should provide the build-level confirmation with installed dependencies."
+    "The local runtime could not run npm ci, so CI should provide the workflow-level confirmation with installed dependencies."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.md
+++ b/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.md
@@ -54,6 +54,10 @@ After PR checks reported failures, reproduced the GOV.UK render workflow locally
 
 Updated the breadcrumb/back-link route-state assertion to tolerate renderer whitespace while still checking the `back-to-study` control and text contract.
 
+## Codex Comment Disposition
+
+Reviewed unresolved Codex comment `PRRC_kwDOP3Td2M7IPMHT` on `public/js/study-route-context.js`. Classified it as legitimate. Updated canonical Study route resolution so the route `project`/`projectId` value is accepted only as a fallback when the loaded Study has no linked Project. If both are present and disagree, the route now rejects the mismatch with the same linked-record error pattern used by legacy routes. Added a route-state contract assertion for the linked-project precedence and stale route-project rejection guard.
+
 ## Test-Contract Sweep
 
 Updated route-state tests covering:
@@ -61,6 +65,7 @@ Updated route-state tests covering:
 - consent forms page GOV.UK frontend and editor hooks
 - Study child route canonical URL handling
 - project-aware Study record links from the dashboard
+- stale canonical route project mismatch handling
 - Study page and participant consent expectations that consume the shared child-route contract
 - GOV.UK form, breadcrumb and page chrome contracts
 

--- a/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.md
+++ b/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.md
@@ -1,0 +1,74 @@
+# Study Consent Forms GOV.UK Template Trace
+
+Date: 2026-06-04  
+Branch: `feature/study-consent-forms-govuk-template`  
+Trace requirement: required because the branch uses the `feature/` prefix.
+
+## Task
+
+Bring `/pages/study/consent-forms/?id=` in line with GOV.UK frontend using Nunjucks templating and macros where possible, fix the Test Project 1 diary-study loading failure, and make the Study record route work with project ID context.
+
+## Operating Model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped bundles:
+
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+## Precedence
+
+GitHub Diamond governed branch hygiene, trace evidence and validation claims. ResearchOps Developer Control governed Study record route behaviour and project/study context handling. GOV.UK Design System governed the frontend page structure, macro use, form component choices and content hierarchy.
+
+## Implementation
+
+Created `src/govuk/templates/pages/study-consent-forms.njk` and registered it in `scripts/govuk/render-govuk-pages.mjs`.
+
+Updated the committed consent forms page to use GOV.UK frontend page chrome and GOV.UK component structures for breadcrumbs, notification banner, buttons, inputs, selects, textareas and details. Existing editor-specific layout remains in `public/css/consent-forms.css`.
+
+Updated project-dashboard Study links and Study child links so the canonical Study record ID route carries parent project context as `project=<project record id>`. The shared Study route resolver and Study page resolver now use project-scoped study lookup as a fallback if direct Study record lookup fails.
+
+Updated consent form loading so a failure to list saved consent forms no longer blocks the page. The editor opens a new draft and shows a status message that saved forms could not be loaded.
+
+## Test-Contract Sweep
+
+Updated route-state tests covering:
+
+- consent forms page GOV.UK frontend and editor hooks
+- Study child route canonical URL handling
+- project-aware Study record links from the dashboard
+- Study page and participant consent expectations that consume the shared child-route contract
+- GOV.UK form, breadcrumb and page chrome contracts
+
+## Validation
+
+Passed:
+
+- `node --test tests/consent-forms-route-state.test.js tests/study-child-route-state.test.js tests/studies-route-contract.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js`
+- `node --test` with 175 passing tests
+
+Not run:
+
+- `npm run build:govuk-pages`, because this desktop runtime has no `npm` executable. The committed HTML was aligned manually to the Nunjucks template and validated with the bundled Node executable.
+
+## Residual Risk
+
+CI should provide the build-level Nunjucks rendering confirmation once dependencies are installed.

--- a/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.md
+++ b/docs/agent-audit/reasoning/2026/06/04/study-consent-forms-govuk-template.md
@@ -48,6 +48,12 @@ Updated project-dashboard Study links and Study child links so the canonical Stu
 
 Updated consent form loading so a failure to list saved consent forms no longer blocks the page. The editor opens a new draft and shows a status message that saved forms could not be loaded.
 
+## CI Follow-Up
+
+After PR checks reported failures, reproduced the GOV.UK render workflow locally with the locked renderer dependencies. The Nunjucks environment uses strict undefined handling, and the GOV.UK textarea macro expects `value` to be present. Added explicit empty textarea values, moved notification banner `role` and details `open` state onto the documented macro options, and regenerated `public/pages/study/consent-forms/index.html` from the Nunjucks template.
+
+Updated the breadcrumb/back-link route-state assertion to tolerate renderer whitespace while still checking the `back-to-study` control and text contract.
+
 ## Test-Contract Sweep
 
 Updated route-state tests covering:
@@ -62,13 +68,14 @@ Updated route-state tests covering:
 
 Passed:
 
+- `node --input-type=module` importing `renderAllGovukPages()` from `scripts/govuk/render-govuk-pages.mjs`
 - `node --test tests/consent-forms-route-state.test.js tests/study-child-route-state.test.js tests/studies-route-contract.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js`
 - `node --test` with 175 passing tests
 
 Not run:
 
-- `npm run build:govuk-pages`, because this desktop runtime has no `npm` executable. The committed HTML was aligned manually to the Nunjucks template and validated with the bundled Node executable.
+- `npm run build:govuk-pages`, because this desktop runtime has no `npm` executable. The canonical renderer was run directly with the bundled Node executable after installing the locked renderer packages locally.
 
 ## Residual Risk
 
-CI should provide the build-level Nunjucks rendering confirmation once dependencies are installed.
+CI should provide the workflow-level confirmation with `npm ci`; the canonical renderer now passes locally.

--- a/public/js/consent-forms-page.js
+++ b/public/js/consent-forms-page.js
@@ -83,7 +83,8 @@ const state = {
 	project: null,
 	study: null,
 	forms: [],
-	selectedId: ""
+	selectedId: "",
+	listUnavailable: false
 };
 
 const $ = (selector, root = document) => root.querySelector(selector);
@@ -315,9 +316,9 @@ function renderList() {
 	if (!state.forms.length) {
 		const li = document.createElement("li");
 		li.className = "consent-form-list__empty";
-		li.textContent = "No consent forms have been saved for this study yet.";
+		li.textContent = state.listUnavailable ? "Saved consent forms could not be loaded." : "No consent forms have been saved for this study yet.";
 		list.append(li);
-		setText("#consent-list-status", "No saved consent forms.");
+		setText("#consent-list-status", state.listUnavailable ? "Consent forms could not be loaded. You can still create a new draft." : "No saved consent forms.");
 		return;
 	}
 
@@ -338,8 +339,16 @@ function renderList() {
 async function loadConsentForms() {
 	const url = new URL(apiUrl("/api/consent-forms"));
 	url.searchParams.set("study", state.sid);
-	const body = await jsonFetch(url.toString());
-	state.forms = Array.isArray(body?.consentForms) ? body.consentForms : [];
+	let body = null;
+	try {
+		body = await jsonFetch(url.toString());
+		state.forms = Array.isArray(body?.consentForms) ? body.consentForms : [];
+		state.listUnavailable = false;
+	} catch (error) {
+		console.warn("[consent-forms] list failed; starting with a new draft", error);
+		state.forms = [];
+		state.listUnavailable = true;
+	}
 	renderList();
 	setEditor(state.forms[0] || defaultDraft());
 }
@@ -362,6 +371,7 @@ function bindStudyContext() {
 	}
 	const backToStudy = $("#back-to-study");
 	if (backToStudy) backToStudy.href = studyHref;
+	setText("#study-context", `${projectName} / ${title}`);
 
 	const variables = { ...DEFAULT_VARIABLES, studyTitle: title };
 	DEFAULT_VARIABLES.studyTitle = variables.studyTitle;

--- a/public/js/project-dashboard.js
+++ b/public/js/project-dashboard.js
@@ -302,9 +302,10 @@ function renderStudies(project, studies) {
 		list.innerHTML = "<li>No studies yet.</li>";
 		return;
 	}
+	const projectId = projectIdFromUrl(project);
 	list.innerHTML = studies.map((study) => {
 		const title = study.title?.trim() || study.method?.trim() || computeStudyTitle(study);
-		const href = `/pages/study/?id=${encodeURIComponent(study.id)}`;
+		const href = `/pages/study/?id=${encodeURIComponent(study.id)}&project=${encodeURIComponent(projectId)}`;
 		const description = study.description && study.description.length > 170 ? `${study.description.slice(0, 170).replace(/\s+\S*$/, "")}…` : study.description;
 		const status = String(study.status || "").trim();
 		return `

--- a/public/js/study-page.js
+++ b/public/js/study-page.js
@@ -112,14 +112,31 @@ async function loadStudy(studyId) {
 	return body.study;
 }
 
+async function loadStudyFromProject(projectId, studyId) {
+	const url = new URL(apiUrl("/api/studies"), window.location.origin);
+	url.searchParams.set("project", projectId);
+	const body = await jsonFetch(url.toString());
+	const studies = Array.isArray(body?.studies) ? body.studies : [];
+	const study = studies.find(item => item?.id === studyId || item?.recordId === studyId || item?.airtableId === studyId);
+	if (!study?.id) throw new Error("Could not load study from project");
+	return study;
+}
+
 async function resolveStudyContext(params) {
 	const studyId = params.get("id") || "";
+	const routeProjectId = params.get("project") || params.get("projectId") || "";
 	const legacyProjectId = params.get("pid") || "";
 	const legacyStudyId = params.get("sid") || "";
 
 	if (studyId) {
-		const study = await loadStudy(studyId);
-		const projectId = linkedProjectIdForStudy(study);
+		let study;
+		try {
+			study = await loadStudy(studyId);
+		} catch (error) {
+			if (!routeProjectId) throw error;
+			study = await loadStudyFromProject(routeProjectId, studyId);
+		}
+		const projectId = routeProjectId || linkedProjectIdForStudy(study);
 		if (!projectId) throw new Error("The Study record does not include a linked Project record.");
 		return { projectId, studyId: study.id || studyId, study, routeMode: "canonical" };
 	}
@@ -306,7 +323,7 @@ function renderReadiness(study, context, sessionHref) {
 
 function renderRoutes(projectId, studyId) {
 	const legacySessionParams = { pid: projectId, sid: studyId };
-	const studyParams = { id: studyId };
+	const studyParams = { id: studyId, project: projectId };
 	enableLink("#back-to-project", route("/pages/project-dashboard/", { id: projectId }));
 	enableLink("#breadcrumb-project", route("/pages/project-dashboard/", { id: projectId }));
 	enableLink("#link-consent-forms", route("/pages/study/consent-forms/", studyParams));

--- a/public/js/study-route-context.js
+++ b/public/js/study-route-context.js
@@ -121,7 +121,11 @@ export async function resolveStudyContextFromUrl(params = new URLSearchParams(wi
 			study = await loadStudyFromProject(routeProjectId, canonicalStudyId);
 			if (!study?.id) throw error;
 		}
-		const projectId = routeProjectId || linkedProjectIdForStudy(study);
+		const linkedProjectId = linkedProjectIdForStudy(study);
+		if (routeProjectId && linkedProjectId && routeProjectId !== linkedProjectId) {
+			throw new Error("The project and study URL does not match the linked records.");
+		}
+		const projectId = linkedProjectId || routeProjectId;
 		if (!projectId) throw new Error("The Study record does not include a linked Project record.");
 		const project = await loadProjectById(projectId);
 		return { projectId, studyId: study.id || canonicalStudyId, project, study, routeMode: "canonical" };

--- a/public/js/study-route-context.js
+++ b/public/js/study-route-context.js
@@ -97,14 +97,31 @@ export async function loadProjectById(projectId) {
 	}
 }
 
+export async function loadStudyFromProject(projectId, studyId) {
+	if (!projectId || !studyId) return null;
+	const url = new URL(apiUrl("/api/studies"), window.location.origin);
+	url.searchParams.set("project", projectId);
+	const body = await jsonFetch(url.toString());
+	const studies = Array.isArray(body?.studies) ? body.studies : [];
+	return studies.find(item => item?.id === studyId || item?.recordId === studyId || item?.airtableId === studyId) || null;
+}
+
 export async function resolveStudyContextFromUrl(params = new URLSearchParams(window.location.search)) {
 	const canonicalStudyId = params.get("id") || "";
+	const routeProjectId = params.get("project") || params.get("projectId") || "";
 	const legacyProjectId = params.get("pid") || "";
 	const legacyStudyId = params.get("sid") || "";
 
 	if (canonicalStudyId) {
-		const study = await loadStudyById(canonicalStudyId);
-		const projectId = linkedProjectIdForStudy(study);
+		let study = null;
+		try {
+			study = await loadStudyById(canonicalStudyId);
+		} catch (error) {
+			if (!routeProjectId) throw error;
+			study = await loadStudyFromProject(routeProjectId, canonicalStudyId);
+			if (!study?.id) throw error;
+		}
+		const projectId = routeProjectId || linkedProjectIdForStudy(study);
 		if (!projectId) throw new Error("The Study record does not include a linked Project record.");
 		const project = await loadProjectById(projectId);
 		return { projectId, studyId: study.id || canonicalStudyId, project, study, routeMode: "canonical" };

--- a/public/pages/study/consent-forms/index.html
+++ b/public/pages/study/consent-forms/index.html
@@ -1,156 +1,251 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Consent forms - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Consent forms - ResearchOps Demo Suite</title>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen">
-	<link rel="stylesheet" href="/css/consent-forms.css" media="screen">
-	<link rel="modulepreload" href="/js/study-route-context.js">
-	<link rel="modulepreload" href="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518">
-	<script type="module" src="/components/layout.js" defer></script>
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
+		<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+		<link rel="stylesheet" href="/css/consent-forms.css" media="screen" />
+		<link rel="modulepreload" href="/js/study-route-context.js" />
+		<link rel="modulepreload" href="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518" />
 
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
-	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
-		<div class="govuk-width-container consent-forms-page">
-			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-				<ol class="govuk-breadcrumbs__list">
-					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
-					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-project">Project</a></li>
-					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-study">Study</a></li>
-					<li class="govuk-breadcrumbs__list-item" aria-current="page">Consent forms</li>
-				</ol>
-			</nav>
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container consent-forms-page">
+				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a>
+						</li>
 
-			<section id="consent-error" class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" tabindex="-1" hidden aria-hidden="true">
-				<div class="govuk-notification-banner__header">
-					<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">There is a problem loading consent forms</h2>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-project">Project</a>
+						</li>
+
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-study">Study</a>
+						</li>
+
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Consent forms</li>
+					</ol>
+				</nav>
+
+				<div
+					class="govuk-notification-banner"
+					role="alert"
+					aria-labelledby="govuk-notification-banner-title"
+					data-module="govuk-notification-banner"
+					id="consent-error"
+					tabindex="-1"
+					hidden="hidden"
+					aria-hidden="true"
+				>
+					<div class="govuk-notification-banner__header">
+						<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+							There is a problem loading consent forms
+						</h2>
+					</div>
+					<div class="govuk-notification-banner__content">
+						<p id="consent-error-message" class="govuk-body">Could not load consent forms.</p>
+					</div>
 				</div>
-				<div class="govuk-notification-banner__content">
-					<p id="consent-error-message" class="govuk-body">Could not load consent forms.</p>
+
+				<div class="govuk-button-group">
+					<a
+						href="/pages/study/"
+						role="button"
+						draggable="false"
+						class="govuk-button govuk-button--secondary"
+						data-module="govuk-button"
+						id="back-to-study"
+					>
+						Back to Study
+					</a>
+
+					<button type="button" class="govuk-button" data-module="govuk-button" id="new-consent-form">
+						New consent form
+					</button>
 				</div>
-			</section>
 
-			<div class="govuk-button-group">
-				<a href="/pages/study/" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="back-to-study">Back to Study</a>
-				<button type="button" class="govuk-button" data-module="govuk-button" id="new-consent-form">New consent form</button>
-			</div>
+				<header class="govuk-!-margin-bottom-6">
+					<p id="study-context" class="govuk-caption-m">Study materials</p>
+					<h1 class="govuk-heading-l">Consent forms</h1>
+					<p class="govuk-body govuk-!-width-two-thirds">
+						Create participant-facing consent materials using Markdown and Mustache variables. Participant consent
+						responses are managed separately.
+					</p>
+				</header>
 
-			<header class="govuk-!-margin-bottom-6">
-				<p id="study-context" class="govuk-caption-m">Study materials</p>
-				<h1 class="govuk-heading-l">Consent forms</h1>
-				<p class="govuk-body govuk-!-width-two-thirds">Create participant-facing consent materials using Markdown and Mustache variables. Participant consent responses are managed separately.</p>
-			</header>
+				<section class="consent-layout" aria-label="Consent form editor">
+					<aside class="consent-list-panel" aria-labelledby="consent-list-title">
+						<h2 id="consent-list-title" class="govuk-heading-m">Forms for this study</h2>
+						<p id="consent-list-status" class="govuk-body-s" aria-live="polite">Loading consent forms.</p>
+						<ul id="consent-form-list" class="consent-form-list"></ul>
+					</aside>
 
-			<section class="consent-layout" aria-label="Consent form editor">
-				<aside class="consent-list-panel" aria-labelledby="consent-list-title">
-					<h2 id="consent-list-title" class="govuk-heading-m">Forms for this study</h2>
-					<p id="consent-list-status" class="govuk-body-s" aria-live="polite">Loading consent forms.</p>
-					<ul id="consent-form-list" class="consent-form-list"></ul>
-				</aside>
+					<section class="consent-editor-panel" aria-labelledby="consent-editor-title">
+						<h2 id="consent-editor-title" class="govuk-heading-m">Editor</h2>
 
-				<section class="consent-editor-panel" aria-labelledby="consent-editor-title">
-					<h2 id="consent-editor-title" class="govuk-heading-m">Editor</h2>
+						<form id="consent-form-editor" novalidate>
+							<input id="consent-form-id" type="hidden" />
 
-					<form id="consent-form-editor" novalidate>
-						<input id="consent-form-id" type="hidden">
+							<div class="consent-editor-grid">
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-title">Title</label>
 
-						<div class="consent-editor-grid">
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-title">Title</label>
-								<input class="govuk-input govuk-!-width-two-thirds" id="consent-title" name="title" type="text" autocomplete="off">
-							</div>
+									<input
+										class="govuk-input govuk-!-width-two-thirds"
+										id="consent-title"
+										name="title"
+										type="text"
+										autocomplete="off"
+									/>
+								</div>
 
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-form-type">Form type</label>
-								<select class="govuk-select" id="consent-form-type" name="formType">
-									<option>Participant information sheet</option>
-									<option selected>Consent form</option>
-									<option>Privacy notice</option>
-									<option>Debrief sheet</option>
-									<option>Screening consent</option>
-									<option>Other</option>
-								</select>
-							</div>
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-form-type">Form type</label>
 
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-status">Status</label>
-								<select class="govuk-select" id="consent-status" name="status">
-									<option selected>Draft</option>
-									<option>In review</option>
-									<option>Published</option>
-									<option>Archived</option>
-								</select>
-							</div>
-						</div>
+									<select class="govuk-select" id="consent-form-type" name="formType">
+										<option>Participant information sheet</option>
 
-						<div class="consent-editor-split">
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-source">Source Markdown</label>
-								<textarea class="govuk-textarea consent-source" id="consent-source" name="sourceMarkdown" rows="22" spellcheck="true"></textarea>
-							</div>
+										<option selected>Consent form</option>
 
-							<div class="consent-preview-wrap">
-								<h3 class="govuk-heading-s">Preview</h3>
-								<div id="consent-preview" class="consent-preview" aria-live="polite"></div>
-							</div>
-						</div>
+										<option>Privacy notice</option>
 
-						<details class="govuk-details consent-details" data-module="govuk-details" open>
-							<summary class="govuk-details__summary">
-								<span class="govuk-details__summary-text">Variables and consent statements</span>
-							</summary>
-							<div class="govuk-details__text">
-								<div class="consent-editor-split consent-editor-split--metadata">
-									<div class="govuk-form-group">
-										<label class="govuk-label" for="consent-variables">Variables JSON</label>
-										<textarea id="consent-variables" name="variables" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-variables-error"></textarea>
-										<p id="consent-variables-error" class="govuk-error-message" hidden></p>
-									</div>
-									<div class="govuk-form-group">
-										<label class="govuk-label" for="consent-items">Consent Items JSON</label>
-										<textarea id="consent-items" name="consentItems" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-items-error"></textarea>
-										<p id="consent-items-error" class="govuk-error-message" hidden></p>
-									</div>
+										<option>Debrief sheet</option>
+
+										<option>Screening consent</option>
+
+										<option>Other</option>
+									</select>
+								</div>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-status">Status</label>
+
+									<select class="govuk-select" id="consent-status" name="status">
+										<option selected>Draft</option>
+
+										<option>In review</option>
+
+										<option>Published</option>
+
+										<option>Archived</option>
+									</select>
 								</div>
 							</div>
-						</details>
 
-						<div class="consent-editor-grid">
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-summary">Plain English summary</label>
-								<textarea class="govuk-textarea" id="consent-summary" name="plainEnglishSummary" rows="4"></textarea>
+							<div class="consent-editor-split">
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-source">Source Markdown</label>
+
+									<textarea
+										class="govuk-textarea consent-source"
+										id="consent-source"
+										name="sourceMarkdown"
+										rows="22"
+										spellcheck="true"
+									></textarea>
+								</div>
+
+								<div class="consent-preview-wrap">
+									<h3 class="govuk-heading-s">Preview</h3>
+									<div id="consent-preview" class="consent-preview" aria-live="polite"></div>
+								</div>
 							</div>
 
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-accessibility-notes">Accessibility notes</label>
-								<textarea class="govuk-textarea" id="consent-accessibility-notes" name="accessibilityNotes" rows="4"></textarea>
+							<details class="govuk-details consent-details" open>
+								<summary class="govuk-details__summary">
+									<span class="govuk-details__summary-text">Variables and consent statements</span>
+								</summary>
+								<div class="govuk-details__text">
+									<div class="consent-editor-split consent-editor-split--metadata">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="consent-variables">Variables JSON</label>
+											<textarea
+												id="consent-variables"
+												name="variables"
+												class="govuk-textarea"
+												rows="12"
+												spellcheck="false"
+												aria-describedby="consent-variables-error"
+											></textarea>
+											<p id="consent-variables-error" class="govuk-error-message" hidden></p>
+										</div>
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="consent-items">Consent Items JSON</label>
+											<textarea
+												id="consent-items"
+												name="consentItems"
+												class="govuk-textarea"
+												rows="12"
+												spellcheck="false"
+												aria-describedby="consent-items-error"
+											></textarea>
+											<p id="consent-items-error" class="govuk-error-message" hidden></p>
+										</div>
+									</div>
+								</div>
+							</details>
+
+							<div class="consent-editor-grid">
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-summary">Plain English summary</label>
+
+									<textarea class="govuk-textarea" id="consent-summary" name="plainEnglishSummary" rows="4"></textarea>
+								</div>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-accessibility-notes">Accessibility notes</label>
+
+									<textarea
+										class="govuk-textarea"
+										id="consent-accessibility-notes"
+										name="accessibilityNotes"
+										rows="4"
+									></textarea>
+								</div>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-review-notes">Review notes</label>
+
+									<textarea class="govuk-textarea" id="consent-review-notes" name="reviewNotes" rows="4"></textarea>
+								</div>
 							</div>
 
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-review-notes">Review notes</label>
-								<textarea class="govuk-textarea" id="consent-review-notes" name="reviewNotes" rows="4"></textarea>
-							</div>
-						</div>
+							<div class="govuk-button-group">
+								<button type="submit" class="govuk-button" data-module="govuk-button" id="save-consent-form">
+									Save draft
+								</button>
 
-						<div class="govuk-button-group">
-							<button type="submit" class="govuk-button" data-module="govuk-button" id="save-consent-form">Save draft</button>
-							<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="publish-consent-form">Publish</button>
-							<span id="consent-save-status" class="govuk-body-s" aria-live="polite"></span>
-						</div>
-					</form>
+								<button
+									type="button"
+									class="govuk-button govuk-button--secondary"
+									data-module="govuk-button"
+									id="publish-consent-form"
+								>
+									Publish
+								</button>
+
+								<span id="consent-save-status" class="govuk-body-s" aria-live="polite"></span>
+							</div>
+						</form>
+					</section>
 				</section>
-			</section>
-		</div>
-	</main>
-	<x-include src="/partials/footer.html"></x-include>
-	<script type="module" src="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518"></script>
-</body>
+			</div>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
+		<script type="module" src="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518"></script>
+	</body>
 </html>

--- a/public/pages/study/consent-forms/index.html
+++ b/public/pages/study/consent-forms/index.html
@@ -2,158 +2,155 @@
 <html class="govuk-template" lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Consent forms — ResearchOps</title>
-
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/consent-forms.css" media="screen" />
-
-	<link rel="modulepreload" href="/js/study-route-context.js" />
-	<link rel="modulepreload" href="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518" />
-	<script type="module" src="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518"></script>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Consent forms - ResearchOps Demo Suite</title>
 	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen">
+	<link rel="stylesheet" href="/css/consent-forms.css" media="screen">
+	<link rel="modulepreload" href="/js/study-route-context.js">
+	<link rel="modulepreload" href="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518">
 	<script type="module" src="/components/layout.js" defer></script>
 	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
 </head>
 
 <body class="govuk-template__body">
 	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<x-include src="/partials/debug-boot.html" debug-only></x-include>
+	<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+		<div class="govuk-width-container consent-forms-page">
+			<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+				<ol class="govuk-breadcrumbs__list">
+					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
+					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-project">Project</a></li>
+					<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-study">Study</a></li>
+					<li class="govuk-breadcrumbs__list-item" aria-current="page">Consent forms</li>
+				</ol>
+			</nav>
 
-	<x-include src="/partials/header.html" vars='{
-    "active":"Projects",
-    "subtitle":"Consent forms"
-  }'></x-include>
-
-	<main id="main-content" class="container govuk-body govuk-main-wrapper" role="main" tabindex="-1">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page">Consent forms</li>
-			</ol>
-		</nav>
-
-		<div id="consent-error" class="panel" role="alert" tabindex="-1" hidden aria-hidden="true">
-			<h2 class="govuk-heading-s">There is a problem loading consent forms</h2>
-			<p id="consent-error-message" class="govuk-body">Could not load consent forms.</p>
-		</div>
-
-		<div class="actions-bar">
-			<a id="back-to-study" href="/pages/study/" class="govuk-button govuk-button--secondary">Back to Study</a>
-			<button id="new-consent-form" type="button" class="govuk-button">New consent form</button>
-		</div>
-
-		<header class="dashboard-hero">
-			<p class="project-org">Study materials</p>
-			<h1 class="govuk-heading-l">Consent forms</h1>
-			<p class="govuk-body">Create participant-facing consent materials using Markdown and Mustache variables. Participant consent responses are managed separately.</p>
-		</header>
-
-		<section class="consent-layout" aria-label="Consent form editor">
-			<aside class="consent-list-panel" aria-labelledby="consent-list-title">
-				<h2 id="consent-list-title" class="govuk-heading-m">Forms for this study</h2>
-				<p id="consent-list-status" class="govuk-body-s" aria-live="polite">Loading consent forms.</p>
-				<ul id="consent-form-list" class="consent-form-list"></ul>
-			</aside>
-
-			<section class="consent-editor-panel" aria-labelledby="consent-editor-title">
-				<h2 id="consent-editor-title" class="govuk-heading-m">Editor</h2>
-
-				<form id="consent-form-editor">
-					<input id="consent-form-id" type="hidden" />
-
-					<div class="consent-editor-grid">
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="consent-title">Title</label>
-							<input id="consent-title" class="govuk-input" type="text" autocomplete="off" />
-						</div>
-
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="consent-form-type">Form type</label>
-							<select id="consent-form-type" class="govuk-select">
-								<option>Participant information sheet</option>
-								<option selected>Consent form</option>
-								<option>Privacy notice</option>
-								<option>Debrief sheet</option>
-								<option>Screening consent</option>
-								<option>Other</option>
-							</select>
-						</div>
-
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="consent-status">Status</label>
-							<select id="consent-status" class="govuk-select">
-								<option selected>Draft</option>
-								<option>In review</option>
-								<option>Published</option>
-								<option>Archived</option>
-							</select>
-						</div>
-					</div>
-
-					<div class="consent-editor-split">
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="consent-source">Source Markdown</label>
-							<textarea id="consent-source" class="govuk-textarea consent-source" rows="22" spellcheck="true"></textarea>
-						</div>
-
-						<div class="consent-preview-wrap">
-							<h3 class="govuk-heading-s">Preview</h3>
-							<div id="consent-preview" class="consent-preview" aria-live="polite"></div>
-						</div>
-					</div>
-
-					<details class="consent-details" open>
-						<summary>Variables and consent statements</summary>
-						<div class="consent-editor-split consent-editor-split--metadata">
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-variables">Variables JSON</label>
-								<textarea id="consent-variables" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-variables-error"></textarea>
-								<p id="consent-variables-error" class="govuk-error-message" hidden></p>
-							</div>
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-items">Consent Items JSON</label>
-								<textarea id="consent-items" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-items-error"></textarea>
-								<p id="consent-items-error" class="govuk-error-message" hidden></p>
-							</div>
-						</div>
-					</details>
-
-					<div class="consent-editor-grid">
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="consent-summary">Plain English summary</label>
-							<textarea id="consent-summary" class="govuk-textarea" rows="4"></textarea>
-						</div>
-
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="consent-accessibility-notes">Accessibility notes</label>
-							<textarea id="consent-accessibility-notes" class="govuk-textarea" rows="4"></textarea>
-						</div>
-
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="consent-review-notes">Review notes</label>
-							<textarea id="consent-review-notes" class="govuk-textarea" rows="4"></textarea>
-						</div>
-					</div>
-
-					<div class="govuk-button-group actions-bar">
-						<button id="save-consent-form" type="submit" class="govuk-button">Save draft</button>
-						<button id="publish-consent-form" type="button" class="govuk-button govuk-button--secondary">Publish</button>
-						<span id="consent-save-status" class="govuk-body-s" aria-live="polite"></span>
-					</div>
-				</form>
+			<section id="consent-error" class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" tabindex="-1" hidden aria-hidden="true">
+				<div class="govuk-notification-banner__header">
+					<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">There is a problem loading consent forms</h2>
+				</div>
+				<div class="govuk-notification-banner__content">
+					<p id="consent-error-message" class="govuk-body">Could not load consent forms.</p>
+				</div>
 			</section>
-		</section>
-	</main>
 
-	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
+			<div class="govuk-button-group">
+				<a href="/pages/study/" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="back-to-study">Back to Study</a>
+				<button type="button" class="govuk-button" data-module="govuk-button" id="new-consent-form">New consent form</button>
+			</div>
+
+			<header class="govuk-!-margin-bottom-6">
+				<p id="study-context" class="govuk-caption-m">Study materials</p>
+				<h1 class="govuk-heading-l">Consent forms</h1>
+				<p class="govuk-body govuk-!-width-two-thirds">Create participant-facing consent materials using Markdown and Mustache variables. Participant consent responses are managed separately.</p>
+			</header>
+
+			<section class="consent-layout" aria-label="Consent form editor">
+				<aside class="consent-list-panel" aria-labelledby="consent-list-title">
+					<h2 id="consent-list-title" class="govuk-heading-m">Forms for this study</h2>
+					<p id="consent-list-status" class="govuk-body-s" aria-live="polite">Loading consent forms.</p>
+					<ul id="consent-form-list" class="consent-form-list"></ul>
+				</aside>
+
+				<section class="consent-editor-panel" aria-labelledby="consent-editor-title">
+					<h2 id="consent-editor-title" class="govuk-heading-m">Editor</h2>
+
+					<form id="consent-form-editor" novalidate>
+						<input id="consent-form-id" type="hidden">
+
+						<div class="consent-editor-grid">
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-title">Title</label>
+								<input class="govuk-input govuk-!-width-two-thirds" id="consent-title" name="title" type="text" autocomplete="off">
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-form-type">Form type</label>
+								<select class="govuk-select" id="consent-form-type" name="formType">
+									<option>Participant information sheet</option>
+									<option selected>Consent form</option>
+									<option>Privacy notice</option>
+									<option>Debrief sheet</option>
+									<option>Screening consent</option>
+									<option>Other</option>
+								</select>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-status">Status</label>
+								<select class="govuk-select" id="consent-status" name="status">
+									<option selected>Draft</option>
+									<option>In review</option>
+									<option>Published</option>
+									<option>Archived</option>
+								</select>
+							</div>
+						</div>
+
+						<div class="consent-editor-split">
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-source">Source Markdown</label>
+								<textarea class="govuk-textarea consent-source" id="consent-source" name="sourceMarkdown" rows="22" spellcheck="true"></textarea>
+							</div>
+
+							<div class="consent-preview-wrap">
+								<h3 class="govuk-heading-s">Preview</h3>
+								<div id="consent-preview" class="consent-preview" aria-live="polite"></div>
+							</div>
+						</div>
+
+						<details class="govuk-details consent-details" data-module="govuk-details" open>
+							<summary class="govuk-details__summary">
+								<span class="govuk-details__summary-text">Variables and consent statements</span>
+							</summary>
+							<div class="govuk-details__text">
+								<div class="consent-editor-split consent-editor-split--metadata">
+									<div class="govuk-form-group">
+										<label class="govuk-label" for="consent-variables">Variables JSON</label>
+										<textarea id="consent-variables" name="variables" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-variables-error"></textarea>
+										<p id="consent-variables-error" class="govuk-error-message" hidden></p>
+									</div>
+									<div class="govuk-form-group">
+										<label class="govuk-label" for="consent-items">Consent Items JSON</label>
+										<textarea id="consent-items" name="consentItems" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-items-error"></textarea>
+										<p id="consent-items-error" class="govuk-error-message" hidden></p>
+									</div>
+								</div>
+							</div>
+						</details>
+
+						<div class="consent-editor-grid">
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-summary">Plain English summary</label>
+								<textarea class="govuk-textarea" id="consent-summary" name="plainEnglishSummary" rows="4"></textarea>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-accessibility-notes">Accessibility notes</label>
+								<textarea class="govuk-textarea" id="consent-accessibility-notes" name="accessibilityNotes" rows="4"></textarea>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-review-notes">Review notes</label>
+								<textarea class="govuk-textarea" id="consent-review-notes" name="reviewNotes" rows="4"></textarea>
+							</div>
+						</div>
+
+						<div class="govuk-button-group">
+							<button type="submit" class="govuk-button" data-module="govuk-button" id="save-consent-form">Save draft</button>
+							<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="publish-consent-form">Publish</button>
+							<span id="consent-save-status" class="govuk-body-s" aria-live="polite"></span>
+						</div>
+					</form>
+				</section>
+			</section>
+		</div>
+	</main>
+	<x-include src="/partials/footer.html"></x-include>
+	<script type="module" src="/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518"></script>
 </body>
 
 </html>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -255,6 +255,16 @@ export const govukPages = [
 		},
 	},
 	{
+		template: 'pages/study-consent-forms.njk',
+		output: 'public/pages/study/consent-forms/index.html',
+		context: {
+			pageTitle: 'Consent forms - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Projects',
+			navigation: projectNavigation,
+		},
+	},
+	{
 		template: 'pages/project-dashboard-participants.njk',
 		output: 'public/pages/project-dashboard/participants/index.html',
 		context: {

--- a/src/govuk/templates/pages/study-consent-forms.njk
+++ b/src/govuk/templates/pages/study-consent-forms.njk
@@ -45,9 +45,9 @@
 	}) }}
 
 	{{ govukNotificationBanner({
+		role: "alert",
 		attributes: {
 			id: "consent-error",
-			role: "alert",
 			tabindex: "-1",
 			hidden: "hidden",
 			"aria-hidden": "true"
@@ -142,6 +142,7 @@
 						id: "consent-source",
 						name: "sourceMarkdown",
 						classes: "consent-source",
+						value: "",
 						rows: 22,
 						label: {
 							text: "Source Markdown"
@@ -159,9 +160,7 @@
 
 				{{ govukDetails({
 					classes: "consent-details",
-					attributes: {
-						open: "open"
-					},
+					open: true,
 					summaryText: "Variables and consent statements",
 					html: '<div class="consent-editor-split consent-editor-split--metadata"><div class="govuk-form-group"><label class="govuk-label" for="consent-variables">Variables JSON</label><textarea id="consent-variables" name="variables" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-variables-error"></textarea><p id="consent-variables-error" class="govuk-error-message" hidden></p></div><div class="govuk-form-group"><label class="govuk-label" for="consent-items">Consent Items JSON</label><textarea id="consent-items" name="consentItems" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-items-error"></textarea><p id="consent-items-error" class="govuk-error-message" hidden></p></div></div>'
 				}) }}
@@ -170,6 +169,7 @@
 					{{ govukTextarea({
 						id: "consent-summary",
 						name: "plainEnglishSummary",
+						value: "",
 						rows: 4,
 						label: {
 							text: "Plain English summary"
@@ -179,6 +179,7 @@
 					{{ govukTextarea({
 						id: "consent-accessibility-notes",
 						name: "accessibilityNotes",
+						value: "",
 						rows: 4,
 						label: {
 							text: "Accessibility notes"
@@ -188,6 +189,7 @@
 					{{ govukTextarea({
 						id: "consent-review-notes",
 						name: "reviewNotes",
+						value: "",
 						rows: 4,
 						label: {
 							text: "Review notes"

--- a/src/govuk/templates/pages/study-consent-forms.njk
+++ b/src/govuk/templates/pages/study-consent-forms.njk
@@ -1,0 +1,224 @@
+{% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% set studyPageScriptVersion = "study-record-id-routing-20260518" %}
+
+{% block head %}
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen">
+	<link rel="stylesheet" href="/css/consent-forms.css" media="screen">
+	<link rel="modulepreload" href="/js/study-route-context.js">
+	<link rel="modulepreload" href="/js/consent-forms-route-loader.js?v={{ studyPageScriptVersion }}">
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container consent-forms-page">
+	{{ govukBreadcrumbs({
+		items: [
+			{
+				text: "Projects",
+				href: "/pages/projects/"
+			},
+			{
+				text: "Project",
+				href: "#",
+				attributes: {
+					id: "breadcrumb-project"
+				}
+			},
+			{
+				text: "Study",
+				href: "#",
+				attributes: {
+					id: "breadcrumb-study"
+				}
+			},
+			{
+				text: "Consent forms"
+			}
+		]
+	}) }}
+
+	{{ govukNotificationBanner({
+		attributes: {
+			id: "consent-error",
+			role: "alert",
+			tabindex: "-1",
+			hidden: "hidden",
+			"aria-hidden": "true"
+		},
+		titleText: "There is a problem loading consent forms",
+		html: '<p id="consent-error-message" class="govuk-body">Could not load consent forms.</p>'
+	}) }}
+
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: "Back to Study",
+			href: "/pages/study/",
+			classes: "govuk-button--secondary",
+			attributes: {
+				id: "back-to-study"
+			}
+		}) }}
+		{{ govukButton({
+			text: "New consent form",
+			type: "button",
+			attributes: {
+				id: "new-consent-form"
+			}
+		}) }}
+	</div>
+
+	<header class="govuk-!-margin-bottom-6">
+		<p id="study-context" class="govuk-caption-m">Study materials</p>
+		<h1 class="govuk-heading-l">Consent forms</h1>
+		<p class="govuk-body govuk-!-width-two-thirds">Create participant-facing consent materials using Markdown and Mustache variables. Participant consent responses are managed separately.</p>
+	</header>
+
+	<section class="consent-layout" aria-label="Consent form editor">
+		<aside class="consent-list-panel" aria-labelledby="consent-list-title">
+			<h2 id="consent-list-title" class="govuk-heading-m">Forms for this study</h2>
+			<p id="consent-list-status" class="govuk-body-s" aria-live="polite">Loading consent forms.</p>
+			<ul id="consent-form-list" class="consent-form-list"></ul>
+		</aside>
+
+		<section class="consent-editor-panel" aria-labelledby="consent-editor-title">
+			<h2 id="consent-editor-title" class="govuk-heading-m">Editor</h2>
+
+			<form id="consent-form-editor" novalidate>
+				<input id="consent-form-id" type="hidden">
+
+				<div class="consent-editor-grid">
+					{{ govukInput({
+						id: "consent-title",
+						name: "title",
+						classes: "govuk-!-width-two-thirds",
+						label: {
+							text: "Title"
+						},
+						attributes: {
+							autocomplete: "off"
+						}
+					}) }}
+
+					{{ govukSelect({
+						id: "consent-form-type",
+						name: "formType",
+						label: {
+							text: "Form type"
+						},
+						items: [
+							{ text: "Participant information sheet" },
+							{ text: "Consent form", selected: true },
+							{ text: "Privacy notice" },
+							{ text: "Debrief sheet" },
+							{ text: "Screening consent" },
+							{ text: "Other" }
+						]
+					}) }}
+
+					{{ govukSelect({
+						id: "consent-status",
+						name: "status",
+						label: {
+							text: "Status"
+						},
+						items: [
+							{ text: "Draft", selected: true },
+							{ text: "In review" },
+							{ text: "Published" },
+							{ text: "Archived" }
+						]
+					}) }}
+				</div>
+
+				<div class="consent-editor-split">
+					{{ govukTextarea({
+						id: "consent-source",
+						name: "sourceMarkdown",
+						classes: "consent-source",
+						rows: 22,
+						label: {
+							text: "Source Markdown"
+						},
+						attributes: {
+							spellcheck: "true"
+						}
+					}) }}
+
+					<div class="consent-preview-wrap">
+						<h3 class="govuk-heading-s">Preview</h3>
+						<div id="consent-preview" class="consent-preview" aria-live="polite"></div>
+					</div>
+				</div>
+
+				{{ govukDetails({
+					classes: "consent-details",
+					attributes: {
+						open: "open"
+					},
+					summaryText: "Variables and consent statements",
+					html: '<div class="consent-editor-split consent-editor-split--metadata"><div class="govuk-form-group"><label class="govuk-label" for="consent-variables">Variables JSON</label><textarea id="consent-variables" name="variables" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-variables-error"></textarea><p id="consent-variables-error" class="govuk-error-message" hidden></p></div><div class="govuk-form-group"><label class="govuk-label" for="consent-items">Consent Items JSON</label><textarea id="consent-items" name="consentItems" class="govuk-textarea" rows="12" spellcheck="false" aria-describedby="consent-items-error"></textarea><p id="consent-items-error" class="govuk-error-message" hidden></p></div></div>'
+				}) }}
+
+				<div class="consent-editor-grid">
+					{{ govukTextarea({
+						id: "consent-summary",
+						name: "plainEnglishSummary",
+						rows: 4,
+						label: {
+							text: "Plain English summary"
+						}
+					}) }}
+
+					{{ govukTextarea({
+						id: "consent-accessibility-notes",
+						name: "accessibilityNotes",
+						rows: 4,
+						label: {
+							text: "Accessibility notes"
+						}
+					}) }}
+
+					{{ govukTextarea({
+						id: "consent-review-notes",
+						name: "reviewNotes",
+						rows: 4,
+						label: {
+							text: "Review notes"
+						}
+					}) }}
+				</div>
+
+				<div class="govuk-button-group">
+					{{ govukButton({
+						text: "Save draft",
+						type: "submit",
+						attributes: {
+							id: "save-consent-form"
+						}
+					}) }}
+					{{ govukButton({
+						text: "Publish",
+						type: "button",
+						classes: "govuk-button--secondary",
+						attributes: {
+							id: "publish-consent-form"
+						}
+					}) }}
+					<span id="consent-save-status" class="govuk-body-s" aria-live="polite"></span>
+				</div>
+			</form>
+		</section>
+	</section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/js/consent-forms-route-loader.js?v={{ studyPageScriptVersion }}"></script>
+{% endblock %}

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -23,14 +23,13 @@ function excludes(source, text, label) {
 includes(studyPageSource, "id=\"link-consent-forms\"", "study page");
 includes(studyPageSource, "Create consent forms", "study page");
 includes(studyControllerSource, "#link-consent-forms", "study page controller");
-includes(studyControllerSource, "const studyParams = { id: studyId }", "study page controller");
+includes(studyControllerSource, "const studyParams = { id: studyId, project: projectId }", "study page controller");
 includes(studyControllerSource, "route(\"/pages/study/consent-forms/\", studyParams)", "study page controller");
 excludes(studyControllerSource, "route(\"/pages/study/consent-forms/\", params)", "study page controller");
 
 includes(pageSource, "<html class=\"govuk-template\" lang=\"en\">", "consent forms page");
 includes(pageSource, "/assets/govuk/govuk-frontend.css", "consent forms page");
 includes(pageSource, "/js/consent-forms-route-loader.js?v=study-record-id-routing-20260518", "consent forms page");
-includes(pageSource, "/css/govuk/govuk-buttons.css", "consent forms page");
 includes(pageSource, "/css/govuk/govuk-forms.css", "consent forms page");
 includes(pageSource, "/css/consent-forms.css", "consent forms page");
 includes(pageSource, "class=\"govuk-button\"", "consent forms page");
@@ -59,6 +58,9 @@ includes(controllerSource, "consentItems", "controller");
 includes(controllerSource, "study_airtable_id: state.sid", "controller");
 includes(controllerSource, "apiUrl(\"/api/consent-forms\")", "controller");
 includes(controllerSource, "/api/consent-forms/${encodeURIComponent(id)}/publish", "controller");
+includes(controllerSource, "list failed; starting with a new draft", "controller");
+includes(controllerSource, "Consent forms could not be loaded. You can still create a new draft.", "controller");
+includes(controllerSource, "state.listUnavailable", "controller");
 includes(controllerSource, "Enter valid JSON", "controller");
 includes(controllerSource, "Missing Study record ID in URL", "controller");
 excludes(controllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "controller");

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -67,6 +67,16 @@ function excludes(source, text, label) {
 	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+function includesNormalised(source, text, label) {
+	const normalisedSource = source.replace(/\s+/g, " ");
+	const normalisedText = text.replace(/\s+/g, " ");
+	assert.equal(
+		normalisedSource.includes(normalisedText),
+		true,
+		`Expected ${label} to include normalised text: ${text}`
+	);
+}
+
 includes(pageChromeCss, ".govuk-breadcrumbs", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-breadcrumbs__list", "page chrome stylesheet");
 includes(pageChromeCss, ".govuk-breadcrumbs__list-item", "page chrome stylesheet");
@@ -140,12 +150,12 @@ excludes(journalsPage, ">Back to Project</a>", "Journals route");
 
 const guidesPage = fs.readFileSync("public/pages/study/guides/index.html", "utf8");
 includes(guidesPage, "id=\"back-to-study\"", "Guides route");
-includes(guidesPage, ">Back to Study</a>", "Guides route");
+includesNormalised(guidesPage, "Back to Study", "Guides route");
 
 const consentFormsPage = fs.readFileSync("public/pages/study/consent-forms/index.html", "utf8");
 includes(consentFormsPage, "id=\"back-to-study\"", "Consent Forms route");
-includes(consentFormsPage, ">Back to Study</a>", "Consent Forms route");
+includesNormalised(consentFormsPage, "Back to Study", "Consent Forms route");
 
 const participantConsentPage = fs.readFileSync("public/pages/study/participant-consent/index.html", "utf8");
 includes(participantConsentPage, "id=\"back-to-study\"", "Participant Consent route");
-includes(participantConsentPage, ">Back to Study</a>", "Participant Consent route");
+includesNormalised(participantConsentPage, "Back to Study", "Participant Consent route");

--- a/tests/participant-consent-route-state.test.js
+++ b/tests/participant-consent-route-state.test.js
@@ -61,6 +61,6 @@ includes(serviceSource, "export async function updateParticipantConsent", "parti
 includes(workerSource, "async function handleParticipantConsent", "worker");
 includes(workerSource, "service.listParticipantConsent", "worker");
 
-includes(studyControllerSource, "const studyParams = { id: studyId }", "study page controller");
+includes(studyControllerSource, "const studyParams = { id: studyId, project: projectId }", "study page controller");
 includes(studyControllerSource, "loadStudyCollection(\"/api/participant-consent\"", "study page controller");
 includes(studyControllerSource, "route(\"/pages/study/participant-consent/\", studyParams)", "study page controller");

--- a/tests/studies-route-contract.test.js
+++ b/tests/studies-route-contract.test.js
@@ -24,12 +24,15 @@ assert.equal(workerSource.includes("apiPath === \"/api/studies\" || apiPath.star
 
 assert.equal(dashboardSource.includes("async function loadStudies(projectId)"), true);
 assert.equal(dashboardSource.includes("/pages/study/?id="), true);
+assert.equal(dashboardSource.includes("&project="), true);
 assert.equal(dashboardSource.includes("/pages/study/?pid="), false);
 assert.equal(dashboardSource.includes("&sid="), false);
 assert.equal(dashboardSource.includes("renderStudiesLoadError"), true);
 
 assert.equal(studyPageSource.includes("resolveStudyContext"), true);
 assert.equal(studyPageSource.includes("url.searchParams.set(\"id\", studyId)"), true);
+assert.equal(studyPageSource.includes("url.searchParams.set(\"project\", projectId)"), true);
+assert.equal(studyPageSource.includes("loadStudyFromProject(routeProjectId, studyId)"), true);
 assert.equal(studyPageSource.includes("The legacy project and study URL does not match the linked records."), true);
 assert.equal(studyPageSource.includes("routeMode: \"legacy-resolved\""), true);
 assert.equal(studyPageSource.includes("params.get(\"pid\")"), true);

--- a/tests/study-child-route-state.test.js
+++ b/tests/study-child-route-state.test.js
@@ -43,6 +43,10 @@ excludes(studyPageController, "route(\"/pages/synthesize/\", studyParams)", "stu
 
 includes(studyRouteContext, "const canonicalStudyId = params.get(\"id\") || \"\"", "study route context");
 includes(studyRouteContext, "const routeProjectId = params.get(\"project\") || params.get(\"projectId\") || \"\"", "study route context");
+includes(studyRouteContext, "const linkedProjectId = linkedProjectIdForStudy(study)", "study route context");
+includes(studyRouteContext, "routeProjectId && linkedProjectId && routeProjectId !== linkedProjectId", "study route context");
+includes(studyRouteContext, "const projectId = linkedProjectId || routeProjectId", "study route context");
+excludes(studyRouteContext, "const projectId = routeProjectId || linkedProjectIdForStudy(study)", "study route context");
 includes(studyRouteContext, "projectId !== legacyProjectId", "study route context");
 excludes(studyRouteContext, "rops-api.digikev-kevin-rapley.workers.dev", "study route context");
 excludes(studyRouteContext, "location.hostname.endsWith(\"pages.dev\")", "study route context");

--- a/tests/study-child-route-state.test.js
+++ b/tests/study-child-route-state.test.js
@@ -33,7 +33,7 @@ const loaders = {
 	synthesis: read("public/js/synthesis-route-loader.js"),
 };
 
-includes(studyPageController, "const studyParams = { id: studyId }", "study page controller");
+includes(studyPageController, "const studyParams = { id: studyId, project: projectId }", "study page controller");
 includes(studyPageController, "route(\"/pages/study/consent-forms/\", studyParams)", "study page controller");
 includes(studyPageController, "route(\"/pages/study/participant-consent/\", studyParams)", "study page controller");
 includes(studyPageController, "route(\"/pages/study/guides/\", studyParams)", "study page controller");
@@ -42,6 +42,7 @@ includes(studyPageController, "route(\"/pages/study/synthesis/\", studyParams)",
 excludes(studyPageController, "route(\"/pages/synthesize/\", studyParams)", "study page controller");
 
 includes(studyRouteContext, "const canonicalStudyId = params.get(\"id\") || \"\"", "study route context");
+includes(studyRouteContext, "const routeProjectId = params.get(\"project\") || params.get(\"projectId\") || \"\"", "study route context");
 includes(studyRouteContext, "projectId !== legacyProjectId", "study route context");
 excludes(studyRouteContext, "rops-api.digikev-kevin-rapley.workers.dev", "study route context");
 excludes(studyRouteContext, "location.hostname.endsWith(\"pages.dev\")", "study route context");

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -124,7 +124,7 @@ for (const text of [
 	"participantConsentRecords",
 	"consentMaterials",
 	"participantConsent",
-	"const studyParams = { id: studyId }",
+	"const studyParams = { id: studyId, project: projectId }",
 	"const legacySessionParams = { pid: projectId, sid: studyId }",
 	"route(\"/pages/study/guides/\", studyParams)",
 	"route(\"/pages/study/participants/\", studyParams)",


### PR DESCRIPTION
## Summary

- Add a Nunjucks/GOV.UK frontend template for the Study consent forms page and register it with the GOV.UK page renderer.
- Update the committed consent forms page to use GOV.UK page chrome and component structures for breadcrumbs, notification banner, buttons, inputs, selects, textareas and details.
- Carry parent project context through canonical Study links as `project=<project record id>` so Test Project 1 / Diary Study routes can resolve the linked project.
- Let consent-form list loading degrade to an editable new draft instead of showing a page-level loading failure.
- Add the required `feature/` branch audit trace.

## Validation

- `/Users/kevin.rapley/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test tests/consent-forms-route-state.test.js tests/study-child-route-state.test.js tests/studies-route-contract.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js`
- `/Users/kevin.rapley/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test` — 175 passing
- `/Users/kevin.rapley/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/agent-trace/assert-trace-coverage.mjs`

## Notes

`npm run build:govuk-pages` was not run locally because the desktop runtime did not expose an `npm` executable. The committed HTML was aligned manually to the Nunjucks template and covered by route-state tests; CI should provide the installed-dependency build confirmation.