### PR TITLE
Fix D1-backed consent forms loading

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
@@ -1,0 +1,103 @@
+{
+  "date": "2026-06-05",
+  "branch": "fix/consent-forms-d1-loading",
+  "traceRequired": true,
+  "task": "Fix consent forms still failing to load from D1 after PR 348 was merged to main.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "path": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "path": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "path": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "cloudflare",
+      "path": ".agent-operating-model/bundles/cloudflare/"
+    }
+  ],
+  "skippedBundles": [
+    "govuk-design-system",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch hygiene, trace evidence and validation claims.",
+    "ResearchOps Developer Control governed the consent forms service boundary and route contracts.",
+    "Cloudflare governed D1 binding and Worker runtime implementation details.",
+    "Multi-Functional Team governed safe user-facing degradation when D1 is present but empty."
+  ],
+  "filesRead": [
+    "public/js/consent-forms-page.js",
+    "infra/cloudflare/src/service/consent-forms.js",
+    "infra/cloudflare/src/service/participant-consent.js",
+    "infra/cloudflare/src/service/studies.js",
+    "infra/cloudflare/src/service/internals/researchops-d1.js",
+    "infra/cloudflare/src/core/fields.js",
+    "infra/cloudflare/migrations/*.sql",
+    "tests/consent-forms-route-state.test.js",
+    "tests/impact-records-d1-runtime.test.js"
+  ],
+  "filesCreated": [
+    "infra/cloudflare/migrations/0011_consent_forms_d1.sql",
+    "tests/consent-forms-d1-runtime.test.js",
+    "docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md",
+    "docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json"
+  ],
+  "filesModified": [
+    "infra/cloudflare/src/service/consent-forms.js",
+    "tests/consent-forms-route-state.test.js"
+  ],
+  "implementationSummary": [
+    "Added a D1 rops_consent_forms table contract and indexes.",
+    "Updated consent forms API list/create/read/update/publish paths to use D1 when RESEARCHOPS_D1 is available.",
+    "Kept Airtable fallback for compatibility when D1 is unavailable or a D1 record is not found.",
+    "Returned an empty D1 consent forms list when D1 is available and Airtable is not configured."
+  ],
+  "testContractImpactSweep": [
+    "Added D1 runtime coverage for consent form empty-list, create, list, update and publish behaviour.",
+    "Updated consent forms route-state assertions for the D1 service and migration contract."
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/consent-forms-d1-runtime.test.js tests/consent-forms-route-state.test.js",
+      "result": "passed",
+      "evidence": "2 tests passed"
+    },
+    {
+      "command": "node --test",
+      "result": "passed",
+      "evidence": "176 tests passed"
+    },
+    {
+      "command": "node scripts/agent-trace/assert-trace-coverage.mjs",
+      "result": "passed",
+      "evidence": "trace coverage confirmed"
+    }
+  ],
+  "validationNotRun": [
+    {
+      "command": "npm ci",
+      "reason": "No npm executable is available in the desktop runtime."
+    }
+  ],
+  "residualRisks": [
+    "CI should provide package-manager-backed validation."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
@@ -68,11 +68,13 @@
     "Added a D1 rops_consent_forms table contract and indexes.",
     "Updated consent forms API list/create/read/update/publish paths to use D1 when RESEARCHOPS_D1 is available.",
     "Kept Airtable fallback for compatibility when D1 is unavailable or a D1 record is not found.",
-    "Returned an empty D1 consent forms list when D1 is available and Airtable is not configured."
+    "Returned an empty D1 consent forms list when D1 is available and Airtable is not configured.",
+    "Handled Codex comment PRRC_kwDOP3Td2M7IPiTh as legitimate by merging D1 and Airtable consent form lists when Airtable is configured."
   ],
   "testContractImpactSweep": [
     "Added D1 runtime coverage for consent form empty-list, create, list, update and publish behaviour.",
-    "Updated consent forms route-state assertions for the D1 service and migration contract."
+    "Added mixed D1 and Airtable runtime coverage so existing Airtable forms do not disappear after a D1 draft is created.",
+    "Updated consent forms route-state assertions for the D1 service, mixed source and migration contract."
   ],
   "validation": [
     {

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
@@ -55,6 +55,10 @@ Added `infra/cloudflare/migrations/0011_consent_forms_d1.sql` for the `rops_cons
 
 Added runtime coverage in `tests/consent-forms-d1-runtime.test.js` for D1 empty-list, create, list, update and publish behaviour. Updated the consent forms route-state contract to check the D1 service and migration path.
 
+## Codex Comment Disposition
+
+Reviewed unresolved Codex comment `PRRC_kwDOP3Td2M7IPiTh` on `infra/cloudflare/src/service/consent-forms.js`. Classified it as legitimate. Updated consent form listing so D1 rows do not short-circuit Airtable when Airtable is configured. The endpoint now merges D1 and Airtable consent forms, de-duplicates by form ID and reports `source: "d1+airtable"` for mixed lists. D1-only short-circuit behaviour remains only when Airtable is not configured or Airtable listing fails.
+
 ## Validation
 
 Passed:

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
@@ -1,0 +1,68 @@
+# Consent Forms D1 Loading Trace
+
+Date: 2026-06-05  
+Branch: `fix/consent-forms-d1-loading`  
+Trace requirement: required because the branch uses the `fix/` prefix.
+
+## Task
+
+Fix consent forms still failing to load from D1 after the GOV.UK consent forms page work was merged to `main`.
+
+## Operating Model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+Skipped bundles:
+
+- `govuk-design-system`
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+## Precedence
+
+GitHub Diamond governed branch hygiene, trace evidence and validation claims. ResearchOps Developer Control governed repository service boundaries and existing API contracts. Cloudflare governed D1 binding and Worker runtime behaviour. Multi-Functional Team governed safe public-service defaults and avoiding unnecessary failure when a local D1 source is available.
+
+## Implementation
+
+Added D1-backed consent form persistence in `infra/cloudflare/src/service/consent-forms.js`.
+
+The consent forms API now:
+
+- lists saved consent forms from `RESEARCHOPS_D1` when available
+- returns a clean empty D1 list when no Airtable credentials are configured
+- creates new consent forms in D1 when the binding is available
+- reads, updates and publishes D1 consent forms before falling back to Airtable
+- keeps Airtable fallback paths for compatibility
+
+Added `infra/cloudflare/migrations/0011_consent_forms_d1.sql` for the `rops_consent_forms` table and indexes.
+
+Added runtime coverage in `tests/consent-forms-d1-runtime.test.js` for D1 empty-list, create, list, update and publish behaviour. Updated the consent forms route-state contract to check the D1 service and migration path.
+
+## Validation
+
+Passed:
+
+- `node --test tests/consent-forms-d1-runtime.test.js tests/consent-forms-route-state.test.js`
+- `node --test` with 176 passing tests
+- `node scripts/agent-trace/assert-trace-coverage.mjs`
+
+## Residual Risk
+
+The local environment cannot run `npm ci` because no package manager is installed in this desktop runtime. CI should provide the package-manager-backed checks.

--- a/infra/cloudflare/migrations/0011_consent_forms_d1.sql
+++ b/infra/cloudflare/migrations/0011_consent_forms_d1.sql
@@ -1,0 +1,33 @@
+-- D1-backed consent forms for study materials.
+-- Date: 2026-06-05
+-- Scope: allow consent form authoring to load and persist without Airtable.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS rops_consent_forms (
+	id TEXT PRIMARY KEY,
+	study_id TEXT NOT NULL,
+	title TEXT NOT NULL,
+	form_type TEXT NOT NULL,
+	status TEXT NOT NULL,
+	version INTEGER NOT NULL DEFAULT 1,
+	source_markdown TEXT NOT NULL,
+	variables_json TEXT NOT NULL DEFAULT '{}',
+	consent_items_json TEXT NOT NULL DEFAULT '[]',
+	plain_english_summary TEXT,
+	accessibility_notes TEXT,
+	review_notes TEXT,
+	owner TEXT,
+	published_at TEXT,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	active INTEGER NOT NULL DEFAULT 1,
+	source TEXT NOT NULL DEFAULT 'd1',
+	payload_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_study
+	ON rops_consent_forms (study_id, active, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_status
+	ON rops_consent_forms (status, active);

--- a/infra/cloudflare/src/service/consent-forms.js
+++ b/infra/cloudflare/src/service/consent-forms.js
@@ -449,6 +449,15 @@ async function getAllRecords(svc) {
 	return records;
 }
 
+function mergeConsentForms(...groups) {
+	const byId = new Map();
+	for (const form of groups.flat()) {
+		if (!form?.id || byId.has(form.id)) continue;
+		byId.set(form.id, form);
+	}
+	return Array.from(byId.values()).sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
+}
+
 export async function listConsentForms(svc, origin, url) {
 	const studyId = url.searchParams.get("study");
 	if (!studyId) return svc.json({ ok: false, error: "Missing study query" }, 400, svc.corsHeaders(origin));
@@ -458,11 +467,8 @@ export async function listConsentForms(svc, origin, url) {
 	if (hasD1(svc)) {
 		try {
 			d1Forms = await listConsentFormsFromD1(svc, studyId);
-			if (d1Forms.length) {
-				return svc.json({ ok: true, consentForms: d1Forms, source: "d1" }, 200, svc.corsHeaders(origin));
-			}
 			if (!airtableConfigured(svc)) {
-				return svc.json({ ok: true, consentForms: [], source: "d1" }, 200, svc.corsHeaders(origin));
+				return svc.json({ ok: true, consentForms: d1Forms, source: "d1" }, 200, svc.corsHeaders(origin));
 			}
 		} catch (error) {
 			d1Error = error;
@@ -476,11 +482,12 @@ export async function listConsentForms(svc, origin, url) {
 		for (const record of records) {
 			const f = record.fields || {};
 			const linkKey = pickFirstField(f, CONSENT_FORM_LINK_FIELD_CANDIDATES);
-			const links = linkKey ? f[linkKey] : undefined;
-			if (Array.isArray(links) && links.includes(studyId)) forms.push(recordToConsentForm(record));
-		}
-		forms.sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
-		return svc.json({ ok: true, consentForms: forms }, 200, svc.corsHeaders(origin));
+				const links = linkKey ? f[linkKey] : undefined;
+				if (Array.isArray(links) && links.includes(studyId)) forms.push(recordToConsentForm(record));
+			}
+			const consentForms = mergeConsentForms(d1Forms || [], forms);
+			const source = d1Forms?.length && forms.length ? "d1+airtable" : d1Forms?.length ? "d1" : "airtable";
+			return svc.json({ ok: true, consentForms, source }, 200, svc.corsHeaders(origin));
 	} catch (err) {
 		if (d1Forms) {
 			return svc.json({

--- a/infra/cloudflare/src/service/consent-forms.js
+++ b/infra/cloudflare/src/service/consent-forms.js
@@ -25,6 +25,33 @@ import {
 } from "../core/fields.js";
 import { airtableTryWrite } from "../core/utils.js";
 import { getRecord } from "./internals/airtable.js";
+import { d1All, d1Get, d1Run } from "./internals/researchops-d1.js";
+
+const CONSENT_FORMS_TABLE = "rops_consent_forms";
+
+const CONSENT_FORMS_SQL = `
+	CREATE TABLE IF NOT EXISTS ${CONSENT_FORMS_TABLE} (
+		id TEXT PRIMARY KEY,
+		study_id TEXT NOT NULL,
+		title TEXT NOT NULL,
+		form_type TEXT NOT NULL,
+		status TEXT NOT NULL,
+		version INTEGER NOT NULL DEFAULT 1,
+		source_markdown TEXT NOT NULL,
+		variables_json TEXT NOT NULL DEFAULT '{}',
+		consent_items_json TEXT NOT NULL DEFAULT '[]',
+		plain_english_summary TEXT,
+		accessibility_notes TEXT,
+		review_notes TEXT,
+		owner TEXT,
+		published_at TEXT,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		active INTEGER NOT NULL DEFAULT 1,
+		source TEXT NOT NULL DEFAULT 'd1',
+		payload_json TEXT
+	)
+`;
 
 const DEFAULT_CONSENT_ITEMS = [
 	{
@@ -92,6 +119,190 @@ You can ask for your contribution to be withdrawn up to {{withdrawalPeriod}}, wh
 If you have questions, contact {{researcherName}} at {{researcherEmail}}.
 `;
 
+function hasD1(svc) {
+	return Boolean(svc?.env?.RESEARCHOPS_D1?.prepare);
+}
+
+function nowIso() {
+	return new Date().toISOString();
+}
+
+function randomHex(length = 10) {
+	const fallback = Math.random().toString(16).replace("0.", "").padEnd(length, "0");
+	if (typeof crypto === "undefined" || !crypto.getRandomValues) return fallback.slice(0, length);
+	const bytes = new Uint8Array(Math.ceil(length / 2));
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes, byte => byte.toString(16).padStart(2, "0")).join("").slice(0, length);
+}
+
+function consentFormId() {
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return `cf_${crypto.randomUUID()}`;
+	}
+	return `cf_${Date.now().toString(36)}_${randomHex(8)}`;
+}
+
+function safeJsonString(value, fallback) {
+	if (value === undefined || value === null || value === "") return JSON.stringify(fallback);
+	if (typeof value === "string") {
+		try {
+			JSON.parse(value);
+			return value;
+		} catch {
+			return JSON.stringify(fallback);
+		}
+	}
+	return JSON.stringify(value);
+}
+
+async function ensureConsentFormsTable(svc) {
+	if (!hasD1(svc)) throw new Error("RESEARCHOPS_D1 binding not available");
+	await d1Run(svc.env, CONSENT_FORMS_SQL);
+	await d1Run(svc.env, `CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_study ON ${CONSENT_FORMS_TABLE} (study_id, active, updated_at)`);
+	await d1Run(svc.env, `CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_status ON ${CONSENT_FORMS_TABLE} (status, active)`);
+}
+
+function rowToConsentForm(row) {
+	if (!row) return null;
+	return {
+		id: row.id,
+		title: row.title || "Untitled consent form",
+		formType: row.form_type || "Consent form",
+		status: row.status || "Draft",
+		version: Number.parseInt(row.version, 10) || 1,
+		sourceMarkdown: row.source_markdown || "",
+		variables: parseJsonField(row.variables_json, {}),
+		consentItems: parseJsonField(row.consent_items_json, []),
+		plainEnglishSummary: row.plain_english_summary || "",
+		accessibilityNotes: row.accessibility_notes || "",
+		reviewNotes: row.review_notes || "",
+		owner: row.owner || "",
+		publishedAt: row.published_at || "",
+		createdAt: row.created_at || "",
+		updatedAt: row.updated_at || ""
+	};
+}
+
+function d1Payload(payload, existing = {}) {
+	return {
+		title: String(payload.title ?? existing.title ?? "Participant information and consent form").trim() || "Participant information and consent form",
+		formType: normaliseFormType(payload.formType ?? existing.form_type ?? "Consent form"),
+		status: normaliseStatus(payload.status ?? existing.status ?? "Draft"),
+		version: Number.isFinite(payload.version) ? payload.version : (Number.parseInt(existing.version, 10) || 1),
+		sourceMarkdown: typeof payload.sourceMarkdown === "string" ? payload.sourceMarkdown : (existing.source_markdown || DEFAULT_SOURCE_MARKDOWN),
+		variablesJson: safeJsonString(payload.variables, existing.variables_json ? parseJsonField(existing.variables_json, {}) : DEFAULT_VARIABLES),
+		consentItemsJson: safeJsonString(payload.consentItems, existing.consent_items_json ? parseJsonField(existing.consent_items_json, []) : DEFAULT_CONSENT_ITEMS),
+		plainEnglishSummary: typeof payload.plainEnglishSummary === "string" ? payload.plainEnglishSummary : (existing.plain_english_summary || ""),
+		accessibilityNotes: typeof payload.accessibilityNotes === "string" ? payload.accessibilityNotes : (existing.accessibility_notes || ""),
+		reviewNotes: typeof payload.reviewNotes === "string" ? payload.reviewNotes : (existing.review_notes || ""),
+		owner: typeof payload.owner === "string" ? payload.owner : (existing.owner || ""),
+		publishedAt: payload.publishedAt || existing.published_at || ""
+	};
+}
+
+async function listConsentFormsFromD1(svc, studyId) {
+	await ensureConsentFormsTable(svc);
+	const rows = await d1All(svc.env, `
+		SELECT *
+		FROM ${CONSENT_FORMS_TABLE}
+		WHERE study_id = ? AND active = 1
+		ORDER BY datetime(created_at) DESC, datetime(updated_at) DESC
+	`, [studyId]);
+	return rows.map(rowToConsentForm).filter(Boolean);
+}
+
+async function readConsentFormFromD1(svc, formId) {
+	await ensureConsentFormsTable(svc);
+	const row = await d1Get(svc.env, `
+		SELECT *
+		FROM ${CONSENT_FORMS_TABLE}
+		WHERE id = ? AND active = 1
+		LIMIT 1
+	`, [formId]);
+	return rowToConsentForm(row);
+}
+
+async function createConsentFormInD1(svc, payload) {
+	await ensureConsentFormsTable(svc);
+	const studyId = payload.study_airtable_id || payload.studyId;
+	const id = consentFormId();
+	const createdAt = nowIso();
+	const fields = d1Payload(payload);
+	await d1Run(svc.env, `
+		INSERT INTO ${CONSENT_FORMS_TABLE} (
+			id, study_id, title, form_type, status, version, source_markdown, variables_json,
+			consent_items_json, plain_english_summary, accessibility_notes, review_notes, owner,
+			published_at, created_at, updated_at, active, source, payload_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'd1', ?)
+	`, [
+		id,
+		studyId,
+		fields.title,
+		fields.formType,
+		fields.status,
+		fields.version,
+		fields.sourceMarkdown,
+		fields.variablesJson,
+		fields.consentItemsJson,
+		fields.plainEnglishSummary,
+		fields.accessibilityNotes,
+		fields.reviewNotes,
+		fields.owner,
+		fields.publishedAt,
+		createdAt,
+		createdAt,
+		JSON.stringify({ ...payload, id, studyId })
+	]);
+	return readConsentFormFromD1(svc, id);
+}
+
+async function updateConsentFormInD1(svc, formId, payload) {
+	await ensureConsentFormsTable(svc);
+	const existing = await d1Get(svc.env, `SELECT * FROM ${CONSENT_FORMS_TABLE} WHERE id = ? AND active = 1 LIMIT 1`, [formId]);
+	if (!existing) return null;
+	const fields = d1Payload(payload, existing);
+	const updatedAt = nowIso();
+	await d1Run(svc.env, `
+		UPDATE ${CONSENT_FORMS_TABLE}
+		SET title = ?, form_type = ?, status = ?, version = ?, source_markdown = ?,
+			variables_json = ?, consent_items_json = ?, plain_english_summary = ?,
+			accessibility_notes = ?, review_notes = ?, owner = ?, published_at = ?,
+			updated_at = ?, payload_json = ?
+		WHERE id = ? AND active = 1
+	`, [
+		fields.title,
+		fields.formType,
+		fields.status,
+		fields.version,
+		fields.sourceMarkdown,
+		fields.variablesJson,
+		fields.consentItemsJson,
+		fields.plainEnglishSummary,
+		fields.accessibilityNotes,
+		fields.reviewNotes,
+		fields.owner,
+		fields.publishedAt,
+		updatedAt,
+		JSON.stringify({ ...parseJsonField(existing.payload_json, {}), ...payload, id: formId, studyId: existing.study_id }),
+		formId
+	]);
+	return readConsentFormFromD1(svc, formId);
+}
+
+async function publishConsentFormInD1(svc, formId) {
+	await ensureConsentFormsTable(svc);
+	const existing = await d1Get(svc.env, `SELECT * FROM ${CONSENT_FORMS_TABLE} WHERE id = ? AND active = 1 LIMIT 1`, [formId]);
+	if (!existing) return null;
+	const publishedAt = nowIso();
+	const version = (Number.parseInt(existing.version, 10) || 0) + 1;
+	await d1Run(svc.env, `
+		UPDATE ${CONSENT_FORMS_TABLE}
+		SET status = 'Published', version = ?, published_at = ?, updated_at = ?
+		WHERE id = ? AND active = 1
+	`, [version, publishedAt, publishedAt, formId]);
+	return readConsentFormFromD1(svc, formId);
+}
+
 function consentFormsTable(svc) {
 	return encodeURIComponent(svc.env.AIRTABLE_TABLE_CONSENT_FORMS || "Consent Forms");
 }
@@ -102,6 +313,10 @@ function airtableBase(svc) {
 
 function airtableKey(svc) {
 	return svc.env.AIRTABLE_API_KEY || svc.env.AIRTABLE_PAT || svc.env.AIRTABLE_ACCESS_TOKEN;
+}
+
+function airtableConfigured(svc) {
+	return Boolean(airtableBase(svc) && airtableKey(svc));
 }
 
 function atBaseUrl(svc) {
@@ -238,6 +453,23 @@ export async function listConsentForms(svc, origin, url) {
 	const studyId = url.searchParams.get("study");
 	if (!studyId) return svc.json({ ok: false, error: "Missing study query" }, 400, svc.corsHeaders(origin));
 
+	let d1Forms = null;
+	let d1Error = null;
+	if (hasD1(svc)) {
+		try {
+			d1Forms = await listConsentFormsFromD1(svc, studyId);
+			if (d1Forms.length) {
+				return svc.json({ ok: true, consentForms: d1Forms, source: "d1" }, 200, svc.corsHeaders(origin));
+			}
+			if (!airtableConfigured(svc)) {
+				return svc.json({ ok: true, consentForms: [], source: "d1" }, 200, svc.corsHeaders(origin));
+			}
+		} catch (error) {
+			d1Error = error;
+			svc.log.warn("d1.consent_forms.list.fail", { detail: String(error?.message || error) });
+		}
+	}
+
 	try {
 		const records = await getAllRecords(svc);
 		const forms = [];
@@ -250,8 +482,16 @@ export async function listConsentForms(svc, origin, url) {
 		forms.sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
 		return svc.json({ ok: true, consentForms: forms }, 200, svc.corsHeaders(origin));
 	} catch (err) {
+		if (d1Forms) {
+			return svc.json({
+				ok: true,
+				consentForms: d1Forms,
+				source: "d1",
+				warning: err.message || "Airtable error"
+			}, 200, svc.corsHeaders(origin));
+		}
 		svc.log.error("airtable.consent_forms.list.fail", { status: err.status, detail: err.detail || err.message });
-		return svc.json({ ok: false, error: err.message || "Airtable error", detail: err.detail }, err.status || 500, svc.corsHeaders(origin));
+		return svc.json({ ok: false, error: err.message || "Airtable error", detail: err.detail, d1: d1Error ? String(d1Error?.message || d1Error) : undefined }, err.status || 500, svc.corsHeaders(origin));
 	}
 }
 
@@ -265,6 +505,16 @@ export async function createConsentForm(svc, request, origin) {
 	}
 
 	const studyId = payload.study_airtable_id || payload.studyId;
+
+	if (hasD1(svc)) {
+		try {
+			const consentForm = await createConsentFormInD1(svc, payload);
+			return svc.json({ ok: true, id: consentForm.id, consentForm, source: "d1" }, 200, svc.corsHeaders(origin));
+		} catch (error) {
+			svc.log.warn("d1.consent_forms.create.fail", { detail: String(error?.message || error) });
+		}
+	}
+
 	const atUrl = atBaseUrl(svc);
 	const fieldsTemplate = fieldsFromPayload(payload, { includeDefaults: true });
 	let lastDetail = "";
@@ -301,6 +551,15 @@ export async function createConsentForm(svc, request, origin) {
 
 export async function readConsentForm(svc, origin, formId) {
 	if (!formId) return svc.json({ ok: false, error: "Missing consent form id" }, 400, svc.corsHeaders(origin));
+	if (hasD1(svc)) {
+		try {
+			const consentForm = await readConsentFormFromD1(svc, formId);
+			if (consentForm) return svc.json({ ok: true, consentForm, source: "d1" }, 200, svc.corsHeaders(origin));
+			if (!airtableConfigured(svc)) return svc.json({ ok: false, error: "consent_form_not_found" }, 404, svc.corsHeaders(origin));
+		} catch (error) {
+			svc.log.warn("d1.consent_forms.read.fail", { detail: String(error?.message || error) });
+		}
+	}
 	try {
 		const record = await getRecord(svc.env, svc.env.AIRTABLE_TABLE_CONSENT_FORMS || "Consent Forms", formId);
 		return svc.json({ ok: true, consentForm: recordToConsentForm(record) }, 200, svc.corsHeaders(origin));
@@ -320,6 +579,16 @@ export async function updateConsentForm(svc, request, origin, formId) {
 	const fields = fieldsFromPayload(payload);
 	if (!Object.keys(fields).length) return svc.json({ ok: false, error: "No updatable fields provided" }, 400, svc.corsHeaders(origin));
 
+	if (hasD1(svc)) {
+		try {
+			const consentForm = await updateConsentFormInD1(svc, formId, payload);
+			if (consentForm) return svc.json({ ok: true, consentForm, source: "d1" }, 200, svc.corsHeaders(origin));
+			if (!airtableConfigured(svc)) return svc.json({ ok: false, error: "consent_form_not_found" }, 404, svc.corsHeaders(origin));
+		} catch (error) {
+			svc.log.warn("d1.consent_forms.update.fail", { detail: String(error?.message || error) });
+		}
+	}
+
 	const resp = await fetchWithTimeout(atBaseUrl(svc), {
 		method: "PATCH",
 		headers: { ...atHeaders(svc), "Content-Type": "application/json" },
@@ -332,6 +601,16 @@ export async function updateConsentForm(svc, request, origin, formId) {
 
 export async function publishConsentForm(svc, origin, formId) {
 	if (!formId) return svc.json({ ok: false, error: "Missing consent form id" }, 400, svc.corsHeaders(origin));
+
+	if (hasD1(svc)) {
+		try {
+			const consentForm = await publishConsentFormInD1(svc, formId);
+			if (consentForm) return svc.json({ ok: true, version: consentForm.version, status: consentForm.status, consentForm, source: "d1" }, 200, svc.corsHeaders(origin));
+			if (!airtableConfigured(svc)) return svc.json({ ok: false, error: "consent_form_not_found" }, 404, svc.corsHeaders(origin));
+		} catch (error) {
+			svc.log.warn("d1.consent_forms.publish.fail", { detail: String(error?.message || error) });
+		}
+	}
 
 	let currentVersion = 0;
 	try {

--- a/tests/consent-forms-d1-runtime.test.js
+++ b/tests/consent-forms-d1-runtime.test.js
@@ -1,15 +1,15 @@
-import assert from "node:assert/strict";
+import assert from 'node:assert/strict';
 import {
 	createConsentForm,
 	listConsentForms,
 	publishConsentForm,
-	updateConsentForm
-} from "../infra/cloudflare/src/service/consent-forms.js";
+	updateConsentForm,
+} from '../infra/cloudflare/src/service/consent-forms.js';
 
 function createMockD1() {
 	const state = {
 		consentForms: [],
-		runs: []
+		runs: [],
 	};
 
 	function statement(sql, args = []) {
@@ -38,8 +38,8 @@ function createMockD1() {
 						created_at: args[14],
 						updated_at: args[15],
 						active: 1,
-						source: "d1",
-						payload_json: args[16]
+						source: 'd1',
+						payload_json: args[16],
 					});
 				}
 				if (/UPDATE rops_consent_forms/i.test(sql) && /SET title = \?/i.test(sql)) {
@@ -64,7 +64,7 @@ function createMockD1() {
 				if (/UPDATE rops_consent_forms/i.test(sql) && /SET status = 'Published'/i.test(sql)) {
 					const row = state.consentForms.find((item) => item.id === args[3] && item.active === 1);
 					if (row) {
-						row.status = "Published";
+						row.status = 'Published';
 						row.version = args[0];
 						row.published_at = args[1];
 						row.updated_at = args[2];
@@ -81,10 +81,14 @@ function createMockD1() {
 			async all() {
 				if (/FROM rops_consent_forms/i.test(sql) && /WHERE study_id = \?/i.test(sql)) {
 					const studyId = args[0];
-					return { results: state.consentForms.filter((row) => row.study_id === studyId && row.active === 1) };
+					return {
+						results: state.consentForms.filter(
+							(row) => row.study_id === studyId && row.active === 1
+						),
+					};
 				}
 				return { results: [] };
-			}
+			},
 		};
 	}
 
@@ -92,7 +96,7 @@ function createMockD1() {
 		state,
 		prepare(sql) {
 			return statement(sql);
-		}
+		},
 	};
 }
 
@@ -106,13 +110,13 @@ function createService(d1) {
 		json(body, status = 200, headers = {}) {
 			return new Response(JSON.stringify(body), {
 				status,
-				headers: { "content-type": "application/json; charset=utf-8", ...headers }
+				headers: { 'content-type': 'application/json; charset=utf-8', ...headers },
 			});
 		},
 		log: {
 			warn() {},
-			error() {}
-		}
+			error() {},
+		},
 	};
 }
 
@@ -123,50 +127,67 @@ async function json(response) {
 const d1 = createMockD1();
 const svc = createService(d1);
 
-const emptyList = await json(await listConsentForms(svc, "", new URL("https://example.test/api/consent-forms?study=rect3biqr")));
+const emptyList = await json(
+	await listConsentForms(svc, '', new URL('https://example.test/api/consent-forms?study=rect3biqr'))
+);
 assert.equal(emptyList.ok, true);
-assert.equal(emptyList.source, "d1");
+assert.equal(emptyList.source, 'd1');
 assert.deepEqual(emptyList.consentForms, []);
 
-const created = await json(await createConsentForm(svc, new Request("https://example.test/api/consent-forms", {
-	method: "POST",
-	body: JSON.stringify({
-		studyId: "rect3biqr",
-		title: "Diary study consent",
-		formType: "Consent form",
-		status: "Draft",
-		sourceMarkdown: "# Diary consent",
-		variables: { studyTitle: "The diary study" },
-		consentItems: [{ id: "participation", label: "I agree", required: true }],
-		plainEnglishSummary: "Consent for the diary study."
-	})
-}), ""));
+const created = await json(
+	await createConsentForm(
+		svc,
+		new Request('https://example.test/api/consent-forms', {
+			method: 'POST',
+			body: JSON.stringify({
+				studyId: 'rect3biqr',
+				title: 'Diary study consent',
+				formType: 'Consent form',
+				status: 'Draft',
+				sourceMarkdown: '# Diary consent',
+				variables: { studyTitle: 'The diary study' },
+				consentItems: [{ id: 'participation', label: 'I agree', required: true }],
+				plainEnglishSummary: 'Consent for the diary study.',
+			}),
+		}),
+		''
+	)
+);
 
 assert.equal(created.ok, true);
-assert.equal(created.source, "d1");
-assert.equal(created.consentForm.title, "Diary study consent");
-assert.equal(created.consentForm.variables.studyTitle, "The diary study");
+assert.equal(created.source, 'd1');
+assert.equal(created.consentForm.title, 'Diary study consent');
+assert.equal(created.consentForm.variables.studyTitle, 'The diary study');
 
-const listed = await json(await listConsentForms(svc, "", new URL("https://example.test/api/consent-forms?study=rect3biqr")));
+const listed = await json(
+	await listConsentForms(svc, '', new URL('https://example.test/api/consent-forms?study=rect3biqr'))
+);
 assert.equal(listed.consentForms.length, 1);
 assert.equal(listed.consentForms[0].id, created.id);
 
-const updated = await json(await updateConsentForm(svc, new Request(`https://example.test/api/consent-forms/${created.id}`, {
-	method: "PATCH",
-	body: JSON.stringify({
-		title: "Updated diary study consent",
-		sourceMarkdown: "# Updated",
-		variables: { studyTitle: "Updated diary study" },
-		consentItems: []
-	})
-}), "", created.id));
+const updated = await json(
+	await updateConsentForm(
+		svc,
+		new Request(`https://example.test/api/consent-forms/${created.id}`, {
+			method: 'PATCH',
+			body: JSON.stringify({
+				title: 'Updated diary study consent',
+				sourceMarkdown: '# Updated',
+				variables: { studyTitle: 'Updated diary study' },
+				consentItems: [],
+			}),
+		}),
+		'',
+		created.id
+	)
+);
 
 assert.equal(updated.ok, true);
-assert.equal(updated.consentForm.title, "Updated diary study consent");
-assert.equal(updated.consentForm.sourceMarkdown, "# Updated");
+assert.equal(updated.consentForm.title, 'Updated diary study consent');
+assert.equal(updated.consentForm.sourceMarkdown, '# Updated');
 
-const published = await json(await publishConsentForm(svc, "", created.id));
+const published = await json(await publishConsentForm(svc, '', created.id));
 assert.equal(published.ok, true);
-assert.equal(published.source, "d1");
-assert.equal(published.status, "Published");
+assert.equal(published.source, 'd1');
+assert.equal(published.status, 'Published');
 assert.equal(published.version, 2);

--- a/tests/consent-forms-d1-runtime.test.js
+++ b/tests/consent-forms-d1-runtime.test.js
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import {
+	createConsentForm,
+	listConsentForms,
+	publishConsentForm,
+	updateConsentForm
+} from "../infra/cloudflare/src/service/consent-forms.js";
+
+function createMockD1() {
+	const state = {
+		consentForms: [],
+		runs: []
+	};
+
+	function statement(sql, args = []) {
+		return {
+			bind(...nextArgs) {
+				return statement(sql, nextArgs);
+			},
+			async run() {
+				state.runs.push({ sql, args });
+				if (/INSERT INTO rops_consent_forms/i.test(sql)) {
+					state.consentForms.push({
+						id: args[0],
+						study_id: args[1],
+						title: args[2],
+						form_type: args[3],
+						status: args[4],
+						version: args[5],
+						source_markdown: args[6],
+						variables_json: args[7],
+						consent_items_json: args[8],
+						plain_english_summary: args[9],
+						accessibility_notes: args[10],
+						review_notes: args[11],
+						owner: args[12],
+						published_at: args[13],
+						created_at: args[14],
+						updated_at: args[15],
+						active: 1,
+						source: "d1",
+						payload_json: args[16]
+					});
+				}
+				if (/UPDATE rops_consent_forms/i.test(sql) && /SET title = \?/i.test(sql)) {
+					const row = state.consentForms.find((item) => item.id === args[14] && item.active === 1);
+					if (row) {
+						row.title = args[0];
+						row.form_type = args[1];
+						row.status = args[2];
+						row.version = args[3];
+						row.source_markdown = args[4];
+						row.variables_json = args[5];
+						row.consent_items_json = args[6];
+						row.plain_english_summary = args[7];
+						row.accessibility_notes = args[8];
+						row.review_notes = args[9];
+						row.owner = args[10];
+						row.published_at = args[11];
+						row.updated_at = args[12];
+						row.payload_json = args[13];
+					}
+				}
+				if (/UPDATE rops_consent_forms/i.test(sql) && /SET status = 'Published'/i.test(sql)) {
+					const row = state.consentForms.find((item) => item.id === args[3] && item.active === 1);
+					if (row) {
+						row.status = "Published";
+						row.version = args[0];
+						row.published_at = args[1];
+						row.updated_at = args[2];
+					}
+				}
+				return { success: true, meta: { changes: 1 } };
+			},
+			async first() {
+				if (/FROM rops_consent_forms/i.test(sql) && /WHERE id = \?/i.test(sql)) {
+					return state.consentForms.find((row) => row.id === args[0] && row.active === 1) || null;
+				}
+				return null;
+			},
+			async all() {
+				if (/FROM rops_consent_forms/i.test(sql) && /WHERE study_id = \?/i.test(sql)) {
+					const studyId = args[0];
+					return { results: state.consentForms.filter((row) => row.study_id === studyId && row.active === 1) };
+				}
+				return { results: [] };
+			}
+		};
+	}
+
+	return {
+		state,
+		prepare(sql) {
+			return statement(sql);
+		}
+	};
+}
+
+function createService(d1) {
+	return {
+		env: { RESEARCHOPS_D1: d1 },
+		cfg: { MAX_BODY_BYTES: 1024 * 1024, TIMEOUT_MS: 1000 },
+		corsHeaders() {
+			return {};
+		},
+		json(body, status = 200, headers = {}) {
+			return new Response(JSON.stringify(body), {
+				status,
+				headers: { "content-type": "application/json; charset=utf-8", ...headers }
+			});
+		},
+		log: {
+			warn() {},
+			error() {}
+		}
+	};
+}
+
+async function json(response) {
+	return response.json();
+}
+
+const d1 = createMockD1();
+const svc = createService(d1);
+
+const emptyList = await json(await listConsentForms(svc, "", new URL("https://example.test/api/consent-forms?study=rect3biqr")));
+assert.equal(emptyList.ok, true);
+assert.equal(emptyList.source, "d1");
+assert.deepEqual(emptyList.consentForms, []);
+
+const created = await json(await createConsentForm(svc, new Request("https://example.test/api/consent-forms", {
+	method: "POST",
+	body: JSON.stringify({
+		studyId: "rect3biqr",
+		title: "Diary study consent",
+		formType: "Consent form",
+		status: "Draft",
+		sourceMarkdown: "# Diary consent",
+		variables: { studyTitle: "The diary study" },
+		consentItems: [{ id: "participation", label: "I agree", required: true }],
+		plainEnglishSummary: "Consent for the diary study."
+	})
+}), ""));
+
+assert.equal(created.ok, true);
+assert.equal(created.source, "d1");
+assert.equal(created.consentForm.title, "Diary study consent");
+assert.equal(created.consentForm.variables.studyTitle, "The diary study");
+
+const listed = await json(await listConsentForms(svc, "", new URL("https://example.test/api/consent-forms?study=rect3biqr")));
+assert.equal(listed.consentForms.length, 1);
+assert.equal(listed.consentForms[0].id, created.id);
+
+const updated = await json(await updateConsentForm(svc, new Request(`https://example.test/api/consent-forms/${created.id}`, {
+	method: "PATCH",
+	body: JSON.stringify({
+		title: "Updated diary study consent",
+		sourceMarkdown: "# Updated",
+		variables: { studyTitle: "Updated diary study" },
+		consentItems: []
+	})
+}), "", created.id));
+
+assert.equal(updated.ok, true);
+assert.equal(updated.consentForm.title, "Updated diary study consent");
+assert.equal(updated.consentForm.sourceMarkdown, "# Updated");
+
+const published = await json(await publishConsentForm(svc, "", created.id));
+assert.equal(published.ok, true);
+assert.equal(published.source, "d1");
+assert.equal(published.status, "Published");
+assert.equal(published.version, 2);

--- a/tests/consent-forms-d1-runtime.test.js
+++ b/tests/consent-forms-d1-runtime.test.js
@@ -100,9 +100,9 @@ function createMockD1() {
 	};
 }
 
-function createService(d1) {
+function createService(d1, env = {}) {
 	return {
-		env: { RESEARCHOPS_D1: d1 },
+		env: { RESEARCHOPS_D1: d1, ...env },
 		cfg: { MAX_BODY_BYTES: 1024 * 1024, TIMEOUT_MS: 1000 },
 		corsHeaders() {
 			return {};
@@ -164,6 +164,53 @@ const listed = await json(
 );
 assert.equal(listed.consentForms.length, 1);
 assert.equal(listed.consentForms[0].id, created.id);
+
+const mixedSourceSvc = createService(d1, {
+	AIRTABLE_BASE_ID: 'app123',
+	AIRTABLE_API_KEY: 'key123',
+	AIRTABLE_TABLE_CONSENT_FORMS: 'Consent Forms',
+});
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async () =>
+	new Response(
+		JSON.stringify({
+			records: [
+				{
+					id: 'recAirtableConsent01',
+					createdTime: '2026-06-05T09:00:00.000Z',
+					fields: {
+						Title: 'Existing Airtable consent',
+						'Form Type': 'Consent form',
+						Status: 'Published',
+						Version: 3,
+						'Source Markdown': '# Existing Airtable consent',
+						'Variables (JSON)': '{"studyTitle":"Airtable study"}',
+						'Consent Items (JSON)': '[]',
+						Study: ['rect3biqr'],
+					},
+				},
+			],
+		}),
+		{ status: 200, headers: { 'content-type': 'application/json' } }
+	);
+try {
+	const mixed = await json(
+		await listConsentForms(
+			mixedSourceSvc,
+			'',
+			new URL('https://example.test/api/consent-forms?study=rect3biqr')
+		)
+	);
+	assert.equal(mixed.ok, true);
+	assert.equal(mixed.source, 'd1+airtable');
+	assert.equal(mixed.consentForms.length, 2);
+	assert.deepEqual(
+		mixed.consentForms.map((form) => form.id).sort(),
+		[created.id, 'recAirtableConsent01'].sort()
+	);
+} finally {
+	globalThis.fetch = originalFetch;
+}
 
 const updated = await json(
 	await updateConsentForm(

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -84,6 +84,8 @@ includes(serviceSource, "export async function publishConsentForm", "service");
 includes(serviceSource, "rops_consent_forms", "service");
 includes(serviceSource, "listConsentFormsFromD1", "service");
 includes(serviceSource, "createConsentFormInD1", "service");
+includes(serviceSource, "mergeConsentForms", "service");
+includes(serviceSource, "d1+airtable", "service");
 includes(serviceSource, "source: \"d1\"", "service");
 includes(serviceSource, "AIRTABLE_TABLE_CONSENT_FORMS", "service");
 includes(serviceSource, "CONSENT_FORM_LINK_FIELD_CANDIDATES", "service");

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -11,6 +11,7 @@ const workerSource = fs.readFileSync("infra/cloudflare/src/worker.js", "utf8");
 const serviceSource = fs.readFileSync("infra/cloudflare/src/service/consent-forms.js", "utf8");
 const serviceIndexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
 const fieldsSource = fs.readFileSync("infra/cloudflare/src/core/fields.js", "utf8");
+const d1MigrationSource = fs.readFileSync("infra/cloudflare/migrations/0011_consent_forms_d1.sql", "utf8");
 
 function includes(source, text, label) {
 	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -80,6 +81,10 @@ includes(workerSource, "service.publishConsentForm", "worker");
 includes(serviceSource, "export async function listConsentForms", "service");
 includes(serviceSource, "export async function createConsentForm", "service");
 includes(serviceSource, "export async function publishConsentForm", "service");
+includes(serviceSource, "rops_consent_forms", "service");
+includes(serviceSource, "listConsentFormsFromD1", "service");
+includes(serviceSource, "createConsentFormInD1", "service");
+includes(serviceSource, "source: \"d1\"", "service");
 includes(serviceSource, "AIRTABLE_TABLE_CONSENT_FORMS", "service");
 includes(serviceSource, "CONSENT_FORM_LINK_FIELD_CANDIDATES", "service");
 includes(serviceSource, "CONSENT_FORM_FIELD_NAMES", "service");
@@ -91,3 +96,7 @@ includes(serviceIndexSource, "publishConsentForm", "service index");
 includes(fieldsSource, "CONSENT_FORM_LINK_FIELD_CANDIDATES", "fields");
 includes(fieldsSource, "CONSENT_FORM_FIELD_NAMES", "fields");
 includes(fieldsSource, "Consent Items (JSON)", "fields");
+
+includes(d1MigrationSource, "CREATE TABLE IF NOT EXISTS rops_consent_forms", "D1 consent forms migration");
+includes(d1MigrationSource, "study_id TEXT NOT NULL", "D1 consent forms migration");
+includes(d1MigrationSource, "idx_rops_consent_forms_study", "D1 consent forms migration");


### PR DESCRIPTION
## Summary

- Add D1-backed consent form persistence for list/create/read/update/publish paths.
- Add `rops_consent_forms` D1 migration and indexes.
- Keep Airtable compatibility fallback, but return clean D1 responses when D1 is available and Airtable is not configured.
- Add D1 runtime coverage for consent form empty-list, create, list, update and publish behaviour.

## Validation

- `node --test tests/consent-forms-d1-runtime.test.js tests/consent-forms-route-state.test.js` passed.
- `node --test` passed with 176/176 tests.
- `node scripts/agent-trace/assert-trace-coverage.mjs` passed.

## Trace

- `docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md`
- `docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json`