### PR TITLE
Hydrate D1 consent forms for diary study

### DIFF
--- a/.github/workflows/apply-d1-diary-study-consent-forms.yml
+++ b/.github/workflows/apply-d1-diary-study-consent-forms.yml
@@ -1,0 +1,97 @@
+name: Apply D1 Diary Study Consent Forms Seed
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql"
+      - ".github/workflows/apply-d1-diary-study-consent-forms.yml"
+  workflow_dispatch:
+    inputs:
+      confirm_database_name:
+        description: Type researchops-d1 to confirm the target D1 database
+        required: true
+        type: string
+      confirm_operation:
+        description: Type APPLY_DIARY_STUDY_CONSENT_FORMS to seed consent forms
+        required: true
+        type: string
+      run_post_apply_checks:
+        description: Run post-apply consent form checks
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.90.0"
+  D1_DATABASE_NAME: "researchops-d1"
+  WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
+  DIARY_STUDY_CONSENT_FORMS_MIGRATION: "infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql"
+  DIARY_STUDY_ID: "rect3o7dt"
+
+jobs:
+  apply:
+    name: Apply diary study consent form seed to remote D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Confirm manual target
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm_database_name }}" != "${D1_DATABASE_NAME}" ]; then
+            echo "confirm_database_name must be ${D1_DATABASE_NAME}"
+            exit 1
+          fi
+
+          if [ "${{ inputs.confirm_operation }}" != "APPLY_DIARY_STUDY_CONSENT_FORMS" ]; then
+            echo "confirm_operation must be APPLY_DIARY_STUDY_CONSENT_FORMS"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Check migration file exists
+        run: test -f "${DIARY_STUDY_CONSENT_FORMS_MIGRATION}"
+
+      - name: Apply diary study consent form seed to remote D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${DIARY_STUDY_CONSENT_FORMS_MIGRATION}"
+
+      - name: Check diary study consent form seed
+        if: ${{ github.event_name == 'push' || inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS consent_form_count FROM rops_consent_forms WHERE study_id = '${DIARY_STUDY_ID}' AND source = 'airtable-hydration' AND active = 1;"
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT id, title, form_type, status, version, published_at FROM rops_consent_forms WHERE study_id = '${DIARY_STUDY_ID}' AND source = 'airtable-hydration' AND active = 1 ORDER BY datetime(created_at) DESC, datetime(updated_at) DESC;"

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
@@ -75,13 +75,15 @@
     "Returned an empty D1 consent forms list when D1 is available and Airtable is not configured.",
     "Handled Codex comment PRRC_kwDOP3Td2M7IPiTh as legitimate by merging D1 and Airtable consent form lists when Airtable is configured.",
     "Added a D1 hydration seed for Airtable consent forms rec2FLw9TwgDgi85y and recw6i67q2DuoZqMe linked to diary study rect3o7dt.",
-    "Added a guarded GitHub Actions workflow to apply the diary study consent form seed to remote researchops-d1 with post-apply checks."
+    "Added a guarded GitHub Actions workflow to apply the diary study consent form seed to remote researchops-d1 with post-apply checks.",
+    "Handled Codex comment PRRC_kwDOP3Td2M7IP8Mr as legitimate by making the diary study consent form seed insert-only so reruns preserve D1 edits and publish state."
   ],
   "testContractImpactSweep": [
     "Added D1 runtime coverage for consent form empty-list, create, list, update and publish behaviour.",
     "Added mixed D1 and Airtable runtime coverage so existing Airtable forms do not disappear after a D1 draft is created.",
     "Updated consent forms route-state assertions for the D1 service, mixed source and migration contract.",
-    "Extended consent forms route-state assertions for the diary study D1 seed and apply workflow."
+    "Extended consent forms route-state assertions for the diary study D1 seed and apply workflow.",
+    "Added route-state assertions that the diary study seed uses INSERT OR IGNORE and does not include an ON CONFLICT update."
   ],
   "validation": [
     {

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json
@@ -51,11 +51,15 @@
     "infra/cloudflare/src/service/internals/researchops-d1.js",
     "infra/cloudflare/src/core/fields.js",
     "infra/cloudflare/migrations/*.sql",
+    ".github/workflows/apply-d1-test-project-1-participants.yml",
+    ".github/workflows/deploy-worker.yml",
     "tests/consent-forms-route-state.test.js",
     "tests/impact-records-d1-runtime.test.js"
   ],
   "filesCreated": [
     "infra/cloudflare/migrations/0011_consent_forms_d1.sql",
+    "infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql",
+    ".github/workflows/apply-d1-diary-study-consent-forms.yml",
     "tests/consent-forms-d1-runtime.test.js",
     "docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md",
     "docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.json"
@@ -69,12 +73,15 @@
     "Updated consent forms API list/create/read/update/publish paths to use D1 when RESEARCHOPS_D1 is available.",
     "Kept Airtable fallback for compatibility when D1 is unavailable or a D1 record is not found.",
     "Returned an empty D1 consent forms list when D1 is available and Airtable is not configured.",
-    "Handled Codex comment PRRC_kwDOP3Td2M7IPiTh as legitimate by merging D1 and Airtable consent form lists when Airtable is configured."
+    "Handled Codex comment PRRC_kwDOP3Td2M7IPiTh as legitimate by merging D1 and Airtable consent form lists when Airtable is configured.",
+    "Added a D1 hydration seed for Airtable consent forms rec2FLw9TwgDgi85y and recw6i67q2DuoZqMe linked to diary study rect3o7dt.",
+    "Added a guarded GitHub Actions workflow to apply the diary study consent form seed to remote researchops-d1 with post-apply checks."
   ],
   "testContractImpactSweep": [
     "Added D1 runtime coverage for consent form empty-list, create, list, update and publish behaviour.",
     "Added mixed D1 and Airtable runtime coverage so existing Airtable forms do not disappear after a D1 draft is created.",
-    "Updated consent forms route-state assertions for the D1 service, mixed source and migration contract."
+    "Updated consent forms route-state assertions for the D1 service, mixed source and migration contract.",
+    "Extended consent forms route-state assertions for the diary study D1 seed and apply workflow."
   ],
   "validation": [
     {

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
@@ -72,6 +72,8 @@ Both records link to Airtable study record `rec6MGawTSZgdENHs`, whose app-facing
 
 Added `.github/workflows/apply-d1-diary-study-consent-forms.yml` to apply the seed to remote `researchops-d1` through the established Cloudflare-secrets GitHub Actions path. The local desktop runtime did not include `wrangler`, `npm` or `npx`, so direct remote D1 execution was not available from this shell.
 
+Reviewed Codex comment `PRRC_kwDOP3Td2M7IP8Mr` on the diary study seed. Classified it as legitimate. Updated `0012_seed_diary_study_consent_forms.sql` from conflict-upsert behaviour to `INSERT OR IGNORE` so rerunning the seed does not overwrite consent forms that have since been edited or published through the app.
+
 ## Validation
 
 Passed:

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-d1-loading.md
@@ -59,6 +59,19 @@ Added runtime coverage in `tests/consent-forms-d1-runtime.test.js` for D1 empty-
 
 Reviewed unresolved Codex comment `PRRC_kwDOP3Td2M7IPiTh` on `infra/cloudflare/src/service/consent-forms.js`. Classified it as legitimate. Updated consent form listing so D1 rows do not short-circuit Airtable when Airtable is configured. The endpoint now merges D1 and Airtable consent forms, de-duplicates by form ID and reports `source: "d1+airtable"` for mixed lists. D1-only short-circuit behaviour remains only when Airtable is not configured or Airtable listing fails.
 
+## D1 Hydration
+
+Used the Airtable connector to inspect base `appkpzVvkof4RFtkh` and the consent form records associated with shared view `shrFDu4a5fVeql5Kq`.
+
+The connector returned two consent form records:
+
+- `rec2FLw9TwgDgi85y`, draft consent form
+- `recw6i67q2DuoZqMe`, published privacy notice
+
+Both records link to Airtable study record `rec6MGawTSZgdENHs`, whose app-facing study ID is `rect3o7dt` and description is "The diary study description". Added `infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql` to hydrate `rops_consent_forms` with those records using `study_id = 'rect3o7dt'` so `/pages/study/consent-forms/?id=rect3o7dt` can load them from D1.
+
+Added `.github/workflows/apply-d1-diary-study-consent-forms.yml` to apply the seed to remote `researchops-d1` through the established Cloudflare-secrets GitHub Actions path. The local desktop runtime did not include `wrangler`, `npm` or `npx`, so direct remote D1 execution was not available from this shell.
+
 ## Validation
 
 Passed:

--- a/infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql
+++ b/infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql
@@ -33,7 +33,7 @@ CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_study
 CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_status
 	ON rops_consent_forms (status, active);
 
-INSERT INTO rops_consent_forms (
+INSERT OR IGNORE INTO rops_consent_forms (
 	id,
 	study_id,
 	title,
@@ -157,22 +157,4 @@ If you have questions, contact {{researcherName}} at {{researcherEmail}}.',
 		'airtable-hydration',
 		'{"airtableBaseId":"appkpzVvkof4RFtkh","airtableShareId":"shrFDu4a5fVeql5Kq","airtableRecordId":"recw6i67q2DuoZqMe","airtableStudyRecordId":"rec6MGawTSZgdENHs","studyId":"rect3o7dt","projectId":"recgdpwEI5hF07bUZ","fields":{"fldVOoSwbTlTBalxc":"Participant information and consent form","fldzGFX0qCCw4BYUK":"Privacy notice","fldGbzlt9uaKuQltR":"Published","fldIZSDzx8I8PHcVD":2,"fldM0E82U9X3LRkux":["rec6MGawTSZgdENHs"],"fldGS7R6NllKSKHkI":"2026-05-01T14:56:53.407Z","fldOCBEVOyxtIMloU":"2026-04-26T01:00:23.909Z","fldS244a10UF871Fv":"2026-05-01T14:56:53.407Z"}}'
 	)
-ON CONFLICT(id) DO UPDATE SET
-	study_id = excluded.study_id,
-	title = excluded.title,
-	form_type = excluded.form_type,
-	status = excluded.status,
-	version = excluded.version,
-	source_markdown = excluded.source_markdown,
-	variables_json = excluded.variables_json,
-	consent_items_json = excluded.consent_items_json,
-	plain_english_summary = excluded.plain_english_summary,
-	accessibility_notes = excluded.accessibility_notes,
-	review_notes = excluded.review_notes,
-	owner = excluded.owner,
-	published_at = excluded.published_at,
-	created_at = excluded.created_at,
-	updated_at = excluded.updated_at,
-	active = 1,
-	source = excluded.source,
-	payload_json = excluded.payload_json;
+;

--- a/infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql
+++ b/infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql
@@ -1,0 +1,178 @@
+-- Seed Airtable consent forms into D1 for the diary study.
+-- Date: 2026-06-05
+-- Source: Airtable base appkpzVvkof4RFtkh, shared view shrFDu4a5fVeql5Kq.
+-- Scope: hydrate D1 so /pages/study/consent-forms/?id=rect3o7dt loads existing forms.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS rops_consent_forms (
+	id TEXT PRIMARY KEY,
+	study_id TEXT NOT NULL,
+	title TEXT NOT NULL,
+	form_type TEXT NOT NULL,
+	status TEXT NOT NULL,
+	version INTEGER NOT NULL DEFAULT 1,
+	source_markdown TEXT NOT NULL,
+	variables_json TEXT NOT NULL DEFAULT '{}',
+	consent_items_json TEXT NOT NULL DEFAULT '[]',
+	plain_english_summary TEXT,
+	accessibility_notes TEXT,
+	review_notes TEXT,
+	owner TEXT,
+	published_at TEXT,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	active INTEGER NOT NULL DEFAULT 1,
+	source TEXT NOT NULL DEFAULT 'd1',
+	payload_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_study
+	ON rops_consent_forms (study_id, active, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_rops_consent_forms_status
+	ON rops_consent_forms (status, active);
+
+INSERT INTO rops_consent_forms (
+	id,
+	study_id,
+	title,
+	form_type,
+	status,
+	version,
+	source_markdown,
+	variables_json,
+	consent_items_json,
+	plain_english_summary,
+	accessibility_notes,
+	review_notes,
+	owner,
+	published_at,
+	created_at,
+	updated_at,
+	active,
+	source,
+	payload_json
+)
+VALUES
+	(
+		'rec2FLw9TwgDgi85y',
+		'rect3o7dt',
+		'Participant information and consent form',
+		'Consent form',
+		'Draft',
+		1,
+		'# {{studyTitle}} participant information and consent form
+
+## About this research
+
+We are doing research for {{organisation}}. The session will help us understand how people use or experience this service.
+
+## What taking part involves
+
+You will take part in a {{sessionFormat}} with a researcher. You can choose not to answer any question. You can stop the session at any time.
+
+## Recording and observers
+
+{{recordingSummary}}
+
+## How your information will be used
+
+We will use what we learn to improve the service. Research notes and outputs should not identify you directly.
+
+## Withdrawal
+
+You can ask for your contribution to be withdrawn up to {{withdrawalPeriod}}, where this is possible.
+
+## Consent statements
+
+{{#consentItems}}
+- {{label}}
+{{/consentItems}}
+
+## Contact
+
+If you have questions, contact {{researcherName}} at {{researcherEmail}}.',
+		'{"studyTitle":"Study title","organisation":"Home Office Biometrics","researcherName":"Researcher name","researcherEmail":"research@example.gov.uk","sessionFormat":"remote research session","recordingSummary":"The session may be audio or video recorded if you agree.","withdrawalPeriod":"14 days after your session"}',
+		'[{"id":"participation","label":"I understand what taking part involves and I agree to take part in this research.","required":true},{"id":"voluntary","label":"I understand that taking part is voluntary and that I can stop the session at any time.","required":true},{"id":"data-use","label":"I understand how my information will be used for this research.","required":true},{"id":"recording","label":"I agree to the session being recorded if recording is being used for this study.","required":false}]',
+		'Participant-facing consent material for this study.',
+		'',
+		'',
+		'',
+		'',
+		'2026-04-26T00:59:53.379Z',
+		'2026-04-26T00:59:53.379Z',
+		1,
+		'airtable-hydration',
+		'{"airtableBaseId":"appkpzVvkof4RFtkh","airtableShareId":"shrFDu4a5fVeql5Kq","airtableRecordId":"rec2FLw9TwgDgi85y","airtableStudyRecordId":"rec6MGawTSZgdENHs","studyId":"rect3o7dt","projectId":"recgdpwEI5hF07bUZ","fields":{"fldVOoSwbTlTBalxc":"Participant information and consent form","fldzGFX0qCCw4BYUK":"Consent form","fldGbzlt9uaKuQltR":"Draft","fldIZSDzx8I8PHcVD":1,"fldM0E82U9X3LRkux":["rec6MGawTSZgdENHs"],"fldOCBEVOyxtIMloU":"2026-04-26T00:59:53.379Z","fldS244a10UF871Fv":"2026-04-26T00:59:53.379Z"}}'
+	),
+	(
+		'recw6i67q2DuoZqMe',
+		'rect3o7dt',
+		'Participant information and consent form',
+		'Privacy notice',
+		'Published',
+		2,
+		'# {{studyTitle}} participant information and consent form
+
+## About this research
+
+We are doing research for {{organisation}}. The session will help us understand how people use or experience this service.
+
+## What taking part involves
+
+You will take part in a {{sessionFormat}} with a researcher. You can choose not to answer any question. You can stop the session at any time.
+
+## Recording and observers
+
+{{recordingSummary}}
+
+## How your information will be used
+
+We will use what we learn to improve the service. Research notes and outputs should not identify you directly.
+
+## Withdrawal
+
+You can ask for your contribution to be withdrawn up to {{withdrawalPeriod}}, where this is possible.
+
+## Consent statements
+
+{{#consentItems}}
+- {{label}}
+{{/consentItems}}
+
+## Contact
+
+If you have questions, contact {{researcherName}} at {{researcherEmail}}.',
+		'{"studyTitle":"Study title","organisation":"Home Office Biometrics","researcherName":"Researcher name","researcherEmail":"research@example.gov.uk","sessionFormat":"remote research session","recordingSummary":"The session may be audio or video recorded if you agree.","withdrawalPeriod":"14 days after your session"}',
+		'[{"id":"participation","label":"I understand what taking part involves and I agree to take part in this research.","required":true},{"id":"voluntary","label":"I understand that taking part is voluntary and that I can stop the session at any time.","required":true},{"id":"data-use","label":"I understand how my information will be used for this research.","required":true},{"id":"recording","label":"I agree to the session being recorded if recording is being used for this study.","required":false}]',
+		'Participant-facing consent material for this study.',
+		'',
+		'',
+		'',
+		'2026-05-01T14:56:53.407Z',
+		'2026-04-26T01:00:23.909Z',
+		'2026-05-01T14:56:53.407Z',
+		1,
+		'airtable-hydration',
+		'{"airtableBaseId":"appkpzVvkof4RFtkh","airtableShareId":"shrFDu4a5fVeql5Kq","airtableRecordId":"recw6i67q2DuoZqMe","airtableStudyRecordId":"rec6MGawTSZgdENHs","studyId":"rect3o7dt","projectId":"recgdpwEI5hF07bUZ","fields":{"fldVOoSwbTlTBalxc":"Participant information and consent form","fldzGFX0qCCw4BYUK":"Privacy notice","fldGbzlt9uaKuQltR":"Published","fldIZSDzx8I8PHcVD":2,"fldM0E82U9X3LRkux":["rec6MGawTSZgdENHs"],"fldGS7R6NllKSKHkI":"2026-05-01T14:56:53.407Z","fldOCBEVOyxtIMloU":"2026-04-26T01:00:23.909Z","fldS244a10UF871Fv":"2026-05-01T14:56:53.407Z"}}'
+	)
+ON CONFLICT(id) DO UPDATE SET
+	study_id = excluded.study_id,
+	title = excluded.title,
+	form_type = excluded.form_type,
+	status = excluded.status,
+	version = excluded.version,
+	source_markdown = excluded.source_markdown,
+	variables_json = excluded.variables_json,
+	consent_items_json = excluded.consent_items_json,
+	plain_english_summary = excluded.plain_english_summary,
+	accessibility_notes = excluded.accessibility_notes,
+	review_notes = excluded.review_notes,
+	owner = excluded.owner,
+	published_at = excluded.published_at,
+	created_at = excluded.created_at,
+	updated_at = excluded.updated_at,
+	active = 1,
+	source = excluded.source,
+	payload_json = excluded.payload_json;

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -12,6 +12,8 @@ const serviceSource = fs.readFileSync("infra/cloudflare/src/service/consent-form
 const serviceIndexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
 const fieldsSource = fs.readFileSync("infra/cloudflare/src/core/fields.js", "utf8");
 const d1MigrationSource = fs.readFileSync("infra/cloudflare/migrations/0011_consent_forms_d1.sql", "utf8");
+const d1DiaryStudySeedSource = fs.readFileSync("infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql", "utf8");
+const d1DiaryStudySeedWorkflow = fs.readFileSync(".github/workflows/apply-d1-diary-study-consent-forms.yml", "utf8");
 
 function includes(source, text, label) {
 	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -102,3 +104,14 @@ includes(fieldsSource, "Consent Items (JSON)", "fields");
 includes(d1MigrationSource, "CREATE TABLE IF NOT EXISTS rops_consent_forms", "D1 consent forms migration");
 includes(d1MigrationSource, "study_id TEXT NOT NULL", "D1 consent forms migration");
 includes(d1MigrationSource, "idx_rops_consent_forms_study", "D1 consent forms migration");
+
+includes(d1DiaryStudySeedSource, "rec2FLw9TwgDgi85y", "D1 diary study consent form seed");
+includes(d1DiaryStudySeedSource, "recw6i67q2DuoZqMe", "D1 diary study consent form seed");
+includes(d1DiaryStudySeedSource, "'rect3o7dt'", "D1 diary study consent form seed");
+includes(d1DiaryStudySeedSource, "airtable-hydration", "D1 diary study consent form seed");
+includes(d1DiaryStudySeedSource, "ON CONFLICT(id) DO UPDATE SET", "D1 diary study consent form seed");
+
+includes(d1DiaryStudySeedWorkflow, "Apply D1 Diary Study Consent Forms Seed", "D1 diary study consent form seed workflow");
+includes(d1DiaryStudySeedWorkflow, "infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql", "D1 diary study consent form seed workflow");
+includes(d1DiaryStudySeedWorkflow, "APPLY_DIARY_STUDY_CONSENT_FORMS", "D1 diary study consent form seed workflow");
+includes(d1DiaryStudySeedWorkflow, "SELECT COUNT(*) AS consent_form_count", "D1 diary study consent form seed workflow");

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -109,7 +109,8 @@ includes(d1DiaryStudySeedSource, "rec2FLw9TwgDgi85y", "D1 diary study consent fo
 includes(d1DiaryStudySeedSource, "recw6i67q2DuoZqMe", "D1 diary study consent form seed");
 includes(d1DiaryStudySeedSource, "'rect3o7dt'", "D1 diary study consent form seed");
 includes(d1DiaryStudySeedSource, "airtable-hydration", "D1 diary study consent form seed");
-includes(d1DiaryStudySeedSource, "ON CONFLICT(id) DO UPDATE SET", "D1 diary study consent form seed");
+includes(d1DiaryStudySeedSource, "INSERT OR IGNORE INTO rops_consent_forms", "D1 diary study consent form seed");
+excludes(d1DiaryStudySeedSource, "ON CONFLICT(id) DO UPDATE", "D1 diary study consent form seed");
 
 includes(d1DiaryStudySeedWorkflow, "Apply D1 Diary Study Consent Forms Seed", "D1 diary study consent form seed workflow");
 includes(d1DiaryStudySeedWorkflow, "infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql", "D1 diary study consent form seed workflow");


### PR DESCRIPTION
## Summary
- Add an idempotent D1 seed for the two Airtable consent-form records from shared view `shrFDu4a5fVeql5Kq`.
- Seed them against diary study `rect3o7dt` so `/pages/study/consent-forms/?id=rect3o7dt` can load existing forms from D1.
- Add a guarded GitHub Action to apply the seed to remote `researchops-d1` on `main`, with post-apply checks.
- Preserve audit trace evidence and route-state coverage for the seed/workflow.

## Validation
- `sqlite3 :memory: < infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql`
- `sqlite3 :memory: ".read infra/cloudflare/migrations/0012_seed_diary_study_consent_forms.sql" "SELECT id, study_id, status, version FROM rops_consent_forms ORDER BY id;"`
- `node --test tests/consent-forms-d1-runtime.test.js tests/consent-forms-route-state.test.js`
- `git diff --check`
- `prettier --check` on changed files
- `node scripts/agent-trace/assert-trace-coverage.mjs`
- `node --test` with 176 passing tests

## Notes
The local desktop runtime did not include Wrangler/npm/npx, so the production D1 write is routed through the repo's existing Cloudflare-secrets GitHub Actions pattern rather than being applied directly from this shell.