### PR TITLE
Fix consent forms loading through Pages proxy

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.json
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-06-05",
+  "branch": "fix/consent-forms-relative-api-url",
+  "traceRequired": true,
+  "task": "Fix the diary study consent forms page still not showing hydrated D1 consent form data after PR 350 merged.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "path": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "path": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "cloudflare",
+      "path": ".agent-operating-model/bundles/cloudflare/"
+    }
+  ],
+  "filesRead": [
+    "public/js/consent-forms-page.js",
+    "public/js/consent-forms-route-loader.js",
+    "public/js/study-route-context.js",
+    "public/js/study-canonical-url-bridge.js",
+    "tests/consent-forms-route-state.test.js"
+  ],
+  "filesModified": [
+    "public/js/consent-forms-page.js",
+    "tests/consent-forms-route-state.test.js"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.md",
+    "docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.json"
+  ],
+  "findings": [
+    "Production Worker and Pages proxy both returned hydrated consent forms for study rect3o7dt.",
+    "Browser inspection showed consent-forms-page.js failed with TypeError: Failed to construct 'URL': Invalid URL.",
+    "The controller constructed new URL(apiUrl('/api/consent-forms')) without a base, which fails when apiUrl returns a relative Pages-proxy path."
+  ],
+  "implementationSummary": [
+    "Updated loadConsentForms to pass window.location.origin as the base to new URL.",
+    "Added route-state coverage for Pages-proxy-safe consent forms API URL construction."
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/consent-forms-route-state.test.js tests/consent-forms-d1-runtime.test.js",
+      "result": "passed",
+      "evidence": "2 tests passed"
+    },
+    {
+      "command": "prettier --check public/js/consent-forms-page.js tests/consent-forms-route-state.test.js docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.md docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.json",
+      "result": "passed",
+      "evidence": "All matched files use Prettier code style"
+    },
+    {
+      "command": "node scripts/agent-trace/assert-trace-coverage.mjs",
+      "result": "passed",
+      "evidence": "trace coverage confirmed"
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed",
+      "evidence": "no whitespace errors"
+    },
+    {
+      "command": "node --test",
+      "result": "passed",
+      "evidence": "176 tests passed"
+    }
+  ],
+  "residualRisks": []
+}

--- a/docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.md
+++ b/docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.md
@@ -1,0 +1,41 @@
+# Consent Forms Relative API URL Trace
+
+Date: 2026-06-05  
+Branch: `fix/consent-forms-relative-api-url`  
+Trace requirement: required because the branch uses the `fix/` prefix.
+
+## Task
+
+Investigate why the diary study consent forms were still not visible after PR #350 merged and D1 hydration completed.
+
+## Findings
+
+Production D1 and API proxy were healthy:
+
+- `https://rops-api.digikev-kevin-rapley.workers.dev/api/consent-forms?study=rect3o7dt` returned the two hydrated consent forms.
+- `https://researchops.pages.dev/api/consent-forms?study=rect3o7dt` also returned the two hydrated consent forms through the Pages API proxy.
+- GitHub Actions showed `Apply D1 Diary Study Consent Forms Seed` completed successfully on `main`.
+
+Browser inspection of `https://researchops.pages.dev/pages/study/consent-forms/?id=rect3o7dt` showed the page failing client-side with:
+
+`TypeError: Failed to construct 'URL': Invalid URL`
+
+The consent forms controller used `new URL(apiUrl("/api/consent-forms"))`. On Pages, `apiUrl` can return a relative `/api/...` path, so `new URL` requires `window.location.origin` as the base.
+
+## Implementation
+
+Updated `public/js/consent-forms-page.js` so `loadConsentForms` constructs the list URL with:
+
+`new URL(apiUrl("/api/consent-forms"), window.location.origin)`
+
+Updated `tests/consent-forms-route-state.test.js` to assert this Pages-proxy-safe URL construction.
+
+## Validation
+
+Passed:
+
+- `node --test tests/consent-forms-route-state.test.js tests/consent-forms-d1-runtime.test.js`
+- `node node_modules/prettier/bin/prettier.cjs --check public/js/consent-forms-page.js tests/consent-forms-route-state.test.js docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.md docs/agent-audit/reasoning/2026/06/05/consent-forms-relative-api-url.json`
+- `node scripts/agent-trace/assert-trace-coverage.mjs`
+- `git diff --check`
+- `node --test` with 176 passing tests

--- a/public/js/consent-forms-page.js
+++ b/public/js/consent-forms-page.js
@@ -337,7 +337,7 @@ function renderList() {
 }
 
 async function loadConsentForms() {
-	const url = new URL(apiUrl("/api/consent-forms"));
+	const url = new URL(apiUrl("/api/consent-forms"), window.location.origin);
 	url.searchParams.set("study", state.sid);
 	let body = null;
 	try {

--- a/tests/consent-forms-route-state.test.js
+++ b/tests/consent-forms-route-state.test.js
@@ -60,6 +60,7 @@ includes(controllerSource, "function renderMarkdown", "controller");
 includes(controllerSource, "consentItems", "controller");
 includes(controllerSource, "study_airtable_id: state.sid", "controller");
 includes(controllerSource, "apiUrl(\"/api/consent-forms\")", "controller");
+includes(controllerSource, "new URL(apiUrl(\"/api/consent-forms\"), window.location.origin)", "controller");
 includes(controllerSource, "/api/consent-forms/${encodeURIComponent(id)}/publish", "controller");
 includes(controllerSource, "list failed; starting with a new draft", "controller");
 includes(controllerSource, "Consent forms could not be loaded. You can still create a new draft.", "controller");


### PR DESCRIPTION
## Summary
- Fix the consent forms page crash when `apiUrl('/api/consent-forms')` resolves to a relative Pages-proxy path.
- Build the list endpoint with `window.location.origin` as the `new URL` base.
- Add route-state coverage for the Pages-proxy-safe URL construction.

## Root cause
D1 was hydrated and both API paths returned the diary study consent forms:
- `https://rops-api.digikev-kevin-rapley.workers.dev/api/consent-forms?study=rect3o7dt`
- `https://researchops.pages.dev/api/consent-forms?study=rect3o7dt`

The browser page still failed because `new URL(apiUrl('/api/consent-forms'))` throws when `apiUrl` returns the relative `/api/consent-forms` path on Pages.

## Validation
- Browser inspection of the live page showed `TypeError: Failed to construct 'URL': Invalid URL` before this fix.
- `node --test tests/consent-forms-route-state.test.js tests/consent-forms-d1-runtime.test.js`
- Prettier check on changed files
- `node scripts/agent-trace/assert-trace-coverage.mjs`
- `git diff --check`
- `node --test` with 176 passing tests