### PR TITLE
Refine Study page GOV.UK readiness actions

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json
+++ b/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json
@@ -1,0 +1,88 @@
+{
+  "date": "2026-06-05",
+  "branch": "fix/study-page-govuk-readiness",
+  "traceRequired": true,
+  "task": "Bring /pages/study/?id=<StudyID>&project=<ProjectID> further into GOV.UK Frontend and tighten Study readiness actions.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "path": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "path": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "govuk-design-system",
+      "path": ".agent-operating-model/bundles/govuk-design-system/"
+    },
+    {
+      "id": "multi-functional-team",
+      "path": ".agent-operating-model/bundles/multi-functional-team/"
+    }
+  ],
+  "filesRead": [
+    "src/govuk/templates/pages/study.njk",
+    "public/pages/study/index.html",
+    "public/js/study-page.js",
+    "src/styles/study-page.scss",
+    "tests/study-page-route-state.test.js",
+    "scripts/govuk/render-govuk-pages.mjs"
+  ],
+  "filesModified": [
+    "src/govuk/templates/pages/study.njk",
+    "public/pages/study/index.html",
+    "public/js/study-page.js",
+    "tests/study-page-route-state.test.js"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md",
+    "docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json"
+  ],
+  "teamCritique": [
+    "Researchers need a quiet control surface with the Study title, description, metadata and readiness state prioritised.",
+    "Breadcrumbs already provide project navigation, so a duplicate Back to Project button creates unnecessary action noise.",
+    "Edit study is a maintenance action and should be secondary.",
+    "Begin session should not be visible as an available action until every readiness task is complete."
+  ],
+  "implementationSummary": [
+    "Removed the Back to Project button from the Study page template and generated HTML.",
+    "Made Edit study a secondary GOV.UK button.",
+    "Changed the initial Begin session action to hidden and unhidden it only when readiness enables the real session URL.",
+    "Removed controller wiring for the deleted Back to Project button.",
+    "Updated route-state coverage for the Study page template, generated HTML and controller."
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/study-page-route-state.test.js tests/study-child-route-state.test.js",
+      "result": "passed",
+      "evidence": "2 tests passed"
+    },
+    {
+      "command": "node scripts/govuk/render-govuk-pages.mjs",
+      "result": "passed",
+      "evidence": "GOV.UK pages rendered including public/pages/study/index.html"
+    },
+    {
+      "command": "node scripts/agent-trace/assert-trace-coverage.mjs",
+      "result": "passed",
+      "evidence": "trace coverage confirmed"
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed",
+      "evidence": "no whitespace errors"
+    },
+    {
+      "command": "prettier --check public/pages/study/index.html public/js/study-page.js tests/study-page-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json",
+      "result": "passed",
+      "evidence": "All matched files use Prettier code style"
+    },
+    {
+      "command": "node --test",
+      "result": "passed",
+      "evidence": "176 tests passed"
+    }
+  ],
+  "residualRisks": []
+}

--- a/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json
+++ b/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json
@@ -52,6 +52,17 @@
     "Removed controller wiring for the deleted Back to Project button.",
     "Updated route-state coverage for the Study page template, generated HTML and controller."
   ],
+  "codexReviewFollowUp": {
+    "threadId": "PRRT_kwDOP3Td2M6HVVet",
+    "commentId": "PRRC_kwDOP3Td2M7IZFiI",
+    "classification": "legitimate",
+    "summary": "The Study page script version needed a cache-key bump because the page now renders the session action hidden until readiness enables it.",
+    "implementation": [
+      "Bumped studyPageScriptVersion to study-readiness-session-gate-20260605.",
+      "Regenerated public/pages/study/index.html so the modulepreload and script URL reference the updated Study page controller version.",
+      "Updated the Study page route-state test to assert the new versioned script URL."
+    ]
+  },
   "validation": [
     {
       "command": "node --test tests/study-page-route-state.test.js tests/study-child-route-state.test.js",
@@ -82,6 +93,36 @@
       "command": "node --test",
       "result": "passed",
       "evidence": "176 tests passed"
+    },
+    {
+      "command": "node --test tests/study-page-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js",
+      "result": "passed",
+      "evidence": "Codex review follow-up focused route-state tests passed"
+    },
+    {
+      "command": "node scripts/govuk/render-govuk-pages.mjs",
+      "result": "passed",
+      "evidence": "Codex review follow-up regenerated GOV.UK pages including public/pages/study/index.html"
+    },
+    {
+      "command": "prettier --check public/pages/study/index.html tests/study-page-route-state.test.js docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json",
+      "result": "passed",
+      "evidence": "Codex review follow-up supported files use Prettier code style"
+    },
+    {
+      "command": "node scripts/agent-trace/assert-trace-coverage.mjs",
+      "result": "passed",
+      "evidence": "Codex review follow-up trace coverage confirmed"
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed",
+      "evidence": "Codex review follow-up found no whitespace errors"
+    },
+    {
+      "command": "node --test",
+      "result": "passed",
+      "evidence": "Codex review follow-up full test suite passed"
     }
   ],
   "residualRisks": []

--- a/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md
+++ b/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md
@@ -34,6 +34,16 @@ Accessibility and service safety: disabled-looking links can still be confusing.
 - Stopped the controller from trying to wire the removed `#back-to-project` link.
 - Updated the Study page route-state contract for the Nunjucks template, generated HTML and controller.
 
+## Codex Review Follow-Up
+
+Review thread `PRRT_kwDOP3Td2M6HVVet` / comment `PRRC_kwDOP3Td2M7IZFiI` was legitimate. The Study page now hides the session action in markup, so the `study-page.js` cache key needed to change to prevent browsers from reusing the previous controller version that enabled the link without clearing `hidden`.
+
+Follow-up implementation:
+
+- Bumped `studyPageScriptVersion` to `study-readiness-session-gate-20260605`.
+- Regenerated `public/pages/study/index.html` so the modulepreload and script URL carry the new Study page controller version.
+- Updated the Study page route-state test to assert the new versioned script URL.
+
 ## Validation
 
 Passed:
@@ -44,3 +54,12 @@ Passed:
 - `git diff --check`
 - `prettier --check` on changed supported files
 - `node --test` with 176 passing tests
+
+Additional Codex review follow-up validation passed:
+
+- `node --test tests/study-page-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js`
+- `node scripts/govuk/render-govuk-pages.mjs`
+- `prettier --check` on changed supported files
+- `node scripts/agent-trace/assert-trace-coverage.mjs`
+- `git diff --check`
+- `node --test`

--- a/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md
+++ b/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md
@@ -1,0 +1,46 @@
+# Study Page GOV.UK Readiness Trace
+
+Date: 2026-06-05  
+Branch: `fix/study-page-govuk-readiness`  
+Trace requirement: required because the branch uses the `fix/` prefix.
+
+## Task
+
+Bring `/pages/study/?id=<StudyID>&project=<ProjectID>` further into GOV.UK Frontend with Nunjucks macros, remove the redundant back button, make "Edit study" secondary and only make "Begin session" available when full Study readiness is complete.
+
+## Operating Model
+
+Selected bundles:
+
+- `github-diamond`
+- `researchops-developer-control`
+- `govuk-design-system`
+- `multi-functional-team`
+
+## Team Critique
+
+Researcher use: the page should behave like a working control surface, not a marketing page. The Study title, description and key metadata stay first, then readiness explains what must be completed before fieldwork begins. Breadcrumbs are enough for returning to the project, so the extra "Back to Project" button added visual noise.
+
+Interaction design: "Edit study" is an available maintenance action, not the primary task on this page, so it should be a secondary GOV.UK button. "Begin session" should not look available until the readiness model says every required item is ready.
+
+Accessibility and service safety: disabled-looking links can still be confusing. The session action now starts hidden and is only unhidden when the readiness gate enables it with the real session URL. The task-list row continues to tell researchers what is missing.
+
+## Implementation
+
+- Removed the "Back to Project" button from the Study page Nunjucks template and generated HTML.
+- Made the "Edit study" action a secondary GOV.UK button.
+- Changed the initial "Begin session" action to be hidden instead of visually disabled.
+- Updated the Study page controller so `#link-session` is unhidden only through `enableLink` when all readiness checks pass.
+- Stopped the controller from trying to wire the removed `#back-to-project` link.
+- Updated the Study page route-state contract for the Nunjucks template, generated HTML and controller.
+
+## Validation
+
+Passed:
+
+- `node --test tests/study-page-route-state.test.js tests/study-child-route-state.test.js`
+- `node scripts/govuk/render-govuk-pages.mjs`
+- `node scripts/agent-trace/assert-trace-coverage.mjs`
+- `git diff --check`
+- `prettier --check` on changed supported files
+- `node --test` with 176 passing tests

--- a/public/js/study-page.js
+++ b/public/js/study-page.js
@@ -185,6 +185,7 @@ function enableLink(selector, href) {
 	const el = $(selector);
 	if (!el) return;
 	el.href = href;
+	el.hidden = false;
 	el.classList.remove("link--disabled", "govuk-button--disabled");
 	el.removeAttribute("aria-disabled");
 	el.removeAttribute("data-disabled-link");
@@ -196,6 +197,7 @@ function disableLink(selector, fallbackHref, reason) {
 	const el = $(selector);
 	if (!el) return;
 	el.href = fallbackHref || "#study-readiness-title";
+	if (selector === "#link-session") el.hidden = true;
 	el.classList.add("link--disabled");
 	if (el.classList.contains("govuk-button")) el.classList.add("govuk-button--disabled");
 	el.setAttribute("aria-disabled", "true");
@@ -324,7 +326,6 @@ function renderReadiness(study, context, sessionHref) {
 function renderRoutes(projectId, studyId) {
 	const legacySessionParams = { pid: projectId, sid: studyId };
 	const studyParams = { id: studyId, project: projectId };
-	enableLink("#back-to-project", route("/pages/project-dashboard/", { id: projectId }));
 	enableLink("#breadcrumb-project", route("/pages/project-dashboard/", { id: projectId }));
 	enableLink("#link-consent-forms", route("/pages/study/consent-forms/", studyParams));
 	enableLink("#link-participant-consent", route("/pages/study/participant-consent/", studyParams));

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -74,17 +74,13 @@
 
 				<div class="study-action-bar govuk-button-group">
 					<a
-						href="/pages/projects/"
+						href="#"
 						role="button"
 						draggable="false"
 						class="govuk-button govuk-button--secondary"
 						data-module="govuk-button"
-						id="back-to-project"
+						id="edit-study"
 					>
-						Back to Project
-					</a>
-
-					<a href="#" role="button" draggable="false" class="govuk-button" data-module="govuk-button" id="edit-study">
 						Edit study
 					</a>
 				</div>
@@ -319,15 +315,13 @@
 					</ul>
 
 					<a
-						href="#study-readiness-title"
+						href="#"
 						role="button"
 						draggable="false"
-						class="govuk-button govuk-button--disabled study-session-button"
+						class="govuk-button study-session-button"
 						data-module="govuk-button"
 						id="link-session"
-						aria-disabled="true"
-						data-disabled-link="true"
-						tabindex="-1"
+						hidden="hidden"
 					>
 						Begin session
 					</a>

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -13,7 +13,7 @@
 		<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
 		<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
 		<link rel="stylesheet" href="/css/study-page.css" media="screen" />
-		<link rel="modulepreload" href="/js/study-page.js?v=study-record-id-routing-20260518" />
+		<link rel="modulepreload" href="/js/study-page.js?v=study-readiness-session-gate-20260605" />
 		<link rel="modulepreload" href="/pages/study/study-desc-controller.js" />
 
 		<script type="module" src="/components/layout.js" defer></script>
@@ -434,7 +434,7 @@
 		</main>
 		<x-include src="/partials/footer.html"></x-include>
 
-		<script type="module" src="/js/study-page.js?v=study-record-id-routing-20260518"></script>
+		<script type="module" src="/js/study-page.js?v=study-readiness-session-gate-20260605"></script>
 		<script type="module" src="/pages/study/study-desc-controller.js"></script>
 	</body>
 </html>

--- a/src/govuk/templates/pages/study.njk
+++ b/src/govuk/templates/pages/study.njk
@@ -66,16 +66,9 @@
 
 	<div class="study-action-bar govuk-button-group">
 		{{ govukButton({
-			text: "Back to Project",
-			href: "/pages/projects/",
-			classes: "govuk-button--secondary",
-			attributes: {
-				id: "back-to-project"
-			}
-		}) }}
-		{{ govukButton({
 			text: "Edit study",
 			href: "#",
+			classes: "govuk-button--secondary",
 			attributes: {
 				id: "edit-study"
 			}
@@ -211,13 +204,11 @@
 		}) }}
 		{{ govukButton({
 			text: "Begin session",
-			href: "#study-readiness-title",
-			classes: "govuk-button--disabled study-session-button",
+			href: "#",
+			classes: "study-session-button",
 			attributes: {
 				id: "link-session",
-				"aria-disabled": "true",
-				"data-disabled-link": "true",
-				tabindex: "-1"
+				hidden: "hidden"
 			}
 		}) }}
 	</section>

--- a/src/govuk/templates/pages/study.njk
+++ b/src/govuk/templates/pages/study.njk
@@ -7,7 +7,7 @@
 {% from "govuk/components/task-list/macro.njk" import govukTaskList %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{% set studyPageScriptVersion = "study-record-id-routing-20260518" %}
+{% set studyPageScriptVersion = "study-readiness-session-gate-20260605" %}
 
 {% block head %}
 	<meta property="schema:name" content="Study — ResearchOps">

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -130,8 +130,8 @@ for (const page of breadcrumbPages) {
 }
 
 const studyPage = fs.readFileSync("public/pages/study/index.html", "utf8");
-includes(studyPage, "id=\"back-to-project\"", "Study route");
-includes(studyPage, "Back to Project", "Study route");
+excludes(studyPage, "id=\"back-to-project\"", "Study route");
+excludes(studyPage, "Back to Project", "Study route");
 
 const outcomesPage = fs.readFileSync("public/pages/projects/outcomes/index.html", "utf8");
 includes(outcomesPage, "rel=\"modulepreload\" href=\"/js/project-context.js?v=20260603-form-interactions\"", "Outcomes route");

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -35,8 +35,8 @@ for (const macro of [
 for (const text of [
 	"data-study-template=\"govuk-task-list\"",
 	"value: \"\"",
-	"id: \"back-to-project\"",
 	"id: \"edit-study\"",
+	"classes: \"govuk-button--secondary\"",
 	"id: \"breadcrumb-project\"",
 	"id=\"description\"",
 	"id: \"desc-input\"",
@@ -47,6 +47,7 @@ for (const text of [
 	"id=\"study-readiness-description-status\"",
 	"id=\"study-readiness-participant-consent-hint\"",
 	"id: \"link-session\"",
+	"hidden: \"hidden\"",
 	"id=\"link-consent-forms\"",
 	"id=\"link-participant-consent\"",
 	"id=\"link-participants\"",
@@ -86,13 +87,12 @@ for (const text of [
 	"id=\"study-readiness-description-status\"",
 	"id=\"study-readiness-session-hint\"",
 	"id=\"link-session\"",
+	"hidden=\"hidden\"",
 	"id=\"link-guides\"",
 	"id=\"link-participants\"",
 	"id=\"link-participant-consent\"",
 	"id=\"link-synthesis\"",
 	"id=\"desc-cancel\"",
-	"aria-disabled=\"true\"",
-	"data-disabled-link=\"true\"",
 	"Not available yet"
 ]) {
 	includes(pageSource, text, "study page");
@@ -102,6 +102,8 @@ excludes(pageSource, "class=\"btn", "study page");
 excludes(pageSource, "class=\"board\"", "study page");
 excludes(pageSource, "Requires study context", "study page");
 excludes(pageSource, "<script type=\"module\">", "study page");
+excludes(pageSource, "id=\"back-to-project\"", "study page");
+excludes(pageSource, "Back to Project", "study page");
 
 includes(descControllerSource, "cancelBtnSel: '#desc-cancel'", "description controller");
 
@@ -131,11 +133,14 @@ for (const text of [
 	"route(\"/pages/study/participant-consent/\", studyParams)",
 	"route(\"/pages/study/session/\", legacySessionParams)",
 	"route(\"/pages/study/synthesis/\", studyParams)",
+	"if (selector === \"#link-session\") el.hidden = true",
+	"el.hidden = false",
 	"study:desc:save"
 ]) {
 	includes(controllerSource, text, "study page controller");
 }
 
+excludes(controllerSource, "enableLink(\"#back-to-project\"", "study page controller");
 excludes(controllerSource, "querySelector(\".readiness-item__status\")", "study page controller");
 excludes(controllerSource, "querySelector(\".readiness-item__body\")", "study page controller");
 excludes(controllerSource, "route(\"/pages/synthesize/\", params)", "study page controller");

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -71,7 +71,7 @@ for (const text of [
 	"/css/govuk/govuk-forms.css",
 	"/css/govuk/govuk-tables.css",
 	"/css/study-page.css",
-	"/js/study-page.js?v=study-record-id-routing-20260518",
+	"/js/study-page.js?v=study-readiness-session-gate-20260605",
 	"class=\"govuk-breadcrumbs\"",
 	"class=\"govuk-summary-list",
 	"class=\"govuk-task-list",


### PR DESCRIPTION
## Summary
- Remove the redundant `Back to Project` button from `/pages/study/`, relying on breadcrumbs for project navigation.
- Make `Edit study` a secondary GOV.UK button.
- Keep the Study page generated from the Nunjucks GOV.UK template and update the generated static HTML.
- Make `Begin session` hidden/inert by default and only reveal it when the full Study readiness gate enables the real session URL.
- Update route-state contracts for the Study page and breadcrumb/back-link expectations.

## Team critique
- Researchers need a quiet control surface: title, description, metadata and readiness first.
- Duplicate project navigation was competing with the primary workflow; breadcrumbs are enough here.
- `Edit study` is maintenance, not the page’s primary action.
- Session launch should not look available until every readiness item is complete.

## Validation
- `node --test tests/study-page-route-state.test.js tests/study-child-route-state.test.js`
- `node scripts/govuk/render-govuk-pages.mjs`
- `node scripts/agent-trace/assert-trace-coverage.mjs`
- `git diff --check`
- Prettier check on changed supported files
- `node --test` with 176 passing tests