### PR TITLE
Apply GOV.UK Study readiness layout

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json
+++ b/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json
@@ -33,6 +33,7 @@
     "src/govuk/templates/pages/study.njk",
     "public/pages/study/index.html",
     "public/js/study-page.js",
+    "public/css/study-page.css",
     "tests/study-page-route-state.test.js"
   ],
   "filesCreated": [
@@ -61,6 +62,19 @@
       "Bumped studyPageScriptVersion to study-readiness-session-gate-20260605.",
       "Regenerated public/pages/study/index.html so the modulepreload and script URL reference the updated Study page controller version.",
       "Updated the Study page route-state test to assert the new versioned script URL."
+    ]
+  },
+  "prototypeReviewFollowUp": {
+    "classification": "accepted multidisciplinary prototype direction",
+    "summary": "Moved the Study page from a stacked readiness page to a GOV.UK two-column control surface using GOV.UK Frontend grid widths and gutters.",
+    "implementation": [
+      "Placed Study details and the Before you can begin a session gate in the left govuk-grid-column-one-half column.",
+      "Placed the Study readiness task list in the right govuk-grid-column-one-half column.",
+      "Added a GOV.UK inset text gate that summarises blocker links and keeps Begin session hidden until readiness is complete.",
+      "Updated the controller to populate the gate summary, blocker links and project caption from loaded context.",
+      "Changed the readiness status row to Ready when study status is present.",
+      "Changed Synthesize study evidence to Synthesise study evidence.",
+      "Removed custom page and readiness max-width overrides so GOV.UK container and grid values own the layout."
     ]
   },
   "validation": [
@@ -123,6 +137,41 @@
       "command": "node --test",
       "result": "passed",
       "evidence": "Codex review follow-up full test suite passed"
+    },
+    {
+      "command": "node --test tests/study-page-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js",
+      "result": "passed",
+      "evidence": "Prototype review follow-up focused route-state tests passed"
+    },
+    {
+      "command": "node scripts/govuk/render-govuk-pages.mjs",
+      "result": "passed",
+      "evidence": "Prototype review follow-up regenerated GOV.UK pages including public/pages/study/index.html"
+    },
+    {
+      "command": "node scripts/styles/format-generated-css.mjs --check",
+      "result": "passed",
+      "evidence": "Generated CSS formatting check passed"
+    },
+    {
+      "command": "node scripts/agent-trace/assert-trace-coverage.mjs",
+      "result": "passed",
+      "evidence": "Prototype review follow-up trace coverage confirmed"
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed",
+      "evidence": "Prototype review follow-up found no whitespace errors"
+    },
+    {
+      "command": "prettier --check public/pages/study/index.html public/js/study-page.js public/css/study-page.css tests/study-page-route-state.test.js docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json",
+      "result": "passed",
+      "evidence": "Prototype review follow-up supported files use Prettier code style"
+    },
+    {
+      "command": "node --test",
+      "result": "passed",
+      "evidence": "Prototype review follow-up full test suite passed with 176 passing tests"
     }
   ],
   "residualRisks": []

--- a/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md
+++ b/docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md
@@ -44,6 +44,20 @@ Follow-up implementation:
 - Regenerated `public/pages/study/index.html` so the modulepreload and script URL carry the new Study page controller version.
 - Updated the Study page route-state test to assert the new versioned script URL.
 
+## Prototype Review Follow-Up
+
+The multidisciplinary review of the standalone prototype settled on a GOV.UK grid implementation rather than custom column widths. The Study page now uses `govuk-grid-row` with two `govuk-grid-column-one-half` columns so the 50/50 split and gutter come from GOV.UK Frontend.
+
+Follow-up implementation:
+
+- Moved Study details and the "Before you can begin a session" gate into the left half-width GOV.UK column.
+- Moved the full Study readiness task list into the right half-width GOV.UK column.
+- Added a GOV.UK inset text gate that summarises blocking setup tasks and keeps "Begin session" hidden until readiness is complete.
+- Updated the controller so the gate summary, blocker links and project caption are populated from the loaded study context.
+- Changed the readiness status row to use "Ready" when the study status is present.
+- Changed "Synthesize study evidence" to "Synthesise study evidence".
+- Removed custom page and readiness max-width overrides so the layout relies on GOV.UK container and grid widths.
+
 ## Validation
 
 Passed:
@@ -63,3 +77,13 @@ Additional Codex review follow-up validation passed:
 - `node scripts/agent-trace/assert-trace-coverage.mjs`
 - `git diff --check`
 - `node --test`
+
+Additional prototype review follow-up validation passed:
+
+- `node --test tests/study-page-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js`
+- `node scripts/govuk/render-govuk-pages.mjs`
+- `node scripts/styles/format-generated-css.mjs --check`
+- `node scripts/agent-trace/assert-trace-coverage.mjs`
+- `git diff --check`
+- `prettier --check` on changed supported files
+- `node --test` with 176 passing tests

--- a/public/css/study-page.css
+++ b/public/css/study-page.css
@@ -1,7 +1,3 @@
-.study-page {
-	max-width: 1100px;
-	}
-
 .study-action-bar {
 	justify-content: flex-end;
 	margin-bottom: 32px;
@@ -24,13 +20,30 @@
 	margin-top: 24px;
 	}
 
-.study-key-information, .study-summary-list, .study-readiness-section {
-	max-width: 960px;
+.study-key-information, .study-summary-list {
+	margin-bottom: 0;
 	}
 
 .study-section {
 	border-top: 1px solid #b1b4b6;
 	padding-top: 24px;
+	}
+
+.study-section--flush, .study-readiness-section {
+	border-top: 0;
+	padding-top: 0;
+	}
+
+.study-overview-grid {
+	margin-bottom: 48px;
+	}
+
+.study-session-gate .govuk-heading-s, .study-session-gate .govuk-body, .study-session-gate .govuk-list {
+	margin-bottom: 16px;
+	}
+
+.study-session-gate .govuk-button {
+	margin-bottom: 0;
 	}
 
 .study-readiness-task-list, .study-setup-task-list, .study-analysis-task-list {
@@ -47,7 +60,13 @@
 
 .govuk-task-list__item .govuk-tag {
 	max-width: 100%;
+	margin-top: 10px;
 	text-align: left;
+	}
+
+.study-analysis-task-list .govuk-tag {
+	max-width: 200px;
+	white-space: normal;
 	}
 
 @media (max-width: 699px) {

--- a/public/js/study-page.js
+++ b/public/js/study-page.js
@@ -224,6 +224,52 @@ function setReadinessItem(key, state, text) {
 	if (hint) hint.textContent = text;
 }
 
+function blockerActionForKey(key) {
+	const actions = {
+		description: { label: "Edit the study description", selector: "#btn-edit-desc" },
+		status: { label: "Review the study status", selector: "#edit-study" },
+		participants: { label: "Add or review participants", selector: "#link-participants" },
+		guide: { label: "Publish a discussion guide", selector: "#link-guides" },
+		consentMaterials: { label: "Create or review consent forms", selector: "#link-consent-forms" },
+		participantConsent: { label: "Record required participant consent", selector: "#link-participant-consent" }
+	};
+	return actions[key] || { label: key.replace(/[A-Z]/g, match => ` ${match.toLowerCase()}`), selector: "" };
+}
+
+function renderSessionGatePanel(ready, blockedKeys) {
+	const summary = $("#study-session-gate-summary");
+	const message = $("#study-session-gate-message");
+	const blockers = $("#study-session-blockers");
+	const action = $("#study-session-action");
+
+	if (action) action.hidden = !ready;
+	if (!summary || !message || !blockers) return;
+
+	if (ready) {
+		summary.textContent = "This study is ready to run";
+		message.textContent = "All required setup tasks are complete. Begin a session when you are ready to start fieldwork.";
+		blockers.hidden = true;
+		blockers.replaceChildren();
+		return;
+	}
+
+	summary.textContent = `${blockedKeys.length} setup ${blockedKeys.length === 1 ? "task needs" : "tasks need"} attention`;
+	message.textContent = "Complete these tasks before starting fieldwork.";
+	blockers.hidden = false;
+	blockers.replaceChildren(
+		...blockedKeys.map(key => {
+			const actionInfo = blockerActionForKey(key);
+			const item = document.createElement("li");
+			const link = document.createElement("a");
+			link.textContent = actionInfo.label;
+			const target = actionInfo.selector ? $(actionInfo.selector) : null;
+			link.href = target?.href || actionInfo.selector || "#study-readiness-title";
+			item.append(link);
+			return item;
+		})
+	);
+}
+
 function normaliseStatus(value) {
 	return String(value || "").trim().toLowerCase();
 }
@@ -261,7 +307,7 @@ function evaluateReadiness(study, context = {}) {
 		},
 		status: {
 			ready: hasStatus,
-			state: hasStatus ? "Set" : "Needs attention",
+			state: hasStatus ? "Ready" : "Needs attention",
 			text: hasStatus ? `Study status is ${status}.` : "Set the study status before running sessions."
 		},
 		participants: {
@@ -293,9 +339,12 @@ function isStudyReady(readiness) {
 
 function renderSessionGate(readiness, sessionHref) {
 	const ready = isStudyReady(readiness);
-	const blockedReasons = Object.entries(readiness)
+	const blockedKeys = Object.entries(readiness)
 		.filter(([, item]) => item.ready !== true)
-		.map(([key]) => key.replace(/[A-Z]/g, match => ` ${match.toLowerCase()}`));
+		.map(([key]) => key);
+	const blockedReasons = blockedKeys.map(key => key.replace(/[A-Z]/g, match => ` ${match.toLowerCase()}`));
+
+	renderSessionGatePanel(ready, blockedKeys);
 
 	if (ready) {
 		setReadinessItem("session", "Available", "Open the session workspace when the study setup is ready.");
@@ -347,6 +396,7 @@ function renderStudy(project, study, projectId, studyId, readinessContext) {
 	document.body.setAttribute("data-project-id", projectId);
 
 	setText("#breadcrumb-project", projectName);
+	setText("#study-eyebrow", projectName);
 	setText("#study-title", studyTitle(study));
 	setText("#description", String(study.description || "").trim() || "No study description has been added yet.");
 	setText("#kv-method", study.method || "—");

--- a/public/pages/study/index.html
+++ b/public/pages/study/index.html
@@ -86,7 +86,7 @@
 				</div>
 
 				<header class="study-hero govuk-!-margin-bottom-6" typeof="schema:ResearchProject" resource="#study">
-					<p id="study-eyebrow" class="govuk-caption-m">Study</p>
+					<p id="study-eyebrow" class="govuk-caption-m">Project</p>
 					<h1 id="study-title" class="govuk-heading-l" property="schema:name">Study</h1>
 					<div id="desc-view-wrap" class="study-description" property="schema:description">
 						<div id="description" class="govuk-body">—</div>
@@ -149,185 +149,213 @@
 					<p id="desc-status" class="govuk-body-s" role="status" aria-live="polite" aria-atomic="true"></p>
 				</header>
 
-				<section class="study-key-information govuk-!-margin-bottom-8" aria-labelledby="study-key-information-title">
-					<h2 id="study-key-information-title" class="govuk-heading-m">Study details</h2>
+				<div class="govuk-grid-row study-overview-grid">
+					<div class="govuk-grid-column-one-half">
+						<section
+							class="study-key-information govuk-!-margin-bottom-8"
+							aria-labelledby="study-key-information-title"
+						>
+							<h2 id="study-key-information-title" class="govuk-heading-m">Study details</h2>
 
-					<dl class="govuk-summary-list study-summary-list">
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">Method</dt>
-							<dd class="govuk-summary-list__value">
-								<span id="kv-method">–</span>
-							</dd>
-						</div>
+							<dl class="govuk-summary-list study-summary-list">
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Method</dt>
+									<dd class="govuk-summary-list__value">
+										<span id="kv-method">–</span>
+									</dd>
+								</div>
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">Status</dt>
-							<dd class="govuk-summary-list__value">
-								<span id="kv-status">–</span>
-							</dd>
-						</div>
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Status</dt>
+									<dd class="govuk-summary-list__value">
+										<span id="kv-status">–</span>
+									</dd>
+								</div>
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">Study ID</dt>
-							<dd class="govuk-summary-list__value">
-								<span id="kv-studyid">–</span>
-							</dd>
-						</div>
-					</dl>
-				</section>
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Study ID</dt>
+									<dd class="govuk-summary-list__value">
+										<span id="kv-studyid">–</span>
+									</dd>
+								</div>
+							</dl>
+						</section>
 
-				<section
-					class="study-section study-readiness-section govuk-!-margin-bottom-8"
-					aria-labelledby="study-readiness-title"
-				>
-					<h2 id="study-readiness-title" class="govuk-heading-m">Study readiness</h2>
-					<p class="govuk-body">Check the essentials before you run a session.</p>
-
-					<ul class="govuk-task-list study-readiness-task-list">
-						<li class="govuk-task-list__item">
-							<div class="govuk-task-list__name-and-hint">
-								<div>Description</div>
-
-								<div id="study-readiness-1-hint" class="govuk-task-list__hint">
-									<span id="study-readiness-description-hint" class="study-readiness-hint">
-										Checking study description.
-									</span>
+						<section
+							class="study-section study-session-gate-section govuk-!-margin-bottom-8"
+							aria-labelledby="study-session-gate-title"
+						>
+							<h2 id="study-session-gate-title" class="govuk-heading-m">Before you can begin a session</h2>
+							<div class="govuk-inset-text study-session-gate">
+								<h3 id="study-session-gate-summary" class="govuk-heading-s">Checking study readiness</h3>
+								<p id="study-session-gate-message" class="govuk-body">
+									Checking the required setup tasks before fieldwork can begin.
+								</p>
+								<ul id="study-session-blockers" class="govuk-list govuk-list--bullet">
+									<li>Checking readiness tasks.</li>
+								</ul>
+								<div id="study-session-action" hidden>
+									<a
+										href="#"
+										role="button"
+										draggable="false"
+										class="govuk-button study-session-button"
+										data-module="govuk-button"
+										id="link-session"
+										hidden="hidden"
+									>
+										Begin session
+									</a>
 								</div>
 							</div>
-							<div class="govuk-task-list__status" id="study-readiness-1-status">
-								<strong
-									id="study-readiness-description-status"
-									class="govuk-tag govuk-tag--grey study-readiness-status"
-								>
-									Checking
-								</strong>
-							</div>
-						</li>
+						</section>
+					</div>
 
-						<li class="govuk-task-list__item">
-							<div class="govuk-task-list__name-and-hint">
-								<div>Status</div>
+					<aside class="govuk-grid-column-one-half study-readiness-column" aria-labelledby="study-readiness-title">
+						<section class="study-readiness-section govuk-!-margin-bottom-8">
+							<h2 id="study-readiness-title" class="govuk-heading-m">Study readiness</h2>
 
-								<div id="study-readiness-2-hint" class="govuk-task-list__hint">
-									<span id="study-readiness-status-hint" class="study-readiness-hint">Checking study status.</span>
-								</div>
-							</div>
-							<div class="govuk-task-list__status" id="study-readiness-2-status">
-								<strong id="study-readiness-status-status" class="govuk-tag govuk-tag--grey study-readiness-status">
-									Checking
-								</strong>
-							</div>
-						</li>
+							<ul class="govuk-task-list study-readiness-task-list">
+								<li class="govuk-task-list__item">
+									<div class="govuk-task-list__name-and-hint">
+										<div>Description</div>
 
-						<li class="govuk-task-list__item">
-							<div class="govuk-task-list__name-and-hint">
-								<div>Participants</div>
+										<div id="study-readiness-1-hint" class="govuk-task-list__hint">
+											<span id="study-readiness-description-hint" class="study-readiness-hint">
+												Checking study description.
+											</span>
+										</div>
+									</div>
+									<div class="govuk-task-list__status" id="study-readiness-1-status">
+										<strong
+											id="study-readiness-description-status"
+											class="govuk-tag govuk-tag--grey study-readiness-status"
+										>
+											Checking
+										</strong>
+									</div>
+								</li>
 
-								<div id="study-readiness-3-hint" class="govuk-task-list__hint">
-									<span id="study-readiness-participants-hint" class="study-readiness-hint">
-										Add or review participants for this study.
-									</span>
-								</div>
-							</div>
-							<div class="govuk-task-list__status" id="study-readiness-3-status">
-								<strong
-									id="study-readiness-participants-status"
-									class="govuk-tag govuk-tag--yellow study-readiness-status"
-								>
-									Action needed
-								</strong>
-							</div>
-						</li>
+								<li class="govuk-task-list__item">
+									<div class="govuk-task-list__name-and-hint">
+										<div>Status</div>
 
-						<li class="govuk-task-list__item">
-							<div class="govuk-task-list__name-and-hint">
-								<div>Discussion guide</div>
+										<div id="study-readiness-2-hint" class="govuk-task-list__hint">
+											<span id="study-readiness-status-hint" class="study-readiness-hint">Checking study status.</span>
+										</div>
+									</div>
+									<div class="govuk-task-list__status" id="study-readiness-2-status">
+										<strong id="study-readiness-status-status" class="govuk-tag govuk-tag--grey study-readiness-status">
+											Checking
+										</strong>
+									</div>
+								</li>
 
-								<div id="study-readiness-4-hint" class="govuk-task-list__hint">
-									<span id="study-readiness-guide-hint" class="study-readiness-hint">
-										Create or review the discussion guide.
-									</span>
-								</div>
-							</div>
-							<div class="govuk-task-list__status" id="study-readiness-4-status">
-								<strong id="study-readiness-guide-status" class="govuk-tag govuk-tag--yellow study-readiness-status">
-									Action needed
-								</strong>
-							</div>
-						</li>
+								<li class="govuk-task-list__item">
+									<div class="govuk-task-list__name-and-hint">
+										<div>Participants</div>
 
-						<li class="govuk-task-list__item">
-							<div class="govuk-task-list__name-and-hint">
-								<div>Consent materials</div>
+										<div id="study-readiness-3-hint" class="govuk-task-list__hint">
+											<span id="study-readiness-participants-hint" class="study-readiness-hint">
+												Add or review participants for this study.
+											</span>
+										</div>
+									</div>
+									<div class="govuk-task-list__status" id="study-readiness-3-status">
+										<strong
+											id="study-readiness-participants-status"
+											class="govuk-tag govuk-tag--yellow study-readiness-status"
+										>
+											Action needed
+										</strong>
+									</div>
+								</li>
 
-								<div id="study-readiness-5-hint" class="govuk-task-list__hint">
-									<span id="study-readiness-consent-materials-hint" class="study-readiness-hint">
-										Create, review and publish consent forms before recording participant consent.
-									</span>
-								</div>
-							</div>
-							<div class="govuk-task-list__status" id="study-readiness-5-status">
-								<strong
-									id="study-readiness-consent-materials-status"
-									class="govuk-tag govuk-tag--yellow study-readiness-status"
-								>
-									Action needed
-								</strong>
-							</div>
-						</li>
+								<li class="govuk-task-list__item">
+									<div class="govuk-task-list__name-and-hint">
+										<div>Discussion guide</div>
 
-						<li class="govuk-task-list__item">
-							<div class="govuk-task-list__name-and-hint">
-								<div>Participant consent</div>
+										<div id="study-readiness-4-hint" class="govuk-task-list__hint">
+											<span id="study-readiness-guide-hint" class="study-readiness-hint">
+												Create or review the discussion guide.
+											</span>
+										</div>
+									</div>
+									<div class="govuk-task-list__status" id="study-readiness-4-status">
+										<strong
+											id="study-readiness-guide-status"
+											class="govuk-tag govuk-tag--yellow study-readiness-status"
+										>
+											Action needed
+										</strong>
+									</div>
+								</li>
 
-								<div id="study-readiness-6-hint" class="govuk-task-list__hint">
-									<span id="study-readiness-participant-consent-hint" class="study-readiness-hint">
-										Record required participant consent before running sessions.
-									</span>
-								</div>
-							</div>
-							<div class="govuk-task-list__status" id="study-readiness-6-status">
-								<strong
-									id="study-readiness-participant-consent-status"
-									class="govuk-tag govuk-tag--yellow study-readiness-status"
-								>
-									Action needed
-								</strong>
-							</div>
-						</li>
+								<li class="govuk-task-list__item">
+									<div class="govuk-task-list__name-and-hint">
+										<div>Consent materials</div>
 
-						<li class="govuk-task-list__item">
-							<div class="govuk-task-list__name-and-hint">
-								<div>Session workspace</div>
+										<div id="study-readiness-5-hint" class="govuk-task-list__hint">
+											<span id="study-readiness-consent-materials-hint" class="study-readiness-hint">
+												Create, review and publish consent forms before recording participant consent.
+											</span>
+										</div>
+									</div>
+									<div class="govuk-task-list__status" id="study-readiness-5-status">
+										<strong
+											id="study-readiness-consent-materials-status"
+											class="govuk-tag govuk-tag--yellow study-readiness-status"
+										>
+											Action needed
+										</strong>
+									</div>
+								</li>
 
-								<div id="study-readiness-7-hint" class="govuk-task-list__hint">
-									<span id="study-readiness-session-hint" class="study-readiness-hint">
-										Complete study readiness tasks before beginning a session.
-									</span>
-								</div>
-							</div>
-							<div class="govuk-task-list__status" id="study-readiness-7-status">
-								<strong id="study-readiness-session-status" class="govuk-tag govuk-tag--grey study-readiness-status">
-									Not available yet
-								</strong>
-							</div>
-						</li>
-					</ul>
+								<li class="govuk-task-list__item">
+									<div class="govuk-task-list__name-and-hint">
+										<div>Participant consent</div>
 
-					<a
-						href="#"
-						role="button"
-						draggable="false"
-						class="govuk-button study-session-button"
-						data-module="govuk-button"
-						id="link-session"
-						hidden="hidden"
-					>
-						Begin session
-					</a>
-				</section>
+										<div id="study-readiness-6-hint" class="govuk-task-list__hint">
+											<span id="study-readiness-participant-consent-hint" class="study-readiness-hint">
+												Record required participant consent before running sessions.
+											</span>
+										</div>
+									</div>
+									<div class="govuk-task-list__status" id="study-readiness-6-status">
+										<strong
+											id="study-readiness-participant-consent-status"
+											class="govuk-tag govuk-tag--yellow study-readiness-status"
+										>
+											Action needed
+										</strong>
+									</div>
+								</li>
 
-				<section class="study-section govuk-!-margin-bottom-8" aria-labelledby="study-setup-title">
+								<li class="govuk-task-list__item">
+									<div class="govuk-task-list__name-and-hint">
+										<div>Session workspace</div>
+
+										<div id="study-readiness-7-hint" class="govuk-task-list__hint">
+											<span id="study-readiness-session-hint" class="study-readiness-hint">
+												Complete study readiness tasks before beginning a session.
+											</span>
+										</div>
+									</div>
+									<div class="govuk-task-list__status" id="study-readiness-7-status">
+										<strong
+											id="study-readiness-session-status"
+											class="govuk-tag govuk-tag--grey study-readiness-status"
+										>
+											Not available yet
+										</strong>
+									</div>
+								</li>
+							</ul>
+						</section>
+					</aside>
+				</div>
+
+				<section class="study-section study-section--flush govuk-!-margin-bottom-8" aria-labelledby="study-setup-title">
 					<h2 id="study-setup-title" class="govuk-heading-m">Study setup tasks</h2>
 
 					<ul class="govuk-task-list study-setup-task-list">
@@ -410,14 +438,17 @@
 					</ul>
 				</section>
 
-				<section class="study-section govuk-!-margin-bottom-8" aria-labelledby="study-analysis-title">
+				<section
+					class="study-section study-section--flush govuk-!-margin-bottom-8"
+					aria-labelledby="study-analysis-title"
+				>
 					<h2 id="study-analysis-title" class="govuk-heading-m">Study analysis tasks</h2>
 
 					<ul class="govuk-task-list study-analysis-task-list">
 						<li class="govuk-task-list__item">
 							<div class="govuk-task-list__name-and-hint">
 								<div>
-									<a id="link-synthesis" class="govuk-link govuk-task-list__link" href="#">Synthesize study evidence</a>
+									<a id="link-synthesis" class="govuk-link govuk-task-list__link" href="#">Synthesise study evidence</a>
 								</div>
 
 								<div id="study-analysis-1-hint" class="govuk-task-list__hint">

--- a/src/govuk/templates/pages/study.njk
+++ b/src/govuk/templates/pages/study.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/task-list/macro.njk" import govukTaskList %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set studyPageScriptVersion = "study-readiness-session-gate-20260605" %}
 
@@ -76,7 +77,7 @@
 	</div>
 
 	<header class="study-hero govuk-!-margin-bottom-6" typeof="schema:ResearchProject" resource="#study">
-		<p id="study-eyebrow" class="govuk-caption-m">Study</p>
+		<p id="study-eyebrow" class="govuk-caption-m">Project</p>
 		<h1 id="study-title" class="govuk-heading-l" property="schema:name">Study</h1>
 		<div id="desc-view-wrap" class="study-description" property="schema:description">
 			<div id="description" class="govuk-body">—</div>
@@ -137,83 +138,95 @@
 		<p id="desc-status" class="govuk-body-s" role="status" aria-live="polite" aria-atomic="true"></p>
 	</header>
 
-	<section class="study-key-information govuk-!-margin-bottom-8" aria-labelledby="study-key-information-title">
-		<h2 id="study-key-information-title" class="govuk-heading-m">Study details</h2>
-		{{ govukSummaryList({
-			classes: "study-summary-list",
-			rows: [
-				{
-					key: { text: "Method" },
-					value: { html: '<span id="kv-method">–</span>' }
-				},
-				{
-					key: { text: "Status" },
-					value: { html: '<span id="kv-status">–</span>' }
-				},
-				{
-					key: { text: "Study ID" },
-					value: { html: '<span id="kv-studyid">–</span>' }
-				}
-			]
-		}) }}
-	</section>
+	<div class="govuk-grid-row study-overview-grid">
+		<div class="govuk-grid-column-one-half">
+			<section class="study-key-information govuk-!-margin-bottom-8" aria-labelledby="study-key-information-title">
+				<h2 id="study-key-information-title" class="govuk-heading-m">Study details</h2>
+				{{ govukSummaryList({
+					classes: "study-summary-list",
+					rows: [
+						{
+							key: { text: "Method" },
+							value: { html: '<span id="kv-method">–</span>' }
+						},
+						{
+							key: { text: "Status" },
+							value: { html: '<span id="kv-status">–</span>' }
+						},
+						{
+							key: { text: "Study ID" },
+							value: { html: '<span id="kv-studyid">–</span>' }
+						}
+					]
+				}) }}
+			</section>
 
-	<section class="study-section study-readiness-section govuk-!-margin-bottom-8" aria-labelledby="study-readiness-title">
-		<h2 id="study-readiness-title" class="govuk-heading-m">Study readiness</h2>
-		<p class="govuk-body">Check the essentials before you run a session.</p>
-		{{ govukTaskList({
-			idPrefix: "study-readiness",
-			classes: "study-readiness-task-list",
-			items: [
-				{
-					title: { text: "Description" },
-					hint: { html: '<span id="study-readiness-description-hint" class="study-readiness-hint">Checking study description.</span>' },
-					status: { html: '<strong id="study-readiness-description-status" class="govuk-tag govuk-tag--grey study-readiness-status">Checking</strong>' }
-				},
-				{
-					title: { text: "Status" },
-					hint: { html: '<span id="study-readiness-status-hint" class="study-readiness-hint">Checking study status.</span>' },
-					status: { html: '<strong id="study-readiness-status-status" class="govuk-tag govuk-tag--grey study-readiness-status">Checking</strong>' }
-				},
-				{
-					title: { text: "Participants" },
-					hint: { html: '<span id="study-readiness-participants-hint" class="study-readiness-hint">Add or review participants for this study.</span>' },
-					status: { html: '<strong id="study-readiness-participants-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
-				},
-				{
-					title: { text: "Discussion guide" },
-					hint: { html: '<span id="study-readiness-guide-hint" class="study-readiness-hint">Create or review the discussion guide.</span>' },
-					status: { html: '<strong id="study-readiness-guide-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
-				},
-				{
-					title: { text: "Consent materials" },
-					hint: { html: '<span id="study-readiness-consent-materials-hint" class="study-readiness-hint">Create, review and publish consent forms before recording participant consent.</span>' },
-					status: { html: '<strong id="study-readiness-consent-materials-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
-				},
-				{
-					title: { text: "Participant consent" },
-					hint: { html: '<span id="study-readiness-participant-consent-hint" class="study-readiness-hint">Record required participant consent before running sessions.</span>' },
-					status: { html: '<strong id="study-readiness-participant-consent-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
-				},
-				{
-					title: { text: "Session workspace" },
-					hint: { html: '<span id="study-readiness-session-hint" class="study-readiness-hint">Complete study readiness tasks before beginning a session.</span>' },
-					status: { html: '<strong id="study-readiness-session-status" class="govuk-tag govuk-tag--grey study-readiness-status">Not available yet</strong>' }
-				}
-			]
-		}) }}
-		{{ govukButton({
-			text: "Begin session",
-			href: "#",
-			classes: "study-session-button",
-			attributes: {
-				id: "link-session",
-				hidden: "hidden"
-			}
-		}) }}
-	</section>
+			<section class="study-section study-session-gate-section govuk-!-margin-bottom-8" aria-labelledby="study-session-gate-title">
+				<h2 id="study-session-gate-title" class="govuk-heading-m">Before you can begin a session</h2>
+				{{ govukInsetText({
+					classes: "study-session-gate",
+					html: '<h3 id="study-session-gate-summary" class="govuk-heading-s">Checking study readiness</h3><p id="study-session-gate-message" class="govuk-body">Checking the required setup tasks before fieldwork can begin.</p><ul id="study-session-blockers" class="govuk-list govuk-list--bullet"><li>Checking readiness tasks.</li></ul><div id="study-session-action" hidden>' + govukButton({
+						text: "Begin session",
+						href: "#",
+						classes: "study-session-button",
+						attributes: {
+							id: "link-session",
+							hidden: "hidden"
+						}
+					}) + '</div>'
+				}) }}
+			</section>
+		</div>
 
-	<section class="study-section govuk-!-margin-bottom-8" aria-labelledby="study-setup-title">
+		<aside class="govuk-grid-column-one-half study-readiness-column" aria-labelledby="study-readiness-title">
+			<section class="study-readiness-section govuk-!-margin-bottom-8">
+				<h2 id="study-readiness-title" class="govuk-heading-m">Study readiness</h2>
+				{{ govukTaskList({
+					idPrefix: "study-readiness",
+					classes: "study-readiness-task-list",
+					items: [
+						{
+							title: { text: "Description" },
+							hint: { html: '<span id="study-readiness-description-hint" class="study-readiness-hint">Checking study description.</span>' },
+							status: { html: '<strong id="study-readiness-description-status" class="govuk-tag govuk-tag--grey study-readiness-status">Checking</strong>' }
+						},
+						{
+							title: { text: "Status" },
+							hint: { html: '<span id="study-readiness-status-hint" class="study-readiness-hint">Checking study status.</span>' },
+							status: { html: '<strong id="study-readiness-status-status" class="govuk-tag govuk-tag--grey study-readiness-status">Checking</strong>' }
+						},
+						{
+							title: { text: "Participants" },
+							hint: { html: '<span id="study-readiness-participants-hint" class="study-readiness-hint">Add or review participants for this study.</span>' },
+							status: { html: '<strong id="study-readiness-participants-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
+						},
+						{
+							title: { text: "Discussion guide" },
+							hint: { html: '<span id="study-readiness-guide-hint" class="study-readiness-hint">Create or review the discussion guide.</span>' },
+							status: { html: '<strong id="study-readiness-guide-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
+						},
+						{
+							title: { text: "Consent materials" },
+							hint: { html: '<span id="study-readiness-consent-materials-hint" class="study-readiness-hint">Create, review and publish consent forms before recording participant consent.</span>' },
+							status: { html: '<strong id="study-readiness-consent-materials-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
+						},
+						{
+							title: { text: "Participant consent" },
+							hint: { html: '<span id="study-readiness-participant-consent-hint" class="study-readiness-hint">Record required participant consent before running sessions.</span>' },
+							status: { html: '<strong id="study-readiness-participant-consent-status" class="govuk-tag govuk-tag--yellow study-readiness-status">Action needed</strong>' }
+						},
+						{
+							title: { text: "Session workspace" },
+							hint: { html: '<span id="study-readiness-session-hint" class="study-readiness-hint">Complete study readiness tasks before beginning a session.</span>' },
+							status: { html: '<strong id="study-readiness-session-status" class="govuk-tag govuk-tag--grey study-readiness-status">Not available yet</strong>' }
+						}
+					]
+				}) }}
+			</section>
+		</aside>
+	</div>
+
+	<section class="study-section study-section--flush govuk-!-margin-bottom-8" aria-labelledby="study-setup-title">
 		<h2 id="study-setup-title" class="govuk-heading-m">Study setup tasks</h2>
 		{{ govukTaskList({
 			idPrefix: "study-setup",
@@ -248,14 +261,14 @@
 		}) }}
 	</section>
 
-	<section class="study-section govuk-!-margin-bottom-8" aria-labelledby="study-analysis-title">
+	<section class="study-section study-section--flush govuk-!-margin-bottom-8" aria-labelledby="study-analysis-title">
 		<h2 id="study-analysis-title" class="govuk-heading-m">Study analysis tasks</h2>
 		{{ govukTaskList({
 			idPrefix: "study-analysis",
 			classes: "study-analysis-task-list",
 			items: [
 				{
-					title: { html: '<a id="link-synthesis" class="govuk-link govuk-task-list__link" href="#">Synthesize study evidence</a>' },
+					title: { html: '<a id="link-synthesis" class="govuk-link govuk-task-list__link" href="#">Synthesise study evidence</a>' },
 					hint: { text: "Group evidence notes into working cluster groupings and create traceable study-level themes." },
 					status: { html: '<strong class="govuk-tag govuk-tag--grey">Available when evidence is captured</strong>' }
 				}

--- a/src/styles/study-page.scss
+++ b/src/styles/study-page.scss
@@ -1,9 +1,4 @@
 // prettier-ignore
-.study-page {
-	max-width: 1100px;
-}
-
-// prettier-ignore
 .study-action-bar {
 	justify-content: flex-end;
 	margin-bottom: 32px;
@@ -32,15 +27,38 @@
 
 // prettier-ignore
 .study-key-information,
-.study-summary-list,
-.study-readiness-section {
-	max-width: 960px;
+.study-summary-list {
+	margin-bottom: 0;
 }
 
 // prettier-ignore
 .study-section {
 	border-top: 1px solid #b1b4b6;
 	padding-top: 24px;
+}
+
+// prettier-ignore
+.study-section--flush,
+.study-readiness-section {
+	border-top: 0;
+	padding-top: 0;
+}
+
+// prettier-ignore
+.study-overview-grid {
+	margin-bottom: 48px;
+}
+
+// prettier-ignore
+.study-session-gate .govuk-heading-s,
+.study-session-gate .govuk-body,
+.study-session-gate .govuk-list {
+	margin-bottom: 16px;
+}
+
+// prettier-ignore
+.study-session-gate .govuk-button {
+	margin-bottom: 0;
 }
 
 // prettier-ignore
@@ -64,7 +82,14 @@
 // prettier-ignore
 .govuk-task-list__item .govuk-tag {
 	max-width: 100%;
+	margin-top: 10px;
 	text-align: left;
+}
+
+// prettier-ignore
+.study-analysis-task-list .govuk-tag {
+	max-width: 200px;
+	white-space: normal;
 }
 
 // prettier-ignore

--- a/tests/study-page-route-state.test.js
+++ b/tests/study-page-route-state.test.js
@@ -24,6 +24,7 @@ for (const macro of [
 	"govukBreadcrumbs({",
 	"govukButton({",
 	"govukDetails({",
+	"govukInsetText({",
 	"govukNotificationBanner({",
 	"govukSummaryList({",
 	"govukTaskList({",
@@ -44,6 +45,12 @@ for (const text of [
 	"id=\"kv-method\"",
 	"id=\"kv-status\"",
 	"id=\"kv-studyid\"",
+	"govuk-grid-row study-overview-grid",
+	"govuk-grid-column-one-half",
+	"study-session-gate",
+	"id=\"study-session-gate-summary\"",
+	"id=\"study-session-blockers\"",
+	"id=\"study-session-action\"",
 	"id=\"study-readiness-description-status\"",
 	"id=\"study-readiness-participant-consent-hint\"",
 	"id: \"link-session\"",
@@ -80,10 +87,17 @@ for (const text of [
 	"id=\"study-error\"",
 	"role=\"alert\"",
 	"Study readiness",
+	"Before you can begin a session",
 	"Study setup tasks",
 	"Study analysis tasks",
-	"Synthesize study evidence",
+	"Synthesise study evidence",
 	"Group evidence notes into working cluster groupings and create traceable study-level themes.",
+	"class=\"govuk-grid-row study-overview-grid\"",
+	"class=\"govuk-grid-column-one-half\"",
+	"class=\"govuk-inset-text study-session-gate\"",
+	"id=\"study-session-gate-summary\"",
+	"id=\"study-session-blockers\"",
+	"id=\"study-session-action\"",
 	"id=\"study-readiness-description-status\"",
 	"id=\"study-readiness-session-hint\"",
 	"id=\"link-session\"",
@@ -114,6 +128,8 @@ for (const text of [
 	"apiUrl(\"/api/studies\")",
 	"showError",
 	"renderReadiness",
+	"function renderSessionGatePanel",
+	"function blockerActionForKey",
 	"async function loadReadinessContext",
 	"function evaluateReadiness",
 	"function renderSessionGate",
@@ -122,6 +138,9 @@ for (const text of [
 	"study-readiness-${key}-status",
 	"study-readiness-${key}-hint",
 	"govuk-tag ${readinessTagClass(state)} study-readiness-status",
+	"summary.textContent = \"This study is ready to run\"",
+	"message.textContent = \"Complete these tasks before starting fieldwork.\"",
+	"setText(\"#study-eyebrow\", projectName)",
 	"loadStudyCollection(\"/api/participant-consent\"",
 	"participantConsentRecords",
 	"consentMaterials",
@@ -146,9 +165,23 @@ excludes(controllerSource, "querySelector(\".readiness-item__body\")", "study pa
 excludes(controllerSource, "route(\"/pages/synthesize/\", params)", "study page controller");
 excludes(controllerSource, "alert(", "study page controller");
 
-for (const text of [".study-page", ".study-action-bar", ".study-readiness-task-list", ".study-session-button", ".govuk-task-list__item .govuk-tag", "/* transparency begins in the cascade */"]) {
+for (const text of [
+	".study-action-bar",
+	".study-overview-grid",
+	".study-session-gate",
+	".study-readiness-task-list",
+	".study-session-button",
+	".govuk-task-list__item .govuk-tag",
+	".study-analysis-task-list .govuk-tag",
+	"/* transparency begins in the cascade */"
+]) {
 	includes(studyScssSource, text, "study SCSS source");
 	includes(studyCssSource, text, "study css");
+}
+
+for (const legacy of ["max-width: 1100px", "max-width: 960px"]) {
+	excludes(studyScssSource, legacy, "study SCSS source");
+	excludes(studyCssSource, legacy, "study css");
 }
 
 for (const legacy of [".study-task-card", ".study-readiness-list", ".readiness-item"]) {


### PR DESCRIPTION
## Summary

Applies the reviewed Study page layout to `/pages/study/?id=<StudyID>&project=<ProjectID>` using GOV.UK Frontend Nunjucks macros and grid classes.

## Changes

- Moves Study details and the session readiness gate into the left `govuk-grid-column-one-half` column.
- Moves the full Study readiness task list into the right `govuk-grid-column-one-half` column.
- Uses GOV.UK grid/container values rather than custom column widths or gutters.
- Adds a GOV.UK inset text gate summarising blocker links before a session can begin.
- Keeps `Begin session` hidden until full Study readiness is complete.
- Populates the page caption from the linked project name.
- Changes readiness Status from `Set` to `Ready` when present.
- Updates `Synthesize study evidence` to British English: `Synthesise study evidence`.
- Updates route-state coverage and the agent audit trace.

## Validation

Passed locally:

- `node --test tests/study-page-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js`
- `node scripts/govuk/render-govuk-pages.mjs`
- `node scripts/styles/format-generated-css.mjs --check`
- `node scripts/agent-trace/assert-trace-coverage.mjs`
- `git diff --check`
- `prettier --check` on changed supported files
- `node --test` with 176 passing tests

## Trace

- `docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.md`
- `docs/agent-audit/reasoning/2026/06/05/study-page-govuk-readiness.json`