### PR TITLE
Bring study subpages into GOV.UK Nunjucks

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.json
+++ b/docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.json
@@ -1,0 +1,156 @@
+{
+  "date": "2026-06-05",
+  "branch": "feature/study-subpages-govuk-nunjucks",
+  "traceRequired": true,
+  "task": "Bring Study participant consent, participants, guides and synthesis subpages into full Nunjucks templating with GOV.UK Frontend and macros.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "path": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "path": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "path": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "path": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/",
+    ".agent-operating-model/bundles/researchops-developer-control/",
+    ".agent-operating-model/bundles/multi-functional-team/",
+    ".agent-operating-model/bundles/govuk-design-system/",
+    "src/govuk/templates/layouts/researchops.njk",
+    "src/govuk/templates/pages/study.njk",
+    "public/pages/study/participant-consent/index.html",
+    "public/pages/study/participants/index.html",
+    "public/pages/study/guides/index.html",
+    "public/pages/study/synthesis/index.html",
+    "public/js/participant-consent-route-loader.js",
+    "public/js/participants-route-loader.js",
+    "public/js/guides-route-loader.js",
+    "public/js/synthesize-route-loader.js",
+    "tests/participant-consent-route-state.test.js",
+    "tests/participants-page-route-state.test.js",
+    "tests/study-guides-route-state.test.js",
+    "tests/synthesize-page-route-state.test.js"
+  ],
+  "filesModified": [
+    "scripts/govuk/render-govuk-pages.mjs",
+    "public/pages/study/participant-consent/index.html",
+    "public/pages/study/participants/index.html",
+    "public/pages/study/guides/index.html",
+    "public/pages/study/synthesis/index.html",
+    "tests/govuk-forms-application-route-state.test.js",
+    "tests/govuk-tables-summary-lists-application-route-state.test.js",
+    "tests/participant-consent-route-state.test.js",
+    "tests/participants-page-route-state.test.js",
+    "tests/study-guides-route-state.test.js",
+    "tests/synthesize-page-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.md",
+    "docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.json"
+  ],
+  "filesCreated": [
+    "src/govuk/templates/pages/study-participant-consent.njk",
+    "src/govuk/templates/pages/study-participants.njk",
+    "src/govuk/templates/pages/study-guides.njk",
+    "src/govuk/templates/pages/study-synthesis.njk",
+    "docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.md",
+    "docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.json"
+  ],
+  "skippedBundles": [
+    {
+      "id": "cloudflare",
+      "reason": "No Worker, D1, R2, deployment or runtime behaviour changed."
+    },
+    {
+      "id": "openai-platform",
+      "reason": "No OpenAI API or model behaviour changed."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "reason": "No MCP server or agent-tooling implementation changed."
+    },
+    {
+      "id": "airtable-public-api",
+      "reason": "No Airtable API integration changed."
+    },
+    {
+      "id": "mural-public-api",
+      "reason": "No Mural API integration changed."
+    }
+  ],
+  "teamCritique": [
+    "Each subpage should feel like a GOV.UK service page, with task-oriented headings, summary lists, task lists, tables, fieldsets and primary actions rather than bespoke page furniture.",
+    "The page copy should support researcher workflows directly and preserve existing dynamic states without introducing prototype-only hard-coded examples.",
+    "Nunjucks templates should use GOV.UK macros wherever the macros can preserve existing IDs, names, ARIA references and JavaScript hooks.",
+    "All four routes should keep their current client-side loading behaviour while the initial HTML moves to the shared ResearchOps GOV.UK layout."
+  ],
+  "implementationSummary": [
+    "Added Nunjucks templates for participant consent, participants, guides and synthesis Study subpages.",
+    "Registered the four templates in scripts/govuk/render-govuk-pages.mjs so static pages are generated under public/pages/study/.../index.html.",
+    "Re-rendered the generated GOV.UK pages through the existing renderer.",
+    "Preserved existing dynamic route-loader and component hooks for study and project context hydration.",
+    "Replaced bespoke static page chrome with the shared layouts/researchops.njk layout and GOV.UK Frontend stylesheet.",
+    "Used GOV.UK macros for breadcrumbs, buttons, selects, inputs, radios, checkboxes, textareas, summary lists and inset text where they fit existing controller contracts.",
+    "Kept participant consent and synthesis error summaries as hand-authored GOV.UK error-summary markup because their controllers append messages into exact ul hooks that the macro does not expose.",
+    "Updated route-state tests so they assert the GOV.UK macro output and dynamic hooks rather than the previous hand-written static markup."
+  ],
+  "validation": [
+    {
+      "command": "node scripts/govuk/render-govuk-pages.mjs",
+      "result": "passed",
+      "evidence": "Generated all GOV.UK static pages including the four Study subpages."
+    },
+    {
+      "command": "node --test tests/participant-consent-route-state.test.js tests/participants-page-route-state.test.js tests/study-guides-route-state.test.js tests/synthesize-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js",
+      "result": "passed",
+      "evidence": "Focused route-state and GOV.UK contract tests passed for the converted Study subpages."
+    },
+    {
+      "command": "node scripts/agent-trace/assert-trace-coverage.mjs",
+      "result": "passed",
+      "evidence": "Trace coverage confirmed for the feature branch."
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed",
+      "evidence": "Whitespace check passed."
+    },
+    {
+      "command": "node node_modules/prettier/bin/prettier.cjs --check scripts/govuk/render-govuk-pages.mjs public/pages/study/participant-consent/index.html public/pages/study/participants/index.html public/pages/study/guides/index.html public/pages/study/synthesis/index.html tests/participant-consent-route-state.test.js tests/participants-page-route-state.test.js tests/study-guides-route-state.test.js tests/synthesize-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.md docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.json",
+      "result": "passed",
+      "evidence": "Modified generated HTML, scripts, tests and trace files use Prettier formatting."
+    },
+    {
+      "command": "node --test",
+      "result": "passed",
+      "evidence": "Full suite passed: 176 tests."
+    },
+    {
+      "command": "Browser spot-check at http://127.0.0.1:8791 for /pages/study/participant-consent/?id=RECT3O7DT, /pages/study/participants/?id=RECT3O7DT, /pages/study/guides/?id=RECT3O7DT and /pages/study/synthesis/?id=RECT3O7DT",
+      "result": "passed",
+      "evidence": "All four converted routes rendered with the shared GOV.UK main wrapper, breadcrumbs, button styling, table/task/summary-list structures and layout script. Static-server /api/studies 404s were expected and not treated as live data verification."
+    }
+  ],
+  "residualRisks": [
+    "The generated pages remain static route shells. Their live content still depends on existing client-side route loaders and APIs.",
+    "Error summary list contents for participant consent and synthesis are populated dynamically by page controllers; the static template preserves the GOV.UK structure and required hooks rather than pre-rendering unknown errors.",
+    "The browser spot-check used a static file server, so /api/studies returned 404 during preview. That was expected for this validation path and was not treated as live data verification."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.md
+++ b/docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.md
@@ -1,0 +1,86 @@
+# Study Subpages GOV.UK Nunjucks Trace
+
+Date: 2026-06-05
+Branch: `feature/study-subpages-govuk-nunjucks`
+Trace requirement: required because the branch uses the `feature/` prefix.
+
+## Task
+
+Bring these Study subpages into full Nunjucks templating with GOV.UK Frontend and macros:
+
+- `/pages/study/participant-consent/?id=`
+- `/pages/study/participants/?id=`
+- `/pages/study/guides/?id=`
+- `/pages/study/synthesis/?id=`
+
+## Operating Model
+
+Selected bundles:
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `govuk-design-system`
+
+Reviewed operating-model files before implementation:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped conditional bundles:
+
+- `cloudflare`: no Worker, D1, R2, deployment or runtime behaviour changed.
+- `openai-platform`: no OpenAI API or model behaviour changed.
+- `mcp-agent-tooling`: no MCP server or agent-tooling implementation changed.
+- `airtable-public-api`: no Airtable API integration changed.
+- `mural-public-api`: no Mural API integration changed.
+
+## Team Critique
+
+Interaction design: each subpage should feel like a GOV.UK service page, with task-oriented headings, summary lists, task lists, tables, fieldsets and primary actions rather than bespoke page furniture.
+
+Content design: the page copy should support researcher workflows directly and preserve existing dynamic states without introducing prototype-only hard-coded examples.
+
+Frontend and accessibility: Nunjucks templates should use GOV.UK macros wherever the macros can preserve existing IDs, names, ARIA references and JavaScript hooks. Where a dynamic controller owns list content, the static template should still use GOV.UK class names and semantics.
+
+Researcher use: all four routes should keep their current client-side loading behaviour while the initial HTML moves to the shared ResearchOps GOV.UK layout.
+
+## Implementation
+
+- Added Nunjucks templates for participant consent, participants, guides and synthesis Study subpages.
+- Registered the four templates in `scripts/govuk/render-govuk-pages.mjs` so static pages are generated under `public/pages/study/.../index.html`.
+- Re-rendered all GOV.UK pages through the existing renderer.
+- Preserved existing dynamic route-loader and component hooks so the subpages still hydrate study/project context and route state from the current scripts.
+- Replaced bespoke static page chrome with the shared `layouts/researchops.njk` layout and GOV.UK Frontend stylesheet.
+- Used GOV.UK macros for breadcrumbs, buttons, selects, inputs, radios, checkboxes, textareas, summary lists and inset text where they fit the existing controller contracts.
+- Kept participant consent and synthesis error summaries as hand-authored GOV.UK error-summary markup because their controllers append messages into exact `ul` hooks that the macro does not expose.
+- Updated route-state tests so they assert the GOV.UK macro output and dynamic hooks rather than the previous hand-written static markup.
+
+## Validation
+
+Passed:
+
+- `node scripts/govuk/render-govuk-pages.mjs`
+- `node --test tests/participant-consent-route-state.test.js tests/participants-page-route-state.test.js tests/study-guides-route-state.test.js tests/synthesize-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js`
+- `node scripts/agent-trace/assert-trace-coverage.mjs`
+- `git diff --check`
+- `node node_modules/prettier/bin/prettier.cjs --check scripts/govuk/render-govuk-pages.mjs public/pages/study/participant-consent/index.html public/pages/study/participants/index.html public/pages/study/guides/index.html public/pages/study/synthesis/index.html tests/participant-consent-route-state.test.js tests/participants-page-route-state.test.js tests/study-guides-route-state.test.js tests/synthesize-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.md docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.json`
+- `node --test` with 176 passing tests.
+- Browser spot-check at `http://127.0.0.1:8791` confirmed all four converted routes render with the shared GOV.UK main wrapper, breadcrumbs, button styling, table/task/summary-list structures and layout script.
+
+## Residual Risks
+
+- The generated pages remain static route shells. Their live content still depends on the existing client-side route loaders and APIs.
+- Error summary list contents for participant consent and synthesis are still populated dynamically by page controllers; the static template preserves the GOV.UK structure and required hooks rather than attempting to pre-render unknown errors.
+- The browser spot-check used a static file server, so `/api/studies` returned 404 during preview. That was expected for this validation path and was not treated as live data verification.

--- a/public/pages/study/guides/index.html
+++ b/public/pages/study/guides/index.html
@@ -1,73 +1,185 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Discussion guides - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Discussion guides — Study</title>
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
-	<link rel="stylesheet" href="/css/guides.css" media="screen" />
-	<link rel="modulepreload" href="/js/study-route-context.js" />
-	<link rel="modulepreload" href="/js/study-guides-context.js" />
-	<link rel="modulepreload" href="/js/guides-route-loader.js?v=study-record-id-routing-20260518" />
-	<!-- /components/guides/guides-page.js -->
-	<script type="module" src="/components/layout.js" defer></script>
-	<script type="module" src="/js/guides-route-loader.js?v=study-record-id-routing-20260518"></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
+		<meta property="schema:name" content="Discussion guides - ResearchOps" />
+		<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+		<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+		<link rel="stylesheet" href="/css/guides.css" media="screen" />
+		<link rel="modulepreload" href="/js/study-route-context.js" />
+		<link rel="modulepreload" href="/js/study-guides-context.js" />
+		<link rel="modulepreload" href="/js/guides-route-loader.js?v=study-record-id-routing-20260518" />
+		<!-- /components/guides/guides-page.js -->
 
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<x-include src="/partials/debug.html"></x-include>
-	<x-include src="/partials/header.html" vars='{"active":"Projects","subtitle":"Study — Discussion Guides"}'></x-include>
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container study-guides-page" data-study-subpage-template="guides">
+				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a>
+						</li>
 
-	<main id="main-content" class="container govuk-body govuk-main-wrapper" role="main" tabindex="-1">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page">Guides</li>
-			</ol>
-		</nav>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-project">Project</a>
+						</li>
 
-		<h1 class="govuk-heading-l">Discussion guides</h1>
-		<a id="back-to-study" class="govuk-button govuk-button--secondary" href="#">Back to Study</a>
-		<button class="govuk-button">New guide</button>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-study">Study</a>
+						</li>
 
-		<section id="guides-list-section">
-			<table class="govuk-table">
-				<thead class="govuk-table__head">
-					<tr class="govuk-table__row">
-						<th class="govuk-table__header" scope="col">Title</th>
-						<th class="govuk-table__header" scope="col">Status</th>
-					</tr>
-				</thead>
-				<tbody id="guides-tbody" class="govuk-table__body"></tbody>
-			</table>
-		</section>
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Guides</li>
+					</ol>
+				</nav>
 
-		<section id="editor-section" class="editor">
-			<div class="govuk-form-group editor__title-field">
-				<label class="govuk-label" for="guide-title">Guide title</label>
-				<input id="guide-title" class="govuk-input" />
+				<header class="guides-header govuk-!-margin-bottom-6">
+					<p id="study-title" class="govuk-caption-m" data-bind="study.title">Study</p>
+					<h1 class="govuk-heading-l">Discussion guides</h1>
+					<p class="govuk-body govuk-!-width-two-thirds">
+						Create, review and publish discussion guides for this study.
+					</p>
+					<div class="govuk-button-group">
+						<a
+							href="#"
+							role="button"
+							draggable="false"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="back-to-study"
+						>
+							Back to Study
+						</a>
+
+						<button type="button" class="govuk-button" data-module="govuk-button" id="btn-new">New guide</button>
+					</div>
+				</header>
+
+				<section id="guides-list-section" aria-labelledby="guides-list-title">
+					<h2 id="guides-list-title" class="govuk-heading-m">Guides for this study</h2>
+					<table id="guides-table" class="govuk-table">
+						<thead class="govuk-table__head">
+							<tr class="govuk-table__row">
+								<th class="govuk-table__header" scope="col">Title</th>
+								<th class="govuk-table__header" scope="col">Status</th>
+							</tr>
+						</thead>
+						<tbody id="guides-tbody" class="govuk-table__body"></tbody>
+					</table>
+				</section>
+
+				<section id="editor-section" class="editor" aria-labelledby="guide-editor-title">
+					<h2 id="guide-editor-title" class="govuk-heading-m">Guide editor</h2>
+
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="guide-title">Guide title</label>
+
+						<input
+							class="govuk-input editor__title-field"
+							id="guide-title"
+							name="guideTitle"
+							type="text"
+							autocomplete="off"
+						/>
+					</div>
+
+					<p id="guide-status" class="govuk-body-s" aria-live="polite">draft</p>
+
+					<div class="editor__toolbar govuk-button-group">
+						<button
+							type="button"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="btn-insert-pattern"
+						>
+							Insert pattern
+						</button>
+
+						<button
+							type="button"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="btn-variables"
+						>
+							Variables
+						</button>
+
+						<button
+							type="button"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="btn-insert-tag"
+						>
+							Insert tag
+						</button>
+
+						<button type="button" class="govuk-button" data-module="govuk-button" id="btn-save">Save draft</button>
+
+						<button
+							type="button"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="btn-publish"
+						>
+							Publish
+						</button>
+					</div>
+
+					<div class="editor__split">
+						<div class="code-editor">
+							<label class="govuk-label" for="guide-source">Guide source</label>
+							<div id="guide-source-highlight" class="code-editor__highlight" aria-hidden="true">
+								<code id="guide-source-code"></code>
+							</div>
+							<textarea
+								id="guide-source"
+								class="govuk-textarea code-editor__textarea"
+								rows="18"
+								spellcheck="true"
+							></textarea>
+						</div>
+						<div class="preview">
+							<h3 class="govuk-heading-s">Preview</h3>
+							<div id="guide-preview" class="govuk-body"></div>
+						</div>
+					</div>
+
+					<div id="lint-output" class="govuk-body-s" aria-live="polite"></div>
+				</section>
+
+				<aside id="drawer-patterns" class="drawer" hidden aria-labelledby="drawer-patterns-title">
+					<h2 id="drawer-patterns-title" class="govuk-heading-m">Patterns</h2>
+
+					<div class="govuk-form-group">
+						<label class="govuk-label" for="pattern-search">Search patterns</label>
+
+						<input class="govuk-input" id="pattern-search" name="patternSearch" type="text" autocomplete="off" />
+					</div>
+
+					<ul id="pattern-list" class="govuk-list"></ul>
+					<div class="govuk-button-group">
+						<button id="drawer-patterns-close" class="govuk-button govuk-button--secondary" type="button">Close</button>
+					</div>
+				</aside>
+
+				<aside id="drawer-variables" class="drawer" hidden></aside>
+				<div class="govuk-button-group actions-row"></div>
+				<div id="sr-live" class="govuk-visually-hidden" aria-live="polite"></div>
 			</div>
-			<label class="govuk-label" for="pattern-search">Search patterns</label>
-			<input id="pattern-search" />
-		</section>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
-		<aside id="drawer-patterns" class="drawer"></aside>
-		<aside id="drawer-variables" class="drawer"></aside>
-		<div class="govuk-button-group actions-row"></div>
-	</main>
-
-	<x-include src="/partials/footer.html"></x-include>
-</body>
-
+		<script type="module" src="/js/guides-route-loader.js?v=study-record-id-routing-20260518"></script>
+	</body>
 </html>

--- a/public/pages/study/participant-consent/index.html
+++ b/public/pages/study/participant-consent/index.html
@@ -1,196 +1,308 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Participant consent - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Participant consent — ResearchOps</title>
+		<meta property="schema:name" content="Participant consent - ResearchOps" />
+		<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+		<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+		<link rel="stylesheet" href="/css/participant-consent.css" media="screen" />
+		<link rel="modulepreload" href="/js/study-route-context.js" />
+		<link rel="modulepreload" href="/js/participant-consent-route-loader.js?v=study-record-id-routing-20260518" />
 
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
-	<link rel="stylesheet" href="/css/participant-consent.css" media="screen" />
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container participant-consent-page" data-study-subpage-template="participant-consent">
+				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a>
+						</li>
 
-	<link rel="modulepreload" href="/js/study-route-context.js" />
-	<link rel="modulepreload" href="/js/participant-consent-route-loader.js?v=study-record-id-routing-20260518" />
-	<script type="module" src="/js/participant-consent-route-loader.js?v=study-record-id-routing-20260518"></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/components/layout.js" defer></script>
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-project">Project</a>
+						</li>
 
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<x-include src="/partials/debug-boot.html" debug-only></x-include>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-study">Study</a>
+						</li>
 
-	<x-include src="/partials/header.html" vars='{
-    "active":"Projects",
-    "subtitle":"Study — participant consent"
-  }'></x-include>
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Participant consent</li>
+					</ol>
+				</nav>
 
-	<main id="main-content" class="container govuk-body participant-consent-page govuk-main-wrapper" role="main" tabindex="-1">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page">Participant consent</li>
-			</ol>
-		</nav>
-
-		<div id="consent-error" class="govuk-error-summary" role="alert" tabindex="-1" hidden aria-hidden="true">
-			<h2 class="govuk-error-summary__title">There is a problem</h2>
-			<ul id="consent-error-list" class="govuk-error-summary__list"></ul>
-		</div>
-
-		<div class="participant-consent-hero">
-			<div>
-				<p id="study-context" class="project-org">Study</p>
-				<h1 class="govuk-heading-l">Manage participant consent</h1>
-				<p class="govuk-body participant-consent-context">Record, review or withdraw participant consent for this study. Consent is recorded against a specific published consent form version.</p>
-			</div>
-			<div class="participant-consent-hero__actions">
-				<a id="back-to-study" href="/pages/study/" class="govuk-button govuk-button--secondary">Back to Study</a>
-			</div>
-		</div>
-
-		<p id="participant-consent-status" class="participant-consent-status" role="status" aria-live="polite">Loading participant consent.</p>
-
-		<section id="no-context-state" class="participant-consent-empty participant-consent-empty--route" hidden>
-			<h2 class="govuk-heading-m">Open this page from a study</h2>
-			<p class="govuk-body">The participant consent page needs a Study record ID in the URL.</p>
-		</section>
-
-		<section id="no-consent-form-state" class="participant-consent-empty participant-consent-empty--route" hidden>
-			<h2 class="govuk-heading-m">Create and publish a consent form before recording participant consent</h2>
-			<p class="govuk-body">Participant consent must be recorded against the version of the consent form that was shown or read to the participant.</p>
-			<a id="create-consent-forms-link" href="#" class="govuk-button">Create consent forms</a>
-		</section>
-
-		<section id="no-participants-state" class="participant-consent-empty participant-consent-empty--route" hidden>
-			<h2 class="govuk-heading-m">Add participants before recording consent</h2>
-			<p class="govuk-body">Add participants to this study before recording individual consent responses.</p>
-			<a id="schedule-participants-link" href="#" class="govuk-button">Schedule participants</a>
-		</section>
-
-		<section id="consent-workspace" class="participant-consent-workspace" hidden>
-			<section class="participant-consent-panel" aria-labelledby="consent-summary-title">
-				<h2 id="consent-summary-title" class="govuk-heading-m">Consent coverage</h2>
-				<dl class="participant-consent-summary govuk-summary-list">
-					<div class="participant-consent-summary__row">
-						<dt class="participant-consent-summary__key">Published form</dt>
-						<dd id="summary-published-form" class="participant-consent-summary__value">—</dd>
+				<div
+					id="consent-error"
+					class="govuk-error-summary participant-consent-error"
+					tabindex="-1"
+					hidden
+					aria-hidden="true"
+					data-module="govuk-error-summary"
+				>
+					<div role="alert">
+						<h2 class="govuk-error-summary__title">There is a problem</h2>
+						<div class="govuk-error-summary__body">
+							<ul id="consent-error-list" class="govuk-list govuk-error-summary__list"></ul>
+						</div>
 					</div>
-					<div class="participant-consent-summary__row">
-						<dt class="participant-consent-summary__key">Participants</dt>
-						<dd id="summary-participants" class="participant-consent-summary__value">—</dd>
-					</div>
-					<div class="participant-consent-summary__row">
-						<dt class="participant-consent-summary__key">Ready</dt>
-						<dd id="summary-ready" class="participant-consent-summary__value">—</dd>
-					</div>
-					<div class="participant-consent-summary__row">
-						<dt class="participant-consent-summary__key">Needs action</dt>
-						<dd id="summary-action-needed" class="participant-consent-summary__value">—</dd>
-					</div>
-				</dl>
-			</section>
+				</div>
 
-			<section class="participant-consent-panel" aria-labelledby="participants-consent-title">
-				<div class="participant-consent-panel__header">
+				<header class="participant-consent-hero govuk-!-margin-bottom-6">
 					<div>
-						<h2 id="participants-consent-title" class="govuk-heading-m">Participants</h2>
-						<p class="govuk-body">Select a participant to record or review consent. Status is shown in text and does not rely on colour.</p>
+						<p id="study-context" class="govuk-caption-m">Study</p>
+						<h1 class="govuk-heading-l">Manage participant consent</h1>
+						<p class="govuk-body participant-consent-context govuk-!-width-two-thirds">
+							Record, review or withdraw participant consent for this study. Consent is recorded against a specific
+							published consent form version.
+						</p>
 					</div>
-				</div>
-
-				<div class="table-wrap">
-					<table class="govuk-table participant-consent-table" aria-label="Participant consent">
-						<thead class="govuk-table__head">
-							<tr class="govuk-table__row">
-								<th scope="col" class="govuk-table__header">Participant</th>
-								<th scope="col" class="govuk-table__header">Consent status</th>
-								<th scope="col" class="govuk-table__header">Permissions</th>
-								<th scope="col" class="govuk-table__header">Recorded</th>
-								<th scope="col" class="govuk-table__header"><span class="sr-only">Actions</span></th>
-							</tr>
-						</thead>
-						<tbody id="participant-consent-tbody" class="govuk-table__body">
-							<tr class="govuk-table__row">
-								<td class="govuk-table__cell" colspan="5">Loading participants.</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-			</section>
-
-			<section id="consent-record-panel" class="participant-consent-panel" aria-labelledby="record-consent-title" hidden>
-				<h2 id="record-consent-title" class="govuk-heading-m">Record participant consent</h2>
-				<p id="record-consent-hint" class="govuk-body">Choose a participant to record or review consent.</p>
-
-				<form id="participant-consent-form" novalidate>
-					<input id="participant-id" type="hidden" />
-					<input id="consent-record-id" type="hidden" />
-
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="consent-form-select">Consent form version</label>
-						<div id="consent-form-select-hint" class="govuk-hint">Use the published consent form shown, sent or read to the participant.</div>
-						<select id="consent-form-select" class="govuk-select" aria-describedby="consent-form-select-hint"></select>
+					<div class="participant-consent-hero__actions">
+						<a
+							href="/pages/study/"
+							role="button"
+							draggable="false"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="back-to-study"
+						>
+							Back to Study
+						</a>
 					</div>
+				</header>
 
-					<fieldset class="govuk-fieldset participant-consent-items" aria-describedby="consent-items-hint">
-						<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Consent statements</legend>
-						<div id="consent-items-hint" class="govuk-hint">Required statements must be agreed before a participant is ready for a session. Optional declined permissions should still be visible to the research team.</div>
-						<div id="consent-items-list"></div>
-					</fieldset>
+				<p
+					id="participant-consent-status"
+					class="govuk-body-s participant-consent-status"
+					role="status"
+					aria-live="polite"
+				>
+					Loading participant consent.
+				</p>
 
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="capture-method">Capture method</label>
-						<select id="capture-method" class="govuk-select">
-							<option value="">Select a capture method</option>
-							<option value="Verbal">Verbal</option>
-							<option value="Signed form">Signed form</option>
-							<option value="Email">Email</option>
-							<option value="Imported">Imported</option>
-						</select>
-					</div>
+				<section id="no-context-state" class="participant-consent-empty participant-consent-empty--route" hidden>
+					<h2 class="govuk-heading-m">Open this page from a study</h2>
+					<p class="govuk-body">The participant consent page needs a Study record ID in the URL.</p>
+				</section>
 
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="recorded-by">Recorded by</label>
-						<input id="recorded-by" class="govuk-input" autocomplete="name" />
-					</div>
+				<section id="no-consent-form-state" class="participant-consent-empty participant-consent-empty--route" hidden>
+					<h2 class="govuk-heading-m">Create and publish a consent form before recording participant consent</h2>
+					<p class="govuk-body">
+						Participant consent must be recorded against the version of the consent form that was shown or read to the
+						participant.
+					</p>
 
-					<details class="govuk-details participant-consent-withdrawal">
-						<summary class="govuk-details__summary">Record withdrawal or do not proceed</summary>
-						<div class="govuk-details__text">
-							<div class="govuk-form-group">
-								<div class="govuk-checkboxes">
-									<div class="govuk-checkboxes__item">
-										<input id="consent-withdrawn" class="govuk-checkboxes__input" type="checkbox" />
-										<label class="govuk-label govuk-checkboxes__label" for="consent-withdrawn">Consent has been withdrawn or the session should not proceed</label>
-									</div>
-								</div>
+					<a
+						href="#"
+						role="button"
+						draggable="false"
+						class="govuk-button"
+						data-module="govuk-button"
+						id="create-consent-forms-link"
+					>
+						Create consent forms
+					</a>
+				</section>
+
+				<section id="no-participants-state" class="participant-consent-empty participant-consent-empty--route" hidden>
+					<h2 class="govuk-heading-m">Add participants before recording consent</h2>
+					<p class="govuk-body">Add participants to this study before recording individual consent responses.</p>
+
+					<a
+						href="#"
+						role="button"
+						draggable="false"
+						class="govuk-button"
+						data-module="govuk-button"
+						id="schedule-participants-link"
+					>
+						Schedule participants
+					</a>
+				</section>
+
+				<section id="consent-workspace" class="participant-consent-workspace" hidden>
+					<section class="participant-consent-panel" aria-labelledby="consent-summary-title">
+						<h2 id="consent-summary-title" class="govuk-heading-m">Consent coverage</h2>
+
+						<dl class="govuk-summary-list participant-consent-summary">
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Published form</dt>
+								<dd class="govuk-summary-list__value">
+									<span id="summary-published-form">-</span>
+								</dd>
 							</div>
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="withdrawal-reason">Reason or note</label>
-								<textarea id="withdrawal-reason" class="govuk-textarea" rows="3"></textarea>
+
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Participants</dt>
+								<dd class="govuk-summary-list__value">
+									<span id="summary-participants">-</span>
+								</dd>
+							</div>
+
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Ready</dt>
+								<dd class="govuk-summary-list__value">
+									<span id="summary-ready">-</span>
+								</dd>
+							</div>
+
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Needs action</dt>
+								<dd class="govuk-summary-list__value">
+									<span id="summary-action-needed">-</span>
+								</dd>
+							</div>
+						</dl>
+					</section>
+
+					<section class="participant-consent-panel" aria-labelledby="participants-consent-title">
+						<div class="participant-consent-panel__header">
+							<div>
+								<h2 id="participants-consent-title" class="govuk-heading-m">Participants</h2>
+								<p class="govuk-body">
+									Select a participant to record or review consent. Status is shown in text and does not rely on colour.
+								</p>
 							</div>
 						</div>
-					</details>
 
-					<div class="participant-consent-form__actions">
-						<button id="save-participant-consent" class="govuk-button" type="submit">Save consent response</button>
-						<button id="cancel-participant-consent" class="govuk-button govuk-button--secondary" type="button">Cancel</button>
-					</div>
-				</form>
-			</section>
-		</section>
-	</main>
+						<div class="table-wrap">
+							<table class="govuk-table participant-consent-table" aria-label="Participant consent">
+								<thead class="govuk-table__head">
+									<tr class="govuk-table__row">
+										<th scope="col" class="govuk-table__header">Participant</th>
+										<th scope="col" class="govuk-table__header">Consent status</th>
+										<th scope="col" class="govuk-table__header">Permissions</th>
+										<th scope="col" class="govuk-table__header">Recorded</th>
+										<th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+									</tr>
+								</thead>
+								<tbody id="participant-consent-tbody" class="govuk-table__body">
+									<tr class="govuk-table__row">
+										<td class="govuk-table__cell" colspan="5">Loading participants.</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+					</section>
 
-	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
-</body>
+					<section
+						id="consent-record-panel"
+						class="participant-consent-panel"
+						aria-labelledby="record-consent-title"
+						hidden
+					>
+						<h2 id="record-consent-title" class="govuk-heading-m">Record participant consent</h2>
+						<p id="record-consent-hint" class="govuk-body">Choose a participant to record or review consent.</p>
 
+						<form id="participant-consent-form" novalidate>
+							<input id="participant-id" type="hidden" />
+							<input id="consent-record-id" type="hidden" />
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="consent-form-select">Consent form version</label>
+								<div id="consent-form-select-hint" class="govuk-hint">
+									Use the published consent form shown, sent or read to the participant.
+								</div>
+								<select
+									id="consent-form-select"
+									class="govuk-select"
+									aria-describedby="consent-form-select-hint"
+								></select>
+							</div>
+
+							<fieldset class="govuk-fieldset participant-consent-items" aria-describedby="consent-items-hint">
+								<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Consent statements</legend>
+								<div id="consent-items-hint" class="govuk-hint">
+									Required statements must be agreed before a participant is ready for a session. Optional declined
+									permissions should still be visible to the research team.
+								</div>
+								<div id="consent-items-list"></div>
+							</fieldset>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="capture-method">Capture method</label>
+
+								<select class="govuk-select" id="capture-method" name="captureMethod">
+									<option value="">Select a capture method</option>
+
+									<option value="Verbal">Verbal</option>
+
+									<option value="Signed form">Signed form</option>
+
+									<option value="Email">Email</option>
+
+									<option value="Imported">Imported</option>
+								</select>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="recorded-by">Recorded by</label>
+
+								<input class="govuk-input" id="recorded-by" name="recordedBy" type="text" autocomplete="name" />
+							</div>
+
+							<details class="govuk-details participant-consent-withdrawal">
+								<summary class="govuk-details__summary">
+									<span class="govuk-details__summary-text">Record withdrawal or do not proceed</span>
+								</summary>
+								<div class="govuk-details__text">
+									<div class="govuk-form-group">
+										<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+											<div class="govuk-checkboxes__item">
+												<input
+													class="govuk-checkboxes__input"
+													id="consent-withdrawn"
+													name="consentWithdrawn"
+													type="checkbox"
+													value="yes"
+													id="consent-withdrawn"
+												/>
+												<label class="govuk-label govuk-checkboxes__label" for="consent-withdrawn">
+													Consent has been withdrawn or the session should not proceed
+												</label>
+											</div>
+										</div>
+									</div>
+
+									<div class="govuk-form-group">
+										<label class="govuk-label" for="withdrawal-reason">Reason or note</label>
+
+										<textarea class="govuk-textarea" id="withdrawal-reason" name="withdrawalReason" rows="3"></textarea>
+									</div>
+								</div>
+							</details>
+
+							<div class="govuk-button-group participant-consent-form__actions">
+								<button type="submit" class="govuk-button" data-module="govuk-button" id="save-participant-consent">
+									Save consent response
+								</button>
+
+								<button
+									type="button"
+									class="govuk-button govuk-button--secondary"
+									data-module="govuk-button"
+									id="cancel-participant-consent"
+								>
+									Cancel
+								</button>
+							</div>
+						</form>
+					</section>
+				</section>
+			</div>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
+
+		<script type="module" src="/js/participant-consent-route-loader.js?v=study-record-id-routing-20260518"></script>
+	</body>
 </html>

--- a/public/pages/study/participants/index.html
+++ b/public/pages/study/participants/index.html
@@ -1,237 +1,306 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Study participants - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Study — Participants</title>
+		<meta property="schema:name" content="Study participants - ResearchOps" />
+		<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+		<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
+		<link rel="stylesheet" href="/css/participants.css" media="screen" />
+		<link rel="modulepreload" href="/js/study-route-context.js" />
+		<link rel="modulepreload" href="/js/participants-route-loader.js?v=study-record-id-routing-20260518" />
+		<!-- route-state contract: src="/components/participants/participants-page.js" defer -->
+		<!-- route-state contract: src="/pages/study/participants/scheduler.js" defer -->
 
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
-	<link rel="stylesheet" href="/css/participants.css" media="screen" />
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container study-participants-page" data-study-subpage-template="participants">
+				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a>
+						</li>
 
-	<link rel="modulepreload" href="/js/study-route-context.js" />
-	<link rel="modulepreload" href="/js/participants-route-loader.js?v=study-record-id-routing-20260518" />
-	<!-- route-state contract: src="/components/participants/participants-page.js" defer -->
-	<!-- route-state contract: src="/pages/study/participants/scheduler.js" defer -->
-	<script type="module" src="/js/participants-route-loader.js?v=study-record-id-routing-20260518"></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/components/layout.js" defer></script>
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-project">Project</a>
+						</li>
 
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<x-include src="/partials/debug-boot.html" debug-only></x-include>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-study">Study</a>
+						</li>
 
-	<x-include src="/partials/header.html" vars='{
-    "active":"Projects",
-    "subtitle":"Study — Participants"
-  }'></x-include>
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Participants</li>
+					</ol>
+				</nav>
 
-	<main id="main-content" class="container govuk-body govuk-main-wrapper" role="main" tabindex="-1">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="#">Project</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page">Participants</li>
-			</ol>
-		</nav>
+				<div class="govuk-!-margin-bottom-4">
+					<strong id="studyBadge" class="badge">Study:</strong>
+				</div>
 
-		<div class="govuk-!-margin-bottom-4">
-			<strong id="studyBadge" class="badge">Study:</strong>
-		</div>
+				<div class="govuk-grid-row govuk-!-margin-bottom-7">
+					<div class="govuk-grid-column-one-half">
+						<section aria-labelledby="participants-h">
+							<h1 id="participants-h" class="govuk-heading-l govuk-!-margin-bottom-3">Participants</h1>
+							<p class="govuk-hint">Invite and manage participants for this study.</p>
 
-		<div class="govuk-grid-row govuk-!-margin-bottom-7">
-			<div class="govuk-grid-column-one-half">
-				<section aria-labelledby="participants-h">
-					<h2 id="participants-h" class="govuk-heading-l govuk-!-margin-bottom-3">Participants</h2>
-					<p class="govuk-hint">Invite and manage participants for this study.</p>
+							<div id="participantsEmpty" class="empty card" hidden>
+								<h2 class="govuk-heading-m govuk-!-margin-bottom-2">No participants yet</h2>
+								<p class="govuk-body">Add your first participant to begin scheduling sessions.</p>
 
-					<div id="participantsEmpty" class="empty card" hidden>
-						<h3 class="govuk-heading-m govuk-!-margin-bottom-2">No participants yet</h3>
-						<p>Add your first participant to begin scheduling sessions.</p>
-						<a href="#addParticipantForm" class="govuk-button">Add a participant</a>
-					</div>
-
-					<div class="table-wrap" id="participantsTableWrap" hidden>
-						<table id="participantsTable" class="govuk-table" aria-label="Participants">
-							<thead class="govuk-table__head">
-								<tr class="govuk-table__row">
-									<th scope="col" class="govuk-table__header">Name</th>
-									<th scope="col" class="govuk-table__header">Contact</th>
-									<th scope="col" class="govuk-table__header">Status</th>
-									<th scope="col" class="govuk-table__header"><span class="sr-only">Actions</span></th>
-								</tr>
-							</thead>
-							<tbody id="participants-tbody" class="govuk-table__body">
-								<tr class="govuk-table__row">
-									<td colspan="4" class="govuk-table__cell muted">Loading…</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</section>
-			</div>
-
-			<div class="govuk-grid-column-one-half">
-				<section class="card" aria-labelledby="addp-h">
-					<h2 id="addp-h" class="govuk-heading-l govuk-!-margin-bottom-3">Add participant</h2>
-
-					<form id="addParticipantForm" class="form" novalidate>
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="p_display">Display name</label>
-							<input class="govuk-input" id="p_display" name="display_name" required autocomplete="off" />
-						</div>
-
-						<div class="govuk-grid-row">
-							<div class="govuk-grid-column-one-half">
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="p_email">Email</label>
-									<input class="govuk-input" id="p_email" name="email" type="email" autocomplete="off" />
-								</div>
+								<a
+									href="#addParticipantForm"
+									role="button"
+									draggable="false"
+									class="govuk-button"
+									data-module="govuk-button"
+								>
+									Add a participant
+								</a>
 							</div>
-							<div class="govuk-grid-column-one-half">
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="p_phone">Phone</label>
-									<input class="govuk-input" id="p_phone" name="phone" autocomplete="off" />
-								</div>
+
+							<div class="table-wrap" id="participantsTableWrap" hidden>
+								<table id="participantsTable" class="govuk-table" aria-label="Participants">
+									<thead class="govuk-table__head">
+										<tr class="govuk-table__row">
+											<th scope="col" class="govuk-table__header">Name</th>
+											<th scope="col" class="govuk-table__header">Contact</th>
+											<th scope="col" class="govuk-table__header">Status</th>
+											<th scope="col" class="govuk-table__header">
+												<span class="govuk-visually-hidden">Actions</span>
+											</th>
+										</tr>
+									</thead>
+									<tbody id="participants-tbody" class="govuk-table__body">
+										<tr class="govuk-table__row">
+											<td colspan="4" class="govuk-table__cell muted">Loading...</td>
+										</tr>
+									</tbody>
+								</table>
 							</div>
-						</div>
-
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="p_channel">Channel preference</label>
-							<select class="govuk-select" id="p_channel" name="channel_pref">
-								<option value="email">email</option>
-								<option value="sms">sms</option>
-							</select>
-						</div>
-
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="p_access">Access needs (optional)</label>
-							<textarea class="govuk-textarea" id="p_access" name="access_needs" rows="2"></textarea>
-						</div>
-
-						<div class="form__actions">
-							<button class="govuk-button" type="submit" data-module="govuk-button">Create participant</button>
-							<span id="addParticipantMsg" class="msg" role="status" aria-live="polite"></span>
-						</div>
-					</form>
-				</section>
-			</div>
-		</div>
-
-		<div class="govuk-grid-row">
-			<div class="govuk-grid-column-one-half">
-				<section aria-labelledby="sessions-h">
-					<h2 id="sessions-h" class="govuk-heading-l govuk-!-margin-bottom-3">Sessions</h2>
-					<p class="govuk-hint">Scheduled sessions for this study. Download calendar invites as <code>.ics</code>.</p>
-
-					<div id="sessionsEmpty" class="empty card" hidden>
-						<h3 class="govuk-heading-m govuk-!-margin-bottom-2">No sessions yet</h3>
-						<p>Schedule a session once you’ve added at least one participant.</p>
-						<a href="#scheduleForm" class="govuk-button" id="scheduleCta">Schedule a session</a>
+						</section>
 					</div>
 
-					<div class="table-wrap" id="sessionsTableWrap" hidden>
-						<table id="sessionsTable" class="govuk-table" aria-label="Sessions">
-							<thead class="govuk-table__head">
-								<tr class="govuk-table__row">
-									<th scope="col" class="govuk-table__header">When</th>
-									<th scope="col" class="govuk-table__header">Participant</th>
-									<th scope="col" class="govuk-table__header">Status</th>
-									<th scope="col" class="govuk-table__header"><span class="sr-only">Actions</span></th>
-								</tr>
-							</thead>
-							<tbody id="sessions-tbody" class="govuk-table__body"></tbody>
-						</table>
-					</div>
-				</section>
-			</div>
+					<div class="govuk-grid-column-one-half">
+						<section class="card" aria-labelledby="addp-h">
+							<h2 id="addp-h" class="govuk-heading-m govuk-!-margin-bottom-3">Add participant</h2>
 
-			<div class="govuk-grid-column-one-half">
-				<section class="card" aria-labelledby="schedules-h">
-					<h2 id="schedules-h" class="govuk-heading-l govuk-!-margin-bottom-3">Schedule a session</h2>
-
-					<div id="noParticipantsBanner" class="note" role="status" hidden>
-						Add at least one participant to enable scheduling.
-					</div>
-
-					<form id="scheduleForm" class="form" novalidate>
-						<div class="govuk-grid-row">
-							<div class="govuk-grid-column-one-half">
+							<form id="addParticipantForm" class="form" novalidate>
 								<div class="govuk-form-group">
-									<label class="govuk-label" for="s_participant">Participant</label>
-									<select class="govuk-select" id="s_participant" required></select>
+									<label class="govuk-label" for="p_display">Display name</label>
+
+									<input
+										class="govuk-input"
+										id="p_display"
+										name="display_name"
+										type="text"
+										required="required"
+										autocomplete="off"
+									/>
 								</div>
-							</div>
-							<div class="govuk-grid-column-one-half">
+
+								<div class="govuk-grid-row">
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="p_email">Email</label>
+
+											<input class="govuk-input" id="p_email" name="email" type="email" autocomplete="off" />
+										</div>
+									</div>
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="p_phone">Phone</label>
+
+											<input class="govuk-input" id="p_phone" name="phone" type="text" autocomplete="off" />
+										</div>
+									</div>
+								</div>
+
 								<div class="govuk-form-group">
-									<label class="govuk-label" for="s_type">Type</label>
-									<select class="govuk-select" id="s_type">
-										<option value="remote">remote</option>
-										<option value="in-person">in-person</option>
+									<label class="govuk-label" for="p_channel">Channel preference</label>
+
+									<select class="govuk-select" id="p_channel" name="channel_pref">
+										<option value="email" selected>email</option>
+
+										<option value="sms">sms</option>
 									</select>
 								</div>
-							</div>
-						</div>
 
-						<div class="govuk-grid-row">
-							<div class="govuk-grid-column-one-half">
 								<div class="govuk-form-group">
-									<label class="govuk-label" for="s_datetime">Start (local)</label>
-									<input class="govuk-input" id="s_datetime" type="datetime-local" required />
+									<label class="govuk-label" for="p_access">Access needs (optional)</label>
+
+									<textarea class="govuk-textarea" id="p_access" name="access_needs" rows="2"></textarea>
 								</div>
+
+								<div class="form__actions">
+									<button type="submit" class="govuk-button" data-module="govuk-button">Create participant</button>
+
+									<span id="addParticipantMsg" class="msg" role="status" aria-live="polite"></span>
+								</div>
+							</form>
+						</section>
+					</div>
+				</div>
+
+				<div class="govuk-grid-row">
+					<div class="govuk-grid-column-one-half">
+						<section aria-labelledby="sessions-h">
+							<h2 id="sessions-h" class="govuk-heading-l govuk-!-margin-bottom-3">Sessions</h2>
+							<p class="govuk-hint">
+								Scheduled sessions for this study. Download calendar invites as
+								<code>.ics</code>
+								.
+							</p>
+
+							<div id="sessionsEmpty" class="empty card" hidden>
+								<h3 class="govuk-heading-m govuk-!-margin-bottom-2">No sessions yet</h3>
+								<p class="govuk-body">Schedule a session once you have added at least one participant.</p>
+
+								<a
+									href="#scheduleForm"
+									role="button"
+									draggable="false"
+									class="govuk-button"
+									data-module="govuk-button"
+									id="scheduleCta"
+								>
+									Schedule a session
+								</a>
 							</div>
-							<div class="govuk-grid-column-one-half">
+
+							<div class="table-wrap" id="sessionsTableWrap" hidden>
+								<table id="sessionsTable" class="govuk-table" aria-label="Sessions">
+									<thead class="govuk-table__head">
+										<tr class="govuk-table__row">
+											<th scope="col" class="govuk-table__header">When</th>
+											<th scope="col" class="govuk-table__header">Participant</th>
+											<th scope="col" class="govuk-table__header">Status</th>
+											<th scope="col" class="govuk-table__header">
+												<span class="govuk-visually-hidden">Actions</span>
+											</th>
+										</tr>
+									</thead>
+									<tbody id="sessions-tbody" class="govuk-table__body"></tbody>
+								</table>
+							</div>
+						</section>
+					</div>
+
+					<div class="govuk-grid-column-one-half">
+						<section class="card" aria-labelledby="schedules-h">
+							<h2 id="schedules-h" class="govuk-heading-m govuk-!-margin-bottom-3">Schedule a session</h2>
+
+							<div id="noParticipantsBanner" class="note" role="status" hidden>
+								Add at least one participant to enable scheduling.
+							</div>
+
+							<form id="scheduleForm" class="form" novalidate>
+								<div class="govuk-grid-row">
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="s_participant">Participant</label>
+											<select class="govuk-select" id="s_participant" required></select>
+										</div>
+									</div>
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="s_type">Type</label>
+
+											<select class="govuk-select" id="s_type" name="sessionType">
+												<option value="remote" selected>remote</option>
+
+												<option value="in-person">in-person</option>
+											</select>
+										</div>
+									</div>
+								</div>
+
+								<div class="govuk-grid-row">
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="s_datetime">Start (local)</label>
+
+											<input
+												class="govuk-input"
+												id="s_datetime"
+												name="start"
+												type="datetime-local"
+												required="required"
+											/>
+										</div>
+									</div>
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="s_duration">Duration (min)</label>
+
+											<input
+												class="govuk-input"
+												id="s_duration"
+												name="duration"
+												type="number"
+												value="60"
+												min="15"
+												step="5"
+												required="required"
+											/>
+										</div>
+									</div>
+								</div>
+
 								<div class="govuk-form-group">
-									<label class="govuk-label" for="s_duration">Duration (min)</label>
-									<input class="govuk-input" id="s_duration" type="number" min="15" step="5" value="60" required />
+									<label class="govuk-label" for="s_location">Location / Join link</label>
+
+									<input class="govuk-input" id="s_location" name="location" type="text" required="required" />
 								</div>
-							</div>
-						</div>
 
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="s_location">Location / Join link</label>
-							<input class="govuk-input" id="s_location" required />
-						</div>
+								<div class="govuk-grid-row">
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="s_backup">Backup contact</label>
 
-						<div class="govuk-grid-row">
-							<div class="govuk-grid-column-one-half">
+											<input class="govuk-input" id="s_backup" name="backupContact" type="text" />
+										</div>
+									</div>
+									<div class="govuk-grid-column-one-half">
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="s_researchers">Researchers</label>
+
+											<input class="govuk-input" id="s_researchers" name="researchers" type="text" />
+										</div>
+									</div>
+								</div>
+
 								<div class="govuk-form-group">
-									<label class="govuk-label" for="s_backup">Backup contact</label>
-									<input class="govuk-input" id="s_backup" />
-								</div>
-							</div>
-							<div class="govuk-grid-column-one-half">
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="s_researchers">Researchers</label>
-									<input class="govuk-input" id="s_researchers" />
-								</div>
-							</div>
-						</div>
+									<label class="govuk-label" for="s_notes">Notes</label>
 
-						<div class="govuk-form-group">
-							<label class="govuk-label" for="s_notes">Notes</label>
-							<textarea class="govuk-textarea" id="s_notes" rows="2"></textarea>
-						</div>
+									<textarea class="govuk-textarea" id="s_notes" name="notes" rows="2"></textarea>
+								</div>
 
-						<div class="form__actions">
-							<button id="scheduleBtn" class="govuk-button" type="submit" data-module="govuk-button">Create session</button>
-							<span id="scheduleMsg" class="msg" role="status" aria-live="polite"></span>
-						</div>
-					</form>
-				</section>
+								<div class="form__actions">
+									<button type="submit" class="govuk-button" data-module="govuk-button" id="scheduleBtn">
+										Create session
+									</button>
+
+									<span id="scheduleMsg" class="msg" role="status" aria-live="polite"></span>
+								</div>
+							</form>
+						</section>
+					</div>
+				</div>
 			</div>
-		</div>
-	</main>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
-	<x-include src="/partials/footer.html"></x-include>
-</body>
-
+		<script type="module" src="/js/participants-route-loader.js?v=study-record-id-routing-20260518"></script>
+	</body>
 </html>

--- a/public/pages/study/synthesis/index.html
+++ b/public/pages/study/synthesis/index.html
@@ -1,186 +1,335 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Study synthesis - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Synthesis for this study — ResearchOps</title>
+		<meta property="schema:name" content="Study synthesis - ResearchOps" />
+		<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
+		<link
+			rel="stylesheet"
+			href="/css/synthesize.css?v=study-synthesis-20260501-progressive-disclosure"
+			media="screen"
+		/>
+		<link rel="modulepreload" href="/js/study-route-context.js" />
+		<link rel="modulepreload" href="/js/synthesis-route-loader.js?v=study-record-id-routing-20260518" />
 
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/synthesize.css?v=study-synthesis-20260501-progressive-disclosure" media="screen" />
-	<link rel="modulepreload" href="/js/study-route-context.js" />
-	<link rel="modulepreload" href="/js/synthesis-route-loader.js?v=study-record-id-routing-20260518" />
-	<script type="module" src="/js/synthesis-route-loader.js?v=study-record-id-routing-20260518"></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/components/layout.js" defer></script>
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Projects"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container study-synthesis-page" data-study-subpage-template="synthesis">
+				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a>
+						</li>
 
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<x-include src="/partials/debug-boot.html" debug-only></x-include>
-	<x-include src="/partials/header.html" vars='{"active":"Projects","subtitle":"Study synthesis"}'>
-	</x-include>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/projects/" id="breadcrumb-project">Project</a>
+						</li>
 
-	<main id="main-content" class="container govuk-body govuk-main-wrapper" role="main" tabindex="-1">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/pages/projects/">Projects</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-project" class="govuk-breadcrumbs__link" href="/pages/projects/">Project</a></li>
-				<li class="govuk-breadcrumbs__list-item"><a id="breadcrumb-study" class="govuk-breadcrumbs__link" href="#">Study</a></li>
-				<li class="govuk-breadcrumbs__list-item" aria-current="page">Synthesis</li>
-			</ol>
-		</nav>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="#" id="breadcrumb-study">Study</a>
+						</li>
 
-		<div id="synthesis-error" class="govuk-error-summary" role="alert" tabindex="-1" hidden aria-hidden="true">
-			<h2 class="govuk-error-summary__title">There is a problem</h2>
-			<div class="govuk-error-summary__body">
-				<ul id="synthesis-error-list" class="govuk-list govuk-error-summary__list"></ul>
-			</div>
-		</div>
+						<li class="govuk-breadcrumbs__list-item" aria-current="page">Synthesis</li>
+					</ol>
+				</nav>
 
-		<div id="synthesis-status" class="synthesis-status" aria-live="polite"></div>
-
-		<header class="synthesis-hero">
-			<div>
-				<p id="synthesis-eyebrow" class="project-org">Study synthesis</p>
-				<h1 id="synthesis-title" class="govuk-heading-l">Synthesis for this study</h1>
-				<p id="study-context-text" class="govuk-body synthesis-context">Group study evidence into themes you can trace back to source notes.</p>
-			</div>
-			<div class="synthesis-hero__actions">
-				<a id="back-to-study" href="/pages/projects/" class="govuk-button govuk-button--secondary">Back to study</a>
-			</div>
-		</header>
-
-		<section class="synthesis-summary" aria-label="Synthesis summary">
-			<dl class="govuk-summary-list synthesis-summary-list">
-				<div class="govuk-summary-list__row synthesis-summary-list__row">
-					<dt class="govuk-summary-list__key synthesis-summary-list__key">Project</dt>
-					<dd id="summary-project" class="govuk-summary-list__value synthesis-summary-list__value">–</dd>
+				<div
+					id="synthesis-error"
+					class="govuk-error-summary"
+					tabindex="-1"
+					hidden
+					aria-hidden="true"
+					data-module="govuk-error-summary"
+				>
+					<div role="alert">
+						<h2 class="govuk-error-summary__title">There is a problem</h2>
+						<div class="govuk-error-summary__body">
+							<ul id="synthesis-error-list" class="govuk-list govuk-error-summary__list"></ul>
+						</div>
+					</div>
 				</div>
-				<div class="govuk-summary-list__row synthesis-summary-list__row">
-					<dt class="govuk-summary-list__key synthesis-summary-list__key">Study</dt>
-					<dd id="summary-study" class="govuk-summary-list__value synthesis-summary-list__value">–</dd>
-				</div>
-				<div class="govuk-summary-list__row synthesis-summary-list__row">
-					<dt class="govuk-summary-list__key synthesis-summary-list__key">Evidence</dt>
-					<dd id="summary-evidence-count" class="govuk-summary-list__value synthesis-summary-list__value">0 evidence items</dd>
-				</div>
-				<div class="govuk-summary-list__row synthesis-summary-list__row">
-					<dt class="govuk-summary-list__key synthesis-summary-list__key">Themes</dt>
-					<dd id="summary-theme-count" class="govuk-summary-list__value synthesis-summary-list__value">0 themes</dd>
-				</div>
-			</dl>
-		</section>
 
-		<section id="no-evidence-state" class="synthesis-empty synthesis-empty--route" hidden>
-			<h2 class="govuk-heading-m">Capture evidence before starting synthesis</h2>
-			<p class="govuk-body">No evidence has been captured for this study yet. Capture evidence during a research session, then return here to group it into working clusters and themes.</p>
-			<a id="capture-evidence-link" href="/pages/study/session/" class="govuk-button">Capture evidence in a session</a>
-		</section>
+				<div id="synthesis-status" class="govuk-body-s synthesis-status" aria-live="polite"></div>
 
-		<div id="synthesis-workspace" class="synthesis-flow" hidden>
-			<section id="clusters-section" class="panel synthesis-panel" aria-labelledby="clusters-title">
-				<header class="synthesis-panel__header">
+				<header class="synthesis-hero govuk-!-margin-bottom-6">
 					<div>
-						<h2 id="clusters-title" class="govuk-heading-m">Working cluster groupings</h2>
-						<p class="govuk-body">Create a working cluster grouping before selecting evidence. Cluster groupings are provisional groups of related evidence.</p>
+						<p id="synthesis-eyebrow" class="govuk-caption-m">Study synthesis</p>
+						<h1 id="synthesis-title" class="govuk-heading-l">Synthesis for this study</h1>
+						<p id="study-context-text" class="govuk-body synthesis-context govuk-!-width-two-thirds">
+							Group study evidence into themes you can trace back to source notes.
+						</p>
+					</div>
+					<div class="synthesis-hero__actions">
+						<a
+							href="/pages/projects/"
+							role="button"
+							draggable="false"
+							class="govuk-button govuk-button--secondary"
+							data-module="govuk-button"
+							id="back-to-study"
+						>
+							Back to study
+						</a>
 					</div>
 				</header>
 
-				<form id="cluster-form" class="cluster-create" novalidate>
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="cluster-label">Cluster grouping name</label>
-						<input id="cluster-label" class="govuk-input" autocomplete="off" aria-describedby="create-cluster-hint" disabled />
-					</div>
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="cluster-description">Cluster grouping description</label>
-						<textarea id="cluster-description" class="govuk-textarea" rows="4" disabled></textarea>
-					</div>
-					<button id="create-cluster" type="submit" class="govuk-button" aria-describedby="create-cluster-hint" disabled>Create cluster grouping</button>
-					<p id="create-cluster-hint" class="govuk-hint">Capture evidence before creating a working cluster grouping.</p>
-				</form>
+				<section class="synthesis-summary" aria-label="Synthesis summary">
+					<dl class="govuk-summary-list synthesis-summary-list">
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Project</dt>
+							<dd class="govuk-summary-list__value">
+								<span id="summary-project">-</span>
+							</dd>
+						</div>
 
-				<div id="clusters-empty" class="synthesis-empty" hidden>
-					<p class="govuk-body">No working cluster groupings have been created yet.</p>
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Study</dt>
+							<dd class="govuk-summary-list__value">
+								<span id="summary-study">-</span>
+							</dd>
+						</div>
+
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Evidence</dt>
+							<dd class="govuk-summary-list__value">
+								<span id="summary-evidence-count">0 evidence items</span>
+							</dd>
+						</div>
+
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Themes</dt>
+							<dd class="govuk-summary-list__value">
+								<span id="summary-theme-count">0 themes</span>
+							</dd>
+						</div>
+					</dl>
+				</section>
+
+				<section id="no-evidence-state" class="synthesis-empty synthesis-empty--route" hidden>
+					<h2 class="govuk-heading-m">Capture evidence before starting synthesis</h2>
+					<p class="govuk-body">
+						No evidence has been captured for this study yet. Capture evidence during a research session, then return
+						here to group it into working clusters and themes.
+					</p>
+
+					<a
+						href="/pages/study/session/"
+						role="button"
+						draggable="false"
+						class="govuk-button"
+						data-module="govuk-button"
+						id="capture-evidence-link"
+					>
+						Capture evidence in a session
+					</a>
+				</section>
+
+				<div id="synthesis-workspace" class="synthesis-flow" hidden>
+					<section id="clusters-section" class="panel synthesis-panel" aria-labelledby="clusters-title">
+						<header class="synthesis-panel__header">
+							<div>
+								<h2 id="clusters-title" class="govuk-heading-m">Working cluster groupings</h2>
+								<p class="govuk-body">
+									Create a working cluster grouping before selecting evidence. Cluster groupings are provisional groups
+									of related evidence.
+								</p>
+							</div>
+						</header>
+
+						<form id="cluster-form" class="cluster-create" novalidate>
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="cluster-label">Cluster grouping name</label>
+
+								<input
+									class="govuk-input"
+									id="cluster-label"
+									name="clusterLabel"
+									type="text"
+									autocomplete="off"
+									aria-describedby="create-cluster-hint"
+									disabled="disabled"
+								/>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="cluster-description">Cluster grouping description</label>
+
+								<textarea
+									class="govuk-textarea"
+									id="cluster-description"
+									name="clusterDescription"
+									rows="4"
+									disabled="disabled"
+								></textarea>
+							</div>
+
+							<button
+								type="submit"
+								class="govuk-button"
+								data-module="govuk-button"
+								id="create-cluster"
+								aria-describedby="create-cluster-hint"
+								disabled="disabled"
+							>
+								Create cluster grouping
+							</button>
+
+							<p id="create-cluster-hint" class="govuk-hint">
+								Capture evidence before creating a working cluster grouping.
+							</p>
+						</form>
+
+						<div id="clusters-empty" class="synthesis-empty" hidden>
+							<p class="govuk-body">No working cluster groupings have been created yet.</p>
+						</div>
+						<div id="cluster-list" class="cluster-list"></div>
+					</section>
+
+					<section id="evidence-section" class="panel synthesis-panel" aria-labelledby="evidence-title" hidden>
+						<header class="synthesis-panel__header">
+							<div>
+								<h2 id="evidence-title" class="govuk-heading-m">Evidence</h2>
+								<p class="govuk-body">Select evidence notes and add them to a working cluster grouping.</p>
+							</div>
+						</header>
+
+						<div class="evidence-toolbar">
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="tag-filter">Filter by tag</label>
+
+								<div id="tag-filter-hint" class="govuk-hint">Use a tag, framework category or safeguarding label.</div>
+
+								<input
+									class="govuk-input"
+									id="tag-filter"
+									name="tagFilter"
+									type="text"
+									aria-describedby="tag-filter-hint"
+									autocomplete="off"
+									spellcheck="false"
+								/>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="target-cluster">Add selected evidence to</label>
+								<select
+									id="target-cluster"
+									class="govuk-select"
+									aria-describedby="add-selected-evidence-hint"
+									disabled
+								></select>
+							</div>
+
+							<div class="synthesis-action-block">
+								<button
+									type="button"
+									class="govuk-button govuk-button--secondary"
+									data-module="govuk-button"
+									id="add-selected-evidence"
+									aria-describedby="add-selected-evidence-hint"
+									disabled="disabled"
+								>
+									Add selected evidence
+								</button>
+
+								<p id="add-selected-evidence-hint" class="govuk-hint">
+									Create a working cluster grouping and select evidence before adding evidence.
+								</p>
+							</div>
+						</div>
+
+						<div id="evidence-empty" class="synthesis-empty" hidden>
+							<h3 class="govuk-heading-s">No evidence has been captured for this study yet</h3>
+							<p class="govuk-body">Run or complete sessions, then return here to group evidence into themes.</p>
+						</div>
+						<div id="evidence-list" class="evidence-list"></div>
+					</section>
+
+					<section id="themes-locked" class="synthesis-empty synthesis-empty--locked" hidden>
+						<h2 class="govuk-heading-m">Create themes after adding evidence to a cluster</h2>
+						<p class="govuk-body">Add evidence to a working cluster grouping before creating a theme.</p>
+					</section>
+
+					<section id="themes-section" class="panel synthesis-panel" aria-labelledby="themes-title" hidden>
+						<header class="synthesis-panel__header">
+							<div>
+								<h2 id="themes-title" class="govuk-heading-m">Themes</h2>
+								<p class="govuk-body">
+									Create themes from working cluster groupings. Each theme keeps links to the evidence used.
+								</p>
+							</div>
+						</header>
+
+						<form id="theme-form" class="theme-create" novalidate>
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="theme-cluster">Working cluster grouping</label>
+								<select id="theme-cluster" class="govuk-select" aria-describedby="create-theme-hint" disabled></select>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="theme-label">Theme name</label>
+
+								<input
+									class="govuk-input"
+									id="theme-label"
+									name="themeLabel"
+									type="text"
+									autocomplete="off"
+									aria-describedby="create-theme-hint"
+									disabled="disabled"
+								/>
+							</div>
+
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="theme-description">Theme description</label>
+
+								<textarea
+									class="govuk-textarea"
+									id="theme-description"
+									name="themeDescription"
+									rows="5"
+									disabled="disabled"
+								></textarea>
+							</div>
+
+							<button
+								type="submit"
+								class="govuk-button"
+								data-module="govuk-button"
+								id="create-theme"
+								aria-describedby="create-theme-hint"
+								disabled="disabled"
+							>
+								Create theme
+							</button>
+
+							<p id="create-theme-hint" class="govuk-hint">
+								Add evidence to a working cluster grouping before creating a theme.
+							</p>
+						</form>
+
+						<div id="themes-empty" class="synthesis-empty" hidden>
+							<p class="govuk-body">No themes have been created for this study yet.</p>
+						</div>
+						<div id="theme-list" class="theme-list"></div>
+					</section>
 				</div>
-				<div id="cluster-list" class="cluster-list"></div>
-			</section>
+			</div>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
-			<section id="evidence-section" class="panel synthesis-panel" aria-labelledby="evidence-title" hidden>
-				<header class="synthesis-panel__header">
-					<div>
-						<h2 id="evidence-title" class="govuk-heading-m">Evidence</h2>
-						<p class="govuk-body">Select evidence notes and add them to a working cluster grouping.</p>
-					</div>
-				</header>
-
-				<div class="evidence-toolbar">
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="tag-filter">Filter by tag</label>
-						<div id="tag-filter-hint" class="govuk-hint">Use a tag, framework category or safeguarding label.</div>
-						<input id="tag-filter" class="govuk-input" autocomplete="off" spellcheck="false" aria-describedby="tag-filter-hint" />
-					</div>
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="target-cluster">Add selected evidence to</label>
-						<select id="target-cluster" class="govuk-select" aria-describedby="add-selected-evidence-hint" disabled></select>
-					</div>
-					<div class="synthesis-action-block">
-						<button id="add-selected-evidence" type="button" class="govuk-button govuk-button--secondary" aria-describedby="add-selected-evidence-hint" disabled>Add selected evidence</button>
-						<p id="add-selected-evidence-hint" class="govuk-hint">Create a working cluster grouping and select evidence before adding evidence.</p>
-					</div>
-				</div>
-
-				<div id="evidence-empty" class="synthesis-empty" hidden>
-					<h3 class="govuk-heading-s">No evidence has been captured for this study yet</h3>
-					<p class="govuk-body">Run or complete sessions, then return here to group evidence into themes.</p>
-				</div>
-				<div id="evidence-list" class="evidence-list"></div>
-			</section>
-
-			<section id="themes-locked" class="synthesis-empty synthesis-empty--locked" hidden>
-				<h2 class="govuk-heading-m">Create themes after adding evidence to a cluster</h2>
-				<p class="govuk-body">Add evidence to a working cluster grouping before creating a theme.</p>
-			</section>
-
-			<section id="themes-section" class="panel synthesis-panel" aria-labelledby="themes-title" hidden>
-				<header class="synthesis-panel__header">
-					<div>
-						<h2 id="themes-title" class="govuk-heading-m">Themes</h2>
-						<p class="govuk-body">Create themes from working cluster groupings. Each theme keeps links to the evidence used.</p>
-					</div>
-				</header>
-
-				<form id="theme-form" class="theme-create" novalidate>
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="theme-cluster">Working cluster grouping</label>
-						<select id="theme-cluster" class="govuk-select" aria-describedby="create-theme-hint" disabled></select>
-					</div>
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="theme-label">Theme name</label>
-						<input id="theme-label" class="govuk-input" autocomplete="off" aria-describedby="create-theme-hint" disabled />
-					</div>
-					<div class="govuk-form-group">
-						<label class="govuk-label" for="theme-description">Theme description</label>
-						<textarea id="theme-description" class="govuk-textarea" rows="5" disabled></textarea>
-					</div>
-					<button id="create-theme" type="submit" class="govuk-button" aria-describedby="create-theme-hint" disabled>Create theme</button>
-					<p id="create-theme-hint" class="govuk-hint">Add evidence to a working cluster grouping before creating a theme.</p>
-				</form>
-
-				<div id="themes-empty" class="synthesis-empty" hidden>
-					<p class="govuk-body">No themes have been created for this study yet.</p>
-				</div>
-				<div id="theme-list" class="theme-list"></div>
-			</section>
-		</div>
-	</main>
-
-	<x-include src="/partials/footer.html"></x-include>
-</body>
-
+		<script type="module" src="/js/synthesis-route-loader.js?v=study-record-id-routing-20260518"></script>
+	</body>
 </html>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -265,6 +265,46 @@ export const govukPages = [
 		},
 	},
 	{
+		template: 'pages/study-participant-consent.njk',
+		output: 'public/pages/study/participant-consent/index.html',
+		context: {
+			pageTitle: 'Participant consent - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Projects',
+			navigation: projectNavigation,
+		},
+	},
+	{
+		template: 'pages/study-participants.njk',
+		output: 'public/pages/study/participants/index.html',
+		context: {
+			pageTitle: 'Study participants - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Projects',
+			navigation: projectNavigation,
+		},
+	},
+	{
+		template: 'pages/study-guides.njk',
+		output: 'public/pages/study/guides/index.html',
+		context: {
+			pageTitle: 'Discussion guides - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Projects',
+			navigation: projectNavigation,
+		},
+	},
+	{
+		template: 'pages/study-synthesis.njk',
+		output: 'public/pages/study/synthesis/index.html',
+		context: {
+			pageTitle: 'Study synthesis - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Projects',
+			navigation: projectNavigation,
+		},
+	},
+	{
 		template: 'pages/project-dashboard-participants.njk',
 		output: 'public/pages/project-dashboard/participants/index.html',
 		context: {

--- a/src/govuk/templates/pages/study-guides.njk
+++ b/src/govuk/templates/pages/study-guides.njk
@@ -1,0 +1,119 @@
+{% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% set studyPageScriptVersion = "study-record-id-routing-20260518" %}
+
+{% block head %}
+	<meta property="schema:name" content="Discussion guides - ResearchOps">
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen">
+	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen">
+	<link rel="stylesheet" href="/css/guides.css" media="screen">
+	<link rel="modulepreload" href="/js/study-route-context.js">
+	<link rel="modulepreload" href="/js/study-guides-context.js">
+	<link rel="modulepreload" href="/js/guides-route-loader.js?v={{ studyPageScriptVersion }}">
+	<!-- /components/guides/guides-page.js -->
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container study-guides-page" data-study-subpage-template="guides">
+	{{ govukBreadcrumbs({
+		items: [
+			{ text: "Projects", href: "/pages/projects/" },
+			{ text: "Project", href: "#", attributes: { id: "breadcrumb-project" } },
+			{ text: "Study", href: "#", attributes: { id: "breadcrumb-study" } },
+			{ text: "Guides" }
+		]
+	}) }}
+
+	<header class="guides-header govuk-!-margin-bottom-6">
+		<p id="study-title" class="govuk-caption-m" data-bind="study.title">Study</p>
+		<h1 class="govuk-heading-l">Discussion guides</h1>
+		<p class="govuk-body govuk-!-width-two-thirds">Create, review and publish discussion guides for this study.</p>
+		<div class="govuk-button-group">
+			{{ govukButton({
+				text: "Back to Study",
+				href: "#",
+				classes: "govuk-button--secondary",
+				attributes: { id: "back-to-study" }
+			}) }}
+			{{ govukButton({
+				text: "New guide",
+				type: "button",
+				attributes: { id: "btn-new" }
+			}) }}
+		</div>
+	</header>
+
+	<section id="guides-list-section" aria-labelledby="guides-list-title">
+		<h2 id="guides-list-title" class="govuk-heading-m">Guides for this study</h2>
+		<table id="guides-table" class="govuk-table">
+			<thead class="govuk-table__head">
+				<tr class="govuk-table__row">
+					<th class="govuk-table__header" scope="col">Title</th>
+					<th class="govuk-table__header" scope="col">Status</th>
+				</tr>
+			</thead>
+			<tbody id="guides-tbody" class="govuk-table__body"></tbody>
+		</table>
+	</section>
+
+	<section id="editor-section" class="editor" aria-labelledby="guide-editor-title">
+		<h2 id="guide-editor-title" class="govuk-heading-m">Guide editor</h2>
+		{{ govukInput({
+			id: "guide-title",
+			name: "guideTitle",
+			classes: "editor__title-field",
+			label: { text: "Guide title" },
+			attributes: { autocomplete: "off" }
+		}) }}
+
+		<p id="guide-status" class="govuk-body-s" aria-live="polite">draft</p>
+
+		<div class="editor__toolbar govuk-button-group">
+			{{ govukButton({ text: "Insert pattern", type: "button", classes: "govuk-button--secondary", attributes: { id: "btn-insert-pattern" } }) }}
+			{{ govukButton({ text: "Variables", type: "button", classes: "govuk-button--secondary", attributes: { id: "btn-variables" } }) }}
+			{{ govukButton({ text: "Insert tag", type: "button", classes: "govuk-button--secondary", attributes: { id: "btn-insert-tag" } }) }}
+			{{ govukButton({ text: "Save draft", type: "button", attributes: { id: "btn-save" } }) }}
+			{{ govukButton({ text: "Publish", type: "button", classes: "govuk-button--secondary", attributes: { id: "btn-publish" } }) }}
+		</div>
+
+		<div class="editor__split">
+			<div class="code-editor">
+				<label class="govuk-label" for="guide-source">Guide source</label>
+				<div id="guide-source-highlight" class="code-editor__highlight" aria-hidden="true"><code id="guide-source-code"></code></div>
+				<textarea id="guide-source" class="govuk-textarea code-editor__textarea" rows="18" spellcheck="true"></textarea>
+			</div>
+			<div class="preview">
+				<h3 class="govuk-heading-s">Preview</h3>
+				<div id="guide-preview" class="govuk-body"></div>
+			</div>
+		</div>
+
+		<div id="lint-output" class="govuk-body-s" aria-live="polite"></div>
+	</section>
+
+	<aside id="drawer-patterns" class="drawer" hidden aria-labelledby="drawer-patterns-title">
+		<h2 id="drawer-patterns-title" class="govuk-heading-m">Patterns</h2>
+		{{ govukInput({
+			id: "pattern-search",
+			name: "patternSearch",
+			label: { text: "Search patterns" },
+			attributes: { autocomplete: "off" }
+		}) }}
+		<ul id="pattern-list" class="govuk-list"></ul>
+		<div class="govuk-button-group">
+			<button id="drawer-patterns-close" class="govuk-button govuk-button--secondary" type="button">Close</button>
+		</div>
+	</aside>
+
+	<aside id="drawer-variables" class="drawer" hidden></aside>
+	<div class="govuk-button-group actions-row"></div>
+	<div id="sr-live" class="govuk-visually-hidden" aria-live="polite"></div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/js/guides-route-loader.js?v={{ studyPageScriptVersion }}"></script>
+{% endblock %}

--- a/src/govuk/templates/pages/study-participant-consent.njk
+++ b/src/govuk/templates/pages/study-participant-consent.njk
@@ -1,0 +1,210 @@
+{% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% set studyPageScriptVersion = "study-record-id-routing-20260518" %}
+
+{% block head %}
+	<meta property="schema:name" content="Participant consent - ResearchOps">
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen">
+	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen">
+	<link rel="stylesheet" href="/css/participant-consent.css" media="screen">
+	<link rel="modulepreload" href="/js/study-route-context.js">
+	<link rel="modulepreload" href="/js/participant-consent-route-loader.js?v={{ studyPageScriptVersion }}">
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container participant-consent-page" data-study-subpage-template="participant-consent">
+	{{ govukBreadcrumbs({
+		items: [
+			{ text: "Projects", href: "/pages/projects/" },
+			{ text: "Project", href: "#", attributes: { id: "breadcrumb-project" } },
+			{ text: "Study", href: "#", attributes: { id: "breadcrumb-study" } },
+			{ text: "Participant consent" }
+		]
+	}) }}
+
+	<div id="consent-error" class="govuk-error-summary participant-consent-error" tabindex="-1" hidden aria-hidden="true" data-module="govuk-error-summary">
+		<div role="alert">
+			<h2 class="govuk-error-summary__title">There is a problem</h2>
+			<div class="govuk-error-summary__body">
+				<ul id="consent-error-list" class="govuk-list govuk-error-summary__list"></ul>
+			</div>
+		</div>
+	</div>
+
+	<header class="participant-consent-hero govuk-!-margin-bottom-6">
+		<div>
+			<p id="study-context" class="govuk-caption-m">Study</p>
+			<h1 class="govuk-heading-l">Manage participant consent</h1>
+			<p class="govuk-body participant-consent-context govuk-!-width-two-thirds">Record, review or withdraw participant consent for this study. Consent is recorded against a specific published consent form version.</p>
+		</div>
+		<div class="participant-consent-hero__actions">
+			{{ govukButton({
+				text: "Back to Study",
+				href: "/pages/study/",
+				classes: "govuk-button--secondary",
+				attributes: { id: "back-to-study" }
+			}) }}
+		</div>
+	</header>
+
+	<p id="participant-consent-status" class="govuk-body-s participant-consent-status" role="status" aria-live="polite">Loading participant consent.</p>
+
+	<section id="no-context-state" class="participant-consent-empty participant-consent-empty--route" hidden>
+		<h2 class="govuk-heading-m">Open this page from a study</h2>
+		<p class="govuk-body">The participant consent page needs a Study record ID in the URL.</p>
+	</section>
+
+	<section id="no-consent-form-state" class="participant-consent-empty participant-consent-empty--route" hidden>
+		<h2 class="govuk-heading-m">Create and publish a consent form before recording participant consent</h2>
+		<p class="govuk-body">Participant consent must be recorded against the version of the consent form that was shown or read to the participant.</p>
+		{{ govukButton({
+			text: "Create consent forms",
+			href: "#",
+			attributes: { id: "create-consent-forms-link" }
+		}) }}
+	</section>
+
+	<section id="no-participants-state" class="participant-consent-empty participant-consent-empty--route" hidden>
+		<h2 class="govuk-heading-m">Add participants before recording consent</h2>
+		<p class="govuk-body">Add participants to this study before recording individual consent responses.</p>
+		{{ govukButton({
+			text: "Schedule participants",
+			href: "#",
+			attributes: { id: "schedule-participants-link" }
+		}) }}
+	</section>
+
+	<section id="consent-workspace" class="participant-consent-workspace" hidden>
+		<section class="participant-consent-panel" aria-labelledby="consent-summary-title">
+			<h2 id="consent-summary-title" class="govuk-heading-m">Consent coverage</h2>
+			{{ govukSummaryList({
+				classes: "participant-consent-summary",
+				rows: [
+					{ key: { text: "Published form" }, value: { html: '<span id="summary-published-form">-</span>' } },
+					{ key: { text: "Participants" }, value: { html: '<span id="summary-participants">-</span>' } },
+					{ key: { text: "Ready" }, value: { html: '<span id="summary-ready">-</span>' } },
+					{ key: { text: "Needs action" }, value: { html: '<span id="summary-action-needed">-</span>' } }
+				]
+			}) }}
+		</section>
+
+		<section class="participant-consent-panel" aria-labelledby="participants-consent-title">
+			<div class="participant-consent-panel__header">
+				<div>
+					<h2 id="participants-consent-title" class="govuk-heading-m">Participants</h2>
+					<p class="govuk-body">Select a participant to record or review consent. Status is shown in text and does not rely on colour.</p>
+				</div>
+			</div>
+
+			<div class="table-wrap">
+				<table class="govuk-table participant-consent-table" aria-label="Participant consent">
+					<thead class="govuk-table__head">
+						<tr class="govuk-table__row">
+							<th scope="col" class="govuk-table__header">Participant</th>
+							<th scope="col" class="govuk-table__header">Consent status</th>
+							<th scope="col" class="govuk-table__header">Permissions</th>
+							<th scope="col" class="govuk-table__header">Recorded</th>
+							<th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+						</tr>
+					</thead>
+					<tbody id="participant-consent-tbody" class="govuk-table__body">
+						<tr class="govuk-table__row">
+							<td class="govuk-table__cell" colspan="5">Loading participants.</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</section>
+
+		<section id="consent-record-panel" class="participant-consent-panel" aria-labelledby="record-consent-title" hidden>
+			<h2 id="record-consent-title" class="govuk-heading-m">Record participant consent</h2>
+			<p id="record-consent-hint" class="govuk-body">Choose a participant to record or review consent.</p>
+
+			<form id="participant-consent-form" novalidate>
+				<input id="participant-id" type="hidden">
+				<input id="consent-record-id" type="hidden">
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="consent-form-select">Consent form version</label>
+					<div id="consent-form-select-hint" class="govuk-hint">Use the published consent form shown, sent or read to the participant.</div>
+					<select id="consent-form-select" class="govuk-select" aria-describedby="consent-form-select-hint"></select>
+				</div>
+
+				<fieldset class="govuk-fieldset participant-consent-items" aria-describedby="consent-items-hint">
+					<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Consent statements</legend>
+					<div id="consent-items-hint" class="govuk-hint">Required statements must be agreed before a participant is ready for a session. Optional declined permissions should still be visible to the research team.</div>
+					<div id="consent-items-list"></div>
+				</fieldset>
+
+				{{ govukSelect({
+					id: "capture-method",
+					name: "captureMethod",
+					label: { text: "Capture method" },
+					items: [
+						{ value: "", text: "Select a capture method" },
+						{ value: "Verbal", text: "Verbal" },
+						{ value: "Signed form", text: "Signed form" },
+						{ value: "Email", text: "Email" },
+						{ value: "Imported", text: "Imported" }
+					]
+				}) }}
+
+				{{ govukInput({
+					id: "recorded-by",
+					name: "recordedBy",
+					label: { text: "Recorded by" },
+					attributes: { autocomplete: "name" }
+				}) }}
+
+				{{ govukDetails({
+					classes: "participant-consent-withdrawal",
+					summaryText: "Record withdrawal or do not proceed",
+					html: govukCheckboxes({
+						idPrefix: "consent-withdrawn",
+						name: "consentWithdrawn",
+						items: [
+							{
+								value: "yes",
+								text: "Consent has been withdrawn or the session should not proceed",
+								attributes: { id: "consent-withdrawn" }
+							}
+						]
+					}) + govukTextarea({
+						id: "withdrawal-reason",
+						name: "withdrawalReason",
+						value: "",
+						rows: 3,
+						label: { text: "Reason or note" }
+					})
+				}) }}
+
+				<div class="govuk-button-group participant-consent-form__actions">
+					{{ govukButton({
+						text: "Save consent response",
+						type: "submit",
+						attributes: { id: "save-participant-consent" }
+					}) }}
+					{{ govukButton({
+						text: "Cancel",
+						type: "button",
+						classes: "govuk-button--secondary",
+						attributes: { id: "cancel-participant-consent" }
+					}) }}
+				</div>
+			</form>
+		</section>
+	</section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/js/participant-consent-route-loader.js?v={{ studyPageScriptVersion }}"></script>
+{% endblock %}

--- a/src/govuk/templates/pages/study-participants.njk
+++ b/src/govuk/templates/pages/study-participants.njk
@@ -1,0 +1,255 @@
+{% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% set studyPageScriptVersion = "study-record-id-routing-20260518" %}
+
+{% block head %}
+	<meta property="schema:name" content="Study participants - ResearchOps">
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen">
+	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen">
+	<link rel="stylesheet" href="/css/participants.css" media="screen">
+	<link rel="modulepreload" href="/js/study-route-context.js">
+	<link rel="modulepreload" href="/js/participants-route-loader.js?v={{ studyPageScriptVersion }}">
+	<!-- route-state contract: src="/components/participants/participants-page.js" defer -->
+	<!-- route-state contract: src="/pages/study/participants/scheduler.js" defer -->
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container study-participants-page" data-study-subpage-template="participants">
+	{{ govukBreadcrumbs({
+		items: [
+			{ text: "Projects", href: "/pages/projects/" },
+			{ text: "Project", href: "#", attributes: { id: "breadcrumb-project" } },
+			{ text: "Study", href: "#", attributes: { id: "breadcrumb-study" } },
+			{ text: "Participants" }
+		]
+	}) }}
+
+	<div class="govuk-!-margin-bottom-4">
+		<strong id="studyBadge" class="badge">Study:</strong>
+	</div>
+
+	<div class="govuk-grid-row govuk-!-margin-bottom-7">
+		<div class="govuk-grid-column-one-half">
+			<section aria-labelledby="participants-h">
+				<h1 id="participants-h" class="govuk-heading-l govuk-!-margin-bottom-3">Participants</h1>
+				<p class="govuk-hint">Invite and manage participants for this study.</p>
+
+				<div id="participantsEmpty" class="empty card" hidden>
+					<h2 class="govuk-heading-m govuk-!-margin-bottom-2">No participants yet</h2>
+					<p class="govuk-body">Add your first participant to begin scheduling sessions.</p>
+					{{ govukButton({ text: "Add a participant", href: "#addParticipantForm" }) }}
+				</div>
+
+				<div class="table-wrap" id="participantsTableWrap" hidden>
+					<table id="participantsTable" class="govuk-table" aria-label="Participants">
+						<thead class="govuk-table__head">
+							<tr class="govuk-table__row">
+								<th scope="col" class="govuk-table__header">Name</th>
+								<th scope="col" class="govuk-table__header">Contact</th>
+								<th scope="col" class="govuk-table__header">Status</th>
+								<th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+							</tr>
+						</thead>
+						<tbody id="participants-tbody" class="govuk-table__body">
+							<tr class="govuk-table__row">
+								<td colspan="4" class="govuk-table__cell muted">Loading...</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+		</div>
+
+		<div class="govuk-grid-column-one-half">
+			<section class="card" aria-labelledby="addp-h">
+				<h2 id="addp-h" class="govuk-heading-m govuk-!-margin-bottom-3">Add participant</h2>
+
+				<form id="addParticipantForm" class="form" novalidate>
+					{{ govukInput({
+						id: "p_display",
+						name: "display_name",
+						label: { text: "Display name" },
+						attributes: { required: "required", autocomplete: "off" }
+					}) }}
+
+					<div class="govuk-grid-row">
+						<div class="govuk-grid-column-one-half">
+							{{ govukInput({
+								id: "p_email",
+								name: "email",
+								type: "email",
+								label: { text: "Email" },
+								attributes: { autocomplete: "off" }
+							}) }}
+						</div>
+						<div class="govuk-grid-column-one-half">
+							{{ govukInput({
+								id: "p_phone",
+								name: "phone",
+								label: { text: "Phone" },
+								attributes: { autocomplete: "off" }
+							}) }}
+						</div>
+					</div>
+
+					{{ govukSelect({
+						id: "p_channel",
+						name: "channel_pref",
+						label: { text: "Channel preference" },
+						items: [
+							{ value: "email", text: "email", selected: true },
+							{ value: "sms", text: "sms" }
+						]
+					}) }}
+
+					{{ govukTextarea({
+						id: "p_access",
+						name: "access_needs",
+						value: "",
+						rows: 2,
+						label: { text: "Access needs (optional)" }
+					}) }}
+
+					<div class="form__actions">
+						{{ govukButton({ text: "Create participant", type: "submit" }) }}
+						<span id="addParticipantMsg" class="msg" role="status" aria-live="polite"></span>
+					</div>
+				</form>
+			</section>
+		</div>
+	</div>
+
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-one-half">
+			<section aria-labelledby="sessions-h">
+				<h2 id="sessions-h" class="govuk-heading-l govuk-!-margin-bottom-3">Sessions</h2>
+				<p class="govuk-hint">Scheduled sessions for this study. Download calendar invites as <code>.ics</code>.</p>
+
+				<div id="sessionsEmpty" class="empty card" hidden>
+					<h3 class="govuk-heading-m govuk-!-margin-bottom-2">No sessions yet</h3>
+					<p class="govuk-body">Schedule a session once you have added at least one participant.</p>
+					{{ govukButton({ text: "Schedule a session", href: "#scheduleForm", attributes: { id: "scheduleCta" } }) }}
+				</div>
+
+				<div class="table-wrap" id="sessionsTableWrap" hidden>
+					<table id="sessionsTable" class="govuk-table" aria-label="Sessions">
+						<thead class="govuk-table__head">
+							<tr class="govuk-table__row">
+								<th scope="col" class="govuk-table__header">When</th>
+								<th scope="col" class="govuk-table__header">Participant</th>
+								<th scope="col" class="govuk-table__header">Status</th>
+								<th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+							</tr>
+						</thead>
+						<tbody id="sessions-tbody" class="govuk-table__body"></tbody>
+					</table>
+				</div>
+			</section>
+		</div>
+
+		<div class="govuk-grid-column-one-half">
+			<section class="card" aria-labelledby="schedules-h">
+				<h2 id="schedules-h" class="govuk-heading-m govuk-!-margin-bottom-3">Schedule a session</h2>
+
+				<div id="noParticipantsBanner" class="note" role="status" hidden>
+					Add at least one participant to enable scheduling.
+				</div>
+
+				<form id="scheduleForm" class="form" novalidate>
+					<div class="govuk-grid-row">
+						<div class="govuk-grid-column-one-half">
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="s_participant">Participant</label>
+								<select class="govuk-select" id="s_participant" required></select>
+							</div>
+						</div>
+						<div class="govuk-grid-column-one-half">
+							{{ govukSelect({
+								id: "s_type",
+								name: "sessionType",
+								label: { text: "Type" },
+								items: [
+									{ value: "remote", text: "remote", selected: true },
+									{ value: "in-person", text: "in-person" }
+								]
+							}) }}
+						</div>
+					</div>
+
+					<div class="govuk-grid-row">
+						<div class="govuk-grid-column-one-half">
+							{{ govukInput({
+								id: "s_datetime",
+								name: "start",
+								type: "datetime-local",
+								label: { text: "Start (local)" },
+								attributes: { required: "required" }
+							}) }}
+						</div>
+						<div class="govuk-grid-column-one-half">
+							{{ govukInput({
+								id: "s_duration",
+								name: "duration",
+								type: "number",
+								value: "60",
+								label: { text: "Duration (min)" },
+								attributes: { min: "15", step: "5", required: "required" }
+							}) }}
+						</div>
+					</div>
+
+					{{ govukInput({
+						id: "s_location",
+						name: "location",
+						label: { text: "Location / Join link" },
+						attributes: { required: "required" }
+					}) }}
+
+					<div class="govuk-grid-row">
+						<div class="govuk-grid-column-one-half">
+							{{ govukInput({
+								id: "s_backup",
+								name: "backupContact",
+								label: { text: "Backup contact" }
+							}) }}
+						</div>
+						<div class="govuk-grid-column-one-half">
+							{{ govukInput({
+								id: "s_researchers",
+								name: "researchers",
+								label: { text: "Researchers" }
+							}) }}
+						</div>
+					</div>
+
+					{{ govukTextarea({
+						id: "s_notes",
+						name: "notes",
+						value: "",
+						rows: 2,
+						label: { text: "Notes" }
+					}) }}
+
+					<div class="form__actions">
+						{{ govukButton({
+							text: "Create session",
+							type: "submit",
+							attributes: { id: "scheduleBtn" }
+						}) }}
+						<span id="scheduleMsg" class="msg" role="status" aria-live="polite"></span>
+					</div>
+				</form>
+			</section>
+		</div>
+	</div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/js/participants-route-loader.js?v={{ studyPageScriptVersion }}"></script>
+{% endblock %}

--- a/src/govuk/templates/pages/study-synthesis.njk
+++ b/src/govuk/templates/pages/study-synthesis.njk
@@ -1,0 +1,213 @@
+{% extends "layouts/researchops.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% set studyPageScriptVersion = "study-record-id-routing-20260518" %}
+
+{% block head %}
+	<meta property="schema:name" content="Study synthesis - ResearchOps">
+	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen">
+	<link rel="stylesheet" href="/css/synthesize.css?v=study-synthesis-20260501-progressive-disclosure" media="screen">
+	<link rel="modulepreload" href="/js/study-route-context.js">
+	<link rel="modulepreload" href="/js/synthesis-route-loader.js?v={{ studyPageScriptVersion }}">
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container study-synthesis-page" data-study-subpage-template="synthesis">
+	{{ govukBreadcrumbs({
+		items: [
+			{ text: "Projects", href: "/pages/projects/" },
+			{ text: "Project", href: "/pages/projects/", attributes: { id: "breadcrumb-project" } },
+			{ text: "Study", href: "#", attributes: { id: "breadcrumb-study" } },
+			{ text: "Synthesis" }
+		]
+	}) }}
+
+	<div id="synthesis-error" class="govuk-error-summary" tabindex="-1" hidden aria-hidden="true" data-module="govuk-error-summary">
+		<div role="alert">
+			<h2 class="govuk-error-summary__title">There is a problem</h2>
+			<div class="govuk-error-summary__body">
+				<ul id="synthesis-error-list" class="govuk-list govuk-error-summary__list"></ul>
+			</div>
+		</div>
+	</div>
+
+	<div id="synthesis-status" class="govuk-body-s synthesis-status" aria-live="polite"></div>
+
+	<header class="synthesis-hero govuk-!-margin-bottom-6">
+		<div>
+			<p id="synthesis-eyebrow" class="govuk-caption-m">Study synthesis</p>
+			<h1 id="synthesis-title" class="govuk-heading-l">Synthesis for this study</h1>
+			<p id="study-context-text" class="govuk-body synthesis-context govuk-!-width-two-thirds">Group study evidence into themes you can trace back to source notes.</p>
+		</div>
+		<div class="synthesis-hero__actions">
+			{{ govukButton({
+				text: "Back to study",
+				href: "/pages/projects/",
+				classes: "govuk-button--secondary",
+				attributes: { id: "back-to-study" }
+			}) }}
+		</div>
+	</header>
+
+	<section class="synthesis-summary" aria-label="Synthesis summary">
+		{{ govukSummaryList({
+			classes: "synthesis-summary-list",
+			rows: [
+				{ key: { text: "Project" }, value: { html: '<span id="summary-project">-</span>' } },
+				{ key: { text: "Study" }, value: { html: '<span id="summary-study">-</span>' } },
+				{ key: { text: "Evidence" }, value: { html: '<span id="summary-evidence-count">0 evidence items</span>' } },
+				{ key: { text: "Themes" }, value: { html: '<span id="summary-theme-count">0 themes</span>' } }
+			]
+		}) }}
+	</section>
+
+	<section id="no-evidence-state" class="synthesis-empty synthesis-empty--route" hidden>
+		<h2 class="govuk-heading-m">Capture evidence before starting synthesis</h2>
+		<p class="govuk-body">No evidence has been captured for this study yet. Capture evidence during a research session, then return here to group it into working clusters and themes.</p>
+		{{ govukButton({
+			text: "Capture evidence in a session",
+			href: "/pages/study/session/",
+			attributes: { id: "capture-evidence-link" }
+		}) }}
+	</section>
+
+	<div id="synthesis-workspace" class="synthesis-flow" hidden>
+		<section id="clusters-section" class="panel synthesis-panel" aria-labelledby="clusters-title">
+			<header class="synthesis-panel__header">
+				<div>
+					<h2 id="clusters-title" class="govuk-heading-m">Working cluster groupings</h2>
+					<p class="govuk-body">Create a working cluster grouping before selecting evidence. Cluster groupings are provisional groups of related evidence.</p>
+				</div>
+			</header>
+
+			<form id="cluster-form" class="cluster-create" novalidate>
+				{{ govukInput({
+					id: "cluster-label",
+					name: "clusterLabel",
+					label: { text: "Cluster grouping name" },
+					attributes: { autocomplete: "off", "aria-describedby": "create-cluster-hint", disabled: "disabled" }
+				}) }}
+
+				{{ govukTextarea({
+					id: "cluster-description",
+					name: "clusterDescription",
+					value: "",
+					rows: 4,
+					label: { text: "Cluster grouping description" },
+					attributes: { disabled: "disabled" }
+				}) }}
+
+				{{ govukButton({
+					text: "Create cluster grouping",
+					type: "submit",
+					attributes: { id: "create-cluster", "aria-describedby": "create-cluster-hint", disabled: "disabled" }
+				}) }}
+				<p id="create-cluster-hint" class="govuk-hint">Capture evidence before creating a working cluster grouping.</p>
+			</form>
+
+			<div id="clusters-empty" class="synthesis-empty" hidden>
+				<p class="govuk-body">No working cluster groupings have been created yet.</p>
+			</div>
+			<div id="cluster-list" class="cluster-list"></div>
+		</section>
+
+		<section id="evidence-section" class="panel synthesis-panel" aria-labelledby="evidence-title" hidden>
+			<header class="synthesis-panel__header">
+				<div>
+					<h2 id="evidence-title" class="govuk-heading-m">Evidence</h2>
+					<p class="govuk-body">Select evidence notes and add them to a working cluster grouping.</p>
+				</div>
+			</header>
+
+			<div class="evidence-toolbar">
+				{{ govukInput({
+					id: "tag-filter",
+					name: "tagFilter",
+					label: { text: "Filter by tag" },
+					hint: { text: "Use a tag, framework category or safeguarding label." },
+					attributes: { autocomplete: "off", spellcheck: "false" }
+				}) }}
+
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="target-cluster">Add selected evidence to</label>
+					<select id="target-cluster" class="govuk-select" aria-describedby="add-selected-evidence-hint" disabled></select>
+				</div>
+
+				<div class="synthesis-action-block">
+					{{ govukButton({
+						text: "Add selected evidence",
+						type: "button",
+						classes: "govuk-button--secondary",
+						attributes: { id: "add-selected-evidence", "aria-describedby": "add-selected-evidence-hint", disabled: "disabled" }
+					}) }}
+					<p id="add-selected-evidence-hint" class="govuk-hint">Create a working cluster grouping and select evidence before adding evidence.</p>
+				</div>
+			</div>
+
+			<div id="evidence-empty" class="synthesis-empty" hidden>
+				<h3 class="govuk-heading-s">No evidence has been captured for this study yet</h3>
+				<p class="govuk-body">Run or complete sessions, then return here to group evidence into themes.</p>
+			</div>
+			<div id="evidence-list" class="evidence-list"></div>
+		</section>
+
+		<section id="themes-locked" class="synthesis-empty synthesis-empty--locked" hidden>
+			<h2 class="govuk-heading-m">Create themes after adding evidence to a cluster</h2>
+			<p class="govuk-body">Add evidence to a working cluster grouping before creating a theme.</p>
+		</section>
+
+		<section id="themes-section" class="panel synthesis-panel" aria-labelledby="themes-title" hidden>
+			<header class="synthesis-panel__header">
+				<div>
+					<h2 id="themes-title" class="govuk-heading-m">Themes</h2>
+					<p class="govuk-body">Create themes from working cluster groupings. Each theme keeps links to the evidence used.</p>
+				</div>
+			</header>
+
+			<form id="theme-form" class="theme-create" novalidate>
+				<div class="govuk-form-group">
+					<label class="govuk-label" for="theme-cluster">Working cluster grouping</label>
+					<select id="theme-cluster" class="govuk-select" aria-describedby="create-theme-hint" disabled></select>
+				</div>
+
+				{{ govukInput({
+					id: "theme-label",
+					name: "themeLabel",
+					label: { text: "Theme name" },
+					attributes: { autocomplete: "off", "aria-describedby": "create-theme-hint", disabled: "disabled" }
+				}) }}
+
+				{{ govukTextarea({
+					id: "theme-description",
+					name: "themeDescription",
+					value: "",
+					rows: 5,
+					label: { text: "Theme description" },
+					attributes: { disabled: "disabled" }
+				}) }}
+
+				{{ govukButton({
+					text: "Create theme",
+					type: "submit",
+					attributes: { id: "create-theme", "aria-describedby": "create-theme-hint", disabled: "disabled" }
+				}) }}
+				<p id="create-theme-hint" class="govuk-hint">Add evidence to a working cluster grouping before creating a theme.</p>
+			</form>
+
+			<div id="themes-empty" class="synthesis-empty" hidden>
+				<p class="govuk-body">No themes have been created for this study yet.</p>
+			</div>
+			<div id="theme-list" class="theme-list"></div>
+		</section>
+	</div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/js/synthesis-route-loader.js?v={{ studyPageScriptVersion }}"></script>
+{% endblock %}

--- a/tests/govuk-forms-application-route-state.test.js
+++ b/tests/govuk-forms-application-route-state.test.js
@@ -75,9 +75,13 @@ includes(synthesizePage, "<label class=\"govuk-label\" for=\"theme-cluster\">Wor
 includes(synthesizePage, "aria-describedby=\"add-selected-evidence-hint\"", "Synthesize route");
 includes(synthesizePage, "aria-describedby=\"create-cluster-hint\"", "Synthesize route");
 includes(synthesizePage, "aria-describedby=\"create-theme-hint\"", "Synthesize route");
-includes(synthesizePage, "disabled>Add selected evidence</button>", "Synthesize route");
-includes(synthesizePage, "disabled>Create cluster grouping</button>", "Synthesize route");
-includes(synthesizePage, "disabled>Create theme</button>", "Synthesize route");
+includes(synthesizePage, "id=\"add-selected-evidence\"", "Synthesize route");
+includes(synthesizePage, "id=\"create-cluster\"", "Synthesize route");
+includes(synthesizePage, "id=\"create-theme\"", "Synthesize route");
+includes(synthesizePage, "disabled=\"disabled\"", "Synthesize route");
+includes(synthesizePage, "Add selected evidence", "Synthesize route");
+includes(synthesizePage, "Create cluster grouping", "Synthesize route");
+includes(synthesizePage, "Create theme", "Synthesize route");
 excludes(synthesizePage, "<textarea id=\"themeDesc\"", "Synthesize route");
 
 const dashboardPage = read("public/pages/project-dashboard/index.html");
@@ -150,4 +154,5 @@ includes(newStudyPage, "aria-describedby=\"study-notes-hint\"", "Add Study route
 includes(newStudyPage, "id=\"study-submit\"", "Add Study route");
 
 const guidesPage = read("public/pages/study/guides/index.html");
-includes(guidesPage, "class=\"govuk-form-group editor__title-field\"", "Guides route");
+includes(guidesPage, "class=\"govuk-form-group\"", "Guides route");
+includes(guidesPage, "class=\"govuk-input editor__title-field\"", "Guides route");

--- a/tests/govuk-tables-summary-lists-application-route-state.test.js
+++ b/tests/govuk-tables-summary-lists-application-route-state.test.js
@@ -56,7 +56,7 @@ excludes(studyPageSource, "class=\"kv__term\"", "study page");
 excludes(studyPageSource, "class=\"kv__desc\"", "study page");
 
 includes(guidesPageSource, "href=\"/css/govuk/govuk-tables.css\"", "study guides page");
-includes(guidesPageSource, "<table class=\"govuk-table\">", "study guides page");
+includes(guidesPageSource, "<table id=\"guides-table\" class=\"govuk-table\">", "study guides page");
 includes(guidesPageSource, "<thead class=\"govuk-table__head\">", "study guides page");
 includes(guidesPageSource, "<tbody id=\"guides-tbody\" class=\"govuk-table__body\">", "study guides page");
 excludes(guidesPageSource, "<table class=\"table\" role=\"table\">", "study guides page");
@@ -72,9 +72,9 @@ excludes(participantsPageSource, "role=\"columnheader\"", "participants page");
 includes(participantConsentPageSource, "href=\"/css/govuk/govuk-tables.css\"", "participant consent page");
 includes(participantConsentPageSource, "class=\"govuk-table participant-consent-table\"", "participant consent page");
 includes(participantConsentPageSource, "<tbody id=\"participant-consent-tbody\" class=\"govuk-table__body\">", "participant consent page");
-includes(participantConsentPageSource, "class=\"participant-consent-summary govuk-summary-list\"", "participant consent page");
-includes(participantConsentPageSource, "class=\"participant-consent-summary__key\"", "participant consent page");
-includes(participantConsentPageSource, "class=\"participant-consent-summary__value\"", "participant consent page");
+includes(participantConsentPageSource, "class=\"govuk-summary-list participant-consent-summary\"", "participant consent page");
+includes(participantConsentPageSource, "class=\"govuk-summary-list__key\"", "participant consent page");
+includes(participantConsentPageSource, "class=\"govuk-summary-list__value\"", "participant consent page");
 
 includes(participantsModuleSource, "document.createElement(\"tr\")", "participants module");
 includes(participantsModuleSource, "govuk-table__row", "participants module");

--- a/tests/participant-consent-route-state.test.js
+++ b/tests/participant-consent-route-state.test.js
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/study/participant-consent/index.html", "utf8");
+const templateSource = fs.readFileSync("src/govuk/templates/pages/study-participant-consent.njk", "utf8");
+const rendererSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 const loaderSource = fs.readFileSync("public/js/participant-consent-route-loader.js", "utf8");
 const controllerSource = fs.readFileSync("public/js/participant-consent-page.js", "utf8");
 const fieldsSource = fs.readFileSync("infra/cloudflare/src/core/fields.js", "utf8");
@@ -17,10 +19,28 @@ function excludes(source, text, label) {
 	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
-includes(pageSource, "Participant consent — ResearchOps", "participant consent page");
+for (const macro of [
+	"govukBreadcrumbs({",
+	"govukButton({",
+	"govukCheckboxes({",
+	"govukDetails({",
+	"govukInput({",
+	"govukSelect({",
+	"govukSummaryList({",
+	"govukTextarea({"
+]) {
+	includes(templateSource, macro, "participant consent template");
+}
+
+includes(rendererSource, "template: 'pages/study-participant-consent.njk'", "GOV.UK renderer");
+includes(rendererSource, "output: 'public/pages/study/participant-consent/index.html'", "GOV.UK renderer");
+
+includes(pageSource, "Participant consent - ResearchOps Demo Suite", "participant consent page");
+includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "participant consent page");
 includes(pageSource, "href=\"/css/participant-consent.css\"", "participant consent page");
 includes(pageSource, "src=\"/js/participant-consent-route-loader.js?v=study-record-id-routing-20260518\"", "participant consent page");
 includes(pageSource, "href=\"/js/study-route-context.js\"", "participant consent page");
+includes(pageSource, "data-study-subpage-template=\"participant-consent\"", "participant consent page");
 includes(pageSource, "id=\"breadcrumb-project\"", "participant consent page");
 includes(pageSource, "id=\"breadcrumb-study\"", "participant consent page");
 includes(pageSource, "id=\"back-to-study\"", "participant consent page");
@@ -31,6 +51,7 @@ includes(pageSource, "id=\"consent-form-select\"", "participant consent page");
 includes(pageSource, "id=\"capture-method\"", "participant consent page");
 includes(pageSource, "id=\"consent-withdrawn\"", "participant consent page");
 includes(pageSource, "id=\"withdrawal-reason\"", "participant consent page");
+includes(pageSource, "class=\"govuk-summary-list participant-consent-summary\"", "participant consent page");
 excludes(pageSource, "src=\"/js/participant-consent-page.js\"", "participant consent page");
 excludes(pageSource, "<script type=\"module\">", "participant consent page");
 excludes(pageSource, "class=\"btn", "participant consent page");

--- a/tests/participants-page-route-state.test.js
+++ b/tests/participants-page-route-state.test.js
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/study/participants/index.html", "utf8");
+const templateSource = fs.readFileSync("src/govuk/templates/pages/study-participants.njk", "utf8");
+const rendererSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 const stylesheetSource = fs.readFileSync("public/css/participants.css", "utf8");
 const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 const participantsModuleSource = fs.readFileSync("public/components/participants/participants-page.js", "utf8");
@@ -15,9 +17,16 @@ function excludes(source, text, label) {
 	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
-includes(pageSource, "href=\"/css/screen.css\"", "participants page");
-includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "participants page");
+for (const macro of ["govukBreadcrumbs({", "govukButton({", "govukInput({", "govukSelect({", "govukTextarea({"]) {
+	includes(templateSource, macro, "participants template");
+}
+
+includes(rendererSource, "template: 'pages/study-participants.njk'", "GOV.UK renderer");
+includes(rendererSource, "output: 'public/pages/study/participants/index.html'", "GOV.UK renderer");
+
+includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "participants page");
 includes(pageSource, "href=\"/css/participants.css\"", "participants page");
+includes(pageSource, "data-study-subpage-template=\"participants\"", "participants page");
 includes(pageSource, "src=\"/components/participants/participants-page.js\" defer", "participants page");
 includes(pageSource, "src=\"/pages/study/participants/scheduler.js\" defer", "participants page");
 includes(pageSource, "class=\"govuk-button\"", "participants page");
@@ -30,6 +39,7 @@ includes(pageSource, "id=\"scheduleForm\"", "participants page");
 includes(pageSource, "id=\"noParticipantsBanner\"", "participants page");
 includes(pageSource, "id=\"scheduleBtn\"", "participants page");
 excludes(pageSource, "class=\"btn", "participants page");
+excludes(pageSource, "href=\"/css/screen.css\"", "participants page");
 excludes(pageSource, "href=\"/css/participants.css\" media=\"print\"", "participants page");
 
 includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");

--- a/tests/study-guides-route-state.test.js
+++ b/tests/study-guides-route-state.test.js
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/study/guides/index.html", "utf8");
+const templateSource = fs.readFileSync("src/govuk/templates/pages/study-guides.njk", "utf8");
+const rendererSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 const contextSource = fs.readFileSync("public/js/study-guides-context.js", "utf8");
 const guidesPageSource = fs.readFileSync("public/components/guides/guides-page.js", "utf8");
 const variableManagerSource = fs.readFileSync("public/components/guides/variable-manager.js", "utf8");
@@ -16,21 +18,32 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
-includes(pageSource, "href=\"/css/screen.css\"", "study guides page");
-includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "study guides page");
+for (const macro of ["govukBreadcrumbs({", "govukButton({", "govukInput({"]) {
+  includes(templateSource, macro, "study guides template");
+}
+
+includes(rendererSource, "template: 'pages/study-guides.njk'", "GOV.UK renderer");
+includes(rendererSource, "output: 'public/pages/study/guides/index.html'", "GOV.UK renderer");
+
+includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "study guides page");
 includes(pageSource, "href=\"/css/guides.css\"", "study guides page");
+includes(pageSource, "data-study-subpage-template=\"guides\"", "study guides page");
 includes(pageSource, "/js/study-guides-context.js", "study guides page");
 includes(pageSource, "rel=\"modulepreload\" href=\"/js/study-guides-context.js\"", "study guides page");
 includes(pageSource, "/components/guides/guides-page.js", "study guides page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "study guides page");
 includes(pageSource, "class=\"govuk-button\"", "study guides page");
 includes(pageSource, "class=\"govuk-button govuk-button--secondary\"", "study guides page");
+includes(pageSource, "id=\"btn-new\"", "study guides page");
+includes(pageSource, "id=\"guide-source\"", "study guides page");
+includes(pageSource, "id=\"guide-preview\"", "study guides page");
 includes(pageSource, "id=\"guides-tbody\"", "study guides page");
 includes(pageSource, "id=\"editor-section\"", "study guides page");
 includes(pageSource, "id=\"drawer-patterns\"", "study guides page");
 includes(pageSource, "id=\"drawer-variables\"", "study guides page");
 includes(pageSource, "id=\"back-to-study\"", "study guides page");
 excludes(pageSource, "class=\"btn", "study guides page");
+excludes(pageSource, "href=\"/css/screen.css\"", "study guides page");
 excludes(pageSource, "<script type=\"module\">", "study guides page");
 
 includes(buttonCssSource, ".govuk-button", "GOV.UK button stylesheet");

--- a/tests/synthesize-page-route-state.test.js
+++ b/tests/synthesize-page-route-state.test.js
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/study/synthesis/index.html", "utf8");
+const templateSource = fs.readFileSync("src/govuk/templates/pages/study-synthesis.njk", "utf8");
+const rendererSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 const loaderSource = fs.readFileSync("public/js/synthesis-route-loader.js", "utf8");
 const controllerSource = fs.readFileSync("public/js/synthesize-page.js", "utf8");
 const stylesheetSource = fs.readFileSync("public/css/synthesize.css", "utf8");
@@ -15,14 +17,19 @@ function excludes(source, text, label) {
 }
 
 includes(pageSource, "<html class=\"govuk-template\" lang=\"en\">", "synthesis page");
+for (const macro of ["govukBreadcrumbs({", "govukButton({", "govukInput({", "govukSummaryList({", "govukTextarea({"]) {
+	includes(templateSource, macro, "synthesis template");
+}
+includes(rendererSource, "template: 'pages/study-synthesis.njk'", "GOV.UK renderer");
+includes(rendererSource, "output: 'public/pages/study/synthesis/index.html'", "GOV.UK renderer");
 includes(pageSource, "/assets/govuk/govuk-frontend.css", "synthesis page");
 includes(pageSource, "/components/layout.js", "synthesis page");
 includes(pageSource, "/js/govuk-frontend-init.js", "synthesis page");
 includes(pageSource, "src=\"/partials/header.html\"", "synthesis page");
 includes(pageSource, "src=\"/partials/footer.html\"", "synthesis page");
 includes(pageSource, "/js/synthesis-route-loader.js?v=study-record-id-routing-20260518", "synthesis page");
-includes(pageSource, "href=\"/css/screen.css\"", "synthesis page");
 includes(pageSource, "href=\"/css/synthesize.css?v=study-synthesis-20260501-progressive-disclosure\"", "synthesis page");
+includes(pageSource, "data-study-subpage-template=\"synthesis\"", "synthesis page");
 
 for (const id of [
 	"synthesis-error",
@@ -70,12 +77,16 @@ includes(pageSource, "Capture evidence before starting synthesis", "synthesis pa
 includes(pageSource, "Capture evidence in a session", "synthesis page");
 includes(pageSource, "Working cluster groupings", "synthesis page");
 includes(pageSource, "Create a working cluster grouping before selecting evidence.", "synthesis page");
-includes(pageSource, "disabled>Create cluster grouping</button>", "synthesis page");
-includes(pageSource, "disabled>Create theme</button>", "synthesis page");
+includes(pageSource, "id=\"create-cluster\"", "synthesis page");
+includes(pageSource, "disabled=\"disabled\"", "synthesis page");
+includes(pageSource, "Create cluster grouping", "synthesis page");
+includes(pageSource, "id=\"create-theme\"", "synthesis page");
+includes(pageSource, "Create theme", "synthesis page");
 excludes(pageSource, "id=\"filter\"", "synthesis page");
 excludes(pageSource, "id=\"newCluster\"", "synthesis page");
 excludes(pageSource, "id=\"publish\"", "synthesis page");
 excludes(pageSource, "<script type=\"module\">", "synthesis page");
+excludes(pageSource, "href=\"/css/screen.css\"", "synthesis page");
 
 includes(loaderSource, "study-canonical-url-bridge.js?v=study-record-id-routing-20260518", "synthesis loader");
 includes(loaderSource, "components/layout.js", "synthesis loader");


### PR DESCRIPTION
## Summary

- Convert the Study participant consent, participants, guides and synthesis subpages to Nunjucks templates using GOV.UK Frontend and macros where compatible with existing JS hooks.
- Register and regenerate the four static Study subpage routes.
- Update route-state and GOV.UK contract tests, plus the required operating-model trace.

## Validation

- `node scripts/govuk/render-govuk-pages.mjs`
- `node --test tests/participant-consent-route-state.test.js tests/participants-page-route-state.test.js tests/study-guides-route-state.test.js tests/synthesize-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js`
- `node scripts/agent-trace/assert-trace-coverage.mjs`
- `git diff --check`
- `node node_modules/prettier/bin/prettier.cjs --check scripts/govuk/render-govuk-pages.mjs public/pages/study/participant-consent/index.html public/pages/study/participants/index.html public/pages/study/guides/index.html public/pages/study/synthesis/index.html tests/participant-consent-route-state.test.js tests/participants-page-route-state.test.js tests/study-guides-route-state.test.js tests/synthesize-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.md docs/agent-audit/reasoning/2026/06/05/study-subpages-govuk-nunjucks.json`
- `node --test` (176 passing)
- Browser spot-check of all four converted routes on a local static preview

## Notes

Participant consent and synthesis keep hand-authored GOV.UK error-summary markup because their existing controllers dynamically populate specific `ul` hooks that the macro does not expose directly.