### PR TITLE
Fix Pages build config and Mural return guard

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.json
+++ b/docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.json
@@ -1,0 +1,65 @@
+{
+	"date": "2026-06-06",
+	"branch": "fix/pages-config-mural-return",
+	"traceRequired": true,
+	"repository": "kevinrapley/ResearchOps",
+	"task": "Pin the Cloudflare Pages build Node version, remove the invalid absolute API proxy redirect, and protect Mural OAuth return-to-Pages behaviour.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		".agent-operating-model/bundles/github/",
+		".agent-operating-model/bundles/researchops-developer-control/",
+		".agent-operating-model/bundles/multi-functional-team/",
+		".agent-operating-model/bundles/cloudflare/",
+		".agent-operating-model/bundles/mural-public-api/"
+	],
+	"skippedBundles": [
+		".agent-operating-model/bundles/govuk-design-system/",
+		".agent-operating-model/bundles/openai/",
+		".agent-operating-model/bundles/mcp-agent-tooling/",
+		".agent-operating-model/bundles/airtable-public-api/"
+	],
+	"filesRead": [
+		"wrangler.toml",
+		"public/_redirects",
+		"functions/api/[[path]].js",
+		"infra/cloudflare/wrangler.toml",
+		"infra/cloudflare/src/service/internals/mural.js",
+		"infra/cloudflare/src/lib/mural.js",
+		"infra/cloudflare/src/core/router.js",
+		"public/components/mural-integration.js",
+		"tests/mural-ui-route-state.test.js",
+		"tests/project-dashboard-route-state.test.js"
+	],
+	"filesModified": [
+		"wrangler.toml",
+		"public/_redirects",
+		"tests/pages-config-mural-return-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.md",
+		"docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.json"
+	],
+	"decisions": [
+		"Add NODE_VERSION = \"20\" under [vars] in the root Pages wrangler.toml.",
+		"Remove the invalid absolute /api/* proxy rule from public/_redirects.",
+		"Keep MURAL_REDIRECT_URI pointing at the API Worker callback so Mural can return the authorization code.",
+		"Test that Mural callback redirects relative return paths using PAGES_ORIGIN rather than the Worker request URL.",
+		"Use route-state coverage to preserve the Pages, redirect and Mural OAuth return contracts."
+	],
+	"validationAttempted": [
+		"Repository-local commands were not run in this environment.",
+		"Added tests/pages-config-mural-return-route-state.test.js for CI execution through npm test.",
+		"Verified the changed-file list after edits."
+	],
+	"residualRisks": [
+		"The Mural UI still uses the production Worker origin on pages.dev hosts unless an API-origin override is present; this was existing behaviour and outside the PR scope.",
+		"Cloudflare Pages should be redeployed after merge to confirm Node 20 and no invalid redirect warnings."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.md
+++ b/docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.md
@@ -1,0 +1,86 @@
+# Pages config and Mural return guard
+
+## Task summary
+
+Pin the Cloudflare Pages build Node version in the root Pages Wrangler configuration, remove the invalid absolute `/api/*` proxy redirect, and protect the Mural OAuth return-to-Pages behaviour with route-state coverage.
+
+## Run metadata
+
+- Date: 2026-06-06
+- Branch: `fix/pages-config-mural-return`
+- Trace required: yes, because `fix/` branches require an auditable trace.
+- Repository: `kevinrapley/ResearchOps`
+
+## Operating model loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Bundles selected
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/cloudflare/`
+- `.agent-operating-model/bundles/mural-public-api/`
+
+## Bundles skipped
+
+- `.agent-operating-model/bundles/govuk-design-system/`: no GOV.UK page, component, content or accessibility implementation changed.
+- `.agent-operating-model/bundles/openai/`: no OpenAI API, model or AI route behaviour changed.
+- `.agent-operating-model/bundles/mcp-agent-tooling/`: no MCP tooling changed.
+- `.agent-operating-model/bundles/airtable-public-api/`: no Airtable API behaviour changed.
+
+## Precedence decisions
+
+- GitHub Diamond governed branch naming, trace requirement, mutation discipline, PR scope and validation evidence.
+- ResearchOps Developer Control governed existing Pages, Worker and route-state test conventions.
+- Cloudflare governed Pages Wrangler configuration, `_redirects` handling and build environment alignment.
+- Mural Public API governed OAuth callback risk framing and return-path protection.
+- Multi-Functional Team governed user-impact framing because a broken OAuth return path can strand users outside the Pages journey.
+
+## Files read
+
+- `wrangler.toml`
+- `public/_redirects`
+- `functions/api/[[path]].js`
+- `infra/cloudflare/wrangler.toml`
+- `infra/cloudflare/src/service/internals/mural.js`
+- `infra/cloudflare/src/lib/mural.js`
+- `infra/cloudflare/src/core/router.js`
+- `public/components/mural-integration.js`
+- `tests/mural-ui-route-state.test.js`
+- `tests/project-dashboard-route-state.test.js`
+
+## Files created or modified
+
+- `wrangler.toml`
+- `public/_redirects`
+- `tests/pages-config-mural-return-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.md`
+- `docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.json`
+
+## Decisions
+
+- Added `NODE_VERSION = "20"` under `[vars]` in the root Pages `wrangler.toml`, because Cloudflare Pages reported that build environment variables are sourced from the root Wrangler configuration.
+- Removed the invalid absolute `/api/*` proxy rule from `public/_redirects`, because Cloudflare rejects absolute 200 proxy redirects to external origins.
+- Kept the Mural OAuth callback on the Worker via `MURAL_REDIRECT_URI`, because Mural must return the authorization code to the API Worker.
+- Preserved the actual return-to-Pages protection by testing that `muralCallback` builds relative return paths against `env.PAGES_ORIGIN`.
+- Added route-state coverage for the root Pages config, redirect contract, Worker Mural callback config, Worker Mural routes and callback return construction.
+
+## Validation attempted
+
+- Repository-local commands were not run in this environment.
+- Added `tests/pages-config-mural-return-route-state.test.js` for CI to execute through the existing `npm test` path.
+- The changed-file list was verified after edits and is scoped to Pages config, redirects, a route-state test and trace artefacts.
+
+## Residual risks
+
+- The Mural UI still uses the production Worker origin on `pages.dev` hosts unless an API-origin override is present. That behaviour was already present and is outside this small PR.
+- Cloudflare Pages should be redeployed after merge to confirm that the build log reports Node 20 and no invalid redirect lines.

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,5 @@
 /assets/fonts/*                 /assets/govuk/assets/fonts/:splat              200
 /assets/images/govuk-crest.svg  /assets/govuk/assets/images/govuk-crest.svg  200
 
-/api/*       https://rops-api.digikev-kevin-rapley.workers.dev/api/:splat   200
 /reporting/* https://reopsreporting.pages.dev/:splat                     301
 /reporting   https://reopsreporting.pages.dev/                           301

--- a/tests/pages-config-mural-return-route-state.test.js
+++ b/tests/pages-config-mural-return-route-state.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pagesConfig = fs.readFileSync("wrangler.toml", "utf8");
+const redirects = fs.readFileSync("public/_redirects", "utf8");
+const muralSource = fs.readFileSync("infra/cloudflare/src/service/internals/mural.js", "utf8");
+const workerConfig = fs.readFileSync("infra/cloudflare/wrangler.toml", "utf8");
+const routerSource = fs.readFileSync("infra/cloudflare/src/core/router.js", "utf8");
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(pagesConfig, 'pages_build_output_dir = "public"', "root Pages Wrangler config");
+includes(pagesConfig, "[vars]", "root Pages Wrangler config");
+includes(pagesConfig, 'NODE_VERSION = "20"', "root Pages Wrangler config");
+
+includes(redirects, "/assets/fonts/*", "Pages redirects");
+includes(redirects, "/assets/images/govuk-crest.svg", "Pages redirects");
+includes(redirects, "/reporting/* https://reopsreporting.pages.dev/:splat", "Pages redirects");
+excludes(redirects, "/api/*", "Pages redirects");
+excludes(redirects, "https://rops-api.digikev-kevin-rapley.workers.dev/api/:splat", "Pages redirects");
+
+includes(workerConfig, 'MURAL_REDIRECT_URI = "https://rops-api.digikev-kevin-rapley.workers.dev/api/mural/callback"', "Worker Mural OAuth config");
+includes(workerConfig, 'PAGES_ORIGIN       = "https://researchops.pages.dev"', "Worker Mural OAuth config");
+
+includes(routerSource, 'if (url.pathname === "/api/mural/auth" && request.method === "GET") return service.mural.muralAuth(origin, url);', "Worker router");
+includes(routerSource, 'if (url.pathname === "/api/mural/callback" && request.method === "GET") return service.mural.muralCallback(origin, url);', "Worker router");
+
+includes(muralSource, 'const ret = url.searchParams.get("return") || "";', "Mural auth route");
+includes(muralSource, 'if (ret && new URL(ret).origin === new URL(origin).origin) safeReturn = ret;', "Mural auth route");
+includes(muralSource, 'if (ret.startsWith("/")) safeReturn = ret;', "Mural auth route");
+includes(muralSource, 'const state = b64Encode(JSON.stringify({ uid, ts: Date.now(), return: safeReturn, dbg }));', "Mural auth route");
+includes(muralSource, 'const pagesOrigin = env.PAGES_ORIGIN || "https://researchops.pages.dev";', "Mural callback route");
+includes(muralSource, 'backUrl = new URL(want, pagesOrigin);', "Mural callback route");
+includes(muralSource, "return Response.redirect(finalUrl, 302);", "Mural callback route");
+
+excludes(muralSource, "backUrl = new URL(want, url);", "Mural callback route");
+excludes(muralSource, 'new URL("/pages/projects/", url)', "Mural callback route");

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,6 @@
 name = "researchops"
 pages_build_output_dir = "public"
 compatibility_date = "2026-05-21"
+
+[vars]
+NODE_VERSION = "20"


### PR DESCRIPTION
## Summary

- Pin the Cloudflare Pages build environment to Node 20 in the root `wrangler.toml`.
- Remove the invalid absolute `/api/*` proxy redirect from `public/_redirects`.
- Add route-state coverage proving Mural OAuth still returns users to the Pages environment through `PAGES_ORIGIN`, not the Worker request URL.
- Add auditable trace artefacts for this `fix/` branch.

## Why

Cloudflare Pages now reads configuration from the root `wrangler.toml`. The recent build log showed `Build environment variables: (none found)` and Node 22.16.0. ResearchOps validation uses Node 20, so the Pages build should be pinned to the same major version.

Cloudflare also rejects the existing `/api/*` redirect because 200 proxy redirects can only target relative paths. The current Mural return-path protection does not depend on that redirect rule: Mural returns the OAuth code to the API Worker callback, and the Worker callback redirects the browser back to `PAGES_ORIGIN`.

## Validation

Repository-local commands were not run in this environment.

Validation added for CI:

- `tests/pages-config-mural-return-route-state.test.js`

The new test asserts:

- root Pages `wrangler.toml` keeps `pages_build_output_dir = "public"`
- root Pages `wrangler.toml` sets `NODE_VERSION = "20"`
- `public/_redirects` no longer contains `/api/*` or the absolute Worker proxy target
- Worker config keeps `MURAL_REDIRECT_URI` on the API Worker
- Worker config keeps `PAGES_ORIGIN` on `https://researchops.pages.dev`
- Worker router still exposes `/api/mural/auth` and `/api/mural/callback`
- Mural callback builds relative return paths against `pagesOrigin`

## Trace

- `docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.md`
- `docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.json`

## Changed-file verification

Changed files: 5

- `wrangler.toml`
- `public/_redirects`
- `tests/pages-config-mural-return-route-state.test.js`
- `docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.md`
- `docs/agent-audit/reasoning/2026/06/06/pages-config-mural-return.json`

## Residual risk

The Mural UI still uses the production Worker origin on `pages.dev` hosts unless an API-origin override is present. That behaviour already existed and is outside this small PR.