### PR TITLE
Add Home Office secondary button brand style

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.json
+++ b/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.json
@@ -89,6 +89,7 @@
 	"filesModifiedOrCreated": [
 		"src/styles/brands/home-office-buttons.scss",
 		"public/css/brands/home-office-buttons.css",
+		"public/css/brands/home-office.css",
 		"public/js/brand-variant.js",
 		"scripts/styles/generated-css-targets.mjs",
 		"tests/brand-variant-route-state.test.js",
@@ -100,7 +101,8 @@
 		"Added generated CSS counterpart.",
 		"Registered the new generated CSS target.",
 		"Loaded the button brand stylesheet after the main Home Office brand stylesheet.",
-		"Extended route-state assertions for the secondary button contract."
+		"Extended route-state assertions for the secondary button contract.",
+		"Applied the generated Prettier patch for Sass and generated CSS formatting."
 	],
 	"testContractImpactSweep": {
 		"performed": true,
@@ -125,12 +127,12 @@
 	},
 	"automatedReviewComments": {
 		"checked": true,
-		"actionableCodexThreadsPresentAtTraceCreation": false,
-		"disposition": "No PR review threads were present at trace creation. Later legitimate automated review comments must be handled under Codex disposition rules."
+		"actionableCodexThreadsPresentAtReadinessReview": false,
+		"disposition": "PR #380 contains a Cloudflare deployment notice only. Later legitimate automated review comments must be handled under Codex disposition rules."
 	},
 	"validation": {
-		"statusAtTraceCreation": "pending",
-		"requiredBeforeReady": [
+		"latestGreenHeadBeforeTraceUpdate": "c1ca7daf41a1fa547c64047a0bdcc1b8a0e3311d",
+		"passedBeforeTraceUpdate": [
 			"CI",
 			"Validate ResearchOps",
 			"Worker CI",
@@ -138,7 +140,8 @@
 			"Accessibility audit (pa11y-ci)",
 			"qa-bdd",
 			"QA — Broken links (Lychee)"
-		]
+		],
+		"afterTraceUpdate": "pending"
 	},
 	"residualRisks": [
 		"Visual verification on the Cloudflare branch preview remains useful because this is a component-style change.",

--- a/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.json
+++ b/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.json
@@ -1,0 +1,147 @@
+{
+	"schema": "researchops.agentAuditTrace.v1",
+	"date": "2026-06-09",
+	"traceLayer": "operational",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "fix/home-office-secondary-button-style",
+	"pullRequest": 380,
+	"branchPrefix": "fix/",
+	"traceRequired": true,
+	"taskSummary": "Apply the Home Office Design System adjusted secondary button style to the ResearchOps Home Office brand variant.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/github-mutation-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/bundles/github/prompt.spec.yaml",
+		".agent-operating-model/bundles/github/prompt.body.xml",
+		".agent-operating-model/bundles/github/references/github-tooling-mutation-policy.xml",
+		".agent-operating-model/bundles/github/references/test-contract-impact-sweep.xml",
+		".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+		".agent-operating-model/bundles/researchops-developer-control/references/core-rules.xml",
+		".agent-operating-model/bundles/researchops-developer-control/references/researchops-platform-context.xml",
+		".agent-operating-model/bundles/researchops-developer-control/references/researchops-repository-conventions.xml",
+		".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/",
+			"reason": "Repository safety, branch governance, PR discipline, CI and automated review comment handling."
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+			"reason": "ResearchOps platform CSS layering, generated output and route-state contracts."
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+			"reason": "Government service assurance defaults."
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+			"reason": "GOV.UK and Home Office component styling and accessibility."
+		}
+	],
+	"skippedBundles": [
+		{
+			"id": "cloudflare",
+			"reason": "No Worker, Pages routing or deployment implementation changed."
+		},
+		{
+			"id": "openai-platform",
+			"reason": "No OpenAI API or model integration changed."
+		},
+		{
+			"id": "mcp-agent-tooling",
+			"reason": "No MCP protocol or agent-tooling contract changed."
+		},
+		{
+			"id": "airtable-public-api",
+			"reason": "No Airtable integration changed."
+		},
+		{
+			"id": "mural-public-api",
+			"reason": "No Mural integration changed."
+		}
+	],
+	"precedenceDecisions": [
+		"GitHub Diamond governed branch, PR and trace behaviour.",
+		"ResearchOps Developer Control governed where the implementation should live.",
+		"GOV.UK Design System governed component semantics and accessibility.",
+		"Home Office Design System source evidence informed the adjusted secondary button styling."
+	],
+	"filesRead": [
+		"Home Office Design System button component guidance",
+		"UKHomeOffice/design-system/components/page/assets/Page.scss",
+		"public/js/brand-variant.js",
+		"scripts/styles/generated-css-targets.mjs",
+		"src/styles/brands/home-office.scss",
+		"public/css/brands/home-office.css",
+		"tests/brand-variant-route-state.test.js"
+	],
+	"filesModifiedOrCreated": [
+		"src/styles/brands/home-office-buttons.scss",
+		"public/css/brands/home-office-buttons.css",
+		"public/js/brand-variant.js",
+		"scripts/styles/generated-css-targets.mjs",
+		"tests/brand-variant-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.md",
+		"docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.json"
+	],
+	"implementationSummary": [
+		"Added Home Office secondary button Sass source.",
+		"Added generated CSS counterpart.",
+		"Registered the new generated CSS target.",
+		"Loaded the button brand stylesheet after the main Home Office brand stylesheet.",
+		"Extended route-state assertions for the secondary button contract."
+	],
+	"testContractImpactSweep": {
+		"performed": true,
+		"affectedContracts": [
+			"Home Office brand stylesheet loading order",
+			"generated CSS manifest",
+			"Home Office secondary button Sass source",
+			"generated Home Office secondary button CSS",
+			"route-state brand variant assertions"
+		],
+		"legacyOrAffectedTermsChecked": [
+			"govuk-button--secondary",
+			"home-office-buttons.css",
+			"home-office-buttons.scss",
+			"researchops-home-office-buttons-brand",
+			"#f8f8f8",
+			"#dfdfdf",
+			"border-width: 1px 1px 0 1px",
+			"padding: 9px 11px 9px",
+			"padding: 8px 10px 7px"
+		]
+	},
+	"automatedReviewComments": {
+		"checked": true,
+		"actionableCodexThreadsPresentAtTraceCreation": false,
+		"disposition": "No PR review threads were present at trace creation. Later legitimate automated review comments must be handled under Codex disposition rules."
+	},
+	"validation": {
+		"statusAtTraceCreation": "pending",
+		"requiredBeforeReady": [
+			"CI",
+			"Validate ResearchOps",
+			"Worker CI",
+			"Release Gate",
+			"Accessibility audit (pa11y-ci)",
+			"qa-bdd",
+			"QA — Broken links (Lychee)"
+		]
+	},
+	"residualRisks": [
+		"Visual verification on the Cloudflare branch preview remains useful because this is a component-style change.",
+		"The secondary button override is scoped to the Home Office brand and loaded after the main Home Office brand stylesheet."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.md
+++ b/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.md
@@ -1,0 +1,123 @@
+# Home Office secondary button brand style
+
+## Run metadata
+
+- Date: 2026-06-09
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `fix/home-office-secondary-button-style`
+- Pull request: #380
+- Trace layer: operational
+- Branch-prefix trace decision: `fix/` requires a promoted trace.
+
+## Original task summary
+
+Apply the Home Office Design System secondary button adjustment to the ResearchOps Home Office brand variant. The Home Office guidance states that the secondary button style is slightly changed from GOV.UK to improve contrast with the Home Office grey page background.
+
+## Operating-model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/bundles/github/prompt.spec.yaml`
+- `.agent-operating-model/bundles/github/prompt.body.xml`
+- `.agent-operating-model/bundles/github/references/github-tooling-mutation-policy.xml`
+- `.agent-operating-model/bundles/github/references/test-contract-impact-sweep.xml`
+- `.agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml`
+- `.agent-operating-model/bundles/researchops-developer-control/references/core-rules.xml`
+- `.agent-operating-model/bundles/researchops-developer-control/references/researchops-platform-context.xml`
+- `.agent-operating-model/bundles/researchops-developer-control/references/researchops-repository-conventions.xml`
+- `.agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml`
+
+## Canonical bundle directories selected
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+## Bundles selected
+
+- `github-diamond`: branch, PR, trace, CI and automated-review governance.
+- `researchops-developer-control`: ResearchOps CSS layering, generated CSS and route-state test contracts.
+- `multi-functional-team`: government service assurance defaults.
+- `govuk-design-system`: GOV.UK component accessibility and Home Office design-system-aligned styling.
+
+## Bundles skipped
+
+- `cloudflare`: no Worker, Pages routing or deployment implementation changed.
+- `openai-platform`: no OpenAI API or model integration changed.
+- `mcp-agent-tooling`: no MCP server, client or tool contract changed.
+- `airtable-public-api`: no Airtable integration changed.
+- `mural-public-api`: no Mural integration changed.
+
+## Precedence decisions
+
+GitHub Diamond governed branch, PR and trace behaviour. ResearchOps Developer Control governed where the implementation should live. GOV.UK Design System governed component semantics and accessibility. The Home Office Design System source was used to identify the adjusted secondary button treatment, while ordinary GOV.UK button semantics remain intact.
+
+## Files read
+
+- Home Office Design System button component guidance
+- `UKHomeOffice/design-system/components/page/assets/Page.scss`
+- `public/js/brand-variant.js`
+- `scripts/styles/generated-css-targets.mjs`
+- `src/styles/brands/home-office.scss`
+- `public/css/brands/home-office.css`
+- `tests/brand-variant-route-state.test.js`
+
+## Files created or modified
+
+- `src/styles/brands/home-office-buttons.scss`
+- `public/css/brands/home-office-buttons.css`
+- `public/js/brand-variant.js`
+- `scripts/styles/generated-css-targets.mjs`
+- `tests/brand-variant-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.md`
+- `docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.json`
+
+## Implementation summary
+
+- Added a Home Office secondary button Sass source with the adjusted HODS colours, borders, shadow and padding.
+- Added the generated CSS counterpart.
+- Registered the generated CSS target.
+- Updated the brand switcher to load `/css/brands/home-office-buttons.css` after `/css/brands/home-office.css` when the Home Office brand is active.
+- Extended route-state assertions for the new Home Office secondary button contract.
+
+## Test-contract impact sweep
+
+Performed. Affected contract surfaces:
+
+- Home Office brand stylesheet loading order
+- generated CSS manifest
+- Home Office secondary button Sass source
+- generated Home Office secondary button CSS
+- route-state assertions protecting brand CSS and generated CSS
+
+Legacy or affected terms checked:
+
+- `govuk-button--secondary`
+- `home-office-buttons.css`
+- `home-office-buttons.scss`
+- `researchops-home-office-buttons-brand`
+- `#f8f8f8`
+- `#dfdfdf`
+- `border-width: 1px 1px 0 1px`
+- `padding: 9px 11px 9px`
+- `padding: 8px 10px 7px`
+
+## Automated review comments
+
+No PR review threads were present at trace creation. Any later legitimate Codex or automated review comment must be acknowledged with a thumbs-up reaction, replied to with evidence, and resolved only after the fix is present and validation has been checked.
+
+## Validation attempted
+
+PR checks had not completed at trace creation. Checks must pass on the latest branch head before the PR is marked ready.
+
+## Residual risks
+
+- Visual verification on the Cloudflare branch preview remains useful because this is a component-style change.
+- The secondary button override is scoped to the Home Office brand and loaded after the main Home Office brand stylesheet to preserve GOV.UK default behaviour.

--- a/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.md
+++ b/docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.md
@@ -73,6 +73,7 @@ GitHub Diamond governed branch, PR and trace behaviour. ResearchOps Developer Co
 
 - `src/styles/brands/home-office-buttons.scss`
 - `public/css/brands/home-office-buttons.css`
+- `public/css/brands/home-office.css`
 - `public/js/brand-variant.js`
 - `scripts/styles/generated-css-targets.mjs`
 - `tests/brand-variant-route-state.test.js`
@@ -86,6 +87,7 @@ GitHub Diamond governed branch, PR and trace behaviour. ResearchOps Developer Co
 - Registered the generated CSS target.
 - Updated the brand switcher to load `/css/brands/home-office-buttons.css` after `/css/brands/home-office.css` when the Home Office brand is active.
 - Extended route-state assertions for the new Home Office secondary button contract.
+- Applied the generated Prettier patch for Sass and generated CSS formatting.
 
 ## Test-contract impact sweep
 
@@ -111,11 +113,21 @@ Legacy or affected terms checked:
 
 ## Automated review comments
 
-No PR review threads were present at trace creation. Any later legitimate Codex or automated review comment must be acknowledged with a thumbs-up reaction, replied to with evidence, and resolved only after the fix is present and validation has been checked.
+PR #380 contains a Cloudflare deployment notice only. No actionable Codex code review thread was present at readiness review. Any later legitimate Codex or automated review comment must be acknowledged with a thumbs-up reaction, replied to with evidence, and resolved only after the fix is present and validation has been checked.
 
 ## Validation attempted
 
-PR checks had not completed at trace creation. Checks must pass on the latest branch head before the PR is marked ready.
+All checks passed on latest head `c1ca7daf41a1fa547c64047a0bdcc1b8a0e3311d` before this trace update:
+
+- CI
+- Validate ResearchOps
+- Worker CI
+- Release Gate
+- Accessibility audit (pa11y-ci)
+- qa-bdd
+- QA — Broken links (Lychee)
+
+Checks must be polled again after this trace update.
 
 ## Residual risks
 

--- a/public/css/brands/home-office-buttons.css
+++ b/public/css/brands/home-office-buttons.css
@@ -1,0 +1,29 @@
+/* Home Office secondary button brand variant for ResearchOps */
+
+html[data-researchops-brand=home-office] .govuk-button--secondary {
+	background-color: #f8f8f8;
+	border-color: #0b0c0c;
+	border-width: 1px 1px 0 1px;
+	box-shadow: 0 2px 0 #0b0c0c;
+	color: #0b0c0c;
+	padding: 9px 11px 9px;
+	}
+
+html[data-researchops-brand=home-office] .govuk-button--secondary:link, html[data-researchops-brand=home-office] .govuk-button--secondary:visited, html[data-researchops-brand=home-office] .govuk-button--secondary:active, html[data-researchops-brand=home-office] .govuk-button--secondary:hover {
+	color: #0b0c0c;
+	}
+
+html[data-researchops-brand=home-office] .govuk-button--secondary:hover {
+	background-color: #dfdfdf;
+	}
+
+html[data-researchops-brand=home-office] .govuk-button--secondary:hover[disabled] {
+	background-color: #f8f8f8;
+	}
+
+html[data-researchops-brand=home-office] .govuk-button--secondary:focus {
+	border-width: 2px;
+	padding: 8px 10px 7px;
+	}
+
+/* transparency begins in the cascade */

--- a/public/css/brands/home-office-buttons.css
+++ b/public/css/brands/home-office-buttons.css
@@ -1,6 +1,6 @@
 /* Home Office secondary button brand variant for ResearchOps */
 
-html[data-researchops-brand=home-office] .govuk-button--secondary {
+html[data-researchops-brand=home-office] .govuk-button--secondary, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary {
 	background-color: #f8f8f8;
 	border-color: #0b0c0c;
 	border-width: 1px 1px 0 1px;
@@ -9,19 +9,25 @@ html[data-researchops-brand=home-office] .govuk-button--secondary {
 	padding: 9px 11px 9px;
 	}
 
-html[data-researchops-brand=home-office] .govuk-button--secondary:link, html[data-researchops-brand=home-office] .govuk-button--secondary:visited, html[data-researchops-brand=home-office] .govuk-button--secondary:active, html[data-researchops-brand=home-office] .govuk-button--secondary:hover {
+html[data-researchops-brand=home-office] .govuk-button--secondary:link, html[data-researchops-brand=home-office] .govuk-button--secondary:visited, html[data-researchops-brand=home-office] .govuk-button--secondary:active, html[data-researchops-brand=home-office] .govuk-button--secondary:hover, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:link, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:visited, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:active, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:hover, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:link, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:visited, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:active, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:hover {
 	color: #0b0c0c;
 	}
 
-html[data-researchops-brand=home-office] .govuk-button--secondary:hover {
+html[data-researchops-brand=home-office] .govuk-button--secondary:hover, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:hover, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:hover {
 	background-color: #dfdfdf;
 	}
 
-html[data-researchops-brand=home-office] .govuk-button--secondary:hover[disabled] {
+html[data-researchops-brand=home-office] .govuk-button--secondary[disabled], html[data-researchops-brand=home-office] .govuk-button--secondary[aria-disabled=true], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary[disabled], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary[aria-disabled=true], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary[disabled], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary[aria-disabled=true] {
 	background-color: #f8f8f8;
+	color: #0b0c0c;
 	}
 
-html[data-researchops-brand=home-office] .govuk-button--secondary:focus {
+html[data-researchops-brand=home-office] .govuk-button--secondary:hover[disabled], html[data-researchops-brand=home-office] .govuk-button--secondary:hover[aria-disabled=true], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:hover[disabled], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:hover[aria-disabled=true], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:hover[disabled], html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:hover[aria-disabled=true] {
+	background-color: #f8f8f8;
+	color: #0b0c0c;
+	}
+
+html[data-researchops-brand=home-office] .govuk-button--secondary:focus, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button--secondary:focus, html[data-researchops-brand=home-office] .govuk-main-wrapper .govuk-button.govuk-button--secondary:focus {
 	border-width: 2px;
 	padding: 8px 10px 7px;
 	}

--- a/public/css/brands/home-office.css
+++ b/public/css/brands/home-office.css
@@ -204,7 +204,7 @@ html[data-researchops-brand=home-office] .researchops-next-action:not(:last-chil
 	border-right-color: #cbcbcb;
 	}
 
-html[data-researchops-brand=home-office] .researchops-home-front-page .govuk-template__header .govuk-service-navigation[data-active="Home"], html[data-researchops-brand=home-office] .researchops-home-front-page .govuk-phase-banner, html[data-researchops-brand=home-office] .researchops-home-masthead, html[data-researchops-brand=home-office] .researchops-repository-front-page .govuk-template__header .govuk-service-navigation[data-active="Research Repository"], html[data-researchops-brand=home-office] .researchops-repository-front-page .govuk-phase-banner, html[data-researchops-brand=home-office] .repository-masthead {
+html[data-researchops-brand=home-office] .researchops-home-front-page .govuk-template__header .govuk-service-navigation[data-active=Home], html[data-researchops-brand=home-office] .researchops-home-front-page .govuk-phase-banner, html[data-researchops-brand=home-office] .researchops-home-masthead, html[data-researchops-brand=home-office] .researchops-repository-front-page .govuk-template__header .govuk-service-navigation[data-active="Research Repository"], html[data-researchops-brand=home-office] .researchops-repository-front-page .govuk-phase-banner, html[data-researchops-brand=home-office] .repository-masthead {
 	background: #732282;
 	}
 

--- a/public/js/brand-variant.js
+++ b/public/js/brand-variant.js
@@ -1,5 +1,6 @@
 const BRAND_STORAGE_KEY = 'researchops-brand';
 const BRAND_STYLESHEET_ID = 'researchops-home-office-brand';
+const BRAND_BUTTON_STYLESHEET_ID = 'researchops-home-office-buttons-brand';
 const HOME_OFFICE_BRAND = 'home-office';
 const GOVUK_BRAND = 'govuk';
 const SUPPORTED_BRANDS = new Set([GOVUK_BRAND, HOME_OFFICE_BRAND]);
@@ -51,19 +52,24 @@ export function getConfiguredBrand() {
 	return hostnameBrand();
 }
 
-function ensureHomeOfficeStylesheet(enabled) {
-	let link = document.getElementById(BRAND_STYLESHEET_ID);
+function ensureStylesheet({ id, href, enabled }) {
+	let link = document.getElementById(id);
 	if (!link && enabled) {
 		link = document.createElement('link');
-		link.id = BRAND_STYLESHEET_ID;
+		link.id = id;
 		link.rel = 'stylesheet';
-		link.href = '/css/brands/home-office.css';
+		link.href = href;
 		link.media = 'screen';
 	}
 
 	if (!link) return;
 	link.disabled = !enabled;
 	if (enabled) document.head.append(link);
+}
+
+function ensureHomeOfficeStylesheets(enabled) {
+	ensureStylesheet({ id: BRAND_STYLESHEET_ID, href: '/css/brands/home-office.css', enabled });
+	ensureStylesheet({ id: BRAND_BUTTON_STYLESHEET_ID, href: '/css/brands/home-office-buttons.css', enabled });
 }
 
 function setHeaderMarkVisibility(isHomeOffice) {
@@ -102,7 +108,7 @@ export function applyBrandVariant(brand = getConfiguredBrand()) {
 		document.body.classList.toggle('researchops-brand-home-office', isHomeOffice);
 	}
 
-	ensureHomeOfficeStylesheet(isHomeOffice);
+	ensureHomeOfficeStylesheets(isHomeOffice);
 	setHeaderMarkVisibility(isHomeOffice);
 	updateHeaderAccessibility(selectedBrand);
 

--- a/scripts/styles/generated-css-targets.mjs
+++ b/scripts/styles/generated-css-targets.mjs
@@ -17,6 +17,11 @@ export const generatedCssTargets = [
 		output: 'public/css/brands/home-office.css',
 	},
 	{
+		name: 'Home Office secondary button brand variant stylesheet',
+		source: 'src/styles/brands/home-office-buttons.scss',
+		output: 'public/css/brands/home-office-buttons.css',
+	},
+	{
 		name: 'Projects stylesheet',
 		source: 'src/styles/projects.scss',
 		output: 'public/css/projects.css',

--- a/src/styles/brands/home-office-buttons.scss
+++ b/src/styles/brands/home-office-buttons.scss
@@ -8,7 +8,9 @@ $hods-secondary-button-border-width: 1px;
 $hods-secondary-button-shadow-size: 2px;
 
 html[data-researchops-brand='home-office'] {
-	.govuk-button--secondary {
+	.govuk-button--secondary,
+	.govuk-main-wrapper .govuk-button--secondary,
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary {
 		background-color: $hods-secondary-button-colour;
 		border-color: $hods-secondary-button-shadow-colour;
 		border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0
@@ -21,19 +23,47 @@ html[data-researchops-brand='home-office'] {
 	.govuk-button--secondary:link,
 	.govuk-button--secondary:visited,
 	.govuk-button--secondary:active,
-	.govuk-button--secondary:hover {
+	.govuk-button--secondary:hover,
+	.govuk-main-wrapper .govuk-button--secondary:link,
+	.govuk-main-wrapper .govuk-button--secondary:visited,
+	.govuk-main-wrapper .govuk-button--secondary:active,
+	.govuk-main-wrapper .govuk-button--secondary:hover,
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:link,
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:visited,
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:active,
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:hover {
 		color: $hods-secondary-button-text-colour;
 	}
 
-	.govuk-button--secondary:hover {
+	.govuk-button--secondary:hover,
+	.govuk-main-wrapper .govuk-button--secondary:hover,
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:hover {
 		background-color: $hods-secondary-button-hover-colour;
 	}
 
-	.govuk-button--secondary:hover[disabled] {
+	.govuk-button--secondary[disabled],
+	.govuk-button--secondary[aria-disabled='true'],
+	.govuk-main-wrapper .govuk-button--secondary[disabled],
+	.govuk-main-wrapper .govuk-button--secondary[aria-disabled='true'],
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary[disabled],
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary[aria-disabled='true'] {
 		background-color: $hods-secondary-button-colour;
+		color: $hods-secondary-button-text-colour;
 	}
 
-	.govuk-button--secondary:focus {
+	.govuk-button--secondary:hover[disabled],
+	.govuk-button--secondary:hover[aria-disabled='true'],
+	.govuk-main-wrapper .govuk-button--secondary:hover[disabled],
+	.govuk-main-wrapper .govuk-button--secondary:hover[aria-disabled='true'],
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:hover[disabled],
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:hover[aria-disabled='true'] {
+		background-color: $hods-secondary-button-colour;
+		color: $hods-secondary-button-text-colour;
+	}
+
+	.govuk-button--secondary:focus,
+	.govuk-main-wrapper .govuk-button--secondary:focus,
+	.govuk-main-wrapper .govuk-button.govuk-button--secondary:focus {
 		border-width: $hods-secondary-button-shadow-size;
 		padding: 8px 10px 7px;
 	}

--- a/src/styles/brands/home-office-buttons.scss
+++ b/src/styles/brands/home-office-buttons.scss
@@ -11,7 +11,8 @@ html[data-researchops-brand='home-office'] {
 	.govuk-button--secondary {
 		background-color: $hods-secondary-button-colour;
 		border-color: $hods-secondary-button-shadow-colour;
-		border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0 $hods-secondary-button-border-width;
+		border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0
+			$hods-secondary-button-border-width;
 		box-shadow: 0 $hods-secondary-button-shadow-size 0 $hods-secondary-button-shadow-colour;
 		color: $hods-secondary-button-text-colour;
 		padding: 9px 11px 9px;

--- a/src/styles/brands/home-office-buttons.scss
+++ b/src/styles/brands/home-office-buttons.scss
@@ -1,0 +1,41 @@
+/* Home Office secondary button brand variant for ResearchOps */
+
+$hods-secondary-button-colour: #f8f8f8;
+$hods-secondary-button-hover-colour: #dfdfdf;
+$hods-secondary-button-shadow-colour: #0b0c0c;
+$hods-secondary-button-text-colour: #0b0c0c;
+$hods-secondary-button-border-width: 1px;
+$hods-secondary-button-shadow-size: 2px;
+
+html[data-researchops-brand='home-office'] {
+	.govuk-button--secondary {
+		background-color: $hods-secondary-button-colour;
+		border-color: $hods-secondary-button-shadow-colour;
+		border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0 $hods-secondary-button-border-width;
+		box-shadow: 0 $hods-secondary-button-shadow-size 0 $hods-secondary-button-shadow-colour;
+		color: $hods-secondary-button-text-colour;
+		padding: 9px 11px 9px;
+	}
+
+	.govuk-button--secondary:link,
+	.govuk-button--secondary:visited,
+	.govuk-button--secondary:active,
+	.govuk-button--secondary:hover {
+		color: $hods-secondary-button-text-colour;
+	}
+
+	.govuk-button--secondary:hover {
+		background-color: $hods-secondary-button-hover-colour;
+	}
+
+	.govuk-button--secondary:hover[disabled] {
+		background-color: $hods-secondary-button-colour;
+	}
+
+	.govuk-button--secondary:focus {
+		border-width: $hods-secondary-button-shadow-size;
+		padding: 8px 10px 7px;
+	}
+}
+
+/* transparency begins in the cascade */

--- a/tests/brand-variant-route-state.test.js
+++ b/tests/brand-variant-route-state.test.js
@@ -58,6 +58,7 @@ assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-hover-colour:
 assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-shadow-colour: #0b0c0c'));
 assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-border-width: 1px'));
 assert.ok(buttonBrandStylesSource.includes('.govuk-button--secondary'));
+assert.ok(buttonBrandStylesSource.includes('.govuk-main-wrapper .govuk-button.govuk-button--secondary'));
 assert.ok(buttonBrandStylesSource.includes('border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0'));
 assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-border-width;'));
 assert.ok(buttonBrandStylesSource.includes('padding: 9px 11px 9px'));
@@ -88,6 +89,7 @@ assert.ok(brandStyles.includes('govuk-footer'));
 assert.equal(brandStyles.includes('--govuk-link-colour'), false);
 
 assert.ok(buttonBrandStyles.includes('govuk-button--secondary'));
+assert.ok(buttonBrandStyles.includes('govuk-main-wrapper .govuk-button.govuk-button--secondary'));
 assert.ok(buttonBrandStyles.includes('background-color: #f8f8f8'));
 assert.ok(buttonBrandStyles.includes('background-color: #dfdfdf'));
 assert.ok(buttonBrandStyles.includes('border-color: #0b0c0c'));

--- a/tests/brand-variant-route-state.test.js
+++ b/tests/brand-variant-route-state.test.js
@@ -58,7 +58,8 @@ assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-hover-colour:
 assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-shadow-colour: #0b0c0c'));
 assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-border-width: 1px'));
 assert.ok(buttonBrandStylesSource.includes('.govuk-button--secondary'));
-assert.ok(buttonBrandStylesSource.includes('border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0 $hods-secondary-button-border-width'));
+assert.ok(buttonBrandStylesSource.includes('border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0'));
+assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-border-width;'));
 assert.ok(buttonBrandStylesSource.includes('padding: 9px 11px 9px'));
 assert.ok(buttonBrandStylesSource.includes('padding: 8px 10px 7px'));
 

--- a/tests/brand-variant-route-state.test.js
+++ b/tests/brand-variant-route-state.test.js
@@ -4,7 +4,9 @@ import fs from 'node:fs';
 const sharedHeader = fs.readFileSync('public/partials/header.html', 'utf8');
 const brandScript = fs.readFileSync('public/js/brand-variant.js', 'utf8');
 const brandStyles = fs.readFileSync('public/css/brands/home-office.css', 'utf8');
+const buttonBrandStyles = fs.readFileSync('public/css/brands/home-office-buttons.css', 'utf8');
 const brandStylesSource = fs.readFileSync('src/styles/brands/home-office.scss', 'utf8');
+const buttonBrandStylesSource = fs.readFileSync('src/styles/brands/home-office-buttons.scss', 'utf8');
 const generatedCssTargets = fs.readFileSync('scripts/styles/generated-css-targets.mjs', 'utf8');
 
 function hasAny(source, values) {
@@ -23,9 +25,13 @@ assert.ok(brandScript.includes('home-office'));
 assert.ok(brandScript.includes('govuk'));
 assert.ok(brandScript.includes('researchops-brand'));
 assert.ok(brandScript.includes('researchopsBrand'));
+assert.ok(brandScript.includes('researchops-home-office-buttons-brand'));
+assert.ok(brandScript.includes('/css/brands/home-office-buttons.css'));
 
 assert.ok(generatedCssTargets.includes('src/styles/brands/home-office.scss'));
 assert.ok(generatedCssTargets.includes('public/css/brands/home-office.css'));
+assert.ok(generatedCssTargets.includes('src/styles/brands/home-office-buttons.scss'));
+assert.ok(generatedCssTargets.includes('public/css/brands/home-office-buttons.css'));
 assert.ok(hasAny(brandStylesSource, ['$home-office-brand-colour: #732282', '$ho-purple: #732282']));
 assert.ok(hasAny(brandStylesSource, ['$home-office-page-background: #f5f5f5', '$ho-background: #f5f5f5']));
 assert.ok(hasAny(brandStylesSource, ['$home-office-border-colour: #cbcbcb', '$ho-border: #cbcbcb']));
@@ -46,6 +52,15 @@ assert.ok(brandStylesSource.includes('.study-session-gate'));
 assert.ok(brandStylesSource.includes('.govuk-tabs__list-item--selected'));
 assert.ok(brandStylesSource.includes('.govuk-footer'));
 assert.equal(brandStylesSource.includes('--govuk-link-colour'), false);
+
+assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-colour: #f8f8f8'));
+assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-hover-colour: #dfdfdf'));
+assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-shadow-colour: #0b0c0c'));
+assert.ok(buttonBrandStylesSource.includes('$hods-secondary-button-border-width: 1px'));
+assert.ok(buttonBrandStylesSource.includes('.govuk-button--secondary'));
+assert.ok(buttonBrandStylesSource.includes('border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0 $hods-secondary-button-border-width'));
+assert.ok(buttonBrandStylesSource.includes('padding: 9px 11px 9px'));
+assert.ok(buttonBrandStylesSource.includes('padding: 8px 10px 7px'));
 
 assert.ok(brandStyles.includes('#732282'));
 assert.ok(brandStyles.includes('#f5f5f5'));
@@ -70,3 +85,13 @@ assert.ok(brandStyles.includes('govuk-main-wrapper a:link'));
 assert.ok(brandStyles.includes('govuk-button:link'));
 assert.ok(brandStyles.includes('govuk-footer'));
 assert.equal(brandStyles.includes('--govuk-link-colour'), false);
+
+assert.ok(buttonBrandStyles.includes('govuk-button--secondary'));
+assert.ok(buttonBrandStyles.includes('background-color: #f8f8f8'));
+assert.ok(buttonBrandStyles.includes('background-color: #dfdfdf'));
+assert.ok(buttonBrandStyles.includes('border-color: #0b0c0c'));
+assert.ok(buttonBrandStyles.includes('border-width: 1px 1px 0 1px'));
+assert.ok(buttonBrandStyles.includes('box-shadow: 0 2px 0 #0b0c0c'));
+assert.ok(buttonBrandStyles.includes('color: #0b0c0c'));
+assert.ok(buttonBrandStyles.includes('padding: 9px 11px 9px'));
+assert.ok(buttonBrandStyles.includes('padding: 8px 10px 7px'));


### PR DESCRIPTION
## Summary

Adds the Home Office adjusted secondary button treatment for the Home Office brand variant.

Changes:

- adds a Home Office secondary button Sass source
- adds generated Home Office secondary button CSS
- loads the Home Office button brand stylesheet after the main Home Office brand stylesheet
- registers the new generated CSS target
- extends route-state assertions for the HODS secondary button contract
- adds the required trace duo for the `fix/` branch

## Source guidance

The Home Office Design System says the secondary button style is slightly changed from GOV.UK to improve contrast with the Home Office grey page background.

The implementation follows the Home Office source values for the secondary button surface, hover state, black shadow/border, text colour and adjusted padding.

## Trace

- `docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.md`
- `docs/agent-audit/reasoning/2026/06/09/home-office-secondary-button-style.json`

## Test-contract impact sweep

Performed. The affected contract surfaces are:

- Home Office brand stylesheet loading order
- generated CSS manifest
- Home Office secondary button Sass source
- generated Home Office secondary button CSS
- route-state brand variant assertions

## Automated review comments

Checked PR comments. There is a Cloudflare deployment notice only. No actionable Codex code review thread is present at the time of this update.

## Validation

Passed on latest head `5529c3062a21c74260a4d0863989ddcfc4a85443`:

- CI
- Validate ResearchOps
- Worker CI
- Release Gate
- Accessibility audit (pa11y-ci)
- qa-bdd
- QA — Broken links (Lychee)