### PR TITLE
Hydrate journals project data from D1 and Airtable

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.json
+++ b/docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.json
@@ -1,0 +1,164 @@
+{
+	"schema": "researchops.agentAuditTrace.v1",
+	"date": "2026-06-09",
+	"traceLayer": "operational",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "fix/journals-project-data-hydration",
+	"branchPrefix": "fix/",
+	"traceRequired": true,
+	"taskSummary": "Correct the Reflexive Journal and Analysis page so project-bound Reflexive Journal entries, Codes and Memos show for Test Project 1 from D1 and Airtable where available.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		"RECENT_LEARNINGS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/bootstrap-checklist.md",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/trace-layers.md",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/github-mutation-policy.md",
+		".agent-operating-model/bundles/github/prompt.spec.yaml",
+		".agent-operating-model/bundles/github/prompt.body.xml",
+		".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+		".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+		".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+		".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+		".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+		".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+		".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+		".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+		".agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml",
+		".agent-operating-model/bundles/airtable-public-api/prompt.body.xml"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/",
+			"reason": "Branch, PR, mutation, trace and CI governance."
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+			"reason": "ResearchOps service boundary, route and data contract ownership."
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+			"reason": "Public-sector product assurance defaults."
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+			"reason": "Visible journals page and component context."
+		},
+		{
+			"id": "cloudflare",
+			"canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+			"reason": "Worker service and D1-backed runtime behaviour."
+		},
+		{
+			"id": "airtable-public-api",
+			"canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+			"reason": "Airtable record-listing and linked-record fallback behaviour."
+		}
+	],
+	"skippedBundles": [
+		{
+			"id": "openai-platform",
+			"reason": "No OpenAI API or model behaviour changed."
+		},
+		{
+			"id": "mcp-agent-tooling",
+			"reason": "No MCP protocol or agent-tooling contract changed."
+		},
+		{
+			"id": "mural-public-api",
+			"reason": "No Mural API behaviour changed; Mural sync is adjacent but not part of this display defect."
+		}
+	],
+	"precedenceDecisions": [
+		"GitHub Diamond governed branch, PR and trace behaviour.",
+		"ResearchOps Developer Control governed service-layer placement and route-state test coverage.",
+		"Cloudflare governed D1-first read behaviour.",
+		"Airtable Public API governed linked-record fallback handling.",
+		"GOV.UK Design System governed the visible page context but did not require markup changes."
+	],
+	"filesRead": [
+		"public/js/journal-tabs.js",
+		"public/js/project-context.js",
+		"infra/cloudflare/src/core/router.js",
+		"infra/cloudflare/src/service/index.js",
+		"infra/cloudflare/src/service/journals.js",
+		"infra/cloudflare/src/service/memos.js",
+		"infra/cloudflare/src/service/reflection/codes.js",
+		"infra/cloudflare/src/service/projects.js",
+		"infra/cloudflare/src/service/projects/airtable.js",
+		"infra/cloudflare/src/service/projects/normalisation.js",
+		"infra/cloudflare/src/service/project-list-d1-airtable.js",
+		"infra/cloudflare/src/service/internals/researchops-d1.js",
+		"infra/cloudflare/migrations/researchops-d1/0001_seed.sql"
+	],
+	"filesModifiedOrCreated": [
+		"infra/cloudflare/src/service/reflection/project-data-hydration.js",
+		"infra/cloudflare/src/service/index.js",
+		"tests/journals-project-data-hydration-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.md",
+		"docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.json"
+	],
+	"implementationSummary": [
+		"Added a shared project data hydration service for journal entries, memos and codes.",
+		"Resolved project identities from project, project_id, project_local_id and project_airtable_id query parameters.",
+		"Read D1 first using local_project_id or project matches.",
+		"Resolved Airtable record ids through findProjectRecord when only a public/local project id is supplied.",
+		"Delegated listJournalEntries, listMemos and listCodes through the shared hydration service while preserving existing create, update and delete handlers.",
+		"Added route-state coverage for service delegation, D1 table assumptions and scoped Airtable fallback behaviour."
+	],
+	"testContractImpactSweep": {
+		"performed": true,
+		"affectedContracts": [
+			"/api/journal-entries read behaviour",
+			"/api/codes read behaviour",
+			"/api/memos read behaviour",
+			"service index delegation",
+			"D1 seed table assumptions for journal entries, memos and codes",
+			"Airtable fallback filtering by linked project record id",
+			"route-state tests for journal data hydration"
+		],
+		"legacyOrAffectedTermsChecked": [
+			"listJournalEntries",
+			"listMemos",
+			"listCodes",
+			"ProjectDataHydration",
+			"journal_entries",
+			"memos",
+			"codes",
+			"local_project_id",
+			"project_airtable_id",
+			"project_local_id",
+			"findProjectRecord"
+		]
+	},
+	"automatedReviewComments": {
+		"checked": false,
+		"reason": "No PR existed at trace creation time. Review threads must be checked after PR creation."
+	},
+	"validation": {
+		"commandsRun": [],
+		"notRunReason": "Repository commands were not available in the connector session.",
+		"requiredBeforeReady": [
+			"node --test tests/journals-project-data-hydration-route-state.test.js",
+			"npm run build",
+			"npm run format:check",
+			"npm run validate",
+			"npm run trace:coverage"
+		]
+	},
+	"residualRisks": [
+		"The new read path has not been validated against the live preview Worker yet.",
+		"The branch should stay draft until CI and preview checks complete.",
+		"Project-context hydration remains asynchronous on the client, but the service read path now resolves the project id variants the page can send."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.md
+++ b/docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.md
@@ -1,0 +1,150 @@
+# Journals project data hydration trace
+
+## Run metadata
+
+- Date: 2026-06-09
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `fix/journals-project-data-hydration`
+- Trace layer: operational
+- Branch-prefix trace decision: `fix/` requires a promoted trace.
+
+## Original task summary
+
+Correct the Reflexive Journal and Analysis page so Test Project 1 can show existing project-bound Reflexive Journal entries, Codes and Memos from available ResearchOps data sources. The defect appeared as empty journal, code and memo tabs despite the project having records in Airtable and likely D1.
+
+## Operating-model files loaded
+
+- `AGENTS.md`
+- `RECENT_LEARNINGS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/github/prompt.spec.yaml`
+- `.agent-operating-model/bundles/github/prompt.body.xml`
+- `.agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml`
+- `.agent-operating-model/bundles/researchops-developer-control/prompt.body.xml`
+- `.agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml`
+- `.agent-operating-model/bundles/multi-functional-team/prompt.body.xml`
+- `.agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml`
+- `.agent-operating-model/bundles/govuk-design-system/prompt.body.xml`
+- `.agent-operating-model/bundles/cloudflare/prompt.spec.yaml`
+- `.agent-operating-model/bundles/cloudflare/prompt.body.xml`
+- `.agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml`
+- `.agent-operating-model/bundles/airtable-public-api/prompt.body.xml`
+
+## Canonical bundle directories selected
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+- `.agent-operating-model/bundles/cloudflare/`
+- `.agent-operating-model/bundles/airtable-public-api/`
+
+## Bundles selected
+
+- `github-diamond`: branch, PR, mutation, trace and CI governance.
+- `researchops-developer-control`: ResearchOps service boundary, route and data contract ownership.
+- `multi-functional-team`: public-sector product assurance defaults.
+- `govuk-design-system`: Journals page UI and component context.
+- `cloudflare`: Worker service and D1-backed runtime behaviour.
+- `airtable-public-api`: Airtable record-listing and linked-record fallback behaviour.
+
+## Bundles skipped
+
+- `openai-platform`: no OpenAI API or model behaviour changed.
+- `mcp-agent-tooling`: no MCP protocol or agent-tooling contract changed.
+- `mural-public-api`: no Mural API behaviour changed; Mural sync is adjacent but not part of this display defect.
+
+## Precedence decisions
+
+GitHub Diamond governed the branch, PR and trace behaviour. ResearchOps Developer Control governed service-layer placement and route-state test coverage. Cloudflare governed D1-first read behaviour. Airtable Public API governed linked-record fallback handling. GOV.UK Design System governed the visible journals page context but did not require markup changes.
+
+## Files read
+
+- `public/js/journal-tabs.js`
+- `public/js/project-context.js`
+- `infra/cloudflare/src/core/router.js`
+- `infra/cloudflare/src/service/index.js`
+- `infra/cloudflare/src/service/journals.js`
+- `infra/cloudflare/src/service/memos.js`
+- `infra/cloudflare/src/service/reflection/codes.js`
+- `infra/cloudflare/src/service/projects.js`
+- `infra/cloudflare/src/service/projects/airtable.js`
+- `infra/cloudflare/src/service/projects/normalisation.js`
+- `infra/cloudflare/src/service/project-list-d1-airtable.js`
+- `infra/cloudflare/src/service/internals/researchops-d1.js`
+- `infra/cloudflare/migrations/researchops-d1/0001_seed.sql`
+
+## Files created or modified
+
+- Created `infra/cloudflare/src/service/reflection/project-data-hydration.js`
+- Modified `infra/cloudflare/src/service/index.js`
+- Created `tests/journals-project-data-hydration-route-state.test.js`
+- Created `docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.md`
+- Created `docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.json`
+
+## Implementation summary
+
+The existing journals page already requested `/api/journal-entries`, `/api/codes` and `/api/memos` with a project identifier. The defect was that those service handlers did not consistently tolerate both public/local project ids and Airtable record ids across all three data types.
+
+The change adds a shared project data hydration service for read paths. It resolves candidate project identifiers from `project`, `project_id`, `project_local_id` and `project_airtable_id`. It reads D1 first where a `RESEARCHOPS_D1` binding exists and matches rows by either `local_project_id` or `project`. If D1 has no matching rows, it resolves Airtable record ids through the existing project lookup and filters Airtable-linked records by the resolved project record id.
+
+`listJournalEntries`, `listMemos` and `listCodes` now delegate to the shared hydration service. Create, update and delete paths remain on their existing service modules.
+
+## Test-contract impact sweep
+
+Performed. Affected contract surfaces:
+
+- `/api/journal-entries` read behaviour
+- `/api/codes` read behaviour
+- `/api/memos` read behaviour
+- service index delegation
+- D1 seed table assumptions for journal entries, memos and codes
+- Airtable fallback filtering by linked project record id
+- route-state tests for journal data hydration
+
+Legacy or affected terms checked:
+
+- `listJournalEntries`
+- `listMemos`
+- `listCodes`
+- `ProjectDataHydration`
+- `journal_entries`
+- `memos`
+- `codes`
+- `local_project_id`
+- `project_airtable_id`
+- `project_local_id`
+- `findProjectRecord`
+
+## Mutation strategy
+
+A new `fix/` branch was created from `main`. Existing service delegation was changed through the available GitHub contents wrapper. A new service module and focused route-state test were added. The branch diff was checked against `main`; the changed-file list is plausible for a service-layer hydration fix plus trace artefacts.
+
+## Automated review comments
+
+No pull request had been opened at the time this trace was created. Review-thread state must be checked after the PR opens. Later legitimate Codex or automated review comments must be classified, fixed or evidenced, acknowledged with a thumbs-up reaction, replied to with validation evidence and resolved only after the fix is complete.
+
+## Validation attempted
+
+No repository commands were run in this connector session. Required before ready for review:
+
+- `node --test tests/journals-project-data-hydration-route-state.test.js`
+- `npm run build`
+- `npm run format:check`
+- `npm run validate`
+- `npm run trace:coverage`
+
+## Residual risks
+
+- The new read path has not been validated against the live preview Worker yet.
+- The branch changes service delegation and should remain draft until CI and preview checks complete.
+- Project-context hydration remains asynchronous on the client, but the service read path now resolves the project id variants the page can send.

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -115,7 +115,7 @@ export class ResearchOpsService {
 	/* ─────────────── Excerpts ─────────────── */
 	listExcerpts = (origin, url) => Excerpts.listExcerpts(this, origin, url);
 	createExcerpt = (req, origin) => Excerpts.createExcerpt(this, req, origin);
-	updateExcerpt = (req, origin, excerptId) => Excerpts.updateExcerpt(this, origin, excerptId);
+	updateExcerpt = (req, origin, excerptId) => Excerpts.updateExcerpt(this, req, origin, excerptId);
 
 	/* ─────────────── Memos ─────────────── */
 	listMemos = (origin, url) => ProjectDataHydration.listMemos(this, origin, url);
@@ -184,7 +184,7 @@ export class ResearchOpsService {
 	listPartials = (origin) => Partials.listPartials(this, origin);
 	createPartial = (req, origin) => Partials.createPartial(this, req, origin);
 	readPartial = (origin, id) => Partials.readPartial(this, origin, id);
-	updatePartial = (req, origin, id) => Partials.updatePartial(this, req, id);
+	updatePartial = (req, origin, id) => Partials.updatePartial(this, req, origin, id);
 	deletePartial = (origin, id) => Partials.deletePartial(this, origin, id);
 
 	/* ─────────────── Participants ─────────────── */

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -30,6 +30,7 @@ import * as Excerpts from "./excerpts.js";
 import * as Memos from "./memos.js";
 import * as CodeApplications from "./reflection/code-applications.js";
 import * as Codes from "./reflection/codes.js";
+import * as ProjectDataHydration from "./reflection/project-data-hydration.js";
 import * as Analysis from "./reflection/analysis.js";
 import * as MuralJournalSync from "./mural-journal-sync-safe-tags.js";
 
@@ -46,48 +47,6 @@ import * as Diag from "./dev/diag.js";
 import * as ImpactService from "./impact.js";
 import { recordProvenanceEvent } from "./provenance.js";
 
-/**
- * @typedef {Object} Env
- * @property {string} ALLOWED_ORIGINS
- * @property {string} AUDIT
- * @property {string} AIRTABLE_BASE_ID
- * @property {string} AIRTABLE_TABLE_PROJECTS
- * @property {string} AIRTABLE_TABLE_DETAILS
- * @property {string} AIRTABLE_TABLE_STUDIES
- * @property {string} AIRTABLE_TABLE_GUIDES
- * @property {string} AIRTABLE_TABLE_CONSENT_FORMS
- * @property {string} AIRTABLE_TABLE_PARTICIPANT_CONSENT
- * @property {string} AIRTABLE_TABLE_PARTIALS
- 	 * @property {string} AIRTABLE_TABLE_PARTICIPANTS
- 	 * @property {string} [AIRTABLE_TABLE_STUDY_SUPPORT]
- 	 * @property {string} [AIRTABLE_TABLE_NOTE_TAKERS_OBSERVERS]
- 	 * @property {string} AIRTABLE_TABLE_SESSIONS
- * @property {string} AIRTABLE_TABLE_SESSION_NOTES
- * @property {string} AIRTABLE_TABLE_COMMSLOG
- * @property {string} AIRTABLE_API_KEY
- * @property {string} GH_OWNER
- * @property {string} GH_REPO
- * @property {string} GH_BRANCH
- * @property {string} GH_PATH_PROJECTS
- * @property {string} GH_PATH_DETAILS
- * @property {string} GH_PATH_STUDIES
- * @property {string} GH_TOKEN
- * @property {any}    ASSETS
- * @property {string} [MODEL]
- * @property {string} [AIRTABLE_TABLE_AI_LOG]
- * @property {string} [AIRTABLE_PROJECT_TEAM_NAME_FIELD]
- * @property {string} [AIRTABLE_PROJECT_TEAM_ID_FIELD]
- * @property {any}    AI
- * @property {KVNamespace} SESSION_KV
- * @property {D1Database} RESEARCHOPS_D1
- * @property {string} [MURAL_CLIENT_ID]
- * @property {string} [MURAL_CLIENT_SECRET]
- * @property {string} [MURAL_REDIRECT_URI]
- * @property {string} [MURAL_HOME_OFFICE_WORKSPACE_ID]
- * @property {string} [MURAL_API_BASE]
- * @property {string} [MURAL_REFLEXIVE_MURAL_ID]
- */
-
 function corsHeaders(env, origin) {
 	const allowed = (env.ALLOWED_ORIGINS || "")
 		.split(",")
@@ -103,18 +62,10 @@ function corsHeaders(env, origin) {
 }
 
 export class ResearchOpsService {
-	/**
-	 * @param {Env} env
-	 * @param {{cfg?:Partial<typeof DEFAULTS>, logger?:BatchLogger}} [opts]
-	 */
 	constructor(env, opts = {}) {
-		/** @type {Env} */
 		this.env = env;
-		/** @type {Readonly<typeof DEFAULTS>} */
 		this.cfg = Object.freeze({ ...DEFAULTS, ...(opts.cfg || {}) });
-		/** @type {BatchLogger} */
 		this.log = opts.logger || new BatchLogger({ batchSize: this.cfg.LOG_BATCH_SIZE });
-		/** @type {boolean} */
 		this.destroyed = false;
 
 		this.corsHeaders = (origin) => corsHeaders(this.env, origin);
@@ -153,7 +104,7 @@ export class ResearchOpsService {
 	updateProjectFraming = (req, origin, projectId, authContext) => Projects.updateProjectFraming(this, req, origin, projectId, authContext);
 
 	/* ─────────────── Journal Entries ─────────────── */
-	listJournalEntries = (origin, url) => Journals.listJournalEntries(this, origin, url);
+	listJournalEntries = (origin, url) => ProjectDataHydration.listJournalEntries(this, origin, url);
 	createJournalEntry = (req, origin) => Journals.createJournalEntry(this, req, origin);
 	diagAirtableCreate = (req, origin) => Journals.diagAirtableCreate(this, req, origin);
 	getJournalEntry = (origin, entryId) => Journals.getJournalEntry(this, origin, entryId);
@@ -164,10 +115,10 @@ export class ResearchOpsService {
 	/* ─────────────── Excerpts ─────────────── */
 	listExcerpts = (origin, url) => Excerpts.listExcerpts(this, origin, url);
 	createExcerpt = (req, origin) => Excerpts.createExcerpt(this, req, origin);
-	updateExcerpt = (req, origin, excerptId) => Excerpts.updateExcerpt(this, req, origin, excerptId);
+	updateExcerpt = (req, origin, excerptId) => Excerpts.updateExcerpt(this, origin, excerptId);
 
 	/* ─────────────── Memos ─────────────── */
-	listMemos = (origin, url) => Memos.listMemos(this, origin, url);
+	listMemos = (origin, url) => ProjectDataHydration.listMemos(this, origin, url);
 	createMemo = (req, origin) => Memos.createMemo(this, req, origin);
 	updateMemo = (req, origin, memoId) => Memos.updateMemo(this, req, origin, memoId);
 
@@ -175,7 +126,7 @@ export class ResearchOpsService {
 	listCodeApplications = (origin, url) => CodeApplications.listCodeApplications(this, origin, url);
 
 	/* ─────────────── Codes ─────────────── */
-	listCodes = (origin, url) => Codes.listCodes(this, origin, url);
+	listCodes = (origin, url) => ProjectDataHydration.listCodes(this, origin, url);
 	createCode = (req, origin) => Codes.createCode(this, req, origin);
 	updateCode = (req, origin, codeId) => Codes.updateCode(this, req, origin, codeId);
 
@@ -233,7 +184,7 @@ export class ResearchOpsService {
 	listPartials = (origin) => Partials.listPartials(this, origin);
 	createPartial = (req, origin) => Partials.createPartial(this, req, origin);
 	readPartial = (origin, id) => Partials.readPartial(this, origin, id);
-	updatePartial = (req, origin, id) => Partials.updatePartial(this, req, origin, id);
+	updatePartial = (req, origin, id) => Partials.updatePartial(this, req, id);
 	deletePartial = (origin, id) => Partials.deletePartial(this, origin, id);
 
 	/* ─────────────── Participants ─────────────── */

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -47,6 +47,48 @@ import * as Diag from "./dev/diag.js";
 import * as ImpactService from "./impact.js";
 import { recordProvenanceEvent } from "./provenance.js";
 
+/**
+ * @typedef {Object} Env
+ * @property {string} ALLOWED_ORIGINS
+ * @property {string} AUDIT
+ * @property {string} AIRTABLE_BASE_ID
+ * @property {string} AIRTABLE_TABLE_PROJECTS
+ * @property {string} AIRTABLE_TABLE_DETAILS
+ * @property {string} AIRTABLE_TABLE_STUDIES
+ * @property {string} AIRTABLE_TABLE_GUIDES
+ * @property {string} AIRTABLE_TABLE_CONSENT_FORMS
+ * @property {string} AIRTABLE_TABLE_PARTICIPANT_CONSENT
+ * @property {string} AIRTABLE_TABLE_PARTIALS
+ * @property {string} AIRTABLE_TABLE_PARTICIPANTS
+ * @property {string} [AIRTABLE_TABLE_STUDY_SUPPORT]
+ * @property {string} [AIRTABLE_TABLE_NOTE_TAKERS_OBSERVERS]
+ * @property {string} AIRTABLE_TABLE_SESSIONS
+ * @property {string} AIRTABLE_TABLE_SESSION_NOTES
+ * @property {string} AIRTABLE_TABLE_COMMSLOG
+ * @property {string} AIRTABLE_API_KEY
+ * @property {string} GH_OWNER
+ * @property {string} GH_REPO
+ * @property {string} GH_BRANCH
+ * @property {string} GH_PATH_PROJECTS
+ * @property {string} GH_PATH_DETAILS
+ * @property {string} GH_PATH_STUDIES
+ * @property {string} GH_TOKEN
+ * @property {any}    ASSETS
+ * @property {string} [MODEL]
+ * @property {string} [AIRTABLE_TABLE_AI_LOG]
+ * @property {string} [AIRTABLE_PROJECT_TEAM_NAME_FIELD]
+ * @property {string} [AIRTABLE_PROJECT_TEAM_ID_FIELD]
+ * @property {any}    AI
+ * @property {KVNamespace} SESSION_KV
+ * @property {D1Database} RESEARCHOPS_D1
+ * @property {string} [MURAL_CLIENT_ID]
+ * @property {string} [MURAL_CLIENT_SECRET]
+ * @property {string} [MURAL_REDIRECT_URI]
+ * @property {string} [MURAL_HOME_OFFICE_WORKSPACE_ID]
+ * @property {string} [MURAL_API_BASE]
+ * @property {string} [MURAL_REFLEXIVE_MURAL_ID]
+ */
+
 function corsHeaders(env, origin) {
 	const allowed = (env.ALLOWED_ORIGINS || "")
 		.split(",")
@@ -62,10 +104,18 @@ function corsHeaders(env, origin) {
 }
 
 export class ResearchOpsService {
+	/**
+	 * @param {Env} env
+	 * @param {{cfg?:Partial<typeof DEFAULTS>, logger?:BatchLogger}} [opts]
+	 */
 	constructor(env, opts = {}) {
+		/** @type {Env} */
 		this.env = env;
+		/** @type {Readonly<typeof DEFAULTS>} */
 		this.cfg = Object.freeze({ ...DEFAULTS, ...(opts.cfg || {}) });
+		/** @type {BatchLogger} */
 		this.log = opts.logger || new BatchLogger({ batchSize: this.cfg.LOG_BATCH_SIZE });
+		/** @type {boolean} */
 		this.destroyed = false;
 
 		this.corsHeaders = (origin) => corsHeaders(this.env, origin);

--- a/infra/cloudflare/src/service/reflection/project-data-hydration.js
+++ b/infra/cloudflare/src/service/reflection/project-data-hydration.js
@@ -12,10 +12,7 @@ function hasD1(env) {
 }
 
 function hasAirtable(env) {
-	return !!(
-		(env?.AIRTABLE_BASE_ID || env?.AIRTABLE_BASE) &&
-		(env?.AIRTABLE_API_KEY || env?.AIRTABLE_PAT || env?.AIRTABLE_ACCESS_TOKEN)
-	);
+	return !!((env?.AIRTABLE_BASE_ID || env?.AIRTABLE_BASE) && (env?.AIRTABLE_API_KEY || env?.AIRTABLE_PAT || env?.AIRTABLE_ACCESS_TOKEN));
 }
 
 function isAirtableRecordId(value) {
@@ -35,12 +32,7 @@ function unique(values = []) {
 }
 
 function projectCandidates(url) {
-	return unique([
-		url.searchParams.get("project"),
-		url.searchParams.get("project_id"),
-		url.searchParams.get("project_local_id"),
-		url.searchParams.get("project_airtable_id")
-	]);
+	return unique([url.searchParams.get("project"), url.searchParams.get("project_id"), url.searchParams.get("project_local_id"), url.searchParams.get("project_airtable_id")]);
 }
 
 function linkedValues(value) {
@@ -50,12 +42,7 @@ function linkedValues(value) {
 }
 
 function linkedProjects(fields = {}) {
-	return unique([
-		...linkedValues(fields.Project),
-		...linkedValues(fields.Projects),
-		...linkedValues(fields["Project ID"]),
-		...linkedValues(fields["Project Ref"]),
-	]);
+	return unique([...linkedValues(fields.Project), ...linkedValues(fields.Projects), ...linkedValues(fields["Project ID"]), ...linkedValues(fields["Project Ref"])]);
 }
 
 function includesAny(values = [], candidates = []) {
@@ -76,9 +63,7 @@ function parseTags(value) {
 	try {
 		const parsed = JSON.parse(text);
 		if (Array.isArray(parsed)) return normTagsArray(parsed);
-	} catch {
-		// Use comma-separated fallback below.
-	}
+	} catch {}
 	return normTagsArray(text);
 }
 
@@ -89,7 +74,6 @@ function placeholders(values = []) {
 async function d1RowsForProjects(env, table, columns, candidates, orderColumn = "createdat") {
 	const ids = unique(candidates);
 	if (!ids.length) return [];
-
 	const list = placeholders(ids);
 	return d1All(env, `
 		SELECT ${columns}
@@ -103,58 +87,29 @@ async function d1RowsForProjects(env, table, columns, candidates, orderColumn = 
 async function resolveAirtableProjectIds(service, candidates = []) {
 	const ids = new Set(candidates.filter(isAirtableRecordId));
 	if (!hasAirtable(service.env)) return [...ids];
-
 	for (const candidate of candidates) {
 		if (!candidate || isAirtableRecordId(candidate)) continue;
 		try {
 			const record = await findProjectRecord(service, candidate);
 			if (record?.id) ids.add(record.id);
 		} catch (error) {
-			service?.log?.warn?.("project_data.project_id_resolution.skip", {
-				project: candidate,
-				err: safeText(error?.message || error).slice(0, 160)
-			});
+			service?.log?.warn?.("project_data.project_id_resolution.skip", { project: candidate, err: safeText(error?.message || error).slice(0, 160) });
 		}
 	}
-
 	return [...ids];
 }
 
 function mapD1JournalEntry(row = {}) {
-	return {
-		id: row.record_id || null,
-		project: row.project || null,
-		category: row.category || "",
-		content: row.content || "",
-		tags: parseTags(row.tags),
-		createdAt: row.createdat || null,
-		source: "d1"
-	};
+	return { id: row.record_id || null, project: row.project || null, category: row.category || "", content: row.content || "", tags: parseTags(row.tags), createdAt: row.createdat || null, source: "d1" };
 }
 
 function mapAirtableJournalEntry(record = {}, projectId = "") {
 	const fields = record.fields || {};
-	return {
-		id: record.id,
-		project: projectId,
-		category: fields.Category || "—",
-		content: fields.Content || fields.Body || fields.Notes || "",
-		tags: normTagsArray(fields.Tags),
-		createdAt: record.createdTime || fields.Created || "",
-		source: "airtable"
-	};
+	return { id: record.id, project: projectId, category: fields.Category || "—", content: fields.Content || fields.Body || fields.Notes || "", tags: normTagsArray(fields.Tags), createdAt: record.createdTime || fields.Created || "", source: "airtable" };
 }
 
 function mapD1Memo(row = {}) {
-	return {
-		id: row.record_id || row.local_memo_id || null,
-		memoType: row.type || "memo",
-		title: row.title || "",
-		content: row.body || "",
-		linkedEntries: [],
-		createdAt: row.createdat || null,
-		source: "d1"
-	};
+	return { id: row.record_id || row.local_memo_id || null, memoType: row.type || "memo", title: row.title || "", content: row.body || "", linkedEntries: [], createdAt: row.createdat || null, source: "d1" };
 }
 
 function mapAirtableMemo(record = {}) {
@@ -165,8 +120,7 @@ function mapAirtableMemo(record = {}) {
 		title: fields.Title || "",
 		content: fields.Content || fields.Body || fields.Notes || "",
 		author: fields.Author || "",
-		linkedEntries: Array.isArray(fields["Linked Entries"]) ? fields["Linked Entries"] :
-			Array.isArray(fields.Entries) ? fields.Entries : [],
+		linkedEntries: Array.isArray(fields["Linked Entries"]) ? fields["Linked Entries"] : Array.isArray(fields.Entries) ? fields.Entries : [],
 		createdAt: record.createdTime || fields.Created || "",
 		source: "airtable"
 	};
@@ -182,36 +136,17 @@ function normaliseHex8(value) {
 }
 
 function mapD1Code(row = {}) {
-	return {
-		id: row.record_id || row.local_code_id || null,
-		name: row.name || row.record_id || row.local_code_id || "",
-		description: row.description || "",
-		colour: normaliseHex8(row.colour || "#505a5fff"),
-		parentId: row.parentcode || null,
-		projectId: row.project || row.local_project_id || null,
-		source: "d1"
-	};
+	return { id: row.record_id || row.local_code_id || null, name: row.name || row.record_id || row.local_code_id || "", description: row.description || "", colour: normaliseHex8(row.colour || "#505a5fff"), parentId: row.parentcode || null, projectId: row.project || row.local_project_id || null, source: "d1" };
 }
 
 function mapAirtableCode(record = {}) {
 	const fields = record.fields || {};
-	const projectId = linkedValues(fields.Project)[0] || null;
-	const parentId = linkedValues(fields.Parent)[0] || null;
-	return {
-		id: record.id,
-		name: fields.Name || fields.Code || fields["Short Name"] || "",
-		description: fields.Description || "",
-		colour: normaliseHex8(fields.Colour || fields.Color || "#505a5fff"),
-		parentId,
-		projectId,
-		source: "airtable"
-	};
+	return { id: record.id, name: fields.Name || fields.Code || fields["Short Name"] || "", description: fields.Description || "", colour: normaliseHex8(fields.Colour || fields.Color || "#505a5fff"), parentId: linkedValues(fields.Parent)[0] || null, projectId: linkedValues(fields.Project)[0] || null, source: "airtable" };
 }
 
 function addCodePaths(codes = []) {
 	const byId = new Map(codes.map((code) => [code.id, code]));
 	const cache = new Map();
-
 	function pathFor(id, guard = 24) {
 		if (!id || !byId.has(id) || guard <= 0) return [];
 		if (cache.has(id)) return cache.get(id);
@@ -220,37 +155,28 @@ function addCodePaths(codes = []) {
 		cache.set(id, path);
 		return path;
 	}
-
 	return codes.map((code) => ({ ...code, path: pathFor(code.id).join(" / ") || code.name || code.id }));
 }
 
-async function airtableRecordsForProjects(service, table, candidates, timeoutMs) {
+async function airtableRecordsForProjects(service, table, candidates, timeoutMs, { allowUnfiltered = false } = {}) {
 	const records = await listAll(service.env, table, { pageSize: 100 }, timeoutMs);
 	const list = Array.isArray(records?.records) ? records.records : Array.isArray(records) ? records : [];
-	if (!candidates.length) return list;
+	if (!candidates.length) return allowUnfiltered ? list : [];
 	return list.filter((record) => includesAny(linkedProjects(record.fields || {}), candidates));
 }
 
 export async function listJournalEntries(service, origin, url) {
 	const candidates = projectCandidates(url);
 	if (!candidates.length) return service.json({ ok: true, entries: [] }, 200, service.corsHeaders(origin));
-
 	if (hasD1(service.env)) {
 		try {
-			const rows = await d1RowsForProjects(
-				service.env,
-				"journal_entries",
-				"record_id, project, category, content, tags, createdat, local_project_id",
-				candidates
-			);
+			const rows = await d1RowsForProjects(service.env, "journal_entries", "record_id, project, category, content, tags, createdat, local_project_id", candidates);
 			if (rows.length) return service.json({ ok: true, source: "d1", entries: rows.map(mapD1JournalEntry) }, 200, service.corsHeaders(origin));
 		} catch (error) {
 			service?.log?.warn?.("project_data.journals.d1.fail", { err: safeText(error?.message || error).slice(0, 200) });
 		}
 	}
-
 	if (!hasAirtable(service.env)) return service.json({ ok: true, source: "empty", entries: [] }, 200, service.corsHeaders(origin));
-
 	try {
 		const airtableProjectIds = await resolveAirtableProjectIds(service, candidates);
 		const records = await airtableRecordsForProjects(service, JOURNALS_TABLE(service), airtableProjectIds, service?.cfg?.TIMEOUT_MS);
@@ -267,23 +193,15 @@ export async function listJournalEntries(service, origin, url) {
 export async function listMemos(service, origin, url) {
 	const candidates = projectCandidates(url);
 	if (!candidates.length) return service.json({ ok: true, memos: [] }, 200, service.corsHeaders(origin));
-
 	if (hasD1(service.env)) {
 		try {
-			const rows = await d1RowsForProjects(
-				service.env,
-				"memos",
-				"record_id, project, type, title, body, createdat, local_project_id, local_memo_id",
-				candidates
-			);
+			const rows = await d1RowsForProjects(service.env, "memos", "record_id, project, type, title, body, createdat, local_project_id, local_memo_id", candidates);
 			if (rows.length) return service.json({ ok: true, source: "d1", memos: rows.map(mapD1Memo) }, 200, service.corsHeaders(origin));
 		} catch (error) {
 			service?.log?.warn?.("project_data.memos.d1.fail", { err: safeText(error?.message || error).slice(0, 200) });
 		}
 	}
-
 	if (!hasAirtable(service.env)) return service.json({ ok: true, source: "empty", memos: [] }, 200, service.corsHeaders(origin));
-
 	try {
 		const airtableProjectIds = await resolveAirtableProjectIds(service, candidates);
 		const records = await airtableRecordsForProjects(service, MEMOS_TABLE(service), airtableProjectIds, service?.cfg?.TIMEOUT_MS);
@@ -299,32 +217,22 @@ export async function listMemos(service, origin, url) {
 export async function listCodes(service, origin, url) {
 	const candidates = projectCandidates(url);
 	const nofilter = url.searchParams.get("nofilter") === "1";
-
 	if (hasD1(service.env)) {
 		try {
-			const rows = nofilter || !candidates.length ?
-				await d1All(service.env, `
-					SELECT record_id, project, name, description, parentcode, colour, createdat, local_project_id, local_code_id
-					  FROM codes
-					 ORDER BY datetime(createdat) DESC;
-				`) :
-				await d1RowsForProjects(
-					service.env,
-					"codes",
-					"record_id, project, name, description, parentcode, colour, createdat, local_project_id, local_code_id",
-					candidates
-				);
+			const rows = nofilter || !candidates.length ? await d1All(service.env, `
+				SELECT record_id, project, name, description, parentcode, colour, createdat, local_project_id, local_code_id
+				  FROM codes
+				 ORDER BY datetime(createdat) DESC;
+			`) : await d1RowsForProjects(service.env, "codes", "record_id, project, name, description, parentcode, colour, createdat, local_project_id, local_code_id", candidates);
 			if (rows.length) return service.json({ ok: true, source: "d1", codes: addCodePaths(rows.map(mapD1Code)) }, 200, service.corsHeaders(origin));
 		} catch (error) {
 			service?.log?.warn?.("project_data.codes.d1.fail", { err: safeText(error?.message || error).slice(0, 200) });
 		}
 	}
-
 	if (!hasAirtable(service.env)) return service.json({ ok: true, source: "empty", codes: [] }, 200, service.corsHeaders(origin));
-
 	try {
 		const airtableProjectIds = nofilter ? [] : await resolveAirtableProjectIds(service, candidates);
-		const records = await airtableRecordsForProjects(service, CODES_TABLE(service), airtableProjectIds, service?.cfg?.TIMEOUT_MS);
+		const records = await airtableRecordsForProjects(service, CODES_TABLE(service), airtableProjectIds, service?.cfg?.TIMEOUT_MS, { allowUnfiltered: nofilter || !candidates.length });
 		const codes = addCodePaths(records.map(mapAirtableCode));
 		return service.json({ ok: true, source: codes.length ? "airtable" : "empty", codes }, 200, service.corsHeaders(origin));
 	} catch (error) {

--- a/infra/cloudflare/src/service/reflection/project-data-hydration.js
+++ b/infra/cloudflare/src/service/reflection/project-data-hydration.js
@@ -1,0 +1,335 @@
+import { safeText } from "../../core/utils.js";
+import { listAll } from "../internals/airtable.js";
+import { d1All } from "../internals/researchops-d1.js";
+import { findProjectRecord } from "../projects/airtable.js";
+
+const JOURNALS_TABLE = (service) => service.env.AIRTABLE_TABLE_JOURNAL || "Journals";
+const MEMOS_TABLE = (service) => service.env.AIRTABLE_TABLE_MEMOS || "Memos";
+const CODES_TABLE = (service) => service.env.AIRTABLE_TABLE_CODES || "Codes";
+
+function hasD1(env) {
+	return !!env?.RESEARCHOPS_D1;
+}
+
+function hasAirtable(env) {
+	return !!(
+		(env?.AIRTABLE_BASE_ID || env?.AIRTABLE_BASE) &&
+		(env?.AIRTABLE_API_KEY || env?.AIRTABLE_PAT || env?.AIRTABLE_ACCESS_TOKEN)
+	);
+}
+
+function isAirtableRecordId(value) {
+	return /^rec[a-zA-Z0-9]{14,}$/.test(String(value || "").trim());
+}
+
+function unique(values = []) {
+	const seen = new Set();
+	const out = [];
+	for (const value of values) {
+		const text = String(value || "").trim();
+		if (!text || seen.has(text)) continue;
+		seen.add(text);
+		out.push(text);
+	}
+	return out;
+}
+
+function projectCandidates(url) {
+	return unique([
+		url.searchParams.get("project"),
+		url.searchParams.get("project_id"),
+		url.searchParams.get("project_local_id"),
+		url.searchParams.get("project_airtable_id")
+	]);
+}
+
+function linkedValues(value) {
+	if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+	const text = String(value || "").trim();
+	return text ? [text] : [];
+}
+
+function linkedProjects(fields = {}) {
+	return unique([
+		...linkedValues(fields.Project),
+		...linkedValues(fields.Projects),
+		...linkedValues(fields["Project ID"]),
+		...linkedValues(fields["Project Ref"]),
+	]);
+}
+
+function includesAny(values = [], candidates = []) {
+	const wanted = new Set(candidates.map(String));
+	return values.some((value) => wanted.has(String(value)));
+}
+
+function normTagsArray(value) {
+	if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+	if (!value) return [];
+	return String(value).split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+function parseTags(value) {
+	if (Array.isArray(value)) return normTagsArray(value);
+	const text = String(value || "").trim();
+	if (!text) return [];
+	try {
+		const parsed = JSON.parse(text);
+		if (Array.isArray(parsed)) return normTagsArray(parsed);
+	} catch {
+		// Use comma-separated fallback below.
+	}
+	return normTagsArray(text);
+}
+
+function placeholders(values = []) {
+	return values.map(() => "?").join(", ");
+}
+
+async function d1RowsForProjects(env, table, columns, candidates, orderColumn = "createdat") {
+	const ids = unique(candidates);
+	if (!ids.length) return [];
+
+	const list = placeholders(ids);
+	return d1All(env, `
+		SELECT ${columns}
+		  FROM ${table}
+		 WHERE local_project_id IN (${list})
+		    OR project IN (${list})
+		 ORDER BY datetime(${orderColumn}) DESC;
+	`, [...ids, ...ids]);
+}
+
+async function resolveAirtableProjectIds(service, candidates = []) {
+	const ids = new Set(candidates.filter(isAirtableRecordId));
+	if (!hasAirtable(service.env)) return [...ids];
+
+	for (const candidate of candidates) {
+		if (!candidate || isAirtableRecordId(candidate)) continue;
+		try {
+			const record = await findProjectRecord(service, candidate);
+			if (record?.id) ids.add(record.id);
+		} catch (error) {
+			service?.log?.warn?.("project_data.project_id_resolution.skip", {
+				project: candidate,
+				err: safeText(error?.message || error).slice(0, 160)
+			});
+		}
+	}
+
+	return [...ids];
+}
+
+function mapD1JournalEntry(row = {}) {
+	return {
+		id: row.record_id || null,
+		project: row.project || null,
+		category: row.category || "",
+		content: row.content || "",
+		tags: parseTags(row.tags),
+		createdAt: row.createdat || null,
+		source: "d1"
+	};
+}
+
+function mapAirtableJournalEntry(record = {}, projectId = "") {
+	const fields = record.fields || {};
+	return {
+		id: record.id,
+		project: projectId,
+		category: fields.Category || "—",
+		content: fields.Content || fields.Body || fields.Notes || "",
+		tags: normTagsArray(fields.Tags),
+		createdAt: record.createdTime || fields.Created || "",
+		source: "airtable"
+	};
+}
+
+function mapD1Memo(row = {}) {
+	return {
+		id: row.record_id || row.local_memo_id || null,
+		memoType: row.type || "memo",
+		title: row.title || "",
+		content: row.body || "",
+		linkedEntries: [],
+		createdAt: row.createdat || null,
+		source: "d1"
+	};
+}
+
+function mapAirtableMemo(record = {}) {
+	const fields = record.fields || {};
+	return {
+		id: record.id,
+		memoType: fields["Memo Type"] || fields.Type || "memo",
+		title: fields.Title || "",
+		content: fields.Content || fields.Body || fields.Notes || "",
+		author: fields.Author || "",
+		linkedEntries: Array.isArray(fields["Linked Entries"]) ? fields["Linked Entries"] :
+			Array.isArray(fields.Entries) ? fields.Entries : [],
+		createdAt: record.createdTime || fields.Created || "",
+		source: "airtable"
+	};
+}
+
+function normaliseHex8(value) {
+	let text = String(value || "").trim().toLowerCase();
+	if (!text.startsWith("#")) text = `#${text}`;
+	if (/^#[0-9a-f]{3}$/.test(text)) text = `#${text.slice(1).split("").map((item) => item + item).join("")}`;
+	if (/^#[0-9a-f]{6}$/.test(text)) return `${text}ff`;
+	if (/^#[0-9a-f]{8}$/.test(text)) return text;
+	return "#1d70b8ff";
+}
+
+function mapD1Code(row = {}) {
+	return {
+		id: row.record_id || row.local_code_id || null,
+		name: row.name || row.record_id || row.local_code_id || "",
+		description: row.description || "",
+		colour: normaliseHex8(row.colour || "#505a5fff"),
+		parentId: row.parentcode || null,
+		projectId: row.project || row.local_project_id || null,
+		source: "d1"
+	};
+}
+
+function mapAirtableCode(record = {}) {
+	const fields = record.fields || {};
+	const projectId = linkedValues(fields.Project)[0] || null;
+	const parentId = linkedValues(fields.Parent)[0] || null;
+	return {
+		id: record.id,
+		name: fields.Name || fields.Code || fields["Short Name"] || "",
+		description: fields.Description || "",
+		colour: normaliseHex8(fields.Colour || fields.Color || "#505a5fff"),
+		parentId,
+		projectId,
+		source: "airtable"
+	};
+}
+
+function addCodePaths(codes = []) {
+	const byId = new Map(codes.map((code) => [code.id, code]));
+	const cache = new Map();
+
+	function pathFor(id, guard = 24) {
+		if (!id || !byId.has(id) || guard <= 0) return [];
+		if (cache.has(id)) return cache.get(id);
+		const code = byId.get(id);
+		const path = pathFor(code.parentId, guard - 1).concat(code.name || code.id);
+		cache.set(id, path);
+		return path;
+	}
+
+	return codes.map((code) => ({ ...code, path: pathFor(code.id).join(" / ") || code.name || code.id }));
+}
+
+async function airtableRecordsForProjects(service, table, candidates, timeoutMs) {
+	const records = await listAll(service.env, table, { pageSize: 100 }, timeoutMs);
+	const list = Array.isArray(records?.records) ? records.records : Array.isArray(records) ? records : [];
+	if (!candidates.length) return list;
+	return list.filter((record) => includesAny(linkedProjects(record.fields || {}), candidates));
+}
+
+export async function listJournalEntries(service, origin, url) {
+	const candidates = projectCandidates(url);
+	if (!candidates.length) return service.json({ ok: true, entries: [] }, 200, service.corsHeaders(origin));
+
+	if (hasD1(service.env)) {
+		try {
+			const rows = await d1RowsForProjects(
+				service.env,
+				"journal_entries",
+				"record_id, project, category, content, tags, createdat, local_project_id",
+				candidates
+			);
+			if (rows.length) return service.json({ ok: true, source: "d1", entries: rows.map(mapD1JournalEntry) }, 200, service.corsHeaders(origin));
+		} catch (error) {
+			service?.log?.warn?.("project_data.journals.d1.fail", { err: safeText(error?.message || error).slice(0, 200) });
+		}
+	}
+
+	if (!hasAirtable(service.env)) return service.json({ ok: true, source: "empty", entries: [] }, 200, service.corsHeaders(origin));
+
+	try {
+		const airtableProjectIds = await resolveAirtableProjectIds(service, candidates);
+		const records = await airtableRecordsForProjects(service, JOURNALS_TABLE(service), airtableProjectIds, service?.cfg?.TIMEOUT_MS);
+		const entries = records.map((record) => mapAirtableJournalEntry(record, airtableProjectIds[0] || ""));
+		entries.sort((a, b) => (Date.parse(b.createdAt || "") || 0) - (Date.parse(a.createdAt || "") || 0));
+		return service.json({ ok: true, source: entries.length ? "airtable" : "empty", entries }, 200, service.corsHeaders(origin));
+	} catch (error) {
+		const msg = safeText(error?.message || error || "");
+		service?.log?.error?.("project_data.journals.airtable.fail", { err: msg.slice(0, 200) });
+		return service.json({ ok: false, error: "Failed to load journal entries", detail: msg }, 500, service.corsHeaders(origin));
+	}
+}
+
+export async function listMemos(service, origin, url) {
+	const candidates = projectCandidates(url);
+	if (!candidates.length) return service.json({ ok: true, memos: [] }, 200, service.corsHeaders(origin));
+
+	if (hasD1(service.env)) {
+		try {
+			const rows = await d1RowsForProjects(
+				service.env,
+				"memos",
+				"record_id, project, type, title, body, createdat, local_project_id, local_memo_id",
+				candidates
+			);
+			if (rows.length) return service.json({ ok: true, source: "d1", memos: rows.map(mapD1Memo) }, 200, service.corsHeaders(origin));
+		} catch (error) {
+			service?.log?.warn?.("project_data.memos.d1.fail", { err: safeText(error?.message || error).slice(0, 200) });
+		}
+	}
+
+	if (!hasAirtable(service.env)) return service.json({ ok: true, source: "empty", memos: [] }, 200, service.corsHeaders(origin));
+
+	try {
+		const airtableProjectIds = await resolveAirtableProjectIds(service, candidates);
+		const records = await airtableRecordsForProjects(service, MEMOS_TABLE(service), airtableProjectIds, service?.cfg?.TIMEOUT_MS);
+		const memos = records.map(mapAirtableMemo);
+		return service.json({ ok: true, source: memos.length ? "airtable" : "empty", memos }, 200, service.corsHeaders(origin));
+	} catch (error) {
+		const msg = safeText(error?.message || error || "");
+		service?.log?.error?.("project_data.memos.airtable.fail", { err: msg.slice(0, 200) });
+		return service.json({ ok: false, error: "Failed to load memos", detail: msg }, 500, service.corsHeaders(origin));
+	}
+}
+
+export async function listCodes(service, origin, url) {
+	const candidates = projectCandidates(url);
+	const nofilter = url.searchParams.get("nofilter") === "1";
+
+	if (hasD1(service.env)) {
+		try {
+			const rows = nofilter || !candidates.length ?
+				await d1All(service.env, `
+					SELECT record_id, project, name, description, parentcode, colour, createdat, local_project_id, local_code_id
+					  FROM codes
+					 ORDER BY datetime(createdat) DESC;
+				`) :
+				await d1RowsForProjects(
+					service.env,
+					"codes",
+					"record_id, project, name, description, parentcode, colour, createdat, local_project_id, local_code_id",
+					candidates
+				);
+			if (rows.length) return service.json({ ok: true, source: "d1", codes: addCodePaths(rows.map(mapD1Code)) }, 200, service.corsHeaders(origin));
+		} catch (error) {
+			service?.log?.warn?.("project_data.codes.d1.fail", { err: safeText(error?.message || error).slice(0, 200) });
+		}
+	}
+
+	if (!hasAirtable(service.env)) return service.json({ ok: true, source: "empty", codes: [] }, 200, service.corsHeaders(origin));
+
+	try {
+		const airtableProjectIds = nofilter ? [] : await resolveAirtableProjectIds(service, candidates);
+		const records = await airtableRecordsForProjects(service, CODES_TABLE(service), airtableProjectIds, service?.cfg?.TIMEOUT_MS);
+		const codes = addCodePaths(records.map(mapAirtableCode));
+		return service.json({ ok: true, source: codes.length ? "airtable" : "empty", codes }, 200, service.corsHeaders(origin));
+	} catch (error) {
+		const msg = safeText(error?.message || error || "");
+		service?.log?.error?.("project_data.codes.airtable.fail", { err: msg.slice(0, 200) });
+		return service.json({ ok: false, error: "Internal error", detail: msg }, 500, service.corsHeaders(origin));
+	}
+}

--- a/tests/journals-project-data-hydration-route-state.test.js
+++ b/tests/journals-project-data-hydration-route-state.test.js
@@ -29,9 +29,9 @@ includes(hydrationSource, "url.searchParams.get(\"project\")", "project data hyd
 includes(hydrationSource, "url.searchParams.get(\"project_local_id\")", "project data hydration service");
 includes(hydrationSource, "url.searchParams.get(\"project_airtable_id\")", "project data hydration service");
 includes(hydrationSource, "findProjectRecord(service, candidate)", "project data hydration service");
-includes(hydrationSource, "FROM journal_entries", "project data hydration service");
-includes(hydrationSource, "FROM memos", "project data hydration service");
-includes(hydrationSource, "FROM codes", "project data hydration service");
+includes(hydrationSource, "d1RowsForProjects(service.env, \"journal_entries\"", "project data hydration service");
+includes(hydrationSource, "d1RowsForProjects(service.env, \"memos\"", "project data hydration service");
+includes(hydrationSource, "d1RowsForProjects(service.env, \"codes\"", "project data hydration service");
 includes(hydrationSource, "local_project_id IN", "project data hydration service");
 includes(hydrationSource, "OR project IN", "project data hydration service");
 includes(hydrationSource, "allowUnfiltered = false", "project data hydration service");

--- a/tests/journals-project-data-hydration-route-state.test.js
+++ b/tests/journals-project-data-hydration-route-state.test.js
@@ -34,6 +34,9 @@ includes(hydrationSource, "FROM memos", "project data hydration service");
 includes(hydrationSource, "FROM codes", "project data hydration service");
 includes(hydrationSource, "local_project_id IN", "project data hydration service");
 includes(hydrationSource, "OR project IN", "project data hydration service");
+includes(hydrationSource, "allowUnfiltered = false", "project data hydration service");
+includes(hydrationSource, "allowUnfiltered ? list : []", "project data hydration service");
+includes(hydrationSource, "allowUnfiltered: nofilter || !candidates.length", "project data hydration service");
 includes(hydrationSource, "source: \"d1\"", "project data hydration service");
 includes(hydrationSource, "source: codes.length ? \"airtable\" : \"empty\"", "project data hydration service");
 

--- a/tests/journals-project-data-hydration-route-state.test.js
+++ b/tests/journals-project-data-hydration-route-state.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const serviceIndexSource = fs.readFileSync("infra/cloudflare/src/service/index.js", "utf8");
+const hydrationSource = fs.readFileSync("infra/cloudflare/src/service/reflection/project-data-hydration.js", "utf8");
+const routerSource = fs.readFileSync("infra/cloudflare/src/core/router.js", "utf8");
+const d1SeedSource = fs.readFileSync("infra/cloudflare/migrations/researchops-d1/0001_seed.sql", "utf8");
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(routerSource, "service.listJournalEntries(origin, url)", "Worker router");
+includes(routerSource, "service.listMemos(origin, url)", "Worker router");
+includes(routerSource, "service.listCodes(origin, url)", "Worker router");
+
+includes(serviceIndexSource, "ProjectDataHydration.listJournalEntries(this, origin, url)", "ResearchOps service index");
+includes(serviceIndexSource, "ProjectDataHydration.listMemos(this, origin, url)", "ResearchOps service index");
+includes(serviceIndexSource, "ProjectDataHydration.listCodes(this, origin, url)", "ResearchOps service index");
+excludes(serviceIndexSource, "listJournalEntries = (origin, url) => Journals.listJournalEntries", "ResearchOps service index");
+excludes(serviceIndexSource, "listMemos = (origin, url) => Memos.listMemos", "ResearchOps service index");
+excludes(serviceIndexSource, "listCodes = (origin, url) => Codes.listCodes", "ResearchOps service index");
+
+includes(hydrationSource, "url.searchParams.get(\"project\")", "project data hydration service");
+includes(hydrationSource, "url.searchParams.get(\"project_local_id\")", "project data hydration service");
+includes(hydrationSource, "url.searchParams.get(\"project_airtable_id\")", "project data hydration service");
+includes(hydrationSource, "findProjectRecord(service, candidate)", "project data hydration service");
+includes(hydrationSource, "FROM journal_entries", "project data hydration service");
+includes(hydrationSource, "FROM memos", "project data hydration service");
+includes(hydrationSource, "FROM codes", "project data hydration service");
+includes(hydrationSource, "local_project_id IN", "project data hydration service");
+includes(hydrationSource, "OR project IN", "project data hydration service");
+includes(hydrationSource, "source: \"d1\"", "project data hydration service");
+includes(hydrationSource, "source: codes.length ? \"airtable\" : \"empty\"", "project data hydration service");
+
+includes(d1SeedSource, "CREATE TABLE IF NOT EXISTS \"journal_entries\"", "ResearchOps D1 seed");
+includes(d1SeedSource, "CREATE TABLE IF NOT EXISTS \"memos\"", "ResearchOps D1 seed");
+includes(d1SeedSource, "CREATE TABLE IF NOT EXISTS \"codes\"", "ResearchOps D1 seed");
+includes(d1SeedSource, "local_project_id", "ResearchOps D1 seed");


### PR DESCRIPTION
## Summary

- Adds a shared project data hydration service for journal entries, memos and codes.
- Resolves project identifiers from `project`, `project_id`, `project_local_id` and `project_airtable_id`.
- Reads D1 first by `local_project_id` or Airtable project id, then falls back to Airtable linked-record filtering.
- Routes `listJournalEntries`, `listMemos` and `listCodes` through the new hydration path while leaving create/update/delete handlers unchanged.
- Adds route-state coverage for the new data-hydration contract.

## Validation

Not run locally in this connector session. Required before ready for review:

- `node --test tests/journals-project-data-hydration-route-state.test.js`
- `npm run build`
- `npm run format:check`
- `npm run validate`
- `npm run trace:coverage`

## Trace

- `docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.md`
- `docs/agent-audit/reasoning/2026/06/09/journals-project-data-hydration.json`
