### PR TITLE
Fix journal hydration for Airtable project lookup fields

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/10/journal-hydration-project-lookup-fix.json
+++ b/docs/agent-audit/reasoning/2026/06/10/journal-hydration-project-lookup-fix.json
@@ -1,0 +1,36 @@
+{
+	"schema": "researchops.agentAuditTrace.v1",
+	"date": "2026-06-10",
+	"traceLayer": "operational",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "fix/journals-project-data-hydration",
+	"pullRequest": 383,
+	"branchPrefix": "fix/",
+	"traceRequired": true,
+	"taskSummary": "Fix Test Project 1 journal hydration by recognising Airtable Project lookup fields.",
+	"selectedBundles": [
+		"github-diamond",
+		"researchops-developer-control",
+		"multi-functional-team",
+		"govuk-design-system",
+		"cloudflare",
+		"airtable-public-api"
+	],
+	"filesModified": [
+		"infra/cloudflare/src/service/reflection/project-data-hydration.js",
+		"tests/journals-project-data-hydration-route-state.test.js"
+	],
+	"implementationSummary": [
+		"Airtable fallback now recognises Project lookup and Project Lookup linked-project fields.",
+		"Route-state coverage asserts support for those fields and confirms the CSV source exports use Project lookup."
+	],
+	"validation": {
+		"commandsRun": [],
+		"required": [
+			"CI",
+			"Validate ResearchOps",
+			"Worker CI",
+			"Release Gate"
+		]
+	}
+}

--- a/docs/agent-audit/reasoning/2026/06/10/journal-hydration-project-lookup-fix.md
+++ b/docs/agent-audit/reasoning/2026/06/10/journal-hydration-project-lookup-fix.md
@@ -1,0 +1,59 @@
+# Journal hydration project lookup fix trace
+
+## Run metadata
+
+- Date: 2026-06-10
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `fix/journals-project-data-hydration`
+- Pull request: #383
+- Trace layer: operational
+- Branch-prefix trace decision: `fix/` requires a promoted trace.
+
+## Task summary
+
+Correct a live Test Project 1 hydration failure where Reflexive Journal entries, Codes and Memos were not reaching the frontend. The failure was traced to the Worker Airtable fallback not recognising `Project lookup`, which is the linked-project field used in existing journal entry and code data exports.
+
+## Operating-model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Bundles selected
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `govuk-design-system`
+- `cloudflare`
+- `airtable-public-api`
+
+## Files read
+
+- `public/js/project-context.js`
+- `public/js/journal-tabs.js`
+- `public/js/project-dashboard.js`
+- `infra/cloudflare/src/service/reflection/project-data-hydration.js`
+- `infra/cloudflare/src/service/projects/airtable.js`
+- `infra/cloudflare/src/service/project-list-d1-airtable.js`
+- `data/journal-entries.csv`
+- `data/codes.csv`
+- `tests/journals-project-data-hydration-route-state.test.js`
+
+## Files modified
+
+- `infra/cloudflare/src/service/reflection/project-data-hydration.js`
+- `tests/journals-project-data-hydration-route-state.test.js`
+
+## Implementation summary
+
+The frontend already calls `/api/journal-entries`, `/api/codes` and `/api/memos` with a project identifier. The Worker read path checked D1 first and then fell back to Airtable. The fallback filtered linked records by fields named `Project`, `Projects`, `Project ID` and `Project Ref`, but existing journal and code data use `Project lookup`. The fallback therefore returned empty lists even when Airtable had Test Project 1 records.
+
+The linked-project resolver now recognises both `Project lookup` and `Project Lookup`. Route-state coverage now asserts that the resolver supports those fields and that the source CSVs use them.
+
+## Validation status
+
+CI polling required after commit `af83f9676e5e27a8b00e631a3867c60b95fcad4b`.

--- a/infra/cloudflare/src/service/reflection/project-data-hydration.js
+++ b/infra/cloudflare/src/service/reflection/project-data-hydration.js
@@ -42,7 +42,14 @@ function linkedValues(value) {
 }
 
 function linkedProjects(fields = {}) {
-	return unique([...linkedValues(fields.Project), ...linkedValues(fields.Projects), ...linkedValues(fields["Project ID"]), ...linkedValues(fields["Project Ref"])]);
+	return unique([
+		...linkedValues(fields.Project),
+		...linkedValues(fields.Projects),
+		...linkedValues(fields["Project lookup"]),
+		...linkedValues(fields["Project Lookup"]),
+		...linkedValues(fields["Project ID"]),
+		...linkedValues(fields["Project Ref"]),
+	]);
 }
 
 function includesAny(values = [], candidates = []) {

--- a/tests/journals-project-data-hydration-route-state.test.js
+++ b/tests/journals-project-data-hydration-route-state.test.js
@@ -5,6 +5,8 @@ const serviceIndexSource = fs.readFileSync("infra/cloudflare/src/service/index.j
 const hydrationSource = fs.readFileSync("infra/cloudflare/src/service/reflection/project-data-hydration.js", "utf8");
 const routerSource = fs.readFileSync("infra/cloudflare/src/core/router.js", "utf8");
 const d1SeedSource = fs.readFileSync("infra/cloudflare/migrations/researchops-d1/0001_seed.sql", "utf8");
+const journalEntriesCsv = fs.readFileSync("data/journal-entries.csv", "utf8");
+const codesCsv = fs.readFileSync("data/codes.csv", "utf8");
 
 function includes(source, text, label) {
 	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
@@ -29,6 +31,8 @@ includes(hydrationSource, "url.searchParams.get(\"project\")", "project data hyd
 includes(hydrationSource, "url.searchParams.get(\"project_local_id\")", "project data hydration service");
 includes(hydrationSource, "url.searchParams.get(\"project_airtable_id\")", "project data hydration service");
 includes(hydrationSource, "findProjectRecord(service, candidate)", "project data hydration service");
+includes(hydrationSource, "fields[\"Project lookup\"]", "project data hydration service");
+includes(hydrationSource, "fields[\"Project Lookup\"]", "project data hydration service");
 includes(hydrationSource, "d1RowsForProjects(service.env, \"journal_entries\"", "project data hydration service");
 includes(hydrationSource, "d1RowsForProjects(service.env, \"memos\"", "project data hydration service");
 includes(hydrationSource, "d1RowsForProjects(service.env, \"codes\"", "project data hydration service");
@@ -39,6 +43,9 @@ includes(hydrationSource, "allowUnfiltered ? list : []", "project data hydration
 includes(hydrationSource, "allowUnfiltered: nofilter || !candidates.length", "project data hydration service");
 includes(hydrationSource, "source: \"d1\"", "project data hydration service");
 includes(hydrationSource, "source: codes.length ? \"airtable\" : \"empty\"", "project data hydration service");
+
+includes(journalEntriesCsv, "Project lookup", "journal entries CSV");
+includes(codesCsv, "Project lookup", "codes CSV");
 
 includes(d1SeedSource, "CREATE TABLE IF NOT EXISTS \"journal_entries\"", "ResearchOps D1 seed");
 includes(d1SeedSource, "CREATE TABLE IF NOT EXISTS \"memos\"", "ResearchOps D1 seed");


### PR DESCRIPTION
## Summary

- Fixes the Worker fallback path for journal entries, codes and memos when D1 has no matching rows yet.
- Adds support for Airtable linked-project fields named `Project lookup` and `Project Lookup`.
- Adds route-state coverage against the existing journal and code CSV exports that use `Project lookup`.

## Why

Test Project 1 records exist in Airtable exports, but the hydration fallback only checked `Project`, `Projects`, `Project ID` and `Project Ref`. That meant the frontend could request Test Project 1 correctly and still receive empty arrays.

## Validation

Pending CI. I will poll checks and fix failures.

## Trace

- `docs/agent-audit/reasoning/2026/06/10/journal-hydration-project-lookup-fix.md`
- `docs/agent-audit/reasoning/2026/06/10/journal-hydration-project-lookup-fix.json`
