### PR TITLE
Canonicalise Test Project 1 D1 project ID

### DIFF
--- a/.github/workflows/apply-d1-test-project-1-id-canonicalisation.yml
+++ b/.github/workflows/apply-d1-test-project-1-id-canonicalisation.yml
@@ -1,0 +1,119 @@
+name: Apply D1 Test Project 1 ID Canonicalisation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql"
+      - ".github/workflows/apply-d1-test-project-1-id-canonicalisation.yml"
+  workflow_dispatch:
+    inputs:
+      confirm_database_name:
+        description: Type researchops-d1 to confirm the target D1 database
+        required: true
+        type: string
+      confirm_operation:
+        description: Type CANONICALISE_TEST_PROJECT_1_ID to repair the O/0 project id mismatch
+        required: true
+        type: string
+      run_post_apply_checks:
+        description: Run post-apply canonicalisation checks
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  WRANGLER_VERSION: "4.90.0"
+  D1_DATABASE_NAME: "researchops-d1"
+  WRANGLER_CONFIG: "infra/cloudflare/wrangler.toml"
+  TEST_PROJECT_1_ID_CANONICALISATION_MIGRATION: "infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql"
+  TEST_PROJECT_1_BAD_ID: "recgdpwEI5hFO7bUZ"
+  TEST_PROJECT_1_CANONICAL_ID: "recgdpwEI5hF07bUZ"
+
+jobs:
+  apply:
+    name: Apply Test Project 1 ID canonicalisation to remote D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Confirm manual target
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm_database_name }}" != "${D1_DATABASE_NAME}" ]; then
+            echo "confirm_database_name must be ${D1_DATABASE_NAME}"
+            exit 1
+          fi
+
+          if [ "${{ inputs.confirm_operation }}" != "CANONICALISE_TEST_PROJECT_1_ID" ]; then
+            echo "confirm_operation must be CANONICALISE_TEST_PROJECT_1_ID"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Check migration file exists
+        run: test -f "${TEST_PROJECT_1_ID_CANONICALISATION_MIGRATION}"
+
+      - name: Apply Test Project 1 ID canonicalisation to remote D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --file "${TEST_PROJECT_1_ID_CANONICALISATION_MIGRATION}"
+
+      - name: Check Test Project 1 ID canonicalisation
+        if: ${{ github.event_name == 'push' || inputs.run_post_apply_checks }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS bad_participant_project_count FROM rops_participants_cache WHERE project_id = '${TEST_PROJECT_1_BAD_ID}' OR payload_json LIKE '%${TEST_PROJECT_1_BAD_ID}%';"
+
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS canonical_participant_project_count FROM rops_participants_cache WHERE project_id = '${TEST_PROJECT_1_CANONICAL_ID}';"
+
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS bad_journal_project_count FROM journal_entries WHERE project = '${TEST_PROJECT_1_BAD_ID}';"
+
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS canonical_journal_project_count FROM journal_entries WHERE project = '${TEST_PROJECT_1_CANONICAL_ID}';"
+
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS bad_code_project_count FROM codes WHERE project = '${TEST_PROJECT_1_BAD_ID}';"
+
+          npx --yes wrangler@${WRANGLER_VERSION} d1 execute "${D1_DATABASE_NAME}" \
+            --remote \
+            --config "${WRANGLER_CONFIG}" \
+            --command "SELECT COUNT(*) AS bad_memo_project_count FROM memos WHERE project = '${TEST_PROJECT_1_BAD_ID}';"

--- a/docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.json
+++ b/docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.json
@@ -1,0 +1,59 @@
+{
+	"schema": "researchops.agentAuditTrace.v1",
+	"date": "2026-06-10",
+	"traceLayer": "operational",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "fix/canonicalise-test-project-id",
+	"branchPrefix": "fix/",
+	"traceRequired": true,
+	"taskSummary": "Canonicalise Test Project 1 D1 references from recgdpwEI5hFO7bUZ to recgdpwEI5hF07bUZ and tolerate legacy inbound links.",
+	"selectedBundles": [
+		"github-diamond",
+		"researchops-developer-control",
+		"multi-functional-team",
+		"cloudflare",
+		"airtable-public-api"
+	],
+	"filesRead": [
+		"infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql",
+		"infra/cloudflare/migrations/preview/0002_seed_projects_cache.sql",
+		"infra/cloudflare/migrations/researchops-d1/0001_seed.sql",
+		"infra/cloudflare/src/service/reflection/project-data-hydration.js",
+		"tests/test-project-1-participants-seed-route-state.test.js",
+		"docs/deployment/d1-migration-ordering.md"
+	],
+	"filesCreatedOrModified": [
+		"infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql",
+		"infra/cloudflare/src/service/reflection/project-data-hydration.js",
+		"docs/deployment/d1-migration-ordering.md",
+		".github/workflows/apply-d1-test-project-1-id-canonicalisation.yml",
+		"tests/test-project-1-id-canonicalisation-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.md",
+		"docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.json"
+	],
+	"canonicalisation": {
+		"legacyId": "recgdpwEI5hFO7bUZ",
+		"canonicalId": "recgdpwEI5hF07bUZ",
+		"d1Tables": [
+			"rops_participants_cache",
+			"journal_entries",
+			"memos",
+			"codes",
+			"rops_studies_cache",
+			"rops_projects_cache"
+		],
+		"runtimeAliasAdded": true
+	},
+	"validation": {
+		"commandsRun": [],
+		"required": [
+			"CI",
+			"Validate ResearchOps",
+			"Worker CI",
+			"Release Gate",
+			"qa-bdd",
+			"Accessibility audit",
+			"Lychee"
+		]
+	}
+}

--- a/docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.md
+++ b/docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.md
@@ -1,0 +1,61 @@
+# Test Project 1 ID canonicalisation trace
+
+## Run metadata
+
+- Date: 2026-06-10
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `fix/canonicalise-test-project-id`
+- Trace layer: operational
+- Branch-prefix trace decision: `fix/` requires a promoted trace.
+
+## Task summary
+
+Correct the Test Project 1 project ID mismatch where historical D1-backed links and seed rows use `recgdpwEI5hFO7bUZ` with the letter `O`, while the canonical Airtable record ID is `recgdpwEI5hF07bUZ` with the number `0`.
+
+## Operating-model files loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Bundles selected
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `cloudflare`
+- `airtable-public-api`
+
+## Files read
+
+- `infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql`
+- `infra/cloudflare/migrations/preview/0002_seed_projects_cache.sql`
+- `infra/cloudflare/migrations/researchops-d1/0001_seed.sql`
+- `infra/cloudflare/src/service/reflection/project-data-hydration.js`
+- `tests/test-project-1-participants-seed-route-state.test.js`
+- `docs/deployment/d1-migration-ordering.md`
+
+## Files created or modified
+
+- Created `infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql`
+- Modified `infra/cloudflare/src/service/reflection/project-data-hydration.js`
+- Modified `docs/deployment/d1-migration-ordering.md`
+- Created `.github/workflows/apply-d1-test-project-1-id-canonicalisation.yml`
+- Created `tests/test-project-1-id-canonicalisation-route-state.test.js`
+- Created `docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.md`
+- Created `docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.json`
+
+## Implementation summary
+
+A new D1 migration canonicalises the legacy `recgdpwEI5hFO7bUZ` identifier to `recgdpwEI5hF07bUZ` across the live D1 tables that can store Test Project 1 references: participant cache, journal entries, memos, codes, studies cache and project cache. JSON payload fields are also repaired using string replacement.
+
+The journal hydration read path now treats the legacy and canonical IDs as aliases. This means existing links using `recgdpwEI5hFO7bUZ` continue to return journal entries, codes and memos even after D1 rows are normalised to `recgdpwEI5hF07bUZ`.
+
+A guarded workflow applies the canonicalisation migration to the remote `researchops-d1` database and checks for remaining bad project references in the main affected tables.
+
+## Validation status
+
+CI polling required after PR creation.

--- a/docs/deployment/d1-migration-ordering.md
+++ b/docs/deployment/d1-migration-ordering.md
@@ -11,6 +11,6 @@ Future main D1 migrations must use a new, monotonically increasing four-digit pr
 
 Do not rename or renumber already-applied migration files. If an applied migration must be corrected, add a new migration with the next available main prefix and document the reason in the migration body or the related pull request.
 
-The next main migration prefix after 0017_seed_test_project_1_journal_analysis.sql is `0018`.
+The next main migration prefix after 0018_canonicalise_test_project_1_id.sql is `0019`.
 
 Preview seed migrations under `infra/cloudflare/migrations/preview/` use an independent sequence. Scoped migration folders such as `infra/cloudflare/migrations/researchops-d1/` also have their own local ordering contract.

--- a/infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql
+++ b/infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql
@@ -1,0 +1,127 @@
+-- Canonicalise Test Project 1 project identifiers in D1.
+-- Date: 2026-06-10
+--
+-- Bad legacy ID: recgdpwEI5hFO7bUZ
+-- Canonical ID:  recgdpwEI5hF07bUZ
+--
+-- The mismatch is the letter O versus the number 0 after hF.
+
+CREATE TABLE IF NOT EXISTS rops_participants_cache (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL,
+	study_id TEXT NOT NULL,
+	participant_airtable_id TEXT,
+	participant_ref TEXT NOT NULL,
+	channel_pref TEXT,
+	consent_status TEXT,
+	status TEXT,
+	access_needs TEXT,
+	active INTEGER NOT NULL DEFAULT 1,
+	source TEXT NOT NULL DEFAULT 'd1-seed',
+	created_at TEXT,
+	updated_at TEXT NOT NULL,
+	sensitive_contact_json TEXT,
+	payload_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS journal_entries (
+	record_id TEXT PRIMARY KEY,
+	project TEXT,
+	category TEXT,
+	content TEXT,
+	tags TEXT,
+	createdat TEXT,
+	local_project_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS memos (
+	record_id TEXT,
+	project TEXT,
+	type TEXT,
+	title TEXT,
+	body TEXT,
+	createdat TEXT,
+	local_project_id TEXT,
+	local_memo_id TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS codes (
+	record_id TEXT,
+	project TEXT,
+	name TEXT,
+	description TEXT,
+	parentcode TEXT,
+	colour TEXT,
+	createdat TEXT,
+	local_project_id TEXT,
+	local_code_id TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS rops_studies_cache (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL,
+	study_id TEXT,
+	title TEXT,
+	method TEXT,
+	status TEXT,
+	description TEXT,
+	created_at TEXT,
+	active INTEGER NOT NULL DEFAULT 1,
+	source TEXT NOT NULL DEFAULT 'airtable',
+	updated_at TEXT NOT NULL,
+	payload_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS rops_projects_cache (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL,
+	org TEXT,
+	phase TEXT,
+	status TEXT,
+	active INTEGER NOT NULL DEFAULT 1,
+	source TEXT NOT NULL DEFAULT 'airtable',
+	updated_at TEXT NOT NULL,
+	payload_json TEXT
+);
+
+UPDATE rops_participants_cache
+SET project_id = 'recgdpwEI5hF07bUZ',
+	payload_json = replace(COALESCE(payload_json, ''), 'recgdpwEI5hFO7bUZ', 'recgdpwEI5hF07bUZ')
+WHERE project_id = 'recgdpwEI5hFO7bUZ'
+	OR payload_json LIKE '%recgdpwEI5hFO7bUZ%';
+
+UPDATE journal_entries
+SET project = 'recgdpwEI5hF07bUZ'
+WHERE project = 'recgdpwEI5hFO7bUZ';
+
+UPDATE memos
+SET project = 'recgdpwEI5hF07bUZ'
+WHERE project = 'recgdpwEI5hFO7bUZ';
+
+UPDATE codes
+SET project = 'recgdpwEI5hF07bUZ'
+WHERE project = 'recgdpwEI5hFO7bUZ';
+
+UPDATE rops_studies_cache
+SET project_id = 'recgdpwEI5hF07bUZ',
+	payload_json = replace(COALESCE(payload_json, ''), 'recgdpwEI5hFO7bUZ', 'recgdpwEI5hF07bUZ')
+WHERE project_id = 'recgdpwEI5hFO7bUZ'
+	OR payload_json LIKE '%recgdpwEI5hFO7bUZ%';
+
+UPDATE rops_projects_cache
+SET id = 'recgdpwEI5hF07bUZ',
+	payload_json = replace(COALESCE(payload_json, ''), 'recgdpwEI5hFO7bUZ', 'recgdpwEI5hF07bUZ')
+WHERE id = 'recgdpwEI5hFO7bUZ'
+	AND NOT EXISTS (
+		SELECT 1 FROM rops_projects_cache WHERE id = 'recgdpwEI5hF07bUZ'
+	);
+
+UPDATE rops_projects_cache
+SET payload_json = replace(COALESCE(payload_json, ''), 'recgdpwEI5hFO7bUZ', 'recgdpwEI5hF07bUZ')
+WHERE payload_json LIKE '%recgdpwEI5hFO7bUZ%';
+
+DELETE FROM rops_projects_cache
+WHERE id = 'recgdpwEI5hFO7bUZ'
+	AND EXISTS (
+		SELECT 1 FROM rops_projects_cache WHERE id = 'recgdpwEI5hF07bUZ'
+	);

--- a/infra/cloudflare/src/service/reflection/project-data-hydration.js
+++ b/infra/cloudflare/src/service/reflection/project-data-hydration.js
@@ -6,6 +6,8 @@ import { findProjectRecord } from "../projects/airtable.js";
 const JOURNALS_TABLE = (service) => service.env.AIRTABLE_TABLE_JOURNAL || "Journals";
 const MEMOS_TABLE = (service) => service.env.AIRTABLE_TABLE_MEMOS || "Memos";
 const CODES_TABLE = (service) => service.env.AIRTABLE_TABLE_CODES || "Codes";
+const TEST_PROJECT_1_LEGACY_ID = "recgdpwEI5hFO7bUZ";
+const TEST_PROJECT_1_CANONICAL_ID = "recgdpwEI5hF07bUZ";
 
 function hasD1(env) {
 	return !!env?.RESEARCHOPS_D1;
@@ -31,8 +33,17 @@ function unique(values = []) {
 	return out;
 }
 
+function withProjectAliases(values = []) {
+	return unique(values.flatMap((value) => {
+		const text = String(value || "").trim();
+		if (text === TEST_PROJECT_1_LEGACY_ID) return [text, TEST_PROJECT_1_CANONICAL_ID];
+		if (text === TEST_PROJECT_1_CANONICAL_ID) return [text, TEST_PROJECT_1_LEGACY_ID];
+		return [text];
+	}));
+}
+
 function projectCandidates(url) {
-	return unique([url.searchParams.get("project"), url.searchParams.get("project_id"), url.searchParams.get("project_local_id"), url.searchParams.get("project_airtable_id")]);
+	return withProjectAliases([url.searchParams.get("project"), url.searchParams.get("project_id"), url.searchParams.get("project_local_id"), url.searchParams.get("project_airtable_id")]);
 }
 
 function linkedValues(value) {
@@ -42,7 +53,7 @@ function linkedValues(value) {
 }
 
 function linkedProjects(fields = {}) {
-	return unique([
+	return withProjectAliases([
 		...linkedValues(fields.Project),
 		...linkedValues(fields.Projects),
 		...linkedValues(fields["Project lookup"]),

--- a/tests/test-project-1-id-canonicalisation-route-state.test.js
+++ b/tests/test-project-1-id-canonicalisation-route-state.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const migration = fs.readFileSync("infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql", "utf8");
+const workflow = fs.readFileSync(".github/workflows/apply-d1-test-project-1-id-canonicalisation.yml", "utf8");
+const hydration = fs.readFileSync("infra/cloudflare/src/service/reflection/project-data-hydration.js", "utf8");
+const participantSeed = fs.readFileSync("infra/cloudflare/migrations/0008_seed_test_project_1_participants.sql", "utf8");
+const previewSeed = fs.readFileSync("infra/cloudflare/migrations/preview/0002_seed_projects_cache.sql", "utf8");
+
+const BAD_ID = "recgdpwEI5hFO7bUZ";
+const CANONICAL_ID = "recgdpwEI5hF07bUZ";
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+includes(participantSeed, BAD_ID, "historical participant seed");
+includes(previewSeed, BAD_ID, "historical preview project cache seed");
+
+for (const required of [
+	BAD_ID,
+	CANONICAL_ID,
+	"CREATE TABLE IF NOT EXISTS rops_participants_cache",
+	"CREATE TABLE IF NOT EXISTS journal_entries",
+	"CREATE TABLE IF NOT EXISTS memos",
+	"CREATE TABLE IF NOT EXISTS codes",
+	"CREATE TABLE IF NOT EXISTS rops_studies_cache",
+	"CREATE TABLE IF NOT EXISTS rops_projects_cache",
+	"UPDATE rops_participants_cache",
+	"UPDATE journal_entries",
+	"UPDATE memos",
+	"UPDATE codes",
+	"UPDATE rops_studies_cache",
+	"UPDATE rops_projects_cache",
+	"DELETE FROM rops_projects_cache",
+	"replace(COALESCE(payload_json, ''), 'recgdpwEI5hFO7bUZ', 'recgdpwEI5hF07bUZ')",
+]) {
+	includes(migration, required, "Test Project 1 ID canonicalisation migration");
+}
+
+for (const required of [
+	"Apply D1 Test Project 1 ID Canonicalisation",
+	"infra/cloudflare/migrations/0018_canonicalise_test_project_1_id.sql",
+	"CANONICALISE_TEST_PROJECT_1_ID",
+	"TEST_PROJECT_1_BAD_ID",
+	"TEST_PROJECT_1_CANONICAL_ID",
+	"bad_participant_project_count",
+	"canonical_participant_project_count",
+	"bad_journal_project_count",
+	"canonical_journal_project_count",
+	"bad_code_project_count",
+	"bad_memo_project_count",
+]) {
+	includes(workflow, required, "Test Project 1 ID canonicalisation workflow");
+}
+
+for (const required of [
+	"TEST_PROJECT_1_LEGACY_ID",
+	"TEST_PROJECT_1_CANONICAL_ID",
+	"withProjectAliases",
+	"if (text === TEST_PROJECT_1_LEGACY_ID) return [text, TEST_PROJECT_1_CANONICAL_ID];",
+	"if (text === TEST_PROJECT_1_CANONICAL_ID) return [text, TEST_PROJECT_1_LEGACY_ID];",
+]) {
+	includes(hydration, required, "project data hydration alias handling");
+}


### PR DESCRIPTION
## Summary

- Adds D1 migration `0018_canonicalise_test_project_1_id.sql` to normalise legacy Test Project 1 references from `recgdpwEI5hFO7bUZ` to canonical `recgdpwEI5hF07bUZ`.
- Repairs known D1 tables that can hold the project id: participant cache, journal entries, memos, codes, studies cache and project cache.
- Updates JSON payload fields that contain the legacy id.
- Adds runtime alias handling so existing links using `recgdpwEI5hFO7bUZ` still resolve to the canonical project data.
- Adds a guarded workflow to apply the canonicalisation migration to remote `researchops-d1`.
- Adds route-state coverage for the migration, workflow and runtime alias behaviour.

## Validation

Pending CI. I will poll checks and fix failures.

## Trace

- `docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.md`
- `docs/agent-audit/reasoning/2026/06/10/test-project-1-id-canonicalisation.json`
