### PR TITLE
Preserve journal entry project context

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.json
+++ b/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.json
@@ -1,0 +1,38 @@
+{
+	"schema": "researchops.agentAuditTrace.v1",
+	"date": "2026-06-10",
+	"traceLayer": "operational",
+	"repository": "kevinrapley/ResearchOps",
+	"branch": "fix/journal-entry-project-context",
+	"branchPrefix": "fix/",
+	"traceRequired": true,
+	"taskSummary": "Preserve project context on journal entry pages.",
+	"selectedBundles": [
+		"github-diamond",
+		"researchops-developer-control",
+		"multi-functional-team",
+		"govuk-design-system",
+		"cloudflare"
+	],
+	"filesModified": [
+		"public/js/journal-entry.js",
+		"tests/journal-entry-page-route-state.test.js"
+	],
+	"implementationSummary": [
+		"Journal entry page resolves project context from query parameters, referrer, session storage and entry payload.",
+		"Back links and breadcrumbs use /pages/projects/journals/?id=<project-id> when context is available.",
+		"Route-state coverage checks project context recovery."
+	],
+	"validation": {
+		"commandsRun": [],
+		"required": [
+			"CI",
+			"Validate ResearchOps",
+			"Worker CI",
+			"Release Gate",
+			"Accessibility audit",
+			"qa-bdd",
+			"Lychee"
+		]
+	}
+}

--- a/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.md
+++ b/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.md
@@ -1,0 +1,38 @@
+# Journal entry project context trace
+
+- Date: 2026-06-10
+- Repository: `kevinrapley/ResearchOps`
+- Branch: `fix/journal-entry-project-context`
+- Pull request: pending
+- Trace layer: operational
+
+## Task summary
+
+Preserve project context on the journal entry page so breadcrumbs, back links and return links point back to the project-scoped Journal and analysis page.
+
+## Operating model loaded
+
+Loaded `AGENTS.md`, orchestration, bundle registry, task signal catalog, selection rules, bootstrap checklist, precedence policy, trace policy, trace layers, GitHub mutation policy and selected bundle specs/bodies.
+
+## Bundles selected
+
+- `github-diamond`
+- `researchops-developer-control`
+- `multi-functional-team`
+- `govuk-design-system`
+- `cloudflare`
+
+## Files modified
+
+- `public/js/journal-entry.js`
+- `tests/journal-entry-page-route-state.test.js`
+
+## Implementation summary
+
+The entry route now resolves project context from route query parameters, the journal page referrer, session storage and the entry API payload. It stores the resolved project ID in session storage so refreshes keep the return-link context.
+
+The route-state test now asserts support for project query parameters, referrer-based recovery, session storage and project-scoped return links.
+
+## Validation status
+
+CI polling required after PR creation.

--- a/public/js/journal-entry.js
+++ b/public/js/journal-entry.js
@@ -1,4 +1,5 @@
 const API_ORIGIN = resolveApiBase();
+const PROJECT_CONTEXT_STORAGE_KEY = "researchops.journalEntry.projectContext";
 
 function resolveApiBase() {
 	const explicit = document.documentElement?.dataset?.apiOrigin || window.API_ORIGIN || "";
@@ -12,6 +13,63 @@ function apiUrl(path) {
 
 function text(value) {
 	return String(value || "").trim();
+}
+
+function firstProjectIdFromParams(params) {
+	return text(
+		params.get("project") ||
+		params.get("project_id") ||
+		params.get("project_local_id") ||
+		params.get("project_airtable_id") ||
+		params.get("id")
+	);
+}
+
+function projectIdFromRoute() {
+	const params = new URLSearchParams(window.location.search);
+	return text(
+		params.get("project") ||
+		params.get("project_id") ||
+		params.get("project_local_id") ||
+		params.get("project_airtable_id")
+	);
+}
+
+function projectIdFromReferrer() {
+	try {
+		if (!document.referrer) return "";
+		const referrer = new URL(document.referrer);
+		if (!referrer.pathname.includes("/pages/projects/journals")) return "";
+		return firstProjectIdFromParams(referrer.searchParams);
+	} catch {
+		return "";
+	}
+}
+
+function storedProjectId() {
+	try {
+		return text(window.sessionStorage?.getItem(PROJECT_CONTEXT_STORAGE_KEY));
+	} catch {
+		return "";
+	}
+}
+
+function rememberProjectId(projectId) {
+	const id = text(projectId);
+	if (!id) return;
+	try {
+		window.sessionStorage?.setItem(PROJECT_CONTEXT_STORAGE_KEY, id);
+	} catch {}
+}
+
+function projectIdFromEntry(entry = {}) {
+	return text(entry.project || entry.projectId || entry.localProjectId || entry.local_project_id || entry.project_id);
+}
+
+function resolveProjectId(entry = {}) {
+	const projectId = text(projectIdFromRoute() || projectIdFromReferrer() || storedProjectId() || projectIdFromEntry(entry));
+	rememberProjectId(projectId);
+	return projectId;
 }
 
 function when(iso) {
@@ -63,7 +121,7 @@ async function readJsonResponse(response) {
 }
 
 function setBackLinks(entry) {
-	const projectId = text(entry.localProjectId || entry.local_project_id || entry.project || entry.projectId);
+	const projectId = resolveProjectId(entry);
 	const href = projectId ? `/pages/projects/journals/?id=${encodeURIComponent(projectId)}` : "/pages/projects/journals/";
 	const dashboardHref = projectId ? `/pages/project-dashboard/?id=${encodeURIComponent(projectId)}` : "/pages/project-dashboard/";
 
@@ -115,6 +173,8 @@ async function loadJournalEntry() {
 		showError("Missing journal entry ID.");
 		return;
 	}
+
+	resolveProjectId();
 
 	try {
 		const data = await readJsonResponse(await fetch(apiUrl(`/api/journal-entries/${encodeURIComponent(id)}?ts=${Date.now()}`), {

--- a/tests/journal-entry-page-route-state.test.js
+++ b/tests/journal-entry-page-route-state.test.js
@@ -20,6 +20,13 @@ includes(template, "id: 'breadcrumb-journals'", "journal entry template");
 includes(template, "script type=\"module\" src=\"/js/journal-entry.js\"", "journal entry template");
 
 includes(script, "new URLSearchParams(window.location.search).get(\"id\")", "journal entry script");
+includes(script, "params.get(\"project\")", "journal entry script");
+includes(script, "params.get(\"project_local_id\")", "journal entry script");
+includes(script, "document.referrer", "journal entry script");
+includes(script, "PROJECT_CONTEXT_STORAGE_KEY", "journal entry script");
+includes(script, "resolveProjectId(entry)", "journal entry script");
+includes(script, "rememberProjectId(projectId)", "journal entry script");
+includes(script, "/pages/projects/journals/?id=${encodeURIComponent(projectId)}", "journal entry script");
 includes(script, "/api/journal-entries/${encodeURIComponent(id)}", "journal entry script");
 includes(script, "renderEntry(entry)", "journal entry script");
 includes(script, "journal-entry-error-summary", "journal entry script");


### PR DESCRIPTION
## Summary

- Updates the journal entry page script so breadcrumbs, back links and return links preserve project context.
- Resolves project context from route query parameters, the Journal and analysis referrer, session storage and the entry payload.
- Adds route-state coverage for project query parameters, referrer recovery, session storage and project-scoped return links.

## Why

The journal entry page loaded correctly, but project context was lost. Returning to Journal and analysis produced `/pages/projects/journals/` without the project ID.

## Validation

Pending CI. I will poll checks and fix failures.

## Trace

- `docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.md`
- `docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.json`
