### PR TITLE
Show project name on journal entry breadcrumb

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.json
+++ b/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.json
@@ -3,10 +3,10 @@
 	"date": "2026-06-10",
 	"traceLayer": "operational",
 	"repository": "kevinrapley/ResearchOps",
-	"branch": "fix/journal-entry-project-context",
+	"branch": "fix/journal-entry-breadcrumb-project-name",
 	"branchPrefix": "fix/",
 	"traceRequired": true,
-	"taskSummary": "Preserve project context on journal entry pages.",
+	"taskSummary": "Preserve project context and project-name breadcrumb labels on journal entry pages.",
 	"selectedBundles": [
 		"github-diamond",
 		"researchops-developer-control",
@@ -16,12 +16,16 @@
 	],
 	"filesModified": [
 		"public/js/journal-entry.js",
+		"src/govuk/templates/pages/journal-entry.njk",
+		"public/pages/journal/entry/index.html",
 		"tests/journal-entry-page-route-state.test.js"
 	],
 	"implementationSummary": [
 		"Journal entry page resolves project context from query parameters, referrer, session storage and entry payload.",
-		"Back links and breadcrumbs use /pages/projects/journals/?id=<project-id> when context is available.",
-		"Route-state coverage checks project context recovery."
+		"Project breadcrumb hydrates from /api/projects/:id and displays the project name when available.",
+		"Back and return links use /pages/projects/journals/?id=<project-id> when context is available.",
+		"Duplicate Back to Journal and analysis link was removed from the template and committed HTML.",
+		"Route-state coverage checks project context recovery, project-name breadcrumb hydration and removed duplicate back link."
 	],
 	"validation": {
 		"commandsRun": [],

--- a/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.md
+++ b/docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.md
@@ -2,13 +2,13 @@
 
 - Date: 2026-06-10
 - Repository: `kevinrapley/ResearchOps`
-- Branch: `fix/journal-entry-project-context`
+- Branch: `fix/journal-entry-breadcrumb-project-name`
 - Pull request: pending
 - Trace layer: operational
 
 ## Task summary
 
-Preserve project context on the journal entry page so breadcrumbs, back links and return links point back to the project-scoped Journal and analysis page.
+Preserve project context on the journal entry page so breadcrumbs and return links point back to the project-scoped Journal and analysis page. Refine the breadcrumb so the project crumb displays the project name, for example Test Project 1, instead of the generic text Project Dashboard. Remove the duplicate Back to Journal and analysis link above the entry heading.
 
 ## Operating model loaded
 
@@ -25,14 +25,18 @@ Loaded `AGENTS.md`, orchestration, bundle registry, task signal catalog, selecti
 ## Files modified
 
 - `public/js/journal-entry.js`
+- `src/govuk/templates/pages/journal-entry.njk`
+- `public/pages/journal/entry/index.html`
 - `tests/journal-entry-page-route-state.test.js`
 
 ## Implementation summary
 
 The entry route now resolves project context from route query parameters, the journal page referrer, session storage and the entry API payload. It stores the resolved project ID in session storage so refreshes keep the return-link context.
 
-The route-state test now asserts support for project query parameters, referrer-based recovery, session storage and project-scoped return links.
+The project breadcrumb now hydrates from `/api/projects/:id` and replaces the generic Project Dashboard label with the project name when available. The standalone Back to Journal and analysis link was removed from the Nunjucks template and committed rendered HTML, leaving the breadcrumb and bottom return link as the navigation pattern.
+
+The route-state test now asserts support for project query parameters, referrer-based recovery, session storage, project-scoped return links, project-name breadcrumb hydration and removal of the duplicate back link.
 
 ## Validation status
 
-CI polling required after PR creation.
+CI polling required after latest commits.

--- a/public/js/journal-entry.js
+++ b/public/js/journal-entry.js
@@ -15,6 +15,28 @@ function text(value) {
 	return String(value || "").trim();
 }
 
+function firstPresent(...values) {
+	for (const value of values) {
+		if (value !== undefined && value !== null && text(value)) return text(value);
+	}
+	return "";
+}
+
+function projectPayloadFrom(data = {}) {
+	return data?.project || data?.record || data;
+}
+
+function normaliseProject(project = {}) {
+	const source = projectPayloadFrom(project);
+	const publicId = firstPresent(source.id, source.airtableId, source.recordId, source.LocalId, source.localId);
+	return {
+		id: publicId,
+		localId: firstPresent(source.localId, source.LocalId, publicId),
+		airtableId: firstPresent(source.airtableId, source.recordId, publicId),
+		name: firstPresent(source.name, source.Name, source.title, source.Title)
+	};
+}
+
 function firstProjectIdFromParams(params) {
 	return text(
 		params.get("project") ||
@@ -120,6 +142,28 @@ async function readJsonResponse(response) {
 	return body || {};
 }
 
+async function loadProject(projectId) {
+	if (!projectId) return null;
+	const response = await fetch(apiUrl(`/api/projects/${encodeURIComponent(projectId)}?ts=${Date.now()}`), {
+		cache: "no-store",
+		credentials: "include"
+	});
+	return normaliseProject(await readJsonResponse(response));
+}
+
+async function hydrateProjectBreadcrumb(projectId, breadcrumbProject) {
+	if (!projectId || !breadcrumbProject) return;
+	try {
+		const project = await loadProject(projectId);
+		if (!project) return;
+		const resolvedProjectId = project.id || project.localId || project.airtableId || projectId;
+		breadcrumbProject.href = `/pages/project-dashboard/?id=${encodeURIComponent(resolvedProjectId)}`;
+		if (project.name) breadcrumbProject.textContent = project.name;
+	} catch (error) {
+		console.warn("[journal-entry] Could not hydrate project breadcrumb", error);
+	}
+}
+
 function setBackLinks(entry) {
 	const projectId = resolveProjectId(entry);
 	const href = projectId ? `/pages/projects/journals/?id=${encodeURIComponent(projectId)}` : "/pages/projects/journals/";
@@ -133,7 +177,10 @@ function setBackLinks(entry) {
 	if (backLink) backLink.href = href;
 	if (returnLink) returnLink.href = href;
 	if (breadcrumbJournals) breadcrumbJournals.href = href;
-	if (breadcrumbProject) breadcrumbProject.href = dashboardHref;
+	if (breadcrumbProject) {
+		breadcrumbProject.href = dashboardHref;
+		hydrateProjectBreadcrumb(projectId, breadcrumbProject);
+	}
 }
 
 function renderEntry(entry) {

--- a/public/pages/journal/entry/index.html
+++ b/public/pages/journal/entry/index.html
@@ -57,10 +57,6 @@
 					</div>
 				</div>
 
-				<a class="govuk-back-link" href="/pages/projects/journals/" id="back-to-journals">
-					Back to Journal and analysis
-				</a>
-
 				<header class="govuk-!-margin-top-6">
 					<p class="govuk-caption-l" id="journal-entry-category">Journal entry</p>
 					<h1 class="govuk-heading-xl" id="journal-entry-title">Journal entry</h1>

--- a/src/govuk/templates/pages/journal-entry.njk
+++ b/src/govuk/templates/pages/journal-entry.njk
@@ -47,8 +47,6 @@
 		}
 	}) }}
 
-	<a class="govuk-back-link" href="/pages/projects/journals/" id="back-to-journals">Back to Journal and analysis</a>
-
 	<header class="govuk-!-margin-top-6">
 		<p class="govuk-caption-l" id="journal-entry-category">Journal entry</p>
 		<h1 class="govuk-heading-xl" id="journal-entry-title">Journal entry</h1>

--- a/tests/journal-entry-page-route-state.test.js
+++ b/tests/journal-entry-page-route-state.test.js
@@ -12,10 +12,15 @@ function includes(source, text, label) {
 	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
 }
 
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
 includes(tabs, "viewEntry: id => '/pages/journal/entry?id=' + encodeURIComponent(id)", "journal tabs link contract");
 includes(page, "id=\"journal-entry-title\"", "rendered journal entry page");
 includes(page, "src=\"/js/journal-entry.js\"", "rendered journal entry page");
-includes(page, "id=\"back-to-journals\"", "rendered journal entry page");
+excludes(page, "id=\"back-to-journals\"", "rendered journal entry page");
+excludes(template, "id=\"back-to-journals\"", "journal entry template");
 includes(template, "id: 'breadcrumb-journals'", "journal entry template");
 includes(template, "script type=\"module\" src=\"/js/journal-entry.js\"", "journal entry template");
 
@@ -24,6 +29,8 @@ includes(script, "params.get(\"project\")", "journal entry script");
 includes(script, "params.get(\"project_local_id\")", "journal entry script");
 includes(script, "document.referrer", "journal entry script");
 includes(script, "PROJECT_CONTEXT_STORAGE_KEY", "journal entry script");
+includes(script, "loadProject(projectId)", "journal entry script");
+includes(script, "breadcrumbProject.textContent = project.name", "journal entry script");
 includes(script, "resolveProjectId(entry)", "journal entry script");
 includes(script, "rememberProjectId(projectId)", "journal entry script");
 includes(script, "/pages/projects/journals/?id=${encodeURIComponent(projectId)}", "journal entry script");


### PR DESCRIPTION
## Summary

- Updates the journal entry page script so the project breadcrumb hydrates from `/api/projects/:id` and shows the project name, for example Test Project 1, instead of the generic Project Dashboard label.
- Removes the duplicate Back to Journal and analysis link from the journal entry page template and committed rendered HTML.
- Keeps the bottom Return to Journal and analysis link project-scoped when context is available.
- Extends route-state coverage for project-name breadcrumb hydration and removal of the duplicate back link.

## Why

The entry page now loads correctly and preserves return context, but the breadcrumb still shows a generic Project Dashboard label and the page has an extra Back to Journal and analysis link below the breadcrumb.

## Validation

Pending CI. I will poll checks and fix failures.

## Trace

- `docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.md`
- `docs/agent-audit/reasoning/2026/06/10/journal-entry-project-context.json`
