### PR TITLE
Fix Home Office brand tabs

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json
+++ b/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json
@@ -5,7 +5,7 @@
   "traceRequired": true,
   "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
   "relatedWork": "Home Office brand GOV.UK tab component visual repair",
-  "task": "Fix Home Office brand tab appearance so non-current tabs use #d2bfd8 and the tab panel uses white, while committing SCSS source only.",
+  "task": "Fix Home Office brand tab appearance so non-current tabs use #d2bfd8 and the tab panel uses white, while preserving GOV.UK keyboard focus styling and committing SCSS source only.",
   "selectedBundles": [
     {
       "id": "github-diamond",
@@ -90,7 +90,9 @@
     "tests/sass-migration-route-state.test.js",
     "scripts/styles/generated-css-targets.mjs",
     "scripts/styles/build-generated-css.mjs",
-    "public/css/brands/home-office.css"
+    "public/css/brands/home-office.css",
+    "GitHub review thread data for PR #398 via gh api graphql",
+    "GitHub review thread data for PR #398 via gh-address-comments/scripts/fetch_comments.py"
   ],
   "filesCreated": [
     "docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md",
@@ -98,10 +100,23 @@
   ],
   "filesModified": [
     "src/styles/brands/home-office.scss",
-    "tests/brand-variant-route-state.test.js"
+    "tests/brand-variant-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md",
+    "docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json"
   ],
   "generatedForValidationOnlyThenRestored": [
     "public/css/brands/home-office.css"
+  ],
+  "reviewThreads": [
+    {
+      "pr": 398,
+      "threadId": "PRRT_kwDOP3Td2M6JkDW7",
+      "status": "unresolved and non-outdated when inspected",
+      "author": "chatgpt-codex-connector",
+      "path": "src/styles/brands/home-office.scss",
+      "summary": "Codex correctly identified that the inactive tab background selector could override the yellow keyboard focus background on focused tab links.",
+      "disposition": "Addressed by narrowing the tab-link background selector to .govuk-tabs__tab:not(:focus)."
+    }
   ],
   "subAgents": [
     {
@@ -145,6 +160,26 @@
       "command": "Browser verification at http://127.0.0.1:4173/pages/projects/journals/?brand=home-office",
       "status": "passed",
       "summary": "Inactive tab backgrounds computed as rgb(210, 191, 216); tab panel background computed as rgb(255, 255, 255)."
+    },
+    {
+      "command": "rg inspection of generated public/css/brands/home-office.css",
+      "status": "passed",
+      "summary": "Generated output contains the .govuk-tabs__tab:not(:focus) background selector and tab panel background rule."
+    },
+    {
+      "command": "node -e JSON parse check for docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json",
+      "status": "passed",
+      "summary": "Trace JSON parsed successfully after review-resolution updates."
+    },
+    {
+      "command": "npx prettier -c src/styles/brands/home-office.scss tests/brand-variant-route-state.test.js docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json",
+      "status": "passed",
+      "summary": "Changed SCSS, test and trace files use Prettier formatting."
+    },
+    {
+      "command": "npm run trace:coverage",
+      "status": "passed",
+      "summary": "Trace coverage confirmed for the fix/ branch."
     }
   ],
   "validationNotRun": [
@@ -155,6 +190,10 @@
     {
       "command": "Generated CSS clean check",
       "reason": "Generated CSS is deliberately excluded from the committed file set for this task."
+    },
+    {
+      "command": "Follow-up local Playwright focus verification after Codex comment",
+      "reason": "The Node runtime did not have the required Playwright browser binary installed. The focus conflict was instead validated by narrowing the generated selector to .govuk-tabs__tab:not(:focus), which cannot match a focused tab link."
     }
   ],
   "residualRisks": [

--- a/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json
+++ b/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json
@@ -1,0 +1,164 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/home-office-brand-tabs",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "relatedWork": "Home Office brand GOV.UK tab component visual repair",
+  "task": "Fix Home Office brand tab appearance so non-current tabs use #d2bfd8 and the tab panel uses white, while committing SCSS source only.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: GOV.UK tab component and CSS visual styling"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: generated CSS is produced on Cloudflare and excluded from commit"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP tool, resource, prompt or consent work was in scope."
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "reason": "No Airtable API or data integration work was in scope."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, surgical mutation and validation evidence.",
+    "ResearchOps Developer Control governed repository conventions and the Sass source/generated CSS pipeline.",
+    "Multi-Functional Team governed public-sector assurance and residual-risk framing.",
+    "GOV.UK Design System governed tab component behaviour and accessibility-safe styling.",
+    "Cloudflare context governed the explicit decision not to commit generated CSS for this task.",
+    "Generated CSS exclusion is recorded as a deliberate generated-output waiver for this unit of work."
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    "src/styles/brands/home-office.scss",
+    "tests/brand-variant-route-state.test.js",
+    "tests/sass-migration-route-state.test.js",
+    "scripts/styles/generated-css-targets.mjs",
+    "scripts/styles/build-generated-css.mjs",
+    "public/css/brands/home-office.css"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md",
+    "docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json"
+  ],
+  "filesModified": [
+    "src/styles/brands/home-office.scss",
+    "tests/brand-variant-route-state.test.js"
+  ],
+  "generatedForValidationOnlyThenRestored": [
+    "public/css/brands/home-office.css"
+  ],
+  "subAgents": [
+    {
+      "nickname": "Boyle",
+      "role": "link-check and CI config worker",
+      "result": "Identified generated-CSS contract risk and CI implications."
+    },
+    {
+      "nickname": "Descartes",
+      "role": "trace and documentation worker",
+      "result": "Identified trace requirements and generated-CSS waiver documentation need."
+    },
+    {
+      "nickname": "Maxwell",
+      "role": "branch drift poller",
+      "result": "Confirmed branch was based on current origin/main."
+    },
+    {
+      "nickname": "Ptolemy",
+      "role": "CI and validation worker",
+      "result": "Identified likely validation commands for SCSS-only visual fix."
+    },
+    {
+      "nickname": "Gauss",
+      "role": "readiness and trace worker",
+      "result": "Monitored trace/readiness needs for the fix branch."
+    }
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/brand-variant-route-state.test.js tests/sass-migration-route-state.test.js",
+      "status": "passed",
+      "summary": "Targeted source and Sass migration tests passed."
+    },
+    {
+      "command": "npm run build:generated-css -- public/css/brands/home-office.css",
+      "status": "passed",
+      "summary": "Generated local Home Office CSS for inspection."
+    },
+    {
+      "command": "Browser verification at http://127.0.0.1:4173/pages/projects/journals/?brand=home-office",
+      "status": "passed",
+      "summary": "Inactive tab backgrounds computed as rgb(210, 191, 216); tab panel background computed as rgb(255, 255, 255)."
+    }
+  ],
+  "validationNotRun": [
+    {
+      "command": "Full repository validation suite",
+      "reason": "Change was confined to Home Office brand SCSS with targeted tests and browser verification."
+    },
+    {
+      "command": "Generated CSS clean check",
+      "reason": "Generated CSS is deliberately excluded from the committed file set for this task."
+    }
+  ],
+  "residualRisks": [
+    "The repository usually tracks generated CSS, but this task deliberately leaves generated CSS out of the commit because Cloudflare regeneration was requested.",
+    "A pipeline that checks generated CSS cleanliness before Cloudflare regeneration may need adjustment or a separate generated-CSS commit."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md
+++ b/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md
@@ -86,8 +86,8 @@ a deliberate generated-output waiver for this unit of work.
 Changed `src/styles/brands/home-office.scss` only for brand styling:
 
 - added a Home Office brand rule for unselected `.govuk-tabs__list-item`
-  elements and their `.govuk-tabs__tab` links to use `$ho-mid`, which is
-  `#d2bfd8`;
+  elements and their non-focused `.govuk-tabs__tab` links to use `$ho-mid`,
+  which is `#d2bfd8`;
 - added a Home Office brand rule for `.govuk-tabs__panel` to use `$ho-white`,
   which is `#ffffff`.
 
@@ -96,6 +96,13 @@ contract without requiring generated CSS to be committed.
 
 Generated `public/css/brands/home-office.css` locally for validation and browser
 inspection, then restored it before completion so it is not part of the commit.
+
+After PR #398 was opened, Codex left one unresolved non-outdated review thread
+against `src/styles/brands/home-office.scss`. The comment correctly identified
+that the inactive tab background rule could override the yellow keyboard focus
+background on focused tab links. The selector was narrowed to
+`.govuk-tabs__tab:not(:focus)` so keyboard users retain the GOV.UK focus
+affordance.
 
 ## Files
 
@@ -110,6 +117,9 @@ Read:
 - `scripts/styles/generated-css-targets.mjs`
 - `scripts/styles/build-generated-css.mjs`
 - `public/css/brands/home-office.css`
+- GitHub review thread data for PR #398, fetched with `gh api graphql`
+- GitHub review thread data for PR #398, fetched with
+  `gh-address-comments/scripts/fetch_comments.py`
 
 Created:
 
@@ -120,6 +130,8 @@ Modified:
 
 - `src/styles/brands/home-office.scss`
 - `tests/brand-variant-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md`
+- `docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json`
 
 Generated for validation only, then restored:
 
@@ -141,6 +153,12 @@ Attempted:
 
 - `node --test tests/brand-variant-route-state.test.js tests/sass-migration-route-state.test.js` - passed.
 - `npm run build:generated-css -- public/css/brands/home-office.css` - passed and generated local CSS for inspection.
+- `rg` inspection of generated `public/css/brands/home-office.css` - passed:
+  generated output contains the `.govuk-tabs__tab:not(:focus)` background
+  selector and the tab panel background rule.
+- `node -e` JSON parse check for the trace file - passed.
+- `npx prettier -c` for the changed SCSS, test and trace files - passed.
+- `npm run trace:coverage` - passed.
 - Local browser verification against
   `http://127.0.0.1:4173/pages/projects/journals/?brand=home-office` - passed:
   inactive tab backgrounds computed as `rgb(210, 191, 216)` and the tab panel
@@ -152,6 +170,11 @@ Not run:
   fix with a targeted source-level test and browser verification.
 - Generated CSS clean check, because this task deliberately excludes generated
   CSS from the committed file set.
+- Follow-up local Playwright focus verification after the Codex comment,
+  because the Node runtime did not have the required Playwright browser binary
+  installed. The focus conflict was instead validated by narrowing the generated
+  selector to `.govuk-tabs__tab:not(:focus)`, which means it cannot match a
+  focused tab link and therefore cannot override GOV.UK focus styling.
 
 ## Residual Risk
 

--- a/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md
+++ b/docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md
@@ -1,0 +1,163 @@
+# Agent trace - Home Office brand tab visual fix
+
+**Date:** 2026-06-15  
+**Trace type:** operational audit trace  
+**Branch:** `fix/home-office-brand-tabs`  
+**Trace required:** yes, because the branch starts with `fix/`  
+**Related work:** Home Office brand GOV.UK tab component visual repair
+
+## Task
+
+Fix the visual appearance of GOV.UK tabs when the Home Office brand variant is
+enabled with `?brand=home-office`.
+
+Requested behaviour:
+
+- tabs that are not the current context use background colour `#d2bfd8`;
+- the tab panel that holds tab content uses a white background;
+- CSS is generated from SCSS;
+- generated CSS is generated on Cloudflare and should not be included in the
+  committed files for this unit of work.
+
+## Branch Trace Decision
+
+The current branch is `fix/home-office-brand-tabs`. Repository policy allows
+`fix/` as a work-branch prefix and requires an auditable trace for
+repository-affecting work on `fix/` branches. This trace is therefore required
+even without the legacy `[reasoning]` token.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+The first three bundles are always-load bundles. `govuk-design-system` applies
+because this is a GOV.UK tab component visual/CSS change. `cloudflare` applies
+because the user explicitly stated generated CSS is produced on Cloudflare and
+should not be committed locally.
+
+Skipped conditional bundles:
+
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP tool, resource, prompt or consent work was in scope.
+- `airtable-public-api` - no Airtable API or data integration work was in scope.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, surgical mutation and
+  validation evidence.
+- ResearchOps Developer Control governed repository conventions and the Sass
+  source/generated CSS pipeline.
+- Multi-Functional Team governed public-sector assurance and residual-risk
+  framing.
+- GOV.UK Design System governed tab component behaviour and accessibility-safe
+  styling.
+- Cloudflare context governed the explicit decision not to commit generated CSS
+  for this task.
+
+No bundle conflicts were identified. There is a repository convention tension:
+generated CSS is normally a tracked output, but the user explicitly scoped this
+task to SCSS-only commits because Cloudflare regenerates CSS. This is recorded as
+a deliberate generated-output waiver for this unit of work.
+
+## Implementation
+
+Changed `src/styles/brands/home-office.scss` only for brand styling:
+
+- added a Home Office brand rule for unselected `.govuk-tabs__list-item`
+  elements and their `.govuk-tabs__tab` links to use `$ho-mid`, which is
+  `#d2bfd8`;
+- added a Home Office brand rule for `.govuk-tabs__panel` to use `$ho-white`,
+  which is `#ffffff`.
+
+Changed `tests/brand-variant-route-state.test.js` to assert the source-level
+contract without requiring generated CSS to be committed.
+
+Generated `public/css/brands/home-office.css` locally for validation and browser
+inspection, then restored it before completion so it is not part of the commit.
+
+## Files
+
+Read:
+
+- `AGENTS.md`
+- operating-model files listed above
+- selected bundle prompt specs and bodies
+- `src/styles/brands/home-office.scss`
+- `tests/brand-variant-route-state.test.js`
+- `tests/sass-migration-route-state.test.js`
+- `scripts/styles/generated-css-targets.mjs`
+- `scripts/styles/build-generated-css.mjs`
+- `public/css/brands/home-office.css`
+
+Created:
+
+- `docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md`
+- `docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json`
+
+Modified:
+
+- `src/styles/brands/home-office.scss`
+- `tests/brand-variant-route-state.test.js`
+
+Generated for validation only, then restored:
+
+- `public/css/brands/home-office.css`
+
+## Sub-Agent Coordination
+
+- Boyle inspected link/CI implications and identified the generated-CSS contract
+  risk of changing SCSS without committing generated CSS.
+- Descartes inspected trace/documentation requirements and identified the need
+  to record the generated-CSS waiver explicitly.
+- Maxwell confirmed the new branch was based on current `origin/main`.
+- Ptolemy identified relevant validation commands for a SCSS-only visual fix.
+- Gauss continued trace/readiness monitoring for the `fix/` branch.
+
+## Validation
+
+Attempted:
+
+- `node --test tests/brand-variant-route-state.test.js tests/sass-migration-route-state.test.js` - passed.
+- `npm run build:generated-css -- public/css/brands/home-office.css` - passed and generated local CSS for inspection.
+- Local browser verification against
+  `http://127.0.0.1:4173/pages/projects/journals/?brand=home-office` - passed:
+  inactive tab backgrounds computed as `rgb(210, 191, 216)` and the tab panel
+  background computed as `rgb(255, 255, 255)`.
+
+Not run:
+
+- Full repository validation suite, because the change is a narrow SCSS visual
+  fix with a targeted source-level test and browser verification.
+- Generated CSS clean check, because this task deliberately excludes generated
+  CSS from the committed file set.
+
+## Residual Risk
+
+The repository usually treats generated CSS as a tracked artefact. This task
+deliberately leaves generated CSS out of the commit because the user stated that
+Cloudflare generates CSS and generated CSS should not be included. If a future
+pipeline checks generated CSS cleanliness before Cloudflare regeneration, that
+pipeline may need to be adjusted or the generated CSS committed in a separate
+unit of work.

--- a/src/styles/brands/home-office.scss
+++ b/src/styles/brands/home-office.scss
@@ -328,7 +328,7 @@ html[data-researchops-brand='home-office'] {
 	}
 
 	.govuk-tabs__list-item:not(.govuk-tabs__list-item--selected),
-	.govuk-tabs__list-item:not(.govuk-tabs__list-item--selected) .govuk-tabs__tab {
+	.govuk-tabs__list-item:not(.govuk-tabs__list-item--selected) .govuk-tabs__tab:not(:focus) {
 		background: $ho-mid;
 	}
 

--- a/src/styles/brands/home-office.scss
+++ b/src/styles/brands/home-office.scss
@@ -327,6 +327,15 @@ html[data-researchops-brand='home-office'] {
 		border-color: $ho-purple;
 	}
 
+	.govuk-tabs__list-item:not(.govuk-tabs__list-item--selected),
+	.govuk-tabs__list-item:not(.govuk-tabs__list-item--selected) .govuk-tabs__tab {
+		background: $ho-mid;
+	}
+
+	.govuk-tabs__panel {
+		background: $ho-white;
+	}
+
 	.govuk-footer {
 		border-top: 10px solid $ho-purple;
 		background: $ho-light;

--- a/tests/brand-variant-route-state.test.js
+++ b/tests/brand-variant-route-state.test.js
@@ -50,6 +50,10 @@ assert.ok(brandStylesSource.includes('.repository-filter-panel'));
 assert.ok(brandStylesSource.includes('.drawer'));
 assert.ok(brandStylesSource.includes('.study-session-gate'));
 assert.ok(brandStylesSource.includes('.govuk-tabs__list-item--selected'));
+assert.ok(brandStylesSource.includes('.govuk-tabs__list-item:not(.govuk-tabs__list-item--selected)'));
+assert.ok(brandStylesSource.includes('.govuk-tabs__panel'));
+assert.ok(brandStylesSource.includes('background: $ho-mid'));
+assert.ok(brandStylesSource.includes('background: $ho-white'));
 assert.ok(brandStylesSource.includes('.govuk-footer'));
 assert.equal(brandStylesSource.includes('--govuk-link-colour'), false);
 

--- a/tests/brand-variant-route-state.test.js
+++ b/tests/brand-variant-route-state.test.js
@@ -51,6 +51,7 @@ assert.ok(brandStylesSource.includes('.drawer'));
 assert.ok(brandStylesSource.includes('.study-session-gate'));
 assert.ok(brandStylesSource.includes('.govuk-tabs__list-item--selected'));
 assert.ok(brandStylesSource.includes('.govuk-tabs__list-item:not(.govuk-tabs__list-item--selected)'));
+assert.ok(brandStylesSource.includes('.govuk-tabs__tab:not(:focus)'));
 assert.ok(brandStylesSource.includes('.govuk-tabs__panel'));
 assert.ok(brandStylesSource.includes('background: $ho-mid'));
 assert.ok(brandStylesSource.includes('background: $ho-white'));


### PR DESCRIPTION
## Summary

- Set inactive Home Office brand GOV.UK tabs to the requested mid-purple background (`#d2bfd8`) via the SCSS source.
- Set Home Office brand tab panels to white via the SCSS source.
- Add source-level route-state assertions for the Home Office tab styling contract.
- Add the required branch audit trace for `fix/home-office-brand-tabs`.

## Validation

- `node --test tests/brand-variant-route-state.test.js tests/sass-migration-route-state.test.js`
- `npm run build:generated-css -- public/css/brands/home-office.css` for local inspection
- Browser computed-style check on `/pages/projects/journals/?brand=home-office`: inactive tabs `rgb(210, 191, 216)`, tab panel `rgb(255, 255, 255)`
- `npm run trace:coverage`
- Trace JSON parse check
- Focused Prettier check for changed files

## Notes

- Generated CSS is intentionally not included in this PR because it is generated on Cloudflare for this workflow.
- Trace: `docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.md`

- Trace JSON: `docs/agent-audit/reasoning/2026/06/15/home-office-brand-tab-visual-fix.json`
