### PR TITLE
Generate role assignments page with GOV.UK template

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json
@@ -1,0 +1,210 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/role-assignments-govuk-template",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "relatedWork": "/pages/team/role-assignments/ GOV.UK frontend templating repair",
+  "task": "Convert the role assignments page to a Nunjucks-generated GOV.UK frontend page so header, breadcrumbs, phase banner and shared page chrome use the repository templating path.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: GOV.UK frontend page chrome, breadcrumbs and component markup"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: Cloudflare Pages publishes committed public/ generated HTML"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP tool, resource, prompt or consent work was in scope."
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "reason": "No Airtable API or data integration work was in scope."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, surgical mutation and validation evidence.",
+    "ResearchOps Developer Control governed repository conventions and the GOV.UK generated-page workflow.",
+    "Multi-Functional Team governed public-sector assurance and residual-risk framing.",
+    "GOV.UK Design System governed the shared frontend layout, breadcrumbs and component markup expectations.",
+    "Cloudflare context governed the decision to commit regenerated public/ HTML while the deployment contract publishes committed files."
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    "docs/deployment/generated-html-policy.md",
+    "src/govuk/templates/layouts/researchops.njk",
+    "src/govuk/templates/pages/team-access-requests.njk",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "public/pages/team/role-assignments/index.html",
+    "tests/auth-role-assignment-ui-route-state.test.js",
+    "adjacent GOV.UK page and route-state tests"
+  ],
+  "filesCreated": [
+    "src/govuk/templates/pages/role-assignments.njk",
+    "docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md",
+    "docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json"
+  ],
+  "filesModified": [
+    "public/pages/team/role-assignments/index.html",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "tests/auth-role-assignment-ui-route-state.test.js"
+  ],
+  "generatedOutput": [
+    {
+      "path": "public/pages/team/role-assignments/index.html",
+      "source": "src/govuk/templates/pages/role-assignments.njk",
+      "reasonCommitted": "Cloudflare Pages currently publishes committed public/ files under docs/deployment/generated-html-policy.md."
+    }
+  ],
+  "subAgents": [
+    {
+      "nickname": "Maxwell",
+      "role": "branch drift poller",
+      "result": "Confirmed the branch was based on current origin/main with no drift blocker."
+    },
+    {
+      "nickname": "Ptolemy",
+      "role": "CI and validation lane",
+      "result": "Ran focused validation and identified template formatting before PR readiness."
+    },
+    {
+      "nickname": "Boyle",
+      "role": "route and generated-output lane",
+      "result": "Confirmed the renderer output blast radius was limited to the intended role assignments public page."
+    },
+    {
+      "nickname": "Descartes",
+      "role": "trace and documentation lane",
+      "result": "Confirmed trace requirements and generated HTML policy details."
+    },
+    {
+      "nickname": "Gauss",
+      "role": "PR readiness lane",
+      "result": "Confirmed changed-file scope was plausible once the trace and template were included."
+    }
+  ],
+  "validation": [
+    {
+      "command": "node scripts/govuk/render-govuk-pages.mjs",
+      "status": "passed",
+      "summary": "Regenerated GOV.UK pages including public/pages/team/role-assignments/index.html."
+    },
+    {
+      "command": "npm run build:govuk-pages",
+      "status": "passed",
+      "summary": "Regenerated GOV.UK pages through the repository build script and post-build normalisation step."
+    },
+    {
+      "command": "node --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js tests/visual-walkthrough-role-assignment-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js tests/govuk-frontend-integration-route-state.test.js",
+      "status": "passed",
+      "summary": "Focused role assignment route-state and GOV.UK frontend tests passed."
+    },
+    {
+      "command": "node -e JSON parse check for docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json",
+      "status": "passed",
+      "summary": "Trace JSON parsed successfully."
+    },
+    {
+      "command": "npm run trace:coverage",
+      "status": "passed",
+      "summary": "Trace coverage confirmed for the fix/ branch."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "No whitespace errors were found."
+    },
+    {
+      "command": "npx prettier -c scripts/govuk/render-govuk-pages.mjs tests/auth-role-assignment-ui-route-state.test.js docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json",
+      "status": "passed",
+      "summary": "Changed JavaScript, test and trace files use Prettier formatting."
+    },
+    {
+      "command": "node --test tests/govuk-pages-render-workflow-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js",
+      "status": "passed",
+      "summary": "Passed in the validation sub-agent lane."
+    },
+    {
+      "command": "node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js",
+      "status": "passed",
+      "summary": "Passed in the validation sub-agent lane."
+    },
+    {
+      "command": "node --test tests/govuk-page-chrome-navigation-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js",
+      "status": "passed",
+      "summary": "Passed in the validation sub-agent lane."
+    },
+    {
+      "command": "npm run generated-css:check",
+      "status": "passed",
+      "summary": "Passed in the validation sub-agent lane."
+    }
+  ],
+  "validationNotRun": [
+    {
+      "command": "Full repository validation suite",
+      "reason": "Change was a narrow GOV.UK page generation migration with focused renderer, generated-page and route-state coverage."
+    },
+    {
+      "command": "Local browser visual verification",
+      "reason": "This unit changes page chrome by switching to the shared GOV.UK template and was covered by generated HTML and route-state checks."
+    }
+  ],
+  "residualRisks": [
+    "The generated HTML diff is large because the page moved from hand-maintained static HTML to the shared GOV.UK renderer.",
+    "Review should focus on the Nunjucks template, renderer registration and route-state assertions, while still checking regenerated public HTML for deployment output."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json
@@ -109,6 +109,12 @@
       "reasonCommitted": "Cloudflare Pages currently publishes committed public/ files under docs/deployment/generated-html-policy.md."
     }
   ],
+  "ciFollowUp": {
+    "pr": 399,
+    "failedChecks": ["Node 20", "Node 22", "Validate Cloudflare Workers", "Release gate"],
+    "rootCause": "The generated GOV.UK page helper renders valid Nunjucks output with different attribute and label line breaks than the committed generated HTML, so route-state assertions that assumed one serialized label shape failed.",
+    "disposition": "Hardened tests to normalize copy checks and accept valid generated label markup."
+  },
   "subAgents": [
     {
       "nickname": "Maxwell",
@@ -151,6 +157,11 @@
       "command": "node --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js tests/visual-walkthrough-role-assignment-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js tests/govuk-frontend-integration-route-state.test.js",
       "status": "passed",
       "summary": "Focused role assignment route-state and GOV.UK frontend tests passed."
+    },
+    {
+      "command": "npm test",
+      "status": "passed",
+      "summary": "Full local unit suite passed after CI assertion hardening: 220 tests passed."
     },
     {
       "command": "node -e JSON parse check for docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json",
@@ -201,6 +212,10 @@
     {
       "command": "Local browser visual verification",
       "reason": "This unit changes page chrome by switching to the shared GOV.UK template and was covered by generated HTML and route-state checks."
+    },
+    {
+      "command": "npm test -- --ci",
+      "reason": "The documented command forwards --ci to the Node test runner in the current script and fails with node: bad option: --ci. The repository's actual npm test command was run instead."
     }
   ],
   "residualRisks": [

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json
@@ -100,6 +100,7 @@
   "filesModified": [
     "public/pages/team/role-assignments/index.html",
     "scripts/govuk/render-govuk-pages.mjs",
+    "src/govuk/templates/pages/role-assignments.njk",
     "tests/auth-role-assignment-ui-route-state.test.js"
   ],
   "generatedOutput": [
@@ -114,6 +115,24 @@
     "failedChecks": ["Node 20", "Node 22", "Validate Cloudflare Workers", "Release gate"],
     "rootCause": "The generated GOV.UK page helper renders valid Nunjucks output with different attribute and label line breaks than the committed generated HTML, so route-state assertions that assumed one serialized label shape failed.",
     "disposition": "Hardened tests to normalize copy checks and accept valid generated label markup."
+  },
+  "previewFollowUp": {
+    "request": "Update the role assignments breadcrumb to Home > Your account > Team administration.",
+    "disposition": "Updated the Nunjucks template, regenerated the committed public HTML, and added a route-state assertion for the linked breadcrumb hierarchy.",
+    "links": [
+      {
+        "text": "Home",
+        "href": "/"
+      },
+      {
+        "text": "Your account",
+        "href": "/pages/account/"
+      },
+      {
+        "text": "Team administration",
+        "href": null
+      }
+    ]
   },
   "subAgents": [
     {
@@ -157,6 +176,11 @@
       "command": "node --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js tests/visual-walkthrough-role-assignment-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js tests/govuk-frontend-integration-route-state.test.js",
       "status": "passed",
       "summary": "Focused role assignment route-state and GOV.UK frontend tests passed."
+    },
+    {
+      "command": "node --test tests/auth-role-assignment-ui-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js",
+      "status": "passed",
+      "summary": "Focused breadcrumb and generated-page checks passed after the breadcrumb hierarchy update."
     },
     {
       "command": "npm test",

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md
@@ -1,0 +1,180 @@
+# Agent trace - Role assignments GOV.UK template migration
+
+**Date:** 2026-06-15  
+**Trace type:** operational audit trace  
+**Branch:** `fix/role-assignments-govuk-template`  
+**Trace required:** yes, because the branch starts with `fix/`  
+**Related work:** `/pages/team/role-assignments/` GOV.UK frontend templating repair
+
+## Task
+
+Fix `/pages/team/role-assignments/` so it uses the full GOV.UK frontend
+templating path expected by the repository. The page had visible styling issues
+around the header, breadcrumbs and phase banner because it was a static HTML
+page with mixed legacy GOV.UK CSS and shared layout assets.
+
+The user clarified that the page needs to be generated from Nunjucks if it is
+not already. The final implementation therefore makes the Nunjucks template and
+renderer registration the source of truth, then regenerates the committed
+`public/` HTML.
+
+## Branch Trace Decision
+
+The current branch is `fix/role-assignments-govuk-template`. Repository policy
+allows `fix/` as a work-branch prefix and requires an auditable trace for
+repository-affecting work on `fix/` branches. This trace is therefore required
+even without the legacy `[reasoning]` token.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+The first three bundles are always-load bundles. `govuk-design-system` applies
+because this is a GOV.UK frontend page chrome, breadcrumbs and component markup
+repair. `cloudflare` applies because `docs/deployment/generated-html-policy.md`
+states Cloudflare Pages currently publishes committed `public/` HTML.
+
+Skipped conditional bundles:
+
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP tool, resource, prompt or consent work was in scope.
+- `airtable-public-api` - no Airtable API or data integration work was in scope.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, surgical mutation and
+  validation evidence.
+- ResearchOps Developer Control governed repository conventions and the GOV.UK
+  generated-page workflow.
+- Multi-Functional Team governed public-sector assurance and residual-risk
+  framing.
+- GOV.UK Design System governed the shared frontend layout, breadcrumbs and
+  component markup expectations.
+- Cloudflare context governed the decision to commit regenerated `public/` HTML
+  while the deployment contract publishes committed files.
+
+No bundle conflicts were identified.
+
+## Implementation
+
+Created `src/govuk/templates/pages/role-assignments.njk` as the source template
+for the role assignments page. It extends `layouts/researchops.njk`, keeps the
+page-specific role-assignment stylesheet and script in Nunjucks blocks, and
+moves only the page content into the content block.
+
+Registered the template in `scripts/govuk/render-govuk-pages.mjs` so it renders
+to `public/pages/team/role-assignments/index.html`.
+
+Regenerated `public/pages/team/role-assignments/index.html` with the GOV.UK page
+renderer. The generated page now uses the shared GOV.UK layout shell, including
+`govuk-template`, `govuk-template__body`, `/assets/govuk/govuk-frontend.css`,
+layout initialisation scripts, the shared header include, the main wrapper and
+the shared footer include. Legacy page-local GOV.UK CSS layers and `/css/screen.css`
+were removed from the generated output.
+
+Updated `tests/auth-role-assignment-ui-route-state.test.js` so the route-state
+guard verifies the Nunjucks renderer registration, shared GOV.UK layout shell,
+absence of legacy CSS, and the role-assignment form controls without depending
+on one-line generated HTML formatting.
+
+## Files
+
+Read:
+
+- `AGENTS.md`
+- operating-model files listed above
+- selected bundle prompt specs and bodies
+- `docs/deployment/generated-html-policy.md`
+- `src/govuk/templates/layouts/researchops.njk`
+- `src/govuk/templates/pages/team-access-requests.njk`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `public/pages/team/role-assignments/index.html`
+- `tests/auth-role-assignment-ui-route-state.test.js`
+- adjacent GOV.UK page and route-state tests
+
+Created:
+
+- `src/govuk/templates/pages/role-assignments.njk`
+- `docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md`
+- `docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json`
+
+Modified:
+
+- `public/pages/team/role-assignments/index.html`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `tests/auth-role-assignment-ui-route-state.test.js`
+
+Generated output:
+
+- `public/pages/team/role-assignments/index.html` was regenerated from
+  `src/govuk/templates/pages/role-assignments.njk`. It remains committed because
+  Cloudflare Pages currently publishes committed `public/` files.
+
+## Sub-Agent Coordination
+
+- Maxwell monitored branch drift and confirmed the branch was based on current
+  `origin/main`.
+- Ptolemy ran validation checks and identified the template-formatting issue
+  before PR readiness.
+- Boyle inspected the renderer/output blast radius and confirmed only the
+  intended role assignments public page changed under `public/`.
+- Descartes checked trace requirements and identified generated HTML policy
+  wording to record in this trace.
+- Gauss checked PR readiness and confirmed the changed-file scope was plausible
+  once the trace and new template were included.
+
+## Validation
+
+Attempted:
+
+- `node scripts/govuk/render-govuk-pages.mjs` - passed and regenerated the role
+  assignments page.
+- `npm run build:govuk-pages` - passed and regenerated GOV.UK pages through the
+  repository build script and post-build normalisation step.
+- `node --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js tests/visual-walkthrough-role-assignment-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js tests/govuk-frontend-integration-route-state.test.js` - passed.
+- `node -e` JSON parse check for `docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json` - passed.
+- `npm run trace:coverage` - passed.
+- `git diff --check` - passed.
+- `npx prettier -c scripts/govuk/render-govuk-pages.mjs tests/auth-role-assignment-ui-route-state.test.js docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json` - passed.
+- `node --test tests/govuk-pages-render-workflow-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js` - passed in the validation sub-agent lane.
+- `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js` - passed in the validation sub-agent lane.
+- `node --test tests/govuk-page-chrome-navigation-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js` - passed in the validation sub-agent lane.
+- `npm run generated-css:check` - passed in the validation sub-agent lane.
+
+Not run:
+
+- Full repository validation suite, because the change is a narrow GOV.UK page
+  generation migration with focused renderer, generated-page and route-state
+  coverage.
+- Local browser visual verification, because this unit changes page chrome by
+  switching to the shared GOV.UK template and was covered by generated HTML and
+  route-state checks.
+
+## Residual Risk
+
+The generated HTML diff is large because the page moved from hand-maintained
+static HTML to the shared GOV.UK renderer. Review should focus on the Nunjucks
+template, renderer registration and route-state assertions, while still checking
+the regenerated public HTML for deployment output.

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md
@@ -99,6 +99,13 @@ guard verifies the Nunjucks renderer registration, shared GOV.UK layout shell,
 absence of legacy CSS, and the role-assignment form controls without depending
 on one-line generated HTML formatting.
 
+After PR #399 opened, the Node 20, Node 22 and Worker CI unit-test jobs failed
+on the role-assignment route-state test. The failing checks used the generated
+GOV.UK page helper, which renders valid Nunjucks output with different
+attribute and label line breaks than the committed generated HTML. The test
+helpers were hardened to normalize copy checks and accept valid generated label
+markup instead of assuming a single serialized shape.
+
 ## Files
 
 Read:
@@ -154,6 +161,7 @@ Attempted:
 - `npm run build:govuk-pages` - passed and regenerated GOV.UK pages through the
   repository build script and post-build normalisation step.
 - `node --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js tests/visual-walkthrough-role-assignment-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js tests/govuk-frontend-integration-route-state.test.js` - passed.
+- `npm test` - passed after the CI assertion hardening, 220 tests passed.
 - `node -e` JSON parse check for `docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json` - passed.
 - `npm run trace:coverage` - passed.
 - `git diff --check` - passed.
@@ -171,6 +179,9 @@ Not run:
 - Local browser visual verification, because this unit changes page chrome by
   switching to the shared GOV.UK template and was covered by generated HTML and
   route-state checks.
+- `npm test -- --ci`, because the documented command forwards `--ci` to the
+  Node test runner in the current script and fails with `node: bad option: --ci`.
+  The repository's actual `npm test` command was run instead.
 
 ## Residual Risk
 

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md
@@ -106,6 +106,10 @@ attribute and label line breaks than the committed generated HTML. The test
 helpers were hardened to normalize copy checks and accept valid generated label
 markup instead of assuming a single serialized shape.
 
+After review of the deployed preview, the breadcrumb was updated to match the
+requested hierarchy: `Home` links to `/`, `Your account` links to
+`/pages/account/`, and `Team administration` remains the current page.
+
 ## Files
 
 Read:
@@ -131,6 +135,7 @@ Modified:
 
 - `public/pages/team/role-assignments/index.html`
 - `scripts/govuk/render-govuk-pages.mjs`
+- `src/govuk/templates/pages/role-assignments.njk`
 - `tests/auth-role-assignment-ui-route-state.test.js`
 
 Generated output:
@@ -161,6 +166,7 @@ Attempted:
 - `npm run build:govuk-pages` - passed and regenerated GOV.UK pages through the
   repository build script and post-build normalisation step.
 - `node --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js tests/visual-walkthrough-role-assignment-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js tests/govuk-frontend-integration-route-state.test.js` - passed.
+- `node --test tests/auth-role-assignment-ui-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js` - passed after the breadcrumb hierarchy update.
 - `npm test` - passed after the CI assertion hardening, 220 tests passed.
 - `node -e` JSON parse check for `docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json` - passed.
 - `npm run trace:coverage` - passed.

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -24,6 +24,9 @@
 						<li class="govuk-breadcrumbs__list-item">
 							<a class="govuk-breadcrumbs__link" href="/">Home</a>
 						</li>
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/pages/account/">Your account</a>
+						</li>
 						<li class="govuk-breadcrumbs__list-item">Team administration</li>
 					</ol>
 				</nav>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -1,250 +1,553 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Assign a role to a team member - ResearchOps Demo Suite</title>
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-frontend-v6.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/auth-role-assignments.css" media="screen" />
-	<script type="module" src="/components/layout.js" defer></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-	<noscript><a class="govuk-skip-link" href="#main-content">Skip to main content</a></noscript>
-	<x-include src="/partials/header.html" vars='{"active":"Team administration","subtitle":"Manage team role access"}'></x-include>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Assign a role to a team member - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-	<div class="govuk-width-container">
-		<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-			<ol class="govuk-breadcrumbs__list">
-				<li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/">Home</a></li>
-				<li class="govuk-breadcrumbs__list-item">Team administration</li>
-			</ol>
-		</nav>
-	</div>
+		<link rel="stylesheet" href="/css/auth-role-assignments.css" media="screen" />
 
-	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
-		<div class="govuk-width-container">
-			<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
-				<h2 class="govuk-error-summary__title">There is a problem</h2>
-				<div class="govuk-error-summary__body">
-					<ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul>
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":""}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container">
+				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+					<ol class="govuk-breadcrumbs__list">
+						<li class="govuk-breadcrumbs__list-item">
+							<a class="govuk-breadcrumbs__link" href="/">Home</a>
+						</li>
+						<li class="govuk-breadcrumbs__list-item">Team administration</li>
+					</ol>
+				</nav>
+
+				<div id="role-assignment-error-summary" class="govuk-error-summary" role="alert" tabindex="-1" hidden>
+					<h2 class="govuk-error-summary__title">There is a problem</h2>
+					<div class="govuk-error-summary__body">
+						<ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul>
+					</div>
 				</div>
+
+				<header class="page-intro auth-role-assignment-page__header">
+					<div class="govuk-grid-row">
+						<div class="govuk-grid-column-two-thirds">
+							<span class="govuk-caption-l">Team administration</span>
+							<h1 class="govuk-heading-xl" id="role-assignment-title">Assign a role to a team member</h1>
+							<p class="lede">Use this page to give someone access to a role in a ResearchOps team you manage.</p>
+							<p class="govuk-body">
+								If the person is not already an active member of the team, ResearchOps will add them when you assign the
+								role.
+							</p>
+							<p class="govuk-body">
+								Only assign the lowest role they need to do their work. Role changes and team creation are recorded in
+								the audit log.
+							</p>
+						</div>
+					</div>
+				</header>
+
+				<section class="auth-role-assignment-scope" aria-labelledby="team-scope-title">
+					<h2 class="govuk-heading-m" id="team-scope-title">Team scope</h2>
+					<div id="auth-context" class="auth-role-assignment-scope__panel" aria-live="polite" aria-busy="true">
+						<p class="govuk-body">Checking which team you can manage.</p>
+					</div>
+				</section>
+
+				<section aria-labelledby="assign-role-form-title" id="role-assignment-form-section">
+					<div class="govuk-grid-row">
+						<div class="govuk-grid-column-two-thirds">
+							<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
+							<form id="role-assignment-form" novalidate>
+								<section class="auth-role-assignment-section" aria-labelledby="team-member-section-title">
+									<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
+									<div class="govuk-form-group" id="target-email-group">
+										<label class="govuk-label govuk-label--s" for="target-email">Team member's email address</label>
+										<div class="govuk-hint" id="target-email-hint">Use the email address they use to sign in.</div>
+										<p class="govuk-error-message" id="target-email-error" hidden></p>
+										<input
+											class="govuk-input govuk-!-width-two-thirds"
+											id="target-email"
+											name="targetEmail"
+											type="email"
+											autocomplete="email"
+											aria-describedby="target-email-hint"
+										/>
+									</div>
+									<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
+										<summary class="govuk-details__summary">
+											<span class="govuk-details__summary-text">Use a user ID instead</span>
+										</summary>
+										<div class="govuk-details__text">
+											<p class="govuk-body">
+												Only use this if you copied the user ID from ResearchOps. If you enter both an email address and
+												a user ID, they must belong to the same person.
+											</p>
+											<div class="govuk-form-group" id="target-user-id-group">
+												<label class="govuk-label" for="target-user-id">User ID</label>
+												<p class="govuk-error-message" id="target-user-id-error" hidden></p>
+												<input
+													class="govuk-input govuk-!-width-one-half"
+													id="target-user-id"
+													name="targetUserId"
+													type="text"
+												/>
+											</div>
+										</div>
+									</details>
+								</section>
+
+								<section class="auth-role-assignment-section" aria-labelledby="team-choice-section-title">
+									<h3 class="govuk-heading-m" id="team-choice-section-title">2. Team</h3>
+									<fieldset class="govuk-fieldset" id="team-action-group">
+										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+											Which team should this role be in?
+										</legend>
+										<div class="govuk-hint" id="team-action-hint">
+											Choose an existing team, or create a new team before assigning this role.
+										</div>
+										<p class="govuk-error-message" id="team-action-error" hidden></p>
+										<div
+											class="govuk-radios auth-role-assignment-radios"
+											data-module="govuk-radios"
+											aria-describedby="team-action-hint"
+										>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="team-action-existing"
+													name="teamAction"
+													type="radio"
+													value="existing"
+													checked
+												/>
+												<label class="govuk-label govuk-radios__label" for="team-action-existing">
+													Use an existing team
+												</label>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="team-action-create"
+													name="teamAction"
+													type="radio"
+													value="create"
+												/>
+												<label class="govuk-label govuk-radios__label" for="team-action-create">
+													Create a new team
+												</label>
+												<div class="govuk-hint govuk-radios__hint">You will become Team Admin for the new team.</div>
+											</div>
+										</div>
+									</fieldset>
+
+									<div class="auth-role-assignment-team-panel" id="existing-team-panel">
+										<fieldset class="govuk-fieldset" id="team-id-group">
+											<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Select a team</legend>
+											<div class="govuk-hint" id="team-id-hint">
+												The person will be added to this team if they are not already a member.
+											</div>
+											<p class="govuk-error-message" id="team-id-error" hidden></p>
+											<div
+												class="govuk-radios auth-role-assignment-radios"
+												id="team-id-options"
+												data-module="govuk-radios"
+												aria-describedby="team-id-hint"
+											>
+												<p class="govuk-body">Loading teams you can manage.</p>
+											</div>
+										</fieldset>
+									</div>
+
+									<div class="auth-role-assignment-team-panel" id="new-team-panel" hidden>
+										<div class="govuk-form-group" id="new-team-name-group">
+											<label class="govuk-label govuk-label--s" for="new-team-name">New team name</label>
+											<div class="govuk-hint" id="new-team-name-hint">
+												Use a short, recognisable name. For example, "Assisted digital research team".
+											</div>
+											<p class="govuk-error-message" id="new-team-name-error" hidden></p>
+											<input
+												class="govuk-input govuk-!-width-two-thirds"
+												id="new-team-name"
+												name="newTeamName"
+												type="text"
+												maxlength="80"
+												aria-describedby="new-team-name-hint"
+											/>
+										</div>
+										<div class="govuk-form-group" id="new-team-reason-group">
+											<label class="govuk-label govuk-label--s" for="new-team-reason">
+												Why are you creating this team?
+											</label>
+											<div class="govuk-hint" id="new-team-reason-hint">
+												Optional. This will be stored in the audit log with the team creation event.
+											</div>
+											<textarea
+												class="govuk-textarea govuk-!-width-two-thirds"
+												id="new-team-reason"
+												name="newTeamReason"
+												rows="3"
+												aria-describedby="new-team-reason-hint"
+											></textarea>
+										</div>
+									</div>
+								</section>
+
+								<section class="auth-role-assignment-section" aria-labelledby="role-section-title">
+									<h3 class="govuk-heading-m" id="role-section-title">3. Role</h3>
+									<fieldset class="govuk-fieldset" id="role-key-group">
+										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What role do they need?</legend>
+										<div class="govuk-hint" id="role-key-hint">
+											Start with the lowest role that gives the person what they need.
+										</div>
+										<p class="govuk-error-message" id="role-key-error" hidden></p>
+										<div
+											class="govuk-radios auth-role-assignment-radios"
+											data-module="govuk-radios"
+											aria-describedby="role-key-hint"
+										>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="role-key-observer"
+													name="roleKey"
+													type="radio"
+													value="observer"
+												/>
+												<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Can observe low-risk research context without seeing participant personal data.
+												</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="role-key-researcher"
+													name="roleKey"
+													type="radio"
+													value="researcher"
+												/>
+												<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Can create and update governed research records.
+												</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="role-key-research-lead"
+													name="roleKey"
+													type="radio"
+													value="research_lead"
+												/>
+												<label class="govuk-label govuk-radios__label" for="role-key-research-lead">
+													Research Lead
+												</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Can create, update and review governed research records.
+												</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="role-key-approver"
+													name="roleKey"
+													type="radio"
+													value="approver"
+												/>
+												<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Can review and approve governed research records.
+												</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="role-key-safeguarding-lead"
+													name="roleKey"
+													type="radio"
+													value="safeguarding_lead"
+												/>
+												<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">
+													Safeguarding Lead
+												</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Can view, record, resolve and audit safeguarding concerns.
+												</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="role-key-team-admin"
+													name="roleKey"
+													type="radio"
+													value="team_admin"
+												/>
+												<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Can manage team membership, role assignment and general audit oversight.
+												</div>
+											</div>
+										</div>
+									</fieldset>
+									<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
+								</section>
+
+								<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
+									<h3 class="govuk-heading-m" id="duration-section-title">4. Access duration</h3>
+									<fieldset class="govuk-fieldset" id="role-duration-group">
+										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+											How long should this role last?
+										</legend>
+										<div class="govuk-hint" id="role-duration-hint">
+											Choose a governed access period. The standard maximum is 180 days.
+										</div>
+										<p class="govuk-error-message" id="role-duration-error" hidden></p>
+										<div
+											class="govuk-radios auth-role-assignment-radios"
+											data-module="govuk-radios"
+											aria-describedby="role-duration-hint"
+										>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="duration-30"
+													name="durationPreset"
+													type="radio"
+													value="30"
+												/>
+												<label class="govuk-label govuk-radios__label" for="duration-30">30 days</label>
+												<div class="govuk-hint govuk-radios__hint">Use for short support tasks or temporary cover.</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="duration-60"
+													name="durationPreset"
+													type="radio"
+													value="60"
+												/>
+												<label class="govuk-label govuk-radios__label" for="duration-60">60 days</label>
+												<div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="duration-90"
+													name="durationPreset"
+													type="radio"
+													value="90"
+												/>
+												<label class="govuk-label govuk-radios__label" for="duration-90">90 days</label>
+												<div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="duration-180"
+													name="durationPreset"
+													type="radio"
+													value="180"
+												/>
+												<label class="govuk-label govuk-radios__label" for="duration-180">180 days</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Use for the standard maximum team access period.
+												</div>
+											</div>
+											<div class="govuk-radios__item">
+												<input
+													class="govuk-radios__input"
+													id="duration-custom"
+													name="durationPreset"
+													type="radio"
+													value="custom"
+												/>
+												<label class="govuk-label govuk-radios__label" for="duration-custom">
+													Until a specific date
+												</label>
+												<div class="govuk-hint govuk-radios__hint">
+													Use for contractors, secondments or known assignment end dates.
+												</div>
+											</div>
+										</div>
+									</fieldset>
+									<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
+										<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
+											<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+												What date should this role expire?
+											</legend>
+											<div class="govuk-hint" id="custom-expiry-date-hint">
+												For example, 30 9 2026. Access ends at the end of the selected day.
+											</div>
+											<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
+											<div class="govuk-date-input" id="custom-expiry-date">
+												<div class="govuk-date-input__item">
+													<div class="govuk-form-group">
+														<label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label>
+														<input
+															class="govuk-input govuk-date-input__input govuk-input--width-2"
+															id="expiry-day"
+															name="expiryDay"
+															type="text"
+															inputmode="numeric"
+															autocomplete="off"
+														/>
+													</div>
+												</div>
+												<div class="govuk-date-input__item">
+													<div class="govuk-form-group">
+														<label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label>
+														<input
+															class="govuk-input govuk-date-input__input govuk-input--width-2"
+															id="expiry-month"
+															name="expiryMonth"
+															type="text"
+															inputmode="numeric"
+															autocomplete="off"
+														/>
+													</div>
+												</div>
+												<div class="govuk-date-input__item">
+													<div class="govuk-form-group">
+														<label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label>
+														<input
+															class="govuk-input govuk-date-input__input govuk-input--width-4"
+															id="expiry-year"
+															name="expiryYear"
+															type="text"
+															inputmode="numeric"
+															autocomplete="off"
+														/>
+													</div>
+												</div>
+											</div>
+										</fieldset>
+									</div>
+								</section>
+
+								<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
+									<h3 class="govuk-heading-m" id="reason-section-title">5. Reason</h3>
+									<div class="govuk-form-group" id="requested-reason-group">
+										<label class="govuk-label govuk-label--s" for="requested-reason">
+											Why are you assigning this role?
+										</label>
+										<div class="govuk-hint" id="requested-reason-hint">
+											This will be stored in the audit log. Include the work they need the role for. For example,
+											"Joining the research team for the May assisted digital study".
+										</div>
+										<p class="govuk-error-message" id="requested-reason-error" hidden></p>
+										<textarea
+											class="govuk-textarea govuk-!-width-two-thirds"
+											id="requested-reason"
+											name="requestedReason"
+											rows="5"
+											aria-describedby="requested-reason-hint"
+										></textarea>
+									</div>
+								</section>
+
+								<div class="govuk-form-group auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
+									<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
+										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+											Sensitive role confirmation
+										</legend>
+										<div class="govuk-warning-text" id="sensitive-role-hint">
+											<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+											<strong class="govuk-warning-text__text">
+												<span class="govuk-warning-text__assistive">Warning</span>
+												This role gives access to sensitive records or administrative controls.
+											</strong>
+										</div>
+										<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
+										<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+											<div class="govuk-checkboxes__item">
+												<input
+													class="govuk-checkboxes__input"
+													id="sensitive-role-confirmation"
+													name="sensitiveRoleConfirmation"
+													type="checkbox"
+													value="ASSIGN_SENSITIVE_ROLE"
+												/>
+												<label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">
+													I confirm this sensitive role assignment is intentional.
+												</label>
+											</div>
+										</div>
+									</fieldset>
+								</div>
+
+								<div class="govuk-form-group auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
+									<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
+										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+											Safeguarding access confirmation
+										</legend>
+										<div class="govuk-warning-text" id="safeguarding-hint">
+											<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+											<strong class="govuk-warning-text__text">
+												<span class="govuk-warning-text__assistive">Warning</span>
+												Safeguarding Lead can view restricted safeguarding details and close safeguarding concerns.
+											</strong>
+										</div>
+										<p class="govuk-error-message" id="safeguarding-error" hidden></p>
+										<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+											<div class="govuk-checkboxes__item">
+												<input
+													class="govuk-checkboxes__input"
+													id="safeguarding-confirmation"
+													name="safeguardingConfirmation"
+													type="checkbox"
+													value="ASSIGN_SAFEGUARDING_LEAD"
+												/>
+												<label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">
+													I confirm this person needs Safeguarding Lead access.
+												</label>
+											</div>
+										</div>
+									</fieldset>
+								</div>
+
+								<div class="govuk-button-group">
+									<button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button>
+								</div>
+							</form>
+
+							<section
+								id="role-assignment-review"
+								class="auth-role-assignment-review"
+								aria-labelledby="role-assignment-review-title"
+								tabindex="-1"
+								hidden
+							>
+								<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
+								<p class="govuk-body">
+									ResearchOps will confirm the person exists. If you create a new team, ResearchOps will make you Team
+									Admin for that team before assigning the selected role.
+								</p>
+								<div id="role-assignment-review-body"></div>
+								<div class="govuk-button-group">
+									<button class="govuk-button" type="button" id="confirm-role-assignment">
+										Confirm and assign role
+									</button>
+									<button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">
+										Change details
+									</button>
+								</div>
+							</section>
+
+							<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
+						</div>
+					</div>
+				</section>
 			</div>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
-			<header class="page-intro auth-role-assignment-page__header">
-				<div class="govuk-grid-row">
-					<div class="govuk-grid-column-two-thirds">
-						<span class="govuk-caption-l">Team administration</span>
-						<h1 class="govuk-heading-xl" id="role-assignment-title">Assign a role to a team member</h1>
-						<p class="lede">Use this page to give someone access to a role in a ResearchOps team you manage.</p>
-						<p class="govuk-body">If the person is not already an active member of the team, ResearchOps will add them when you assign the role.</p>
-						<p class="govuk-body">Only assign the lowest role they need to do their work. Role changes and team creation are recorded in the audit log.</p>
-					</div>
-				</div>
-			</header>
-
-			<section class="auth-role-assignment-scope" aria-labelledby="team-scope-title">
-				<h2 class="govuk-heading-m" id="team-scope-title">Team scope</h2>
-				<div id="auth-context" class="auth-role-assignment-scope__panel" aria-live="polite" aria-busy="true">
-					<p class="govuk-body">Checking which team you can manage.</p>
-				</div>
-			</section>
-
-			<section aria-labelledby="assign-role-form-title" id="role-assignment-form-section">
-				<div class="govuk-grid-row">
-					<div class="govuk-grid-column-two-thirds">
-						<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
-						<form id="role-assignment-form" novalidate>
-							<section class="auth-role-assignment-section" aria-labelledby="team-member-section-title">
-								<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
-								<div class="govuk-form-group" id="target-email-group">
-									<label class="govuk-label govuk-label--s" for="target-email">Team member's email address</label>
-									<div class="govuk-hint" id="target-email-hint">Use the email address they use to sign in.</div>
-									<p class="govuk-error-message" id="target-email-error" hidden></p>
-									<input class="govuk-input govuk-!-width-two-thirds" id="target-email" name="targetEmail" type="email" autocomplete="email" aria-describedby="target-email-hint" />
-								</div>
-								<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
-									<summary class="govuk-details__summary"><span class="govuk-details__summary-text">Use a user ID instead</span></summary>
-									<div class="govuk-details__text">
-										<p class="govuk-body">Only use this if you copied the user ID from ResearchOps. If you enter both an email address and a user ID, they must belong to the same person.</p>
-										<div class="govuk-form-group" id="target-user-id-group">
-											<label class="govuk-label" for="target-user-id">User ID</label>
-											<p class="govuk-error-message" id="target-user-id-error" hidden></p>
-											<input class="govuk-input govuk-!-width-one-half" id="target-user-id" name="targetUserId" type="text" />
-										</div>
-									</div>
-								</details>
-							</section>
-
-							<section class="auth-role-assignment-section" aria-labelledby="team-choice-section-title">
-								<h3 class="govuk-heading-m" id="team-choice-section-title">2. Team</h3>
-								<fieldset class="govuk-fieldset" id="team-action-group">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Which team should this role be in?</legend>
-									<div class="govuk-hint" id="team-action-hint">Choose an existing team, or create a new team before assigning this role.</div>
-									<p class="govuk-error-message" id="team-action-error" hidden></p>
-									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="team-action-hint">
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="team-action-existing" name="teamAction" type="radio" value="existing" checked />
-											<label class="govuk-label govuk-radios__label" for="team-action-existing">Use an existing team</label>
-										</div>
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="team-action-create" name="teamAction" type="radio" value="create" />
-											<label class="govuk-label govuk-radios__label" for="team-action-create">Create a new team</label>
-											<div class="govuk-hint govuk-radios__hint">You will become Team Admin for the new team.</div>
-										</div>
-									</div>
-								</fieldset>
-
-								<div class="auth-role-assignment-team-panel" id="existing-team-panel">
-									<fieldset class="govuk-fieldset" id="team-id-group">
-										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Select a team</legend>
-										<div class="govuk-hint" id="team-id-hint">The person will be added to this team if they are not already a member.</div>
-										<p class="govuk-error-message" id="team-id-error" hidden></p>
-										<div class="govuk-radios auth-role-assignment-radios" id="team-id-options" data-module="govuk-radios" aria-describedby="team-id-hint">
-											<p class="govuk-body">Loading teams you can manage.</p>
-										</div>
-									</fieldset>
-								</div>
-
-								<div class="auth-role-assignment-team-panel" id="new-team-panel" hidden>
-									<div class="govuk-form-group" id="new-team-name-group">
-										<label class="govuk-label govuk-label--s" for="new-team-name">New team name</label>
-										<div class="govuk-hint" id="new-team-name-hint">Use a short, recognisable name. For example, "Assisted digital research team".</div>
-										<p class="govuk-error-message" id="new-team-name-error" hidden></p>
-										<input class="govuk-input govuk-!-width-two-thirds" id="new-team-name" name="newTeamName" type="text" maxlength="80" aria-describedby="new-team-name-hint" />
-									</div>
-									<div class="govuk-form-group" id="new-team-reason-group">
-										<label class="govuk-label govuk-label--s" for="new-team-reason">Why are you creating this team?</label>
-										<div class="govuk-hint" id="new-team-reason-hint">Optional. This will be stored in the audit log with the team creation event.</div>
-										<textarea class="govuk-textarea govuk-!-width-two-thirds" id="new-team-reason" name="newTeamReason" rows="3" aria-describedby="new-team-reason-hint"></textarea>
-									</div>
-								</div>
-							</section>
-
-							<section class="auth-role-assignment-section" aria-labelledby="role-section-title">
-								<h3 class="govuk-heading-m" id="role-section-title">3. Role</h3>
-								<fieldset class="govuk-fieldset" id="role-key-group">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What role do they need?</legend>
-									<div class="govuk-hint" id="role-key-hint">Start with the lowest role that gives the person what they need.</div>
-									<p class="govuk-error-message" id="role-key-error" hidden></p>
-									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-key-hint">
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" />
-											<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer</label>
-											<div class="govuk-hint govuk-radios__hint">Can observe low-risk research context without seeing participant personal data.</div>
-										</div>
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" />
-											<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher</label>
-											<div class="govuk-hint govuk-radios__hint">Can create and update governed research records.</div>
-										</div>
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" />
-											<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead</label>
-											<div class="govuk-hint govuk-radios__hint">Can create, update and review governed research records.</div>
-										</div>
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" />
-											<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver</label>
-											<div class="govuk-hint govuk-radios__hint">Can review and approve governed research records.</div>
-										</div>
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" />
-											<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead</label>
-											<div class="govuk-hint govuk-radios__hint">Can view, record, resolve and audit safeguarding concerns.</div>
-										</div>
-										<div class="govuk-radios__item">
-											<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" />
-											<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin</label>
-											<div class="govuk-hint govuk-radios__hint">Can manage team membership, role assignment and general audit oversight.</div>
-										</div>
-									</div>
-								</fieldset>
-								<div id="role-summary" class="auth-role-assignment-summary" aria-live="polite" hidden></div>
-							</section>
-
-							<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
-								<h3 class="govuk-heading-m" id="duration-section-title">4. Access duration</h3>
-								<fieldset class="govuk-fieldset" id="role-duration-group">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">How long should this role last?</legend>
-									<div class="govuk-hint" id="role-duration-hint">Choose a governed access period. The standard maximum is 180 days.</div>
-									<p class="govuk-error-message" id="role-duration-error" hidden></p>
-									<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-duration-hint">
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-30" name="durationPreset" type="radio" value="30" /><label class="govuk-label govuk-radios__label" for="duration-30">30 days</label><div class="govuk-hint govuk-radios__hint">Use for short support tasks or temporary cover.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-60" name="durationPreset" type="radio" value="60" /><label class="govuk-label govuk-radios__label" for="duration-60">60 days</label><div class="govuk-hint govuk-radios__hint">Use for short project involvement.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-90" name="durationPreset" type="radio" value="90" /><label class="govuk-label govuk-radios__label" for="duration-90">90 days</label><div class="govuk-hint govuk-radios__hint">Use for one research phase or delivery cycle.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-180" name="durationPreset" type="radio" value="180" /><label class="govuk-label govuk-radios__label" for="duration-180">180 days</label><div class="govuk-hint govuk-radios__hint">Use for the standard maximum team access period.</div></div>
-										<div class="govuk-radios__item"><input class="govuk-radios__input" id="duration-custom" name="durationPreset" type="radio" value="custom" /><label class="govuk-label govuk-radios__label" for="duration-custom">Until a specific date</label><div class="govuk-hint govuk-radios__hint">Use for contractors, secondments or known assignment end dates.</div></div>
-									</div>
-								</fieldset>
-								<div class="govuk-form-group auth-role-assignment-custom-date" id="custom-expiry-date-group" hidden>
-									<fieldset class="govuk-fieldset" role="group" aria-describedby="custom-expiry-date-hint">
-										<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">What date should this role expire?</legend>
-										<div class="govuk-hint" id="custom-expiry-date-hint">For example, 30 9 2026. Access ends at the end of the selected day.</div>
-										<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
-										<div class="govuk-date-input" id="custom-expiry-date">
-											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-day" name="expiryDay" type="text" inputmode="numeric" autocomplete="off" /></div></div>
-											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-month">Month</label><input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiry-month" name="expiryMonth" type="text" inputmode="numeric" autocomplete="off" /></div></div>
-											<div class="govuk-date-input__item"><div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="expiry-year">Year</label><input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiry-year" name="expiryYear" type="text" inputmode="numeric" autocomplete="off" /></div></div>
-										</div>
-									</fieldset>
-								</div>
-							</section>
-
-							<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
-								<h3 class="govuk-heading-m" id="reason-section-title">5. Reason</h3>
-								<div class="govuk-form-group" id="requested-reason-group">
-									<label class="govuk-label govuk-label--s" for="requested-reason">Why are you assigning this role?</label>
-									<div class="govuk-hint" id="requested-reason-hint">This will be stored in the audit log. Include the work they need the role for. For example, "Joining the research team for the May assisted digital study".</div>
-									<p class="govuk-error-message" id="requested-reason-error" hidden></p>
-									<textarea class="govuk-textarea govuk-!-width-two-thirds" id="requested-reason" name="requestedReason" rows="5" aria-describedby="requested-reason-hint"></textarea>
-								</div>
-							</section>
-
-							<div class="govuk-form-group auth-role-assignment-sensitive" id="sensitive-role-fieldset" hidden>
-								<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Sensitive role confirmation</legend>
-									<div class="govuk-warning-text" id="sensitive-role-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>This role gives access to sensitive records or administrative controls.</strong></div>
-									<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
-									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="sensitive-role-confirmation" name="sensitiveRoleConfirmation" type="checkbox" value="ASSIGN_SENSITIVE_ROLE" /><label class="govuk-label govuk-checkboxes__label" for="sensitive-role-confirmation">I confirm this sensitive role assignment is intentional.</label></div></div>
-								</fieldset>
-							</div>
-
-							<div class="govuk-form-group auth-role-assignment-sensitive" id="safeguarding-fieldset" hidden>
-								<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
-									<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Safeguarding access confirmation</legend>
-									<div class="govuk-warning-text" id="safeguarding-hint"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Safeguarding Lead can view restricted safeguarding details and close safeguarding concerns.</strong></div>
-									<p class="govuk-error-message" id="safeguarding-error" hidden></p>
-									<div class="govuk-checkboxes" data-module="govuk-checkboxes"><div class="govuk-checkboxes__item"><input class="govuk-checkboxes__input" id="safeguarding-confirmation" name="safeguardingConfirmation" type="checkbox" value="ASSIGN_SAFEGUARDING_LEAD" /><label class="govuk-label govuk-checkboxes__label" for="safeguarding-confirmation">I confirm this person needs Safeguarding Lead access.</label></div></div>
-								</fieldset>
-							</div>
-
-							<div class="govuk-button-group"><button class="govuk-button" type="submit" id="submit-role-assignment">Check details</button></div>
-						</form>
-
-						<section id="role-assignment-review" class="auth-role-assignment-review" aria-labelledby="role-assignment-review-title" tabindex="-1" hidden>
-							<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
-							<p class="govuk-body">ResearchOps will confirm the person exists. If you create a new team, ResearchOps will make you Team Admin for that team before assigning the selected role.</p>
-							<div id="role-assignment-review-body"></div>
-							<div class="govuk-button-group"><button class="govuk-button" type="button" id="confirm-role-assignment">Confirm and assign role</button><button class="govuk-button govuk-button--secondary" type="button" id="change-role-assignment">Change details</button></div>
-						</section>
-
-						<div id="role-assignment-result" class="auth-role-assignment-result" aria-live="polite" hidden></div>
-					</div>
-				</div>
-			</section>
-		</div>
-	</main>
-
-	<x-include src="/partials/footer.html" vars='{"org":"Home Office Biometrics","build":"ResearchOps v1.0.0 (demo)"}'></x-include>
-	<script type="module" src="/js/auth-role-assignment-page.js?v=inline-team-creation-20260513"></script>
-</body>
+		<script type="module" src="/js/auth-role-assignment-page.js?v=inline-team-creation-20260513"></script>
+	</body>
 </html>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -227,6 +227,16 @@ export const govukPages = [
 		},
 	},
 	{
+		template: 'pages/role-assignments.njk',
+		output: 'public/pages/team/role-assignments/index.html',
+		context: {
+			pageTitle: 'Assign a role to a team member - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: '',
+			navigation: accountNavigation,
+		},
+	},
+	{
 		template: 'pages/projects.njk',
 		output: 'public/pages/projects/index.html',
 		context: {

--- a/src/govuk/templates/pages/role-assignments.njk
+++ b/src/govuk/templates/pages/role-assignments.njk
@@ -11,6 +11,9 @@
 			<li class="govuk-breadcrumbs__list-item">
 				<a class="govuk-breadcrumbs__link" href="/">Home</a>
 			</li>
+			<li class="govuk-breadcrumbs__list-item">
+				<a class="govuk-breadcrumbs__link" href="/pages/account/">Your account</a>
+			</li>
 			<li class="govuk-breadcrumbs__list-item">Team administration</li>
 		</ol>
 	</nav>

--- a/src/govuk/templates/pages/role-assignments.njk
+++ b/src/govuk/templates/pages/role-assignments.njk
@@ -1,0 +1,609 @@
+{% extends "layouts/researchops.njk" %}
+
+{% block head %}
+<link rel="stylesheet" href="/css/auth-role-assignments.css" media="screen" />
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+	<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+		<ol class="govuk-breadcrumbs__list">
+			<li class="govuk-breadcrumbs__list-item">
+				<a class="govuk-breadcrumbs__link" href="/">Home</a>
+			</li>
+			<li class="govuk-breadcrumbs__list-item">Team administration</li>
+		</ol>
+	</nav>
+
+	<div
+		id="role-assignment-error-summary"
+		class="govuk-error-summary"
+		role="alert"
+		tabindex="-1"
+		hidden
+	>
+		<h2 class="govuk-error-summary__title">There is a problem</h2>
+		<div class="govuk-error-summary__body">
+			<ul class="govuk-error-summary__list" id="role-assignment-error-list"></ul>
+		</div>
+	</div>
+
+	<header class="page-intro auth-role-assignment-page__header">
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+				<span class="govuk-caption-l">Team administration</span>
+				<h1 class="govuk-heading-xl" id="role-assignment-title">Assign a role to a team member</h1>
+				<p class="lede">
+					Use this page to give someone access to a role in a ResearchOps team you manage.
+				</p>
+				<p class="govuk-body">
+					If the person is not already an active member of the team, ResearchOps will add them when
+					you assign the role.
+				</p>
+				<p class="govuk-body">
+					Only assign the lowest role they need to do their work. Role changes and team creation are
+					recorded in the audit log.
+				</p>
+			</div>
+		</div>
+	</header>
+
+	<section class="auth-role-assignment-scope" aria-labelledby="team-scope-title">
+		<h2 class="govuk-heading-m" id="team-scope-title">Team scope</h2>
+		<div
+			id="auth-context"
+			class="auth-role-assignment-scope__panel"
+			aria-live="polite"
+			aria-busy="true"
+		>
+			<p class="govuk-body">Checking which team you can manage.</p>
+		</div>
+	</section>
+
+	<section aria-labelledby="assign-role-form-title" id="role-assignment-form-section">
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+				<h2 class="govuk-heading-l" id="assign-role-form-title">Role assignment details</h2>
+				<form id="role-assignment-form" novalidate>
+					<section class="auth-role-assignment-section" aria-labelledby="team-member-section-title">
+						<h3 class="govuk-heading-m" id="team-member-section-title">1. Team member</h3>
+						<div class="govuk-form-group" id="target-email-group">
+							<label class="govuk-label govuk-label--s" for="target-email"
+								>Team member's email address</label
+							>
+							<div class="govuk-hint" id="target-email-hint">
+								Use the email address they use to sign in.
+							</div>
+							<p class="govuk-error-message" id="target-email-error" hidden></p>
+							<input
+								class="govuk-input govuk-!-width-two-thirds"
+								id="target-email"
+								name="targetEmail"
+								type="email"
+								autocomplete="email"
+								aria-describedby="target-email-hint"
+							/>
+						</div>
+						<details class="govuk-details auth-role-assignment-details" id="target-user-id-details">
+							<summary class="govuk-details__summary">
+								<span class="govuk-details__summary-text">Use a user ID instead</span>
+							</summary>
+							<div class="govuk-details__text">
+								<p class="govuk-body">
+									Only use this if you copied the user ID from ResearchOps. If you enter both an
+									email address and a user ID, they must belong to the same person.
+								</p>
+								<div class="govuk-form-group" id="target-user-id-group">
+									<label class="govuk-label" for="target-user-id">User ID</label>
+									<p class="govuk-error-message" id="target-user-id-error" hidden></p>
+									<input
+										class="govuk-input govuk-!-width-one-half"
+										id="target-user-id"
+										name="targetUserId"
+										type="text"
+									/>
+								</div>
+							</div>
+						</details>
+					</section>
+
+					<section class="auth-role-assignment-section" aria-labelledby="team-choice-section-title">
+						<h3 class="govuk-heading-m" id="team-choice-section-title">2. Team</h3>
+						<fieldset class="govuk-fieldset" id="team-action-group">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+								Which team should this role be in?
+							</legend>
+							<div class="govuk-hint" id="team-action-hint">
+								Choose an existing team, or create a new team before assigning this role.
+							</div>
+							<p class="govuk-error-message" id="team-action-error" hidden></p>
+							<div
+								class="govuk-radios auth-role-assignment-radios"
+								data-module="govuk-radios"
+								aria-describedby="team-action-hint"
+							>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="team-action-existing"
+										name="teamAction"
+										type="radio"
+										value="existing"
+										checked
+									/>
+									<label class="govuk-label govuk-radios__label" for="team-action-existing"
+										>Use an existing team</label
+									>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="team-action-create"
+										name="teamAction"
+										type="radio"
+										value="create"
+									/>
+									<label class="govuk-label govuk-radios__label" for="team-action-create"
+										>Create a new team</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										You will become Team Admin for the new team.
+									</div>
+								</div>
+							</div>
+						</fieldset>
+
+						<div class="auth-role-assignment-team-panel" id="existing-team-panel">
+							<fieldset class="govuk-fieldset" id="team-id-group">
+								<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+									Select a team
+								</legend>
+								<div class="govuk-hint" id="team-id-hint">
+									The person will be added to this team if they are not already a member.
+								</div>
+								<p class="govuk-error-message" id="team-id-error" hidden></p>
+								<div
+									class="govuk-radios auth-role-assignment-radios"
+									id="team-id-options"
+									data-module="govuk-radios"
+									aria-describedby="team-id-hint"
+								>
+									<p class="govuk-body">Loading teams you can manage.</p>
+								</div>
+							</fieldset>
+						</div>
+
+						<div class="auth-role-assignment-team-panel" id="new-team-panel" hidden>
+							<div class="govuk-form-group" id="new-team-name-group">
+								<label class="govuk-label govuk-label--s" for="new-team-name">New team name</label>
+								<div class="govuk-hint" id="new-team-name-hint">
+									Use a short, recognisable name. For example, "Assisted digital research team".
+								</div>
+								<p class="govuk-error-message" id="new-team-name-error" hidden></p>
+								<input
+									class="govuk-input govuk-!-width-two-thirds"
+									id="new-team-name"
+									name="newTeamName"
+									type="text"
+									maxlength="80"
+									aria-describedby="new-team-name-hint"
+								/>
+							</div>
+							<div class="govuk-form-group" id="new-team-reason-group">
+								<label class="govuk-label govuk-label--s" for="new-team-reason"
+									>Why are you creating this team?</label
+								>
+								<div class="govuk-hint" id="new-team-reason-hint">
+									Optional. This will be stored in the audit log with the team creation event.
+								</div>
+								<textarea
+									class="govuk-textarea govuk-!-width-two-thirds"
+									id="new-team-reason"
+									name="newTeamReason"
+									rows="3"
+									aria-describedby="new-team-reason-hint"
+								></textarea>
+							</div>
+						</div>
+					</section>
+
+					<section class="auth-role-assignment-section" aria-labelledby="role-section-title">
+						<h3 class="govuk-heading-m" id="role-section-title">3. Role</h3>
+						<fieldset class="govuk-fieldset" id="role-key-group">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+								What role do they need?
+							</legend>
+							<div class="govuk-hint" id="role-key-hint">
+								Start with the lowest role that gives the person what they need.
+							</div>
+							<p class="govuk-error-message" id="role-key-error" hidden></p>
+							<div
+								class="govuk-radios auth-role-assignment-radios"
+								data-module="govuk-radios"
+								aria-describedby="role-key-hint"
+							>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="role-key-observer"
+										name="roleKey"
+										type="radio"
+										value="observer"
+									/>
+									<label class="govuk-label govuk-radios__label" for="role-key-observer"
+										>Observer</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Can observe low-risk research context without seeing participant personal data.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="role-key-researcher"
+										name="roleKey"
+										type="radio"
+										value="researcher"
+									/>
+									<label class="govuk-label govuk-radios__label" for="role-key-researcher"
+										>Researcher</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Can create and update governed research records.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="role-key-research-lead"
+										name="roleKey"
+										type="radio"
+										value="research_lead"
+									/>
+									<label class="govuk-label govuk-radios__label" for="role-key-research-lead"
+										>Research Lead</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Can create, update and review governed research records.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="role-key-approver"
+										name="roleKey"
+										type="radio"
+										value="approver"
+									/>
+									<label class="govuk-label govuk-radios__label" for="role-key-approver"
+										>Approver</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Can review and approve governed research records.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="role-key-safeguarding-lead"
+										name="roleKey"
+										type="radio"
+										value="safeguarding_lead"
+									/>
+									<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead"
+										>Safeguarding Lead</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Can view, record, resolve and audit safeguarding concerns.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="role-key-team-admin"
+										name="roleKey"
+										type="radio"
+										value="team_admin"
+									/>
+									<label class="govuk-label govuk-radios__label" for="role-key-team-admin"
+										>Team Admin</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Can manage team membership, role assignment and general audit oversight.
+									</div>
+								</div>
+							</div>
+						</fieldset>
+						<div
+							id="role-summary"
+							class="auth-role-assignment-summary"
+							aria-live="polite"
+							hidden
+						></div>
+					</section>
+
+					<section class="auth-role-assignment-section" aria-labelledby="duration-section-title">
+						<h3 class="govuk-heading-m" id="duration-section-title">4. Access duration</h3>
+						<fieldset class="govuk-fieldset" id="role-duration-group">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+								How long should this role last?
+							</legend>
+							<div class="govuk-hint" id="role-duration-hint">
+								Choose a governed access period. The standard maximum is 180 days.
+							</div>
+							<p class="govuk-error-message" id="role-duration-error" hidden></p>
+							<div
+								class="govuk-radios auth-role-assignment-radios"
+								data-module="govuk-radios"
+								aria-describedby="role-duration-hint"
+							>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="duration-30"
+										name="durationPreset"
+										type="radio"
+										value="30"
+									/><label class="govuk-label govuk-radios__label" for="duration-30">30 days</label>
+									<div class="govuk-hint govuk-radios__hint">
+										Use for short support tasks or temporary cover.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="duration-60"
+										name="durationPreset"
+										type="radio"
+										value="60"
+									/><label class="govuk-label govuk-radios__label" for="duration-60">60 days</label>
+									<div class="govuk-hint govuk-radios__hint">
+										Use for short project involvement.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="duration-90"
+										name="durationPreset"
+										type="radio"
+										value="90"
+									/><label class="govuk-label govuk-radios__label" for="duration-90">90 days</label>
+									<div class="govuk-hint govuk-radios__hint">
+										Use for one research phase or delivery cycle.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="duration-180"
+										name="durationPreset"
+										type="radio"
+										value="180"
+									/><label class="govuk-label govuk-radios__label" for="duration-180"
+										>180 days</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Use for the standard maximum team access period.
+									</div>
+								</div>
+								<div class="govuk-radios__item">
+									<input
+										class="govuk-radios__input"
+										id="duration-custom"
+										name="durationPreset"
+										type="radio"
+										value="custom"
+									/><label class="govuk-label govuk-radios__label" for="duration-custom"
+										>Until a specific date</label
+									>
+									<div class="govuk-hint govuk-radios__hint">
+										Use for contractors, secondments or known assignment end dates.
+									</div>
+								</div>
+							</div>
+						</fieldset>
+						<div
+							class="govuk-form-group auth-role-assignment-custom-date"
+							id="custom-expiry-date-group"
+							hidden
+						>
+							<fieldset
+								class="govuk-fieldset"
+								role="group"
+								aria-describedby="custom-expiry-date-hint"
+							>
+								<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+									What date should this role expire?
+								</legend>
+								<div class="govuk-hint" id="custom-expiry-date-hint">
+									For example, 30 9 2026. Access ends at the end of the selected day.
+								</div>
+								<p class="govuk-error-message" id="custom-expiry-date-error" hidden></p>
+								<div class="govuk-date-input" id="custom-expiry-date">
+									<div class="govuk-date-input__item">
+										<div class="govuk-form-group">
+											<label class="govuk-label govuk-date-input__label" for="expiry-day">Day</label
+											><input
+												class="govuk-input govuk-date-input__input govuk-input--width-2"
+												id="expiry-day"
+												name="expiryDay"
+												type="text"
+												inputmode="numeric"
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+									<div class="govuk-date-input__item">
+										<div class="govuk-form-group">
+											<label class="govuk-label govuk-date-input__label" for="expiry-month"
+												>Month</label
+											><input
+												class="govuk-input govuk-date-input__input govuk-input--width-2"
+												id="expiry-month"
+												name="expiryMonth"
+												type="text"
+												inputmode="numeric"
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+									<div class="govuk-date-input__item">
+										<div class="govuk-form-group">
+											<label class="govuk-label govuk-date-input__label" for="expiry-year"
+												>Year</label
+											><input
+												class="govuk-input govuk-date-input__input govuk-input--width-4"
+												id="expiry-year"
+												name="expiryYear"
+												type="text"
+												inputmode="numeric"
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+							</fieldset>
+						</div>
+					</section>
+
+					<section class="auth-role-assignment-section" aria-labelledby="reason-section-title">
+						<h3 class="govuk-heading-m" id="reason-section-title">5. Reason</h3>
+						<div class="govuk-form-group" id="requested-reason-group">
+							<label class="govuk-label govuk-label--s" for="requested-reason"
+								>Why are you assigning this role?</label
+							>
+							<div class="govuk-hint" id="requested-reason-hint">
+								This will be stored in the audit log. Include the work they need the role for. For
+								example, "Joining the research team for the May assisted digital study".
+							</div>
+							<p class="govuk-error-message" id="requested-reason-error" hidden></p>
+							<textarea
+								class="govuk-textarea govuk-!-width-two-thirds"
+								id="requested-reason"
+								name="requestedReason"
+								rows="5"
+								aria-describedby="requested-reason-hint"
+							></textarea>
+						</div>
+					</section>
+
+					<div
+						class="govuk-form-group auth-role-assignment-sensitive"
+						id="sensitive-role-fieldset"
+						hidden
+					>
+						<fieldset class="govuk-fieldset" aria-describedby="sensitive-role-hint">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+								Sensitive role confirmation
+							</legend>
+							<div class="govuk-warning-text" id="sensitive-role-hint">
+								<span class="govuk-warning-text__icon" aria-hidden="true">!</span
+								><strong class="govuk-warning-text__text"
+									><span class="govuk-warning-text__assistive">Warning</span>This role gives access
+									to sensitive records or administrative controls.</strong
+								>
+							</div>
+							<p class="govuk-error-message" id="sensitive-role-error" hidden></p>
+							<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+								<div class="govuk-checkboxes__item">
+									<input
+										class="govuk-checkboxes__input"
+										id="sensitive-role-confirmation"
+										name="sensitiveRoleConfirmation"
+										type="checkbox"
+										value="ASSIGN_SENSITIVE_ROLE"
+									/><label
+										class="govuk-label govuk-checkboxes__label"
+										for="sensitive-role-confirmation"
+										>I confirm this sensitive role assignment is intentional.</label
+									>
+								</div>
+							</div>
+						</fieldset>
+					</div>
+
+					<div
+						class="govuk-form-group auth-role-assignment-sensitive"
+						id="safeguarding-fieldset"
+						hidden
+					>
+						<fieldset class="govuk-fieldset" aria-describedby="safeguarding-hint">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+								Safeguarding access confirmation
+							</legend>
+							<div class="govuk-warning-text" id="safeguarding-hint">
+								<span class="govuk-warning-text__icon" aria-hidden="true">!</span
+								><strong class="govuk-warning-text__text"
+									><span class="govuk-warning-text__assistive">Warning</span>Safeguarding Lead can
+									view restricted safeguarding details and close safeguarding concerns.</strong
+								>
+							</div>
+							<p class="govuk-error-message" id="safeguarding-error" hidden></p>
+							<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+								<div class="govuk-checkboxes__item">
+									<input
+										class="govuk-checkboxes__input"
+										id="safeguarding-confirmation"
+										name="safeguardingConfirmation"
+										type="checkbox"
+										value="ASSIGN_SAFEGUARDING_LEAD"
+									/><label
+										class="govuk-label govuk-checkboxes__label"
+										for="safeguarding-confirmation"
+										>I confirm this person needs Safeguarding Lead access.</label
+									>
+								</div>
+							</div>
+						</fieldset>
+					</div>
+
+					<div class="govuk-button-group">
+						<button class="govuk-button" type="submit" id="submit-role-assignment">
+							Check details
+						</button>
+					</div>
+				</form>
+
+				<section
+					id="role-assignment-review"
+					class="auth-role-assignment-review"
+					aria-labelledby="role-assignment-review-title"
+					tabindex="-1"
+					hidden
+				>
+					<h2 class="govuk-heading-l" id="role-assignment-review-title">Check and confirm</h2>
+					<p class="govuk-body">
+						ResearchOps will confirm the person exists. If you create a new team, ResearchOps will
+						make you Team Admin for that team before assigning the selected role.
+					</p>
+					<div id="role-assignment-review-body"></div>
+					<div class="govuk-button-group">
+						<button class="govuk-button" type="button" id="confirm-role-assignment">
+							Confirm and assign role</button
+						><button
+							class="govuk-button govuk-button--secondary"
+							type="button"
+							id="change-role-assignment"
+						>
+							Change details
+						</button>
+					</div>
+				</section>
+
+				<div
+					id="role-assignment-result"
+					class="auth-role-assignment-result"
+					aria-live="polite"
+					hidden
+				></div>
+			</div>
+		</div>
+	</section>
+</div>
+{% endblock %} {% block scripts %}
+<script
+	type="module"
+	src="/js/auth-role-assignment-page.js?v=inline-team-creation-20260513"
+></script>
+{% endblock %}

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -5,6 +5,21 @@ const pageSource = fs.readFileSync('public/pages/team/role-assignments/index.htm
 const scriptSource = fs.readFileSync('public/js/auth-role-assignment-page.js', 'utf8');
 const styleSource = fs.readFileSync('public/css/auth-role-assignments.css', 'utf8');
 const govukFrontendSource = fs.readFileSync('public/css/govuk/govuk-frontend-v6.css', 'utf8');
+const rendererSource = fs.readFileSync('scripts/govuk/render-govuk-pages.mjs', 'utf8');
+const templateSource = fs.readFileSync('src/govuk/templates/pages/role-assignments.njk', 'utf8');
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function assertRadioOption(id, name, value, label) {
+	assert.match(
+		pageSource,
+		new RegExp(
+			`<input\\s+class="govuk-radios__input"\\s+id="${id}"\\s+name="${name}"\\s+type="radio"\\s+value="${value}"\\s*/>\\s*<label\\s+class="govuk-label govuk-radios__label"\\s+for="${id}">\\s*${escapeRegExp(label)}\\s*</label>`,
+		),
+	);
+}
 
 function assertPageStructure() {
 	assert.match(pageSource, /<title>Assign a role to a team member [-—] ResearchOps Demo Suite<\/title>/);
@@ -44,13 +59,45 @@ function assertTopLevelAdminInformationArchitecture() {
 	assert.match(pageSource, /govuk-breadcrumbs/);
 	assert.ok(breadcrumbIndex > -1, 'Expected breadcrumb navigation to exist');
 	assert.ok(mainIndex > -1, 'Expected main landmark to exist');
-	assert.ok(breadcrumbIndex < mainIndex, 'Expected breadcrumb navigation to sit before main');
+	assert.ok(breadcrumbIndex > mainIndex, 'Expected breadcrumb navigation to sit inside main');
 	assert.match(pageSource, />Home</);
 	assert.match(pageSource, />Team administration</);
 	assert.doesNotMatch(pageSource, /govuk-back-link/);
 	assert.doesNotMatch(pageSource, /Back to projects/);
 	assert.doesNotMatch(pageSource, /type="reset"/);
 	assert.doesNotMatch(pageSource, /Clear form/);
+}
+
+function assertUsesFullGOVUKFrontendTemplate() {
+	assert.match(pageSource, /<html class="govuk-template" lang="en">/);
+	assert.match(pageSource, /<body class="govuk-template__body">/);
+	assert.match(pageSource, /\/assets\/govuk\/govuk-frontend\.css/);
+	assert.match(pageSource, /\/components\/layout\.js/);
+	assert.match(pageSource, /\/js\/govuk-frontend-init\.js/);
+	assert.match(pageSource, /<x-include src="\/partials\/header\.html"/);
+	assert.match(pageSource, /<x-include src="\/partials\/footer\.html"/);
+	assert.doesNotMatch(pageSource, /\/css\/govuk\/govuk-typography\.css/);
+	assert.doesNotMatch(pageSource, /\/css\/govuk\/govuk-colours\.css/);
+	assert.doesNotMatch(pageSource, /\/css\/govuk\/govuk-page-chrome\.css/);
+	assert.doesNotMatch(pageSource, /\/css\/govuk\/govuk-buttons\.css/);
+	assert.doesNotMatch(pageSource, /\/css\/govuk\/govuk-forms\.css/);
+	assert.doesNotMatch(pageSource, /\/css\/govuk\/govuk-frontend-v6\.css/);
+	assert.doesNotMatch(pageSource, /\/css\/screen\.css/);
+}
+
+function assertRoleAssignmentPageIsGeneratedFromNunjucks() {
+	assert.match(rendererSource, /template: 'pages\/role-assignments\.njk'/);
+	assert.match(rendererSource, /output: 'public\/pages\/team\/role-assignments\/index\.html'/);
+	assert.match(templateSource, /{% extends "layouts\/researchops\.njk" %}/);
+	assert.match(templateSource, /{% block head %}/);
+	assert.match(templateSource, /\/css\/auth-role-assignments\.css/);
+	assert.match(templateSource, /{% block content %}/);
+	assert.match(templateSource, /id="role-assignment-form"/);
+	assert.match(templateSource, /{% block scripts %}/);
+	assert.match(templateSource, /\/js\/auth-role-assignment-page\.js\?v=inline-team-creation-20260513/);
+	assert.doesNotMatch(templateSource, /<html class="govuk-template"/);
+	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/header\.html"/);
+	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/footer\.html"/);
 }
 
 function assertCurrentAccessPanelIsReducedToTeamScope() {
@@ -68,7 +115,7 @@ function assertExplicitTeamChoiceExists() {
 	assert.match(pageSource, /Use an existing team/);
 	assert.match(pageSource, /Create a new team/);
 	assert.match(pageSource, /You will become Team Admin for the new team/);
-	assert.match(pageSource, /The person will be added to this team if they are not already a member/);
+	assert.match(pageSource, /The person will be added to this team if they are not already a\s+member/);
 	assert.match(scriptSource, /teamOptions: document\.getElementById\("team-id-options"\)/);
 	assert.match(scriptSource, /existingTeamPanel: document\.getElementById\("existing-team-panel"\)/);
 	assert.match(scriptSource, /newTeamPanel: document\.getElementById\("new-team-panel"\)/);
@@ -89,8 +136,8 @@ function assertExplicitTeamChoiceExists() {
 
 function assertMembershipCreationCopyExists() {
 	assert.match(pageSource, /give someone access to a role in a ResearchOps team you manage/);
-	assert.match(pageSource, /ResearchOps will add them when you assign the role/);
-	assert.match(pageSource, /If you create a new team, ResearchOps will make you Team Admin for that team/);
+	assert.match(pageSource, /ResearchOps will add them when you assign the\s+role/);
+	assert.match(pageSource, /If you create a new team, ResearchOps will make you Team\s+Admin for that team/);
 	assert.match(scriptSource, /They were also added as an active member of this team/);
 	assert.match(scriptSource, /teamMembership/);
 	assert.match(scriptSource, /createdOrReactivated/);
@@ -105,13 +152,16 @@ function assertUserIdUsesDetailsWithoutExample() {
 
 function assertRoleOptionsUseGOVUKRadios() {
 	assert.doesNotMatch(pageSource, /<select class="govuk-select" id="role-key"/);
-	assert.match(pageSource, /<div class="govuk-radios auth-role-assignment-radios" data-module="govuk-radios" aria-describedby="role-key-hint">/);
-	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-observer" name="roleKey" type="radio" value="observer" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-observer">Observer<\/label>/);
-	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-researcher" name="roleKey" type="radio" value="researcher" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-researcher">Researcher<\/label>/);
-	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-research-lead" name="roleKey" type="radio" value="research_lead" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-research-lead">Research Lead<\/label>/);
-	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-approver" name="roleKey" type="radio" value="approver" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-approver">Approver<\/label>/);
-	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-safeguarding-lead" name="roleKey" type="radio" value="safeguarding_lead" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-safeguarding-lead">Safeguarding Lead<\/label>/);
-	assert.match(pageSource, /<input class="govuk-radios__input" id="role-key-team-admin" name="roleKey" type="radio" value="team_admin" \/>\s*<label class="govuk-label govuk-radios__label" for="role-key-team-admin">Team Admin<\/label>/);
+	assert.match(
+		pageSource,
+		/class="govuk-radios auth-role-assignment-radios"[\s\S]*?data-module="govuk-radios"[\s\S]*?aria-describedby="role-key-hint"/,
+	);
+	assertRadioOption('role-key-observer', 'roleKey', 'observer', 'Observer');
+	assertRadioOption('role-key-researcher', 'roleKey', 'researcher', 'Researcher');
+	assertRadioOption('role-key-research-lead', 'roleKey', 'research_lead', 'Research Lead');
+	assertRadioOption('role-key-approver', 'roleKey', 'approver', 'Approver');
+	assertRadioOption('role-key-safeguarding-lead', 'roleKey', 'safeguarding_lead', 'Safeguarding Lead');
+	assertRadioOption('role-key-team-admin', 'roleKey', 'team_admin', 'Team Admin');
 	assert.match(pageSource, /Start with the lowest role that gives the person what they need/);
 }
 
@@ -155,11 +205,11 @@ function assertPageStylesDoNotRecreateGOVUKRadioInternals() {
 function assertDurationModelUsesGovernedPresets() {
 	assert.doesNotMatch(pageSource, /type="datetime-local"/);
 	assert.match(pageSource, /How long should this role last\?/);
-	assert.match(pageSource, /name="durationPreset" type="radio" value="30"/);
-	assert.match(pageSource, /name="durationPreset" type="radio" value="60"/);
-	assert.match(pageSource, /name="durationPreset" type="radio" value="90"/);
-	assert.match(pageSource, /name="durationPreset" type="radio" value="180"/);
-	assert.match(pageSource, /name="durationPreset" type="radio" value="custom"/);
+	assertRadioOption('duration-30', 'durationPreset', '30', '30 days');
+	assertRadioOption('duration-60', 'durationPreset', '60', '60 days');
+	assertRadioOption('duration-90', 'durationPreset', '90', '90 days');
+	assertRadioOption('duration-180', 'durationPreset', '180', '180 days');
+	assertRadioOption('duration-custom', 'durationPreset', 'custom', 'Until a specific date');
 	assert.match(pageSource, /Access ends at the end of the selected day/);
 	assert.match(scriptSource, /const DURATION_LABELS = Object\.freeze/);
 	assert.match(scriptSource, /expiresAtFor/);
@@ -272,6 +322,8 @@ function assertStylesExist() {
 
 assertPageStructure();
 assertTopLevelAdminInformationArchitecture();
+assertUsesFullGOVUKFrontendTemplate();
+assertRoleAssignmentPageIsGeneratedFromNunjucks();
 assertCurrentAccessPanelIsReducedToTeamScope();
 assertExplicitTeamChoiceExists();
 assertMembershipCreationCopyExists();

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -7,6 +7,7 @@ const styleSource = fs.readFileSync('public/css/auth-role-assignments.css', 'utf
 const govukFrontendSource = fs.readFileSync('public/css/govuk/govuk-frontend-v6.css', 'utf8');
 const rendererSource = fs.readFileSync('scripts/govuk/render-govuk-pages.mjs', 'utf8');
 const templateSource = fs.readFileSync('src/govuk/templates/pages/role-assignments.njk', 'utf8');
+const normalizedPageText = pageSource.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 
 function escapeRegExp(value) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -16,7 +17,7 @@ function assertRadioOption(id, name, value, label) {
 	assert.match(
 		pageSource,
 		new RegExp(
-			`<input\\s+class="govuk-radios__input"\\s+id="${id}"\\s+name="${name}"\\s+type="radio"\\s+value="${value}"\\s*/>\\s*<label\\s+class="govuk-label govuk-radios__label"\\s+for="${id}">\\s*${escapeRegExp(label)}\\s*</label>`,
+			`<input\\s+class="govuk-radios__input"\\s+id="${id}"\\s+name="${name}"\\s+type="radio"\\s+value="${value}"\\s*/>\\s*<label\\s+class="govuk-label govuk-radios__label"\\s+for="${id}"\\s*>\\s*${escapeRegExp(label)}\\s*</label\\s*>`,
 		),
 	);
 }
@@ -136,8 +137,14 @@ function assertExplicitTeamChoiceExists() {
 
 function assertMembershipCreationCopyExists() {
 	assert.match(pageSource, /give someone access to a role in a ResearchOps team you manage/);
-	assert.match(pageSource, /ResearchOps will add them when you assign the\s+role/);
-	assert.match(pageSource, /If you create a new team, ResearchOps will make you Team\s+Admin for that team/);
+	assert.ok(
+		normalizedPageText.includes('ResearchOps will add them when you assign the role'),
+		'Expected membership creation copy to explain the person is added when the role is assigned',
+	);
+	assert.ok(
+		normalizedPageText.includes('If you create a new team, ResearchOps will make you Team Admin for that team'),
+		'Expected review copy to explain the assigner becomes Team Admin for a new team',
+	);
 	assert.match(scriptSource, /They were also added as an active member of this team/);
 	assert.match(scriptSource, /teamMembership/);
 	assert.match(scriptSource, /createdOrReactivated/);

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -61,7 +61,10 @@ function assertTopLevelAdminInformationArchitecture() {
 	assert.ok(breadcrumbIndex > -1, 'Expected breadcrumb navigation to exist');
 	assert.ok(mainIndex > -1, 'Expected main landmark to exist');
 	assert.ok(breadcrumbIndex > mainIndex, 'Expected breadcrumb navigation to sit inside main');
-	assert.match(pageSource, />Home</);
+	assert.match(
+		pageSource,
+		/<a class="govuk-breadcrumbs__link" href="\/">Home<\/a>[\s\S]*?<a class="govuk-breadcrumbs__link" href="\/pages\/account\/">Your account<\/a>[\s\S]*?>Team administration</,
+	);
 	assert.match(pageSource, />Team administration</);
 	assert.doesNotMatch(pageSource, /govuk-back-link/);
 	assert.doesNotMatch(pageSource, /Back to projects/);


### PR DESCRIPTION
## Summary
- Convert `/pages/team/role-assignments/` to a Nunjucks-generated GOV.UK frontend page using the shared `layouts/researchops.njk` shell.
- Register the template in the GOV.UK page renderer and commit the regenerated public HTML required by the current Cloudflare Pages deployment contract.
- Update the route-state guard to verify the renderer registration, shared GOV.UK chrome, legacy CSS removal, and role assignment controls without depending on one-line generated markup.
- Add the required audit trace for the `fix/` branch.

## Validation
- `npm run build:govuk-pages`
- `node --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js tests/visual-walkthrough-role-assignment-route-state.test.js tests/govuk-generated-html-test-source-route-state.test.js tests/govuk-frontend-service-pages-route-state.test.js tests/govuk-frontend-integration-route-state.test.js`
- `npm run trace:coverage`
- `git diff --check`
- `npx prettier -c scripts/govuk/render-govuk-pages.mjs tests/auth-role-assignment-ui-route-state.test.js docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json`

## Trace
- `docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.md`
- `docs/agent-audit/reasoning/2026/06/15/role-assignments-govuk-template.json`