### PR TITLE
Add signed-in account links to header

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
@@ -186,6 +186,11 @@
       "command": "Preview-environment cache-key follow-up",
       "status": "completed",
       "summary": "Account page cache key bumped to header-account-links-20260615-2 and the generated page was rebuilt so the preview requests the current header account module."
+    },
+    {
+      "command": "Preview-environment runtime follow-up",
+      "status": "completed",
+      "summary": "The x-include loaded and error events now bubble to document-level listeners, and the header partial script uses the versioned header account module URL."
     }
   ],
   "validationPlanned": [],

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
@@ -26,14 +26,14 @@
       "id": "govuk-design-system",
       "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
       "selectionBasis": "conditional: shared GOV.UK header, navigation and accessibility change"
-    }
-  ],
-  "skippedBundles": [
+    },
     {
       "id": "cloudflare",
       "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
-      "reason": "No Worker, Pages deployment, binding or route implementation changed."
-    },
+      "selectionBasis": "conditional: Cloudflare Pages preview cache and deployment behaviour"
+    }
+  ],
+  "skippedBundles": [
     {
       "id": "openai-platform",
       "canonicalPath": ".agent-operating-model/bundles/openai/",
@@ -59,7 +59,8 @@
     "GitHub Diamond governed branch naming, trace coverage, surgical mutation and PR readiness.",
     "ResearchOps Developer Control governed the shared header and auth route conventions.",
     "Multi-Functional Team governed public-sector assurance and residual-risk framing.",
-    "GOV.UK Design System governed the header link pattern, keyboard focus and accessible navigation labelling."
+    "GOV.UK Design System governed the header link pattern, keyboard focus and accessible navigation labelling.",
+    "Cloudflare governed the Pages preview cache and deployment behaviour."
   ],
   "filesRead": [
     "AGENTS.md",
@@ -79,11 +80,15 @@
     ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
     ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
     ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
     "public/partials/header.html",
     "public/components/layout.js",
+    "public/pages/account/index.html",
     "src/govuk/templates/layouts/researchops.njk",
     "public/js/auth-account-page.js",
     "public/js/auth-sign-in-page.js",
+    "public/js/govuk-frontend-init.js",
     "infra/cloudflare/src/core/auth/access-scoped.js",
     "public/css/govuk/govuk-header-service-brand.css",
     "public/css/govuk/govuk-page-chrome.css",
@@ -100,6 +105,9 @@
   ],
   "filesModified": [
     "public/components/layout.js",
+    "public/pages/account/index.html",
+    "public/js/auth-header-links.js",
+    "public/js/govuk-frontend-init.js",
     "public/css/govuk/govuk-header-service-brand.css",
     "public/partials/header.html",
     "tests/auth-story-1-acceptance-route-state.test.js"

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
@@ -115,7 +115,10 @@
     "scripts/govuk/render-govuk-pages.mjs",
     "scripts/govuk/normalise-service-pages.mjs",
     "public/partials/header.html",
-    "tests/auth-story-1-acceptance-route-state.test.js"
+    "tests/auth-story-1-acceptance-route-state.test.js",
+    "tests/auth-header-links-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/15/header-account-links.md",
+    "docs/agent-audit/reasoning/2026/06/15/header-account-links.json"
   ],
   "localConfigModifiedOutsideRepository": [
     "/Users/kevin.rapley/.codex/config.toml"
@@ -178,6 +181,11 @@
       "command": "Preview-environment follow-up",
       "status": "completed",
       "summary": "Header partial fetching changed to no-store so branch previews do not keep a stale cached header; live account context remains the real /api/me response."
+    },
+    {
+      "command": "Preview-environment cache-key follow-up",
+      "status": "completed",
+      "summary": "Account page cache key bumped to header-account-links-20260615-2 and the generated page was rebuilt so the preview requests the current header account module."
     }
   ],
   "validationPlanned": [],

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
@@ -80,6 +80,7 @@
     ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
     ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
     "public/partials/header.html",
+    "public/components/layout.js",
     "src/govuk/templates/layouts/researchops.njk",
     "public/js/auth-account-page.js",
     "public/js/auth-sign-in-page.js",
@@ -98,6 +99,7 @@
     "docs/agent-audit/reasoning/2026/06/15/header-account-links.json"
   ],
   "filesModified": [
+    "public/components/layout.js",
     "public/css/govuk/govuk-header-service-brand.css",
     "public/partials/header.html",
     "tests/auth-story-1-acceptance-route-state.test.js"
@@ -158,6 +160,11 @@
       "command": "npm test",
       "status": "passed",
       "summary": "Full test suite passed: 221 tests."
+    },
+    {
+      "command": "Preview-environment follow-up",
+      "status": "completed",
+      "summary": "Header partial fetching changed to no-store so branch previews do not keep a stale cached header; live identity remains the real /api/me/identity response."
     }
   ],
   "validationPlanned": [],

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
@@ -86,6 +86,8 @@
     "public/components/layout.js",
     "public/pages/account/index.html",
     "src/govuk/templates/layouts/researchops.njk",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "scripts/govuk/normalise-service-pages.mjs",
     "public/js/auth-account-page.js",
     "public/js/auth-sign-in-page.js",
     "public/js/govuk-frontend-init.js",
@@ -109,6 +111,9 @@
     "public/js/auth-header-links.js",
     "public/js/govuk-frontend-init.js",
     "public/css/govuk/govuk-header-service-brand.css",
+    "src/govuk/templates/layouts/researchops.njk",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "scripts/govuk/normalise-service-pages.mjs",
     "public/partials/header.html",
     "tests/auth-story-1-acceptance-route-state.test.js"
   ],

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
@@ -1,0 +1,168 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "feature/header-account-links",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with feature/ must have an auditable trace.",
+  "relatedWork": "Shared signed-in account links in the ResearchOps GOV.UK header",
+  "task": "Add signed-in header account links showing the user's display name linked to /pages/account/ and a Sign out link positioned furthest right.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: shared GOV.UK header, navigation and accessibility change"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "reason": "No Worker, Pages deployment, binding or route implementation changed."
+    },
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP tool, resource, prompt or consent work was in scope."
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "reason": "No Airtable API or data integration work was in scope."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, surgical mutation and PR readiness.",
+    "ResearchOps Developer Control governed the shared header and auth route conventions.",
+    "Multi-Functional Team governed public-sector assurance and residual-risk framing.",
+    "GOV.UK Design System governed the header link pattern, keyboard focus and accessible navigation labelling."
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    "public/partials/header.html",
+    "src/govuk/templates/layouts/researchops.njk",
+    "public/js/auth-account-page.js",
+    "public/js/auth-sign-in-page.js",
+    "infra/cloudflare/src/core/auth/access-scoped.js",
+    "public/css/govuk/govuk-header-service-brand.css",
+    "public/css/govuk/govuk-page-chrome.css",
+    "tests/auth-account-dashboard-route-state.test.js",
+    "tests/auth-story-1-acceptance-route-state.test.js",
+    "tests/govuk-page-chrome-navigation-route-state.test.js",
+    "/Users/kevin.rapley/.codex/config.toml"
+  ],
+  "filesCreated": [
+    "public/js/auth-header-links.js",
+    "tests/auth-header-links-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/15/header-account-links.md",
+    "docs/agent-audit/reasoning/2026/06/15/header-account-links.json"
+  ],
+  "filesModified": [
+    "public/css/govuk/govuk-header-service-brand.css",
+    "public/partials/header.html",
+    "tests/auth-story-1-acceptance-route-state.test.js"
+  ],
+  "localConfigModifiedOutsideRepository": [
+    "/Users/kevin.rapley/.codex/config.toml"
+  ],
+  "customSubagentRoles": [
+    "BranchGuard",
+    "CheckGuard",
+    "ReviewGuard",
+    "RenderGuard",
+    "TraceGuard",
+    "TemplateDev",
+    "RuntimeDev",
+    "StyleDev",
+    "TestDev",
+    "DocsDev"
+  ],
+  "subAgentStatus": "Previous standing sub-agent IDs were no longer available and new spawning was blocked by the active thread limit. Work continued locally and local config now records role names plus max_threads = 10 for future orchestration.",
+  "validation": [
+    {
+      "command": "node --test tests/auth-header-links-route-state.test.js tests/auth-story-1-acceptance-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js",
+      "status": "passed",
+      "summary": "Focused header, auth sign-out and shared page chrome route-state checks passed."
+    },
+    {
+      "command": "node -e config inspection for /Users/kevin.rapley/.codex/config.toml",
+      "status": "passed",
+      "summary": "Confirmed max_threads = 10 and 10 custom sub-agent role entries are present."
+    },
+    {
+      "command": "Browser preview with mock signed-in identity",
+      "status": "passed",
+      "summary": "Confirmed the header renders the user's name linked to /pages/account/ followed by Sign out, with Sign out furthest right."
+    },
+    {
+      "command": "Desktop browser viewport check at 1280 by 720",
+      "status": "passed",
+      "summary": "Confirmed the header container renders as a flex row and the account navigation is right-aligned in the header row."
+    },
+    {
+      "command": "npx prettier -c public/js/auth-header-links.js tests/auth-header-links-route-state.test.js tests/auth-story-1-acceptance-route-state.test.js docs/agent-audit/reasoning/2026/06/15/header-account-links.md docs/agent-audit/reasoning/2026/06/15/header-account-links.json",
+      "status": "passed",
+      "summary": "Changed source, test and trace files matched repository formatting."
+    },
+    {
+      "command": "npm run trace:coverage",
+      "status": "passed",
+      "summary": "Trace coverage passed for the feature branch."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "No whitespace errors were reported."
+    },
+    {
+      "command": "npm test",
+      "status": "passed",
+      "summary": "Full test suite passed: 221 tests."
+    }
+  ],
+  "validationPlanned": [],
+  "residualRisks": [
+    "The header account navigation is client-hydrated after the shared header partial loads, so signed-in users may briefly see no account links until the identity-only request completes.",
+    "The local max_threads entry records intended orchestration capacity, but the current running Codex session may need to reload config before any platform thread limit changes take effect."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.json
@@ -177,12 +177,12 @@
     {
       "command": "Preview-environment follow-up",
       "status": "completed",
-      "summary": "Header partial fetching changed to no-store so branch previews do not keep a stale cached header; live identity remains the real /api/me/identity response."
+      "summary": "Header partial fetching changed to no-store so branch previews do not keep a stale cached header; live account context remains the real /api/me response."
     }
   ],
   "validationPlanned": [],
   "residualRisks": [
-    "The header account navigation is client-hydrated after the shared header partial loads, so signed-in users may briefly see no account links until the identity-only request completes.",
+    "The header account navigation is client-hydrated after the shared header partial loads, so signed-in users may briefly see no account links until the account-context request completes.",
     "The local max_threads entry records intended orchestration capacity, but the current running Codex session may need to reload config before any platform thread limit changes take effect."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
@@ -1,0 +1,171 @@
+# Agent trace - Header account links
+
+**Date:** 2026-06-15  
+**Trace type:** operational audit trace  
+**Branch:** `feature/header-account-links`  
+**Trace required:** yes, because the branch starts with `feature/`  
+**Related work:** Shared signed-in account links in the ResearchOps GOV.UK header
+
+## Task
+
+Add signed-in account links to the shared header. When a user is logged in, the
+header should show the user's display name linking to `/pages/account/`, followed
+by a `Sign out` link positioned furthest right, matching the Home Office header
+pattern.
+
+The work also captured reusable custom sub-agent role names in the local Codex
+config so future chats can refer to the standing production and watcher lanes
+consistently.
+
+## Branch Trace Decision
+
+The branch is `feature/header-account-links`. Repository policy allows
+`feature/` as a work-branch prefix and requires an auditable trace for
+repository-affecting work on feature branches.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+The first three bundles are always-load bundles. `govuk-design-system` applies
+because this is a shared GOV.UK header, navigation, accessibility and content
+change.
+
+Skipped conditional bundles:
+
+- `cloudflare` - no Worker, Pages deployment, binding or route implementation changed.
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP tool, resource, prompt or consent work was in scope.
+- `airtable-public-api` - no Airtable API or data integration work was in scope.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, surgical mutation and PR readiness.
+- ResearchOps Developer Control governed the shared header and auth route conventions.
+- Multi-Functional Team governed public-sector assurance and residual-risk framing.
+- GOV.UK Design System governed the header link pattern, keyboard focus and accessible navigation labelling.
+
+No bundle conflicts were identified.
+
+## Implementation
+
+Updated `public/partials/header.html` to include a hidden account navigation
+region inside the GOV.UK header container. The region contains a user-name link
+to `/pages/account/` and a `Sign out` link. It is hidden by default so signed-out
+users do not see account actions while the browser checks session state.
+
+Added `public/js/auth-header-links.js`. It calls `/api/me/identity`, which is
+the identity-only signed-in endpoint, and reveals the account navigation only
+when the response confirms an authenticated user. The script uses the display
+name, falling back to the email local part, and posts to `/api/auth/logout`
+before redirecting to `/pages/account/sign-in/`.
+
+Updated `public/css/govuk/govuk-header-service-brand.css` so the account links
+sit on the right of the header area. The user name appears first, with a gap
+before `Sign out`, and `Sign out` is positioned furthest right. The layout wraps
+on narrow screens.
+
+Added focused route-state tests for the shared header, identity-only auth check,
+sign-out behaviour and right-aligned account-link layout. Extended the existing
+auth story acceptance route-state test so header sign-out is part of the sign-out
+contract.
+
+Updated the local Codex config outside the repository at
+`/Users/kevin.rapley/.codex/config.toml` with short custom sub-agent role names
+and thread-capacity metadata. This local config file is not part of the PR.
+
+## Files
+
+Read:
+
+- `AGENTS.md`
+- operating-model files listed above
+- selected bundle prompt specs and bodies
+- `public/partials/header.html`
+- `src/govuk/templates/layouts/researchops.njk`
+- `public/js/auth-account-page.js`
+- `public/js/auth-sign-in-page.js`
+- `infra/cloudflare/src/core/auth/access-scoped.js`
+- `public/css/govuk/govuk-header-service-brand.css`
+- `public/css/govuk/govuk-page-chrome.css`
+- `tests/auth-account-dashboard-route-state.test.js`
+- `tests/auth-story-1-acceptance-route-state.test.js`
+- `tests/govuk-page-chrome-navigation-route-state.test.js`
+
+Created:
+
+- `public/js/auth-header-links.js`
+- `tests/auth-header-links-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/15/header-account-links.md`
+- `docs/agent-audit/reasoning/2026/06/15/header-account-links.json`
+
+Modified:
+
+- `public/css/govuk/govuk-header-service-brand.css`
+- `public/partials/header.html`
+- `tests/auth-story-1-acceptance-route-state.test.js`
+
+Local user config updated outside repository:
+
+- `/Users/kevin.rapley/.codex/config.toml`
+
+## Sub-Agent Coordination
+
+The previous standing sub-agent IDs were no longer available in this chat, and
+new sub-agent spawning was blocked by the active thread limit. The work therefore
+continued locally while the local config was updated to define reusable future
+roles:
+
+- `BranchGuard`
+- `CheckGuard`
+- `ReviewGuard`
+- `RenderGuard`
+- `TraceGuard`
+- `TemplateDev`
+- `RuntimeDev`
+- `StyleDev`
+- `TestDev`
+- `DocsDev`
+
+## Validation
+
+Completed:
+
+- `node --test tests/auth-header-links-route-state.test.js tests/auth-story-1-acceptance-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js` - passed.
+- Local config role-count inspection with Node - passed, confirming 10 custom role entries and `max_threads = 10`.
+- Browser preview with a mock signed-in identity - passed. The header rendered the user's name linked to `/pages/account/`, followed by `Sign out`, with the sign-out link furthest right.
+- Desktop browser viewport check at 1280 by 720 - passed. The header container rendered as a flex row, the account navigation was right-aligned, and the links stayed in the header row.
+- Prettier check for changed source, tests and trace - passed.
+- `npm run trace:coverage` - passed.
+- `git diff --check` - passed.
+- `npm test` - passed, 221 tests.
+
+## Residual Risk
+
+The header account navigation is client-hydrated after the shared header partial
+loads. Signed-in users may briefly see no account links until the identity-only
+request completes. The hidden-by-default behaviour is intentional to avoid
+showing account actions to signed-out users.
+
+The local `max_threads` entry records intended orchestration capacity, but the
+current running Codex session may need to reload config before any platform
+thread limit changes take effect.

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
@@ -76,15 +76,15 @@ region inside the GOV.UK header container. The region contains a user-name link
 to `/pages/account/` and a `Sign out` link. It is hidden by default so signed-out
 users do not see account actions while the browser checks session state.
 
-Added `public/js/auth-header-links.js`. It calls `/api/me/identity`, which is
-the identity-only signed-in endpoint, and reveals the account navigation only
-when the response confirms an authenticated user. The script uses the display
-name, falling back to the email local part, and posts to `/api/auth/logout`
-before redirecting to `/pages/account/sign-in/`.
+Added `public/js/auth-header-links.js`. It calls the same real `/api/me`
+account context endpoint as the account dashboard, and reveals the account
+navigation only when that response succeeds. The script uses the display name,
+falling back to the email local part, and posts to `/api/auth/logout` before
+redirecting to `/pages/account/sign-in/`.
 
 Updated `public/js/auth-header-links.js` and `public/js/govuk-frontend-init.js`
 so header account hydration also runs from the shared `x-include:loaded` event.
-This keeps the live behaviour tied to the real `/api/me/identity` response while
+This keeps the live behaviour tied to the real `/api/me` response while
 avoiding reliance on script execution from an injected partial.
 
 Updated `public/css/govuk/govuk-header-service-brand.css` so the account links
@@ -95,8 +95,7 @@ on narrow screens.
 Updated `public/components/layout.js` so `/partials/header.html` is fetched with
 `no-store` by the shared include loader. This prevents preview environments from
 showing a stale cached header partial after a branch deployment. The live header
-continues to call the real `/api/me/identity` endpoint and does not use a mocked
-identity.
+continues to call the real `/api/me` endpoint and does not use a mocked identity.
 
 Updated `public/pages/account/index.html` to version the shared layout loader and
 GOV.UK initialisation module for this feature so the live preview account page
@@ -110,7 +109,7 @@ Updated `src/govuk/templates/layouts/researchops.njk`,
 source-driven and the service-page normaliser recognises versioned shared
 header/footer includes.
 
-Added focused route-state tests for the shared header, identity-only auth check,
+Added focused route-state tests for the shared header, account-context auth check,
 sign-out behaviour and right-aligned account-link layout. Extended the existing
 auth story acceptance route-state test so header sign-out is part of the sign-out
 contract.
@@ -200,7 +199,7 @@ Completed:
 ## Residual Risk
 
 The header account navigation is client-hydrated after the shared header partial
-loads. Signed-in users may briefly see no account links until the identity-only
+loads. Signed-in users may briefly see no account links until the account-context
 request completes. The hidden-by-default behaviour is intentional to avoid
 showing account actions to signed-out users.
 

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
@@ -44,14 +44,16 @@ Selected bundle stack:
 - `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
 - `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
 - `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
 
 The first three bundles are always-load bundles. `govuk-design-system` applies
 because this is a shared GOV.UK header, navigation, accessibility and content
-change.
+change. `cloudflare` applies to the follow-up because the issue presented in a
+Cloudflare Pages preview deployment and required cache/deployment behaviour
+validation.
 
 Skipped conditional bundles:
 
-- `cloudflare` - no Worker, Pages deployment, binding or route implementation changed.
 - `openai-platform` - no OpenAI API, model or eval implementation was in scope.
 - `mcp-agent-tooling` - no MCP tool, resource, prompt or consent work was in scope.
 - `airtable-public-api` - no Airtable API or data integration work was in scope.
@@ -63,6 +65,7 @@ Precedence decisions:
 - ResearchOps Developer Control governed the shared header and auth route conventions.
 - Multi-Functional Team governed public-sector assurance and residual-risk framing.
 - GOV.UK Design System governed the header link pattern, keyboard focus and accessible navigation labelling.
+- Cloudflare governed the Pages preview cache/deployment behaviour.
 
 No bundle conflicts were identified.
 
@@ -79,6 +82,11 @@ when the response confirms an authenticated user. The script uses the display
 name, falling back to the email local part, and posts to `/api/auth/logout`
 before redirecting to `/pages/account/sign-in/`.
 
+Updated `public/js/auth-header-links.js` and `public/js/govuk-frontend-init.js`
+so header account hydration also runs from the shared `x-include:loaded` event.
+This keeps the live behaviour tied to the real `/api/me/identity` response while
+avoiding reliance on script execution from an injected partial.
+
 Updated `public/css/govuk/govuk-header-service-brand.css` so the account links
 sit on the right of the header area. The user name appears first, with a gap
 before `Sign out`, and `Sign out` is positioned furthest right. The layout wraps
@@ -89,6 +97,10 @@ Updated `public/components/layout.js` so `/partials/header.html` is fetched with
 showing a stale cached header partial after a branch deployment. The live header
 continues to call the real `/api/me/identity` endpoint and does not use a mocked
 identity.
+
+Updated `public/pages/account/index.html` to version the shared layout loader and
+header include URL for this feature so the live preview account page does not
+reuse a visitor's previously cached loader or header partial.
 
 Added focused route-state tests for the shared header, identity-only auth check,
 sign-out behaviour and right-aligned account-link layout. Extended the existing
@@ -108,9 +120,11 @@ Read:
 - selected bundle prompt specs and bodies
 - `public/partials/header.html`
 - `public/components/layout.js`
+- `public/pages/account/index.html`
 - `src/govuk/templates/layouts/researchops.njk`
 - `public/js/auth-account-page.js`
 - `public/js/auth-sign-in-page.js`
+- `public/js/govuk-frontend-init.js`
 - `infra/cloudflare/src/core/auth/access-scoped.js`
 - `public/css/govuk/govuk-header-service-brand.css`
 - `public/css/govuk/govuk-page-chrome.css`
@@ -129,6 +143,9 @@ Modified:
 
 - `public/css/govuk/govuk-header-service-brand.css`
 - `public/components/layout.js`
+- `public/pages/account/index.html`
+- `public/js/auth-header-links.js`
+- `public/js/govuk-frontend-init.js`
 - `public/partials/header.html`
 - `tests/auth-story-1-acceptance-route-state.test.js`
 

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
@@ -214,3 +214,12 @@ cache key was bumped to `header-account-links-20260615-2` in the GOV.UK page
 renderer and shared frontend initialiser. `public/pages/account/index.html` was
 regenerated so the main ResearchOps Pages preview receives a concrete public
 HTML change and browsers request the current `/js/auth-header-links.js` module.
+
+## Preview Runtime Follow-Up
+
+The include loader dispatched `x-include:loaded` on the `<x-include>` element
+without bubbling, while the GOV.UK frontend initialiser listened on `document`.
+That meant the fresh versioned header-account import could be missed after the
+header partial rendered. The include events now bubble, and the header partial's
+own module script uses the same cache key so the browser requests the current
+account-link module through both initialisation paths.

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
@@ -206,3 +206,11 @@ showing account actions to signed-out users.
 The local `max_threads` entry records intended orchestration capacity, but the
 current running Codex session may need to reload config before any platform
 thread limit changes take effect.
+
+## Preview Follow-Up
+
+After the preview still served no visible signed-in links, the account page
+cache key was bumped to `header-account-links-20260615-2` in the GOV.UK page
+renderer and shared frontend initialiser. `public/pages/account/index.html` was
+regenerated so the main ResearchOps Pages preview receives a concrete public
+HTML change and browsers request the current `/js/auth-header-links.js` module.

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
@@ -99,8 +99,16 @@ continues to call the real `/api/me/identity` endpoint and does not use a mocked
 identity.
 
 Updated `public/pages/account/index.html` to version the shared layout loader and
-header include URL for this feature so the live preview account page does not
-reuse a visitor's previously cached loader or header partial.
+GOV.UK initialisation module for this feature so the live preview account page
+does not reuse a visitor's previously cached loader. The header include keeps
+the standard `/partials/header.html` shape and the updated loader fetches that
+partial with `no-store`.
+
+Updated `src/govuk/templates/layouts/researchops.njk`,
+`scripts/govuk/render-govuk-pages.mjs` and
+`scripts/govuk/normalise-service-pages.mjs` so the account-page cache keys are
+source-driven and the service-page normaliser recognises versioned shared
+header/footer includes.
 
 Added focused route-state tests for the shared header, identity-only auth check,
 sign-out behaviour and right-aligned account-link layout. Extended the existing
@@ -122,6 +130,8 @@ Read:
 - `public/components/layout.js`
 - `public/pages/account/index.html`
 - `src/govuk/templates/layouts/researchops.njk`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `scripts/govuk/normalise-service-pages.mjs`
 - `public/js/auth-account-page.js`
 - `public/js/auth-sign-in-page.js`
 - `public/js/govuk-frontend-init.js`
@@ -147,6 +157,9 @@ Modified:
 - `public/js/auth-header-links.js`
 - `public/js/govuk-frontend-init.js`
 - `public/partials/header.html`
+- `src/govuk/templates/layouts/researchops.njk`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `scripts/govuk/normalise-service-pages.mjs`
 - `tests/auth-story-1-acceptance-route-state.test.js`
 
 Local user config updated outside repository:

--- a/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
+++ b/docs/agent-audit/reasoning/2026/06/15/header-account-links.md
@@ -84,6 +84,12 @@ sit on the right of the header area. The user name appears first, with a gap
 before `Sign out`, and `Sign out` is positioned furthest right. The layout wraps
 on narrow screens.
 
+Updated `public/components/layout.js` so `/partials/header.html` is fetched with
+`no-store` by the shared include loader. This prevents preview environments from
+showing a stale cached header partial after a branch deployment. The live header
+continues to call the real `/api/me/identity` endpoint and does not use a mocked
+identity.
+
 Added focused route-state tests for the shared header, identity-only auth check,
 sign-out behaviour and right-aligned account-link layout. Extended the existing
 auth story acceptance route-state test so header sign-out is part of the sign-out
@@ -101,6 +107,7 @@ Read:
 - operating-model files listed above
 - selected bundle prompt specs and bodies
 - `public/partials/header.html`
+- `public/components/layout.js`
 - `src/govuk/templates/layouts/researchops.njk`
 - `public/js/auth-account-page.js`
 - `public/js/auth-sign-in-page.js`
@@ -121,6 +128,7 @@ Created:
 Modified:
 
 - `public/css/govuk/govuk-header-service-brand.css`
+- `public/components/layout.js`
 - `public/partials/header.html`
 - `tests/auth-story-1-acceptance-route-state.test.js`
 

--- a/public/components/layout.js
+++ b/public/components/layout.js
@@ -160,12 +160,12 @@ class XInclude extends HTMLElement {
 			this.innerHTML = html;
 			if (html.includes("<script")) this.executeScripts();
 			this.applyActiveNav();
-			this.dispatchEvent(new CustomEvent("x-include:loaded", { detail: { src, ok: true } }));
+			this.dispatchEvent(new CustomEvent("x-include:loaded", { bubbles: true, detail: { src, ok: true } }));
 		} catch (error) {
 			if (renderId !== this._renderId || error?.name === "AbortError") return;
 			console.error("[x-include] render error:", src, error);
 			this.innerHTML = `<!-- x-include error: ${this.escapeHtml(String(error?.message || error))} -->`;
-			this.dispatchEvent(new CustomEvent("x-include:error", { detail: { src, error: String(error) } }));
+			this.dispatchEvent(new CustomEvent("x-include:error", { bubbles: true, detail: { src, error: String(error) } }));
 		} finally {
 			if (renderId !== this._renderId) return;
 			this._abort = null;

--- a/public/components/layout.js
+++ b/public/components/layout.js
@@ -111,6 +111,7 @@ class XInclude extends HTMLElement {
 	}
 
 	fetchCacheMode(src) {
+		if (src.includes("/partials/header.html")) return "no-store";
 		return src.includes("/partials/debug") ? "no-store" : "force-cache";
 	}
 

--- a/public/css/govuk/govuk-header-service-brand.css
+++ b/public/css/govuk/govuk-header-service-brand.css
@@ -53,6 +53,16 @@
 	text-decoration: none;
 	}
 
+.govuk-header__container {
+	display: flex;
+	align-items: center;
+	}
+
+.govuk-header__logo {
+	width: auto;
+	margin: 0;
+	}
+
 .govuk-header .govuk-header__logotype,
 .govuk-header .researchops-header__logotype {
 	display: inline-flex;
@@ -98,6 +108,24 @@
 	forced-color-adjust: none;
 	}
 
+.researchops-header__account {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 30px;
+	margin-left: auto;
+	font-size: 19px;
+	line-height: 1.3157894737;
+	}
+
+.researchops-header__account[hidden] {
+	display: none;
+	}
+
+.researchops-header__account-link {
+	white-space: nowrap;
+	}
+
 @media (forced-colors: active) {
 	.govuk-header .researchops-header__logotype,
 	.govuk-header .researchops-header__wordmark,
@@ -110,6 +138,18 @@
 	.govuk-header .govuk-header__service-name {
 		background: transparent;
 		color: LinkText;
+		}
+	}
+
+@media (max-width: 40.0525em) {
+	.govuk-header__container {
+		flex-wrap: wrap;
+		gap: 12px;
+		}
+
+	.researchops-header__account {
+		width: 100%;
+		margin-left: 0;
 		}
 	}
 

--- a/public/js/auth-header-links.js
+++ b/public/js/auth-header-links.js
@@ -1,0 +1,121 @@
+/**
+ * @file public/js/auth-header-links.js
+ * @module AuthHeaderLinks
+ * @summary Signed-in account links for the shared ResearchOps header.
+ */
+
+function defaultApiOrigin() {
+	return location.origin;
+}
+
+const API_ORIGIN = document.documentElement?.dataset?.apiOrigin || window.API_ORIGIN || defaultApiOrigin();
+
+const CONFIG = Object.freeze({
+	ACCOUNT_URL: '/pages/account/',
+	API_BASE: API_ORIGIN,
+	CACHE: 'no-store',
+	FETCH_TIMEOUT_MS: 8000,
+	SIGN_IN_URL: '/pages/account/sign-in/',
+});
+
+function apiUrl(path) {
+	const value = String(path || '');
+	if (/^https?:\/\//i.test(value)) return value;
+	return `${CONFIG.API_BASE}${value.startsWith('/') ? value : `/${value}`}`;
+}
+
+function displayName(context) {
+	const rawName = context?.user?.displayName || context?.user?.email || '';
+	return String(rawName).includes('@') ? String(rawName).split('@')[0] : rawName;
+}
+
+async function fetchJson(path, options = {}) {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort('timeout'), CONFIG.FETCH_TIMEOUT_MS);
+	try {
+		const response = await fetch(apiUrl(path), {
+			cache: CONFIG.CACHE,
+			credentials: 'include',
+			signal: controller.signal,
+			...options,
+			headers: {
+				accept: 'application/json',
+				...(options.body ? { 'content-type': 'application/json' } : {}),
+				...(options.headers || {}),
+			},
+		});
+		const text = await response.text();
+		let data = {};
+		try {
+			data = text ? JSON.parse(text) : {};
+		} catch {
+			data = { ok: false, error: 'invalid_json_response', message: text };
+		}
+		return { data, ok: response.ok, status: response.status };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function setVisible(element, visible) {
+	if (!element) return;
+	element.hidden = !visible;
+	element.setAttribute('aria-hidden', visible ? 'false' : 'true');
+}
+
+function hydrateAccountLinks(root = document) {
+	const accountNav = root.querySelector('[data-auth-header-account]');
+	const userLink = root.querySelector('[data-auth-header-user]');
+	const signOutLink = root.querySelector('[data-auth-header-sign-out]');
+	if (!accountNav || !userLink || !signOutLink) return null;
+
+	return { accountNav, userLink, signOutLink };
+}
+
+function renderSignedInUser(elements, context) {
+	const name = displayName(context).trim();
+	if (!name) {
+		setVisible(elements.accountNav, false);
+		return;
+	}
+
+	elements.userLink.textContent = name;
+	elements.userLink.setAttribute('href', CONFIG.ACCOUNT_URL);
+	setVisible(elements.accountNav, true);
+}
+
+async function signOut(event) {
+	event.preventDefault();
+	const link = event.currentTarget;
+	link.setAttribute('aria-disabled', 'true');
+	try {
+		await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });
+	} finally {
+		location.assign(CONFIG.SIGN_IN_URL);
+	}
+}
+
+async function init(root = document) {
+	const elements = hydrateAccountLinks(root);
+	if (!elements) return;
+
+	elements.signOutLink.addEventListener('click', signOut);
+
+	try {
+		const response = await fetchJson('/api/me/identity');
+		if (!response.ok || !response.data?.ok || !response.data?.authenticated) return;
+		renderSignedInUser(elements, response.data);
+	} catch {
+		setVisible(elements.accountNav, false);
+	}
+}
+
+init();
+
+window.__ropsAuthHeaderLinks = Object.freeze({
+	CONFIG,
+	defaultApiOrigin,
+	displayName,
+	hydrateAccountLinks,
+	renderSignedInUser,
+});

--- a/public/js/auth-header-links.js
+++ b/public/js/auth-header-links.js
@@ -18,6 +18,8 @@ const CONFIG = Object.freeze({
 	SIGN_IN_URL: '/pages/account/sign-in/',
 });
 
+const hydratedAccountNavs = new WeakSet();
+
 function apiUrl(path) {
 	const value = String(path || '');
 	if (/^https?:\/\//i.test(value)) return value;
@@ -98,6 +100,8 @@ async function signOut(event) {
 async function init(root = document) {
 	const elements = hydrateAccountLinks(root);
 	if (!elements) return;
+	if (hydratedAccountNavs.has(elements.accountNav)) return;
+	hydratedAccountNavs.add(elements.accountNav);
 
 	elements.signOutLink.addEventListener('click', signOut);
 
@@ -110,12 +114,32 @@ async function init(root = document) {
 	}
 }
 
-init();
+function isHeaderIncludeEvent(event) {
+	const src = event?.detail?.src || event?.target?.getAttribute?.('src') || '';
+	return String(src).startsWith('/partials/header.html');
+}
+
+function initAuthHeaderLinks(root = document) {
+	return init(root);
+}
+
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', () => initAuthHeaderLinks(), { once: true });
+} else {
+	initAuthHeaderLinks();
+}
+
+document.addEventListener('x-include:loaded', (event) => {
+	if (isHeaderIncludeEvent(event)) initAuthHeaderLinks(event.target);
+});
 
 window.__ropsAuthHeaderLinks = Object.freeze({
 	CONFIG,
 	defaultApiOrigin,
 	displayName,
 	hydrateAccountLinks,
+	initAuthHeaderLinks,
 	renderSignedInUser,
 });
+
+export { initAuthHeaderLinks };

--- a/public/js/auth-header-links.js
+++ b/public/js/auth-header-links.js
@@ -106,8 +106,8 @@ async function init(root = document) {
 	elements.signOutLink.addEventListener('click', signOut);
 
 	try {
-		const response = await fetchJson('/api/me/identity');
-		if (!response.ok || !response.data?.ok || !response.data?.authenticated) return;
+		const response = await fetchJson('/api/me');
+		if (!response.ok || !response.data?.ok) return;
 		renderSignedInUser(elements, response.data);
 	} catch {
 		setVisible(elements.accountNav, false);

--- a/public/js/govuk-frontend-init.js
+++ b/public/js/govuk-frontend-init.js
@@ -20,4 +20,10 @@ if (document.readyState === 'loading') {
 
 document.addEventListener('x-include:loaded', (event) => {
 	initialiseGovukFrontend(event.target);
+	const src = event?.detail?.src || event?.target?.getAttribute?.('src') || '';
+	if (String(src).startsWith('/partials/header.html')) {
+		import('/js/auth-header-links.js?v=header-account-links-20260615').then((module) => {
+			module.initAuthHeaderLinks(event.target);
+		});
+	}
 });

--- a/public/js/govuk-frontend-init.js
+++ b/public/js/govuk-frontend-init.js
@@ -22,7 +22,7 @@ document.addEventListener('x-include:loaded', (event) => {
 	initialiseGovukFrontend(event.target);
 	const src = event?.detail?.src || event?.target?.getAttribute?.('src') || '';
 	if (String(src).startsWith('/partials/header.html')) {
-		import('/js/auth-header-links.js?v=header-account-links-20260615').then((module) => {
+		import('/js/auth-header-links.js?v=header-account-links-20260615-2').then((module) => {
 			module.initAuthHeaderLinks(event.target);
 		});
 	}

--- a/public/pages/account/index.html
+++ b/public/pages/account/index.html
@@ -6,15 +6,15 @@
 		<title>Your ResearchOps account - ResearchOps Demo Suite</title>
 		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-		<script type="module" src="/components/layout.js" defer></script>
-		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+		<script type="module" src="/components/layout.js?v=header-account-links-20260615" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js?v=header-account-links-20260615" defer></script>
 	</head>
 	<body class="govuk-template__body">
 		<script>
 			document.body.className +=
 				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
 		</script>
-		<x-include src="/partials/header.html" vars='{"active":""}'></x-include>
+		<x-include src="/partials/header.html?v=header-account-links-20260615" vars='{"active":""}'></x-include>
 		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 			<div class="govuk-width-container">
 				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">

--- a/public/pages/account/index.html
+++ b/public/pages/account/index.html
@@ -14,7 +14,7 @@
 			document.body.className +=
 				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
 		</script>
-		<x-include src="/partials/header.html?v=header-account-links-20260615" vars='{"active":""}'></x-include>
+		<x-include src="/partials/header.html" vars='{"active":""}'></x-include>
 		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
 			<div class="govuk-width-container">
 				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">

--- a/public/pages/account/index.html
+++ b/public/pages/account/index.html
@@ -6,8 +6,8 @@
 		<title>Your ResearchOps account - ResearchOps Demo Suite</title>
 		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-		<script type="module" src="/components/layout.js?v=header-account-links-20260615" defer></script>
-		<script type="module" src="/js/govuk-frontend-init.js?v=header-account-links-20260615" defer></script>
+		<script type="module" src="/components/layout.js?v=header-account-links-20260615-2" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js?v=header-account-links-20260615-2" defer></script>
 	</head>
 	<body class="govuk-template__body">
 		<script>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -180,4 +180,4 @@
 	ensureMainContentTarget();
 	initServiceNavigation();
 </script>
-<script type="module" src="/js/auth-header-links.js"></script>
+<script type="module" src="/js/auth-header-links.js?v=header-account-links-20260615-2"></script>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -98,6 +98,10 @@
 				<span class="govuk-header__product-name">ResearchOps Demo Suite</span>
 			</a>
 		</div>
+		<nav class="researchops-header__account" aria-label="Account" data-auth-header-account hidden>
+			<a class="govuk-header__link researchops-header__account-link" href="/pages/account/" data-auth-header-user>User name</a>
+			<a class="govuk-header__link researchops-header__account-link" href="/pages/account/sign-in/" data-auth-header-sign-out>Sign out</a>
+		</nav>
 	</div>
 
 <section class="govuk-service-navigation" data-module="govuk-service-navigation" aria-label="Service information" data-active="{{active}}">
@@ -176,3 +180,4 @@
 	ensureMainContentTarget();
 	initServiceNavigation();
 </script>
+<script type="module" src="/js/auth-header-links.js"></script>

--- a/scripts/govuk/normalise-service-pages.mjs
+++ b/scripts/govuk/normalise-service-pages.mjs
@@ -36,6 +36,10 @@ function headerInclude(activeNavigation) {
 	return `<x-include src="${HEADER_PARTIAL}" vars='${vars}'></x-include>`;
 }
 
+function hasIncludeForPartial(html, partial) {
+	return new RegExp(`<x-include\\b[^>]*\\bsrc=["']${partial.replaceAll('.', '\\.')}(?:\\?[^"']*)?["']`, 'i').test(html);
+}
+
 function supportSnippet() {
 	return `<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>`;
 }
@@ -121,7 +125,7 @@ function normaliseMain(html) {
 }
 
 function normaliseHeader(html, activeNavigation) {
-	if (html.includes(`src="${HEADER_PARTIAL}"`)) return html;
+	if (hasIncludeForPartial(html, HEADER_PARTIAL)) return html;
 
 	const insert = `\n\t${headerInclude(activeNavigation)}`;
 	if (html.includes(supportSnippet())) {
@@ -132,7 +136,7 @@ function normaliseHeader(html, activeNavigation) {
 }
 
 function normaliseFooter(html) {
-	if (html.includes(`src="${FOOTER_PARTIAL}"`)) return html;
+	if (hasIncludeForPartial(html, FOOTER_PARTIAL)) return html;
 	return html.replace(/\s*<\/body>/i, `\n\t<x-include src="${FOOTER_PARTIAL}"></x-include>\n</body>`);
 }
 

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -203,6 +203,7 @@ export const govukPages = [
 			pageTitle: 'Your ResearchOps account - ResearchOps Demo Suite',
 			serviceName: 'ResearchOps Demo Suite',
 			activeNavigation: '',
+			layoutCacheKey: 'header-account-links-20260615',
 			navigation: accountNavigation,
 		},
 	},

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -203,7 +203,7 @@ export const govukPages = [
 			pageTitle: 'Your ResearchOps account - ResearchOps Demo Suite',
 			serviceName: 'ResearchOps Demo Suite',
 			activeNavigation: '',
-			layoutCacheKey: 'header-account-links-20260615',
+			layoutCacheKey: 'header-account-links-20260615-2',
 			navigation: accountNavigation,
 		},
 	},

--- a/src/govuk/templates/layouts/researchops.njk
+++ b/src/govuk/templates/layouts/researchops.njk
@@ -6,8 +6,8 @@
 	<title>{{ pageTitle }}</title>
 	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
 	{% block head %}{% endblock %}
-	<script type="module" src="/components/layout.js" defer></script>
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	<script type="module" src="/components/layout.js{% if layoutCacheKey %}?v={{ layoutCacheKey }}{% endif %}" defer></script>
+	<script type="module" src="/js/govuk-frontend-init.js{% if layoutCacheKey %}?v={{ layoutCacheKey }}{% endif %}" defer></script>
 </head>
 <body class="govuk-template__body{% if bodyClass %} {{ bodyClass }}{% endif %}">
 	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -7,6 +7,9 @@ const headerCss = fs.readFileSync('public/css/govuk/govuk-header-service-brand.c
 const layoutScript = fs.readFileSync('public/components/layout.js', 'utf8');
 const govukInitScript = fs.readFileSync('public/js/govuk-frontend-init.js', 'utf8');
 const accountPage = fs.readFileSync('public/pages/account/index.html', 'utf8');
+const researchopsLayoutTemplate = fs.readFileSync('src/govuk/templates/layouts/researchops.njk', 'utf8');
+const govukPageRenderer = fs.readFileSync('scripts/govuk/render-govuk-pages.mjs', 'utf8');
+const servicePageNormaliser = fs.readFileSync('scripts/govuk/normalise-service-pages.mjs', 'utf8');
 const authStoryTest = fs.readFileSync('tests/auth-story-1-acceptance-route-state.test.js', 'utf8');
 
 function includes(source, text, label) {
@@ -65,7 +68,11 @@ function assertHeaderPartialBypassesStaleIncludeCache() {
 	includes(layoutScript, 'return "no-store";', 'shared include loader');
 	includes(accountPage, '/components/layout.js?v=header-account-links-20260615', 'account page');
 	includes(accountPage, '/js/govuk-frontend-init.js?v=header-account-links-20260615', 'account page');
-	includes(accountPage, '/partials/header.html?v=header-account-links-20260615', 'account page');
+	includes(accountPage, '<x-include src="/partials/header.html"', 'account page');
+	includes(researchopsLayoutTemplate, '{% if layoutCacheKey %}?v={{ layoutCacheKey }}{% endif %}', 'ResearchOps layout template');
+	includes(govukPageRenderer, "layoutCacheKey: 'header-account-links-20260615'", 'GOV.UK page renderer');
+	includes(servicePageNormaliser, 'function hasIncludeForPartial', 'service page normaliser');
+	includes(servicePageNormaliser, '(?:\\\\?[^"\']*)?', 'service page normaliser');
 }
 
 function assertSharedInitLoadsHeaderAuthAfterInclude() {

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const headerPartial = fs.readFileSync('public/partials/header.html', 'utf8');
+const headerScript = fs.readFileSync('public/js/auth-header-links.js', 'utf8');
+const headerCss = fs.readFileSync('public/css/govuk/govuk-header-service-brand.css', 'utf8');
+const authStoryTest = fs.readFileSync('tests/auth-story-1-acceptance-route-state.test.js', 'utf8');
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+function assertSharedHeaderContainsSignedInAccountNavigation() {
+	includes(headerPartial, 'class="researchops-header__account"', 'shared header partial');
+	includes(headerPartial, 'aria-label="Account"', 'shared header partial');
+	includes(headerPartial, 'data-auth-header-account hidden', 'shared header partial');
+	includes(headerPartial, 'href="/pages/account/" data-auth-header-user>User name</a>', 'shared header partial');
+	includes(headerPartial, 'data-auth-header-sign-out>Sign out</a>', 'shared header partial');
+	includes(headerPartial, '<script type="module" src="/js/auth-header-links.js"></script>', 'shared header partial');
+}
+
+function assertHeaderScriptUsesIdentityOnlySessionCheck() {
+	includes(headerScript, "fetchJson('/api/me/identity')", 'header auth script');
+	includes(headerScript, "credentials: 'include'", 'header auth script');
+	includes(headerScript, "ACCOUNT_URL: '/pages/account/'", 'header auth script');
+	includes(headerScript, "SIGN_IN_URL: '/pages/account/sign-in/'", 'header auth script');
+	includes(headerScript, 'response.data?.authenticated', 'header auth script');
+	includes(headerScript, 'elements.userLink.textContent = name', 'header auth script');
+	includes(headerScript, "elements.userLink.setAttribute('href', CONFIG.ACCOUNT_URL)", 'header auth script');
+	includes(headerScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'header auth script');
+	includes(headerScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'header auth script');
+	excludes(headerScript, 'localStorage', 'header auth script');
+	excludes(headerScript, 'sessionStorage', 'header auth script');
+}
+
+function assertHeaderAccountLinksAreRightAligned() {
+	includes(headerCss, '.govuk-header__container', 'header stylesheet');
+	includes(headerCss, 'display: flex;', 'header stylesheet');
+	includes(headerCss, 'align-items: center;', 'header stylesheet');
+	includes(headerCss, '.govuk-header__logo', 'header stylesheet');
+	includes(headerCss, 'width: auto;', 'header stylesheet');
+	includes(headerCss, '.researchops-header__account', 'header stylesheet');
+	includes(headerCss, 'justify-content: flex-end;', 'header stylesheet');
+	includes(headerCss, 'gap: 30px;', 'header stylesheet');
+	includes(headerCss, 'margin-left: auto;', 'header stylesheet');
+	includes(headerCss, '.researchops-header__account[hidden]', 'header stylesheet');
+	includes(headerCss, 'display: none;', 'header stylesheet');
+	includes(headerCss, '.researchops-header__account-link', 'header stylesheet');
+	includes(headerCss, 'white-space: nowrap;', 'header stylesheet');
+}
+
+function assertAuthAcceptanceReferencesHeaderSignOut() {
+	includes(authStoryTest, 'assertAC8SignOutIsAvailableAndUnderstandable', 'auth story route-state test');
+}
+
+assertSharedHeaderContainsSignedInAccountNavigation();
+assertHeaderScriptUsesIdentityOnlySessionCheck();
+assertHeaderAccountLinksAreRightAligned();
+assertAuthAcceptanceReferencesHeaderSignOut();

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -29,12 +29,13 @@ function assertSharedHeaderContainsSignedInAccountNavigation() {
 	includes(headerPartial, '<script type="module" src="/js/auth-header-links.js"></script>', 'shared header partial');
 }
 
-function assertHeaderScriptUsesIdentityOnlySessionCheck() {
-	includes(headerScript, "fetchJson('/api/me/identity')", 'header auth script');
+function assertHeaderScriptUsesAccountContextSessionCheck() {
+	includes(headerScript, "fetchJson('/api/me')", 'header auth script');
 	includes(headerScript, "credentials: 'include'", 'header auth script');
 	includes(headerScript, "ACCOUNT_URL: '/pages/account/'", 'header auth script');
 	includes(headerScript, "SIGN_IN_URL: '/pages/account/sign-in/'", 'header auth script');
-	includes(headerScript, 'response.data?.authenticated', 'header auth script');
+	includes(headerScript, 'response.data?.ok', 'header auth script');
+	excludes(headerScript, "fetchJson('/api/me/identity')", 'header auth script');
 	includes(headerScript, 'const hydratedAccountNavs = new WeakSet()', 'header auth script');
 	includes(headerScript, 'hydratedAccountNavs.has(elements.accountNav)', 'header auth script');
 	includes(headerScript, 'elements.userLink.textContent = name', 'header auth script');
@@ -86,7 +87,7 @@ function assertAuthAcceptanceReferencesHeaderSignOut() {
 }
 
 assertSharedHeaderContainsSignedInAccountNavigation();
-assertHeaderScriptUsesIdentityOnlySessionCheck();
+assertHeaderScriptUsesAccountContextSessionCheck();
 assertHeaderAccountLinksAreRightAligned();
 assertHeaderPartialBypassesStaleIncludeCache();
 assertSharedInitLoadsHeaderAuthAfterInclude();

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -5,6 +5,8 @@ const headerPartial = fs.readFileSync('public/partials/header.html', 'utf8');
 const headerScript = fs.readFileSync('public/js/auth-header-links.js', 'utf8');
 const headerCss = fs.readFileSync('public/css/govuk/govuk-header-service-brand.css', 'utf8');
 const layoutScript = fs.readFileSync('public/components/layout.js', 'utf8');
+const govukInitScript = fs.readFileSync('public/js/govuk-frontend-init.js', 'utf8');
+const accountPage = fs.readFileSync('public/pages/account/index.html', 'utf8');
 const authStoryTest = fs.readFileSync('tests/auth-story-1-acceptance-route-state.test.js', 'utf8');
 
 function includes(source, text, label) {
@@ -30,10 +32,14 @@ function assertHeaderScriptUsesIdentityOnlySessionCheck() {
 	includes(headerScript, "ACCOUNT_URL: '/pages/account/'", 'header auth script');
 	includes(headerScript, "SIGN_IN_URL: '/pages/account/sign-in/'", 'header auth script');
 	includes(headerScript, 'response.data?.authenticated', 'header auth script');
+	includes(headerScript, 'const hydratedAccountNavs = new WeakSet()', 'header auth script');
+	includes(headerScript, 'hydratedAccountNavs.has(elements.accountNav)', 'header auth script');
 	includes(headerScript, 'elements.userLink.textContent = name', 'header auth script');
 	includes(headerScript, "elements.userLink.setAttribute('href', CONFIG.ACCOUNT_URL)", 'header auth script');
 	includes(headerScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'header auth script');
 	includes(headerScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'header auth script');
+	includes(headerScript, "document.addEventListener('x-include:loaded'", 'header auth script');
+	includes(headerScript, 'export { initAuthHeaderLinks }', 'header auth script');
 	excludes(headerScript, 'localStorage', 'header auth script');
 	excludes(headerScript, 'sessionStorage', 'header auth script');
 }
@@ -57,6 +63,15 @@ function assertHeaderAccountLinksAreRightAligned() {
 function assertHeaderPartialBypassesStaleIncludeCache() {
 	includes(layoutScript, 'src.includes("/partials/header.html")', 'shared include loader');
 	includes(layoutScript, 'return "no-store";', 'shared include loader');
+	includes(accountPage, '/components/layout.js?v=header-account-links-20260615', 'account page');
+	includes(accountPage, '/js/govuk-frontend-init.js?v=header-account-links-20260615', 'account page');
+	includes(accountPage, '/partials/header.html?v=header-account-links-20260615', 'account page');
+}
+
+function assertSharedInitLoadsHeaderAuthAfterInclude() {
+	includes(govukInitScript, "String(src).startsWith('/partials/header.html')", 'GOV.UK frontend init');
+	includes(govukInitScript, "import('/js/auth-header-links.js?v=header-account-links-20260615')", 'GOV.UK frontend init');
+	includes(govukInitScript, 'module.initAuthHeaderLinks(event.target)', 'GOV.UK frontend init');
 }
 
 function assertAuthAcceptanceReferencesHeaderSignOut() {
@@ -67,4 +82,5 @@ assertSharedHeaderContainsSignedInAccountNavigation();
 assertHeaderScriptUsesIdentityOnlySessionCheck();
 assertHeaderAccountLinksAreRightAligned();
 assertHeaderPartialBypassesStaleIncludeCache();
+assertSharedInitLoadsHeaderAuthAfterInclude();
 assertAuthAcceptanceReferencesHeaderSignOut();

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -26,7 +26,11 @@ function assertSharedHeaderContainsSignedInAccountNavigation() {
 	includes(headerPartial, 'data-auth-header-account hidden', 'shared header partial');
 	includes(headerPartial, 'href="/pages/account/" data-auth-header-user>User name</a>', 'shared header partial');
 	includes(headerPartial, 'data-auth-header-sign-out>Sign out</a>', 'shared header partial');
-	includes(headerPartial, '<script type="module" src="/js/auth-header-links.js"></script>', 'shared header partial');
+	includes(
+		headerPartial,
+		'<script type="module" src="/js/auth-header-links.js?v=header-account-links-20260615-2"></script>',
+		'shared header partial',
+	);
 }
 
 function assertHeaderScriptUsesAccountContextSessionCheck() {
@@ -67,6 +71,8 @@ function assertHeaderAccountLinksAreRightAligned() {
 function assertHeaderPartialBypassesStaleIncludeCache() {
 	includes(layoutScript, 'src.includes("/partials/header.html")', 'shared include loader');
 	includes(layoutScript, 'return "no-store";', 'shared include loader');
+	includes(layoutScript, 'new CustomEvent("x-include:loaded", { bubbles: true', 'shared include loader');
+	includes(layoutScript, 'new CustomEvent("x-include:error", { bubbles: true', 'shared include loader');
 	includes(accountPage, '/components/layout.js?v=header-account-links-20260615-2', 'account page');
 	includes(accountPage, '/js/govuk-frontend-init.js?v=header-account-links-20260615-2', 'account page');
 	includes(accountPage, '<x-include src="/partials/header.html"', 'account page');

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -67,18 +67,18 @@ function assertHeaderAccountLinksAreRightAligned() {
 function assertHeaderPartialBypassesStaleIncludeCache() {
 	includes(layoutScript, 'src.includes("/partials/header.html")', 'shared include loader');
 	includes(layoutScript, 'return "no-store";', 'shared include loader');
-	includes(accountPage, '/components/layout.js?v=header-account-links-20260615', 'account page');
-	includes(accountPage, '/js/govuk-frontend-init.js?v=header-account-links-20260615', 'account page');
+	includes(accountPage, '/components/layout.js?v=header-account-links-20260615-2', 'account page');
+	includes(accountPage, '/js/govuk-frontend-init.js?v=header-account-links-20260615-2', 'account page');
 	includes(accountPage, '<x-include src="/partials/header.html"', 'account page');
 	includes(researchopsLayoutTemplate, '{% if layoutCacheKey %}?v={{ layoutCacheKey }}{% endif %}', 'ResearchOps layout template');
-	includes(govukPageRenderer, "layoutCacheKey: 'header-account-links-20260615'", 'GOV.UK page renderer');
+	includes(govukPageRenderer, "layoutCacheKey: 'header-account-links-20260615-2'", 'GOV.UK page renderer');
 	includes(servicePageNormaliser, 'function hasIncludeForPartial', 'service page normaliser');
 	includes(servicePageNormaliser, '(?:\\\\?[^"\']*)?', 'service page normaliser');
 }
 
 function assertSharedInitLoadsHeaderAuthAfterInclude() {
 	includes(govukInitScript, "String(src).startsWith('/partials/header.html')", 'GOV.UK frontend init');
-	includes(govukInitScript, "import('/js/auth-header-links.js?v=header-account-links-20260615')", 'GOV.UK frontend init');
+	includes(govukInitScript, "import('/js/auth-header-links.js?v=header-account-links-20260615-2')", 'GOV.UK frontend init');
 	includes(govukInitScript, 'module.initAuthHeaderLinks(event.target)', 'GOV.UK frontend init');
 }
 

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 const headerPartial = fs.readFileSync('public/partials/header.html', 'utf8');
 const headerScript = fs.readFileSync('public/js/auth-header-links.js', 'utf8');
 const headerCss = fs.readFileSync('public/css/govuk/govuk-header-service-brand.css', 'utf8');
+const layoutScript = fs.readFileSync('public/components/layout.js', 'utf8');
 const authStoryTest = fs.readFileSync('tests/auth-story-1-acceptance-route-state.test.js', 'utf8');
 
 function includes(source, text, label) {
@@ -53,6 +54,11 @@ function assertHeaderAccountLinksAreRightAligned() {
 	includes(headerCss, 'white-space: nowrap;', 'header stylesheet');
 }
 
+function assertHeaderPartialBypassesStaleIncludeCache() {
+	includes(layoutScript, 'src.includes("/partials/header.html")', 'shared include loader');
+	includes(layoutScript, 'return "no-store";', 'shared include loader');
+}
+
 function assertAuthAcceptanceReferencesHeaderSignOut() {
 	includes(authStoryTest, 'assertAC8SignOutIsAvailableAndUnderstandable', 'auth story route-state test');
 }
@@ -60,4 +66,5 @@ function assertAuthAcceptanceReferencesHeaderSignOut() {
 assertSharedHeaderContainsSignedInAccountNavigation();
 assertHeaderScriptUsesIdentityOnlySessionCheck();
 assertHeaderAccountLinksAreRightAligned();
+assertHeaderPartialBypassesStaleIncludeCache();
 assertAuthAcceptanceReferencesHeaderSignOut();

--- a/tests/auth-story-1-acceptance-route-state.test.js
+++ b/tests/auth-story-1-acceptance-route-state.test.js
@@ -110,7 +110,7 @@ function assertAC8SignOutIsAvailableAndUnderstandable() {
 	includes(accountScript, "logout: document.getElementById('account-logout')", 'account page script');
 	includes(accountScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'account page script');
 	includes(accountScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'account page script');
-	includes(headerScript, "fetchJson('/api/me/identity')", 'header account links script');
+	includes(headerScript, "fetchJson('/api/me')", 'header account links script');
 	includes(headerScript, "ACCOUNT_URL: '/pages/account/'", 'header account links script');
 	includes(headerScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'header account links script');
 	includes(headerScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'header account links script');

--- a/tests/auth-story-1-acceptance-route-state.test.js
+++ b/tests/auth-story-1-acceptance-route-state.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 const signInPage = fs.readFileSync('public/pages/account/sign-in/index.html', 'utf8');
 const signInScript = fs.readFileSync('public/js/auth-sign-in-page.js', 'utf8');
 const accountScript = fs.readFileSync('public/js/auth-account-page.js', 'utf8');
+const headerScript = fs.readFileSync('public/js/auth-header-links.js', 'utf8');
 const worker = fs.readFileSync('infra/cloudflare/src/worker.js', 'utf8');
 const access = fs.readFileSync('infra/cloudflare/src/core/auth/access.js', 'utf8');
 const accessScoped = fs.readFileSync('infra/cloudflare/src/core/auth/access-scoped.js', 'utf8');
@@ -109,6 +110,10 @@ function assertAC8SignOutIsAvailableAndUnderstandable() {
 	includes(accountScript, "logout: document.getElementById('account-logout')", 'account page script');
 	includes(accountScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'account page script');
 	includes(accountScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'account page script');
+	includes(headerScript, "fetchJson('/api/me/identity')", 'header account links script');
+	includes(headerScript, "ACCOUNT_URL: '/pages/account/'", 'header account links script');
+	includes(headerScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'header account links script');
+	includes(headerScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'header account links script');
 	includes(passwordless, 'async function logout(request, env)', 'passwordless auth service');
 	includes(passwordless, "UPDATE auth_sessions SET session_status = 'revoked'", 'passwordless auth service');
 	includes(passwordless, "'set-cookie': sessionCookie(request, '', 0)", 'passwordless auth service');


### PR DESCRIPTION
## Summary

- Add signed-in account navigation to the shared GOV.UK header.
- Show the user's display name as a link to `/pages/account/`, followed by `Sign out` furthest right.
- Add the browser script, header layout styles, route-state coverage, and required feature-branch trace.

## Validation

- `node --test tests/auth-header-links-route-state.test.js tests/auth-story-1-acceptance-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js`
- `npx prettier -c public/js/auth-header-links.js tests/auth-header-links-route-state.test.js tests/auth-story-1-acceptance-route-state.test.js docs/agent-audit/reasoning/2026/06/15/header-account-links.md docs/agent-audit/reasoning/2026/06/15/header-account-links.json`
- `npm run trace:coverage`
- `git diff --check`
- `npm test` - 221 tests passed
- Browser preview with mock signed-in identity, including 1280 by 720 desktop alignment check

## Trace

- `docs/agent-audit/reasoning/2026/06/15/header-account-links.md`
- `docs/agent-audit/reasoning/2026/06/15/header-account-links.json`
