### PR TITLE
Fix role assignment check-answers layout and hide internal codes in success message

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
@@ -1,0 +1,164 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/role-assignment-check-answers",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "relatedWork": "PR #401 Codex review comment",
+  "task": "Move the branch from an unapproved claude/ prefix to a sensible fix/ branch and inspect Codex review comments.",
+  "branchCorrection": {
+    "from": "claude/lucid-ritchie-s7jjmz",
+    "to": "fix/role-assignment-check-answers",
+    "reason": "Repository policy allows fix/ work branches and prohibits claude/ work branches."
+  },
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: GOV.UK page template and generated route output"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: cached Pages asset concern"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP server, resource, prompt or tool contract work was in scope."
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "reason": "No Airtable API or data integration work was in scope."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, PR comment handling and validation evidence.",
+    "ResearchOps Developer Control governed repository conventions and generated-page output.",
+    "Multi-Functional Team governed public-sector privacy risk framing.",
+    "GOV.UK Design System governed the Nunjucks page/template output boundary.",
+    "Cloudflare governed the cache-risk interpretation for committed public assets."
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    "src/govuk/templates/pages/role-assignments.njk",
+    "public/pages/team/role-assignments/index.html",
+    "tests/auth-role-assignment-ui-route-state.test.js",
+    "tests/auth-role-assignment-error-copy-route-state.test.js",
+    "PR #401 comments and review threads"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md",
+    "docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json"
+  ],
+  "filesModified": [
+    "public/pages/team/role-assignments/index.html",
+    "src/govuk/templates/pages/role-assignments.njk",
+    "tests/auth-role-assignment-ui-route-state.test.js",
+    "tests/auth-role-assignment-error-copy-route-state.test.js"
+  ],
+  "unrelatedLocalChangesPreserved": [
+    "infra/cloudflare/src/core/auth/passwordless.js",
+    "ResearchOps.sublime-workspace"
+  ],
+  "codexReviewThreads": [
+    {
+      "pr": 401,
+      "threadId": "PRRT_kwDOP3Td2M6JqmG9",
+      "commentId": 3415564495,
+      "path": "public/js/auth-role-assignment-page.js",
+      "line": 639,
+      "isResolved": false,
+      "isOutdated": false,
+      "classification": "legitimate",
+      "workItem": "Bump the role-assignment script query string in the page and template so cached clients fetch the updated success-message script.",
+      "disposition": "Implemented locally; not yet acknowledged or resolved because the fix has not been committed and pushed to the PR branch."
+    }
+  ],
+  "subAgents": [
+    {
+      "nickname": "Popper",
+      "role": "PR comment state inspection",
+      "result": "Read-only inspection of PR #401 comments and review threads."
+    },
+    {
+      "nickname": "Socrates",
+      "role": "script version reference inspection",
+      "result": "Read-only inspection of cache-key references and route-state assertions."
+    }
+  ],
+  "validation": [
+    {
+      "command": "rg \"inline-team-creation-20260513|hide-internal-codes-20260615|auth-role-assignment-page\\\\.js\\\\?v=\" public/pages/team/role-assignments/index.html src/govuk/templates/pages/role-assignments.njk tests docs --glob '!node_modules'",
+      "status": "passed",
+      "summary": "Only the new role-assignment script version remains in active page, template and test references."
+    },
+    {
+      "command": "node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js",
+      "status": "passed",
+      "summary": "Focused role-assignment route-state tests passed: 2 tests passed."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "No whitespace errors were found."
+    },
+    {
+      "command": "npm test -- --ci tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js",
+      "status": "failed",
+      "summary": "The npm script forwards --ci to Node, which fails with node: bad option: --ci."
+    }
+  ],
+  "residualRisk": [
+    "The local branch tracks origin/claude/lucid-ritchie-s7jjmz until a remote fix/ branch or PR branch update is pushed.",
+    "The Codex thread has not yet been reacted to, replied to or resolved because the fix has not been committed and pushed to the PR branch."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
@@ -1,0 +1,129 @@
+# Agent trace - Role assignment cache-bust Codex review
+
+**Date:** 2026-06-15  
+**Trace type:** operational audit trace  
+**Branch:** `fix/role-assignment-check-answers`  
+**Trace required:** yes, because the branch starts with `fix/`  
+**Related work:** PR #401 Codex review comment
+
+## Task
+
+Move the working branch from an unapproved `claude/` prefix to a sensible `fix/`
+branch and inspect Codex review comments. PR #401 had one active Codex review
+thread requiring the role-assignment script cache key to be refreshed so cached
+clients do not continue to run the old success-message code.
+
+## Branch Trace Decision
+
+The work started on `claude/lucid-ritchie-s7jjmz`, which is not an approved
+work-branch prefix under the repository operating model. The local branch was
+renamed to `fix/role-assignment-check-answers`.
+
+Repository policy requires an auditable trace for repository-affecting work on
+`fix/` branches, so this trace is required even without the legacy `[reasoning]`
+token.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+The first three bundles are always-load bundles. `govuk-design-system` applies
+because the fix updates a GOV.UK page template and generated route output.
+`cloudflare` applies because the Codex review comment concerned cached Pages
+assets served from committed `public/` output.
+
+Skipped conditional bundles:
+
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP server, resource, prompt or tool contract work was in scope.
+- `airtable-public-api` - no Airtable API or data integration work was in scope.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, PR comment handling and validation evidence.
+- ResearchOps Developer Control governed repository conventions and generated-page output.
+- Multi-Functional Team governed public-sector privacy risk framing.
+- GOV.UK Design System governed the Nunjucks page/template output boundary.
+- Cloudflare governed the cache-risk interpretation for committed public assets.
+
+No bundle conflicts were identified.
+
+## Codex Review Thread
+
+PR #401 had one unresolved, non-outdated Codex review thread:
+
+- `public/js/auth-role-assignment-page.js`, lines 636-639
+- Comment ID `3415564495`
+- Thread ID `PRRT_kwDOP3Td2M6JqmG9`
+- Disposition: legitimate
+
+The comment noted that `/js/auth-role-assignment-page.js?v=inline-team-creation-20260513`
+was still used by the rendered page and Nunjucks template after the success
+message privacy fix, while `/js/*` assets are cached. The requested work item
+was to bump the script version in both page and template.
+
+## Implementation
+
+Updated the role-assignment script query string from
+`inline-team-creation-20260513` to `hide-internal-codes-20260615` in:
+
+- `src/govuk/templates/pages/role-assignments.njk`
+- `public/pages/team/role-assignments/index.html`
+
+Updated route-state tests that assert the generated route and template script
+URL:
+
+- `tests/auth-role-assignment-ui-route-state.test.js`
+- `tests/auth-role-assignment-error-copy-route-state.test.js`
+
+Existing unrelated local changes were preserved and not reverted:
+
+- `infra/cloudflare/src/core/auth/passwordless.js`
+- `ResearchOps.sublime-workspace`
+
+## Sub-Agent Coordination
+
+- Popper inspected PR #401 comment state and review threads in a read-only lane.
+- Socrates checked script cache-key references and generated/test assertion locations in a read-only lane.
+
+## Validation
+
+Attempted:
+
+- `rg "inline-team-creation-20260513|hide-internal-codes-20260615|auth-role-assignment-page\\.js\\?v=" ...` - passed; only the new version remains in active page/template/test references.
+- `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js` - passed; 2 tests passed.
+- `git diff --check` - passed.
+
+Not run:
+
+- Full repository validation suite, because the change is a narrow PR-review cache-key update with focused route-state coverage.
+- `npm test -- --ci tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js`, because the current npm script forwards `--ci` to Node and fails with `node: bad option: --ci`.
+
+## Residual Risk
+
+The local branch now has an approved `fix/` name, but its upstream still points
+at `origin/claude/lucid-ritchie-s7jjmz` until a remote branch or PR head update
+is pushed. The Codex thread has not yet been reacted to, replied to or resolved
+because the fix has not been committed and pushed to the PR branch in this step.

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -241,15 +241,22 @@
 	}
 
 .govuk-summary-list {
+	display: block;
+	width: 100%;
 	margin: 0 0 25px;
 	}
 
 .govuk-summary-list__row {
 	display: grid;
 	gap: 15px;
-	grid-template-columns: minmax(140px, 1fr) 2fr auto;
+	grid-template-columns: minmax(160px, 1fr) 2fr auto;
 	padding: 10px 0;
 	border-bottom: 1px solid #b1b4b6;
+	}
+
+.govuk-summary-list__key {
+	overflow-wrap: break-word;
+	word-break: normal;
 	}
 
 .govuk-summary-list__key {

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -626,7 +626,6 @@ function showResult(data) {
 	if (!dom.result) return;
 	const role = data.role || {};
 	const targetUser = data.targetUser || {};
-	const assignment = data.assignment || {};
 	const membership = data.teamMembership || {};
 	const team = data.team || {};
 
@@ -637,8 +636,6 @@ function showResult(data) {
 ${team.created ? `<p class="govuk-body">The team <strong>${escapeHtml(teamLabel(team))}</strong> was created.</p>` : ""}
 <p class="govuk-body"><strong>${escapeHtml(role.label || role.key)}</strong> was assigned to ${escapeHtml(targetUser.displayName || targetUser.email || targetUser.id)} in ${escapeHtml(teamLabel(team))}.</p>
 ${membership.createdOrReactivated ? '<p class="govuk-body">They were also added as an active member of this team.</p>' : ""}
-<p class="govuk-body">Assignment ID: <code>${escapeHtml(assignment.id)}</code></p>
-<p class="govuk-body">Scope: <code>${escapeHtml(assignment.scopeId)}</code></p>
 `;
 	dom.result.focus?.();
 }

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -551,6 +551,6 @@
 		</main>
 		<x-include src="/partials/footer.html"></x-include>
 
-		<script type="module" src="/js/auth-role-assignment-page.js?v=inline-team-creation-20260513"></script>
+		<script type="module" src="/js/auth-role-assignment-page.js?v=hide-internal-codes-20260615"></script>
 	</body>
 </html>

--- a/src/govuk/templates/pages/role-assignments.njk
+++ b/src/govuk/templates/pages/role-assignments.njk
@@ -607,6 +607,6 @@
 {% endblock %} {% block scripts %}
 <script
 	type="module"
-	src="/js/auth-role-assignment-page.js?v=inline-team-creation-20260513"
+	src="/js/auth-role-assignment-page.js?v=hide-internal-codes-20260615"
 ></script>
 {% endblock %}

--- a/tests/auth-role-assignment-error-copy-route-state.test.js
+++ b/tests/auth-role-assignment-error-copy-route-state.test.js
@@ -31,7 +31,7 @@ function assertRoleAssignmentErrorsDoNotExposeProgrammaticTerms() {
 }
 
 function assertRoleAssignmentScriptCacheKeyWasRefreshed() {
-	assert.match(pageSource, /auth-role-assignment-page\.js\?v=inline-team-creation-20260513/);
+	assert.match(pageSource, /auth-role-assignment-page\.js\?v=hide-internal-codes-20260615/);
 }
 
 assertRoleAssignmentErrorsAreUserFacing();

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -49,7 +49,7 @@ function assertPageStructure() {
 	assert.match(pageSource, /id="confirm-role-assignment"/);
 	assert.match(pageSource, /Confirm and assign role/);
 	assert.match(pageSource, /id="role-assignment-result"/);
-	assert.match(pageSource, /\/js\/auth-role-assignment-page\.js\?v=inline-team-creation-20260513/);
+	assert.match(pageSource, /\/js\/auth-role-assignment-page\.js\?v=hide-internal-codes-20260615/);
 	assert.match(pageSource, /\/css\/auth-role-assignments\.css/);
 }
 
@@ -98,7 +98,7 @@ function assertRoleAssignmentPageIsGeneratedFromNunjucks() {
 	assert.match(templateSource, /{% block content %}/);
 	assert.match(templateSource, /id="role-assignment-form"/);
 	assert.match(templateSource, /{% block scripts %}/);
-	assert.match(templateSource, /\/js\/auth-role-assignment-page\.js\?v=inline-team-creation-20260513/);
+	assert.match(templateSource, /\/js\/auth-role-assignment-page\.js\?v=hide-internal-codes-20260615/);
 	assert.doesNotMatch(templateSource, /<html class="govuk-template"/);
 	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/header\.html"/);
 	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/footer\.html"/);


### PR DESCRIPTION
## What

Two fixes to the **Assign a role to a team member** page (`/pages/team/role-assignments/`), both reported from live testing.

### 1. Broken "Check and confirm" layout
The summary-list keys wrapped character-by-character (e.g. `Team / mem / ber / email`, `Acces / s / durati / on`).

**Cause:** a `display` conflict between the two stylesheets the page loads. `govuk-frontend.css` sets `.govuk-summary-list{display:table; table-layout:fixed}` and `.govuk-summary-list__row{display:table-row}`, but `auth-role-assignments.css` overrode only the **row** to `display:grid` while leaving the `<dl>` as `display:table`. A `display:table` parent with `display:grid` children generates broken anonymous table boxes, collapsing the key column to minimum width.

**Fix:** set `.govuk-summary-list{display:block; width:100%}` so grid rows are direct flow children; widen the key column min from `140px` to `160px`; add `overflow-wrap:break-word; word-break:normal` to the key so it wraps at spaces. Change is page-scoped (this CSS only loads on the role-assignments page).

### 2. Internal codes leaked into the success message
The "Role assigned" panel exposed developer-facing identifiers:

```
Assignment ID: asn_031bc56b
Scope: team_daas
```

**Fix:** removed both lines (and the now-unused `assignment` variable). The confirmation still names the role, person and team in plain language, consistent with the page's principle of not exposing implementation terms to users.

## Testing
- `node --test` on the three relevant suites — all pass:
  - `tests/auth-role-assignment-ui-route-state.test.js`
  - `tests/auth-role-assignment-api-route-state.test.js`
  - `tests/govuk-tables-summary-lists-application-route-state.test.js`

## Files
- `public/css/auth-role-assignments.css`
- `public/js/auth-role-assignment-page.js`

https://claude.ai/code/session_01SikGXSRUJZJRTmv962RUVn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SikGXSRUJZJRTmv962RUVn)_