### PR TITLE
Fix role assignment check-answers layout and hide internal codes

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
@@ -5,7 +5,7 @@
   "traceRequired": true,
   "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
   "relatedWork": "PR #401 Codex review comment; replacement PR #402",
-  "task": "Move the branch from an unapproved claude/ prefix to a sensible fix/ branch and inspect Codex review comments.",
+  "task": "Move the branch from an unapproved claude/ prefix to a sensible fix/ branch, inspect Codex review comments, and ensure the role-assignment check-answers view uses GOV.UK Summary list layout from Sass/Nunjucks sources.",
   "branchCorrection": {
     "from": "claude/lucid-ritchie-s7jjmz",
     "to": "fix/role-assignment-check-answers",
@@ -92,20 +92,32 @@
     ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
     ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
     "src/govuk/templates/pages/role-assignments.njk",
+    "src/styles/auth-role-assignments.scss",
+    "scripts/styles/generated-css-targets.mjs",
     "public/pages/team/role-assignments/index.html",
+    "public/css/auth-role-assignments.css",
     "tests/auth-role-assignment-ui-route-state.test.js",
     "tests/auth-role-assignment-error-copy-route-state.test.js",
     "PR #401 comments and review threads"
   ],
   "filesCreated": [
+    "src/styles/auth-role-assignments.scss",
     "docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md",
     "docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json"
   ],
   "filesModified": [
+    "public/css/auth-role-assignments.css",
     "public/pages/team/role-assignments/index.html",
+    "scripts/styles/generated-css-targets.mjs",
     "src/govuk/templates/pages/role-assignments.njk",
     "tests/auth-role-assignment-ui-route-state.test.js",
     "tests/auth-role-assignment-error-copy-route-state.test.js"
+  ],
+  "followUps": [
+    {
+      "request": "Make certain the check-answers layout is only using GOV.UK component code with Sass and Nunjucks.",
+      "disposition": "Added a Sass source for the role-assignment stylesheet, registered it as a generated CSS target, removed page-specific .govuk-summary-list layout overrides, and asserted that Summary list layout comes from GOV.UK frontend."
+    }
   ],
   "unrelatedLocalChangesPreserved": [
     "infra/cloudflare/src/core/auth/passwordless.js",
@@ -147,6 +159,26 @@
       "command": "node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js",
       "status": "passed",
       "summary": "Focused role-assignment route-state tests passed: 2 tests passed."
+    },
+    {
+      "command": "npm run build:generated-css -- public/css/auth-role-assignments.css",
+      "status": "passed",
+      "summary": "Regenerated public/css/auth-role-assignments.css from src/styles/auth-role-assignments.scss."
+    },
+    {
+      "command": "npm run generated-css:check",
+      "status": "passed",
+      "summary": "Generated CSS formatting check passed."
+    },
+    {
+      "command": "node --test tests/sass-migration-route-state.test.js tests/govuk-frontend-integration-route-state.test.js",
+      "status": "passed",
+      "summary": "Sass migration and GOV.UK frontend integration route-state tests passed."
+    },
+    {
+      "command": "Local browser preview at http://127.0.0.1:4175/pages/team/role-assignments/",
+      "status": "passed",
+      "summary": "Computed check-answers Summary list layout used table, table-row and table-cell display values from GOV.UK frontend, with no grid template columns."
     },
     {
       "command": "git diff --check",

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
@@ -1,0 +1,164 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/role-assignment-check-answers",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "relatedWork": "PR #401 Codex review comment",
+  "task": "Move the branch from an unapproved claude/ prefix to a sensible fix/ branch and inspect Codex review comments.",
+  "branchCorrection": {
+    "from": "claude/lucid-ritchie-s7jjmz",
+    "to": "fix/role-assignment-check-answers",
+    "reason": "Repository policy allows fix/ work branches and prohibits claude/ work branches."
+  },
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: GOV.UK page template and generated route output"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: cached Pages asset concern"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP server, resource, prompt or tool contract work was in scope."
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "reason": "No Airtable API or data integration work was in scope."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, PR comment handling and validation evidence.",
+    "ResearchOps Developer Control governed repository conventions and generated-page output.",
+    "Multi-Functional Team governed public-sector privacy risk framing.",
+    "GOV.UK Design System governed the Nunjucks page/template output boundary.",
+    "Cloudflare governed the cache-risk interpretation for committed public assets."
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    "src/govuk/templates/pages/role-assignments.njk",
+    "public/pages/team/role-assignments/index.html",
+    "tests/auth-role-assignment-ui-route-state.test.js",
+    "tests/auth-role-assignment-error-copy-route-state.test.js",
+    "PR #401 comments and review threads"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md",
+    "docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json"
+  ],
+  "filesModified": [
+    "public/pages/team/role-assignments/index.html",
+    "src/govuk/templates/pages/role-assignments.njk",
+    "tests/auth-role-assignment-ui-route-state.test.js",
+    "tests/auth-role-assignment-error-copy-route-state.test.js"
+  ],
+  "unrelatedLocalChangesPreserved": [
+    "infra/cloudflare/src/core/auth/passwordless.js",
+    "ResearchOps.sublime-workspace"
+  ],
+  "codexReviewThreads": [
+    {
+      "pr": 401,
+      "threadId": "PRRT_kwDOP3Td2M6JqmG9",
+      "commentId": 3415564495,
+      "path": "public/js/auth-role-assignment-page.js",
+      "line": 639,
+      "isResolved": false,
+      "isOutdated": false,
+      "classification": "legitimate",
+      "workItem": "Bump the role-assignment script query string in the page and template so cached clients fetch the updated success-message script.",
+      "disposition": "Implemented locally; not yet acknowledged or resolved because the fix has not been committed and pushed to the PR branch."
+    }
+  ],
+  "subAgents": [
+    {
+      "nickname": "Popper",
+      "role": "PR comment state inspection",
+      "result": "Read-only inspection of PR #401 comments and review threads."
+    },
+    {
+      "nickname": "Socrates",
+      "role": "script version reference inspection",
+      "result": "Read-only inspection of cache-key references and route-state assertions."
+    }
+  ],
+  "validation": [
+    {
+      "command": "rg \"inline-team-creation-20260513|hide-internal-codes-20260615|auth-role-assignment-page\\\\.js\\\\?v=\" public/pages/team/role-assignments/index.html src/govuk/templates/pages/role-assignments.njk tests docs --glob '!node_modules'",
+      "status": "passed",
+      "summary": "Only the new role-assignment script version remains in active page, template and test references."
+    },
+    {
+      "command": "node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js",
+      "status": "passed",
+      "summary": "Focused role-assignment route-state tests passed: 2 tests passed."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "No whitespace errors were found."
+    },
+    {
+      "command": "npm test -- --ci tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js",
+      "status": "failed",
+      "summary": "The npm script forwards --ci to Node, which fails with node: bad option: --ci."
+    }
+  ],
+  "residualRisk": [
+    "The local branch tracks origin/claude/lucid-ritchie-s7jjmz until a remote fix/ branch or PR branch update is pushed.",
+    "The Codex thread has not yet been reacted to, replied to or resolved because the fix has not been committed and pushed to the PR branch."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.json
@@ -4,12 +4,14 @@
   "branch": "fix/role-assignment-check-answers",
   "traceRequired": true,
   "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
-  "relatedWork": "PR #401 Codex review comment",
+  "relatedWork": "PR #401 Codex review comment; replacement PR #402",
   "task": "Move the branch from an unapproved claude/ prefix to a sensible fix/ branch and inspect Codex review comments.",
   "branchCorrection": {
     "from": "claude/lucid-ritchie-s7jjmz",
     "to": "fix/role-assignment-check-answers",
-    "reason": "Repository policy allows fix/ work branches and prohibits claude/ work branches."
+    "reason": "Repository policy allows fix/ work branches and prohibits claude/ work branches.",
+    "remoteRename": "The remote GitHub branch was renamed to fix/role-assignment-check-answers after PR #401 still showed the old claude/ head ref.",
+    "pullRequestOutcome": "GitHub closed PR #401 when the old head ref was removed; replacement PR #402 was opened from the approved fix/ branch."
   },
   "selectedBundles": [
     {
@@ -120,7 +122,7 @@
       "isOutdated": false,
       "classification": "legitimate",
       "workItem": "Bump the role-assignment script query string in the page and template so cached clients fetch the updated success-message script.",
-      "disposition": "Implemented locally; not yet acknowledged or resolved because the fix has not been committed and pushed to the PR branch."
+      "disposition": "Implemented, pushed, acknowledged with a thumbs-up reaction, replied to with commit and validation evidence, and resolved before PR #401 was closed by the remote branch rename."
     }
   ],
   "subAgents": [
@@ -158,7 +160,7 @@
     }
   ],
   "residualRisk": [
-    "The local branch tracks origin/claude/lucid-ritchie-s7jjmz until a remote fix/ branch or PR branch update is pushed.",
-    "The Codex thread has not yet been reacted to, replied to or resolved because the fix has not been committed and pushed to the PR branch."
+    "PR #401 is closed because GitHub could not reopen it after the old claude/ head ref was removed.",
+    "Replacement PR #402 carries the same commits on the approved fix/role-assignment-check-answers branch."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
@@ -1,0 +1,129 @@
+# Agent trace - Role assignment cache-bust Codex review
+
+**Date:** 2026-06-15  
+**Trace type:** operational audit trace  
+**Branch:** `fix/role-assignment-check-answers`  
+**Trace required:** yes, because the branch starts with `fix/`  
+**Related work:** PR #401 Codex review comment
+
+## Task
+
+Move the working branch from an unapproved `claude/` prefix to a sensible `fix/`
+branch and inspect Codex review comments. PR #401 had one active Codex review
+thread requiring the role-assignment script cache key to be refreshed so cached
+clients do not continue to run the old success-message code.
+
+## Branch Trace Decision
+
+The work started on `claude/lucid-ritchie-s7jjmz`, which is not an approved
+work-branch prefix under the repository operating model. The local branch was
+renamed to `fix/role-assignment-check-answers`.
+
+Repository policy requires an auditable trace for repository-affecting work on
+`fix/` branches, so this trace is required even without the legacy `[reasoning]`
+token.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+The first three bundles are always-load bundles. `govuk-design-system` applies
+because the fix updates a GOV.UK page template and generated route output.
+`cloudflare` applies because the Codex review comment concerned cached Pages
+assets served from committed `public/` output.
+
+Skipped conditional bundles:
+
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP server, resource, prompt or tool contract work was in scope.
+- `airtable-public-api` - no Airtable API or data integration work was in scope.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, PR comment handling and validation evidence.
+- ResearchOps Developer Control governed repository conventions and generated-page output.
+- Multi-Functional Team governed public-sector privacy risk framing.
+- GOV.UK Design System governed the Nunjucks page/template output boundary.
+- Cloudflare governed the cache-risk interpretation for committed public assets.
+
+No bundle conflicts were identified.
+
+## Codex Review Thread
+
+PR #401 had one unresolved, non-outdated Codex review thread:
+
+- `public/js/auth-role-assignment-page.js`, lines 636-639
+- Comment ID `3415564495`
+- Thread ID `PRRT_kwDOP3Td2M6JqmG9`
+- Disposition: legitimate
+
+The comment noted that `/js/auth-role-assignment-page.js?v=inline-team-creation-20260513`
+was still used by the rendered page and Nunjucks template after the success
+message privacy fix, while `/js/*` assets are cached. The requested work item
+was to bump the script version in both page and template.
+
+## Implementation
+
+Updated the role-assignment script query string from
+`inline-team-creation-20260513` to `hide-internal-codes-20260615` in:
+
+- `src/govuk/templates/pages/role-assignments.njk`
+- `public/pages/team/role-assignments/index.html`
+
+Updated route-state tests that assert the generated route and template script
+URL:
+
+- `tests/auth-role-assignment-ui-route-state.test.js`
+- `tests/auth-role-assignment-error-copy-route-state.test.js`
+
+Existing unrelated local changes were preserved and not reverted:
+
+- `infra/cloudflare/src/core/auth/passwordless.js`
+- `ResearchOps.sublime-workspace`
+
+## Sub-Agent Coordination
+
+- Popper inspected PR #401 comment state and review threads in a read-only lane.
+- Socrates checked script cache-key references and generated/test assertion locations in a read-only lane.
+
+## Validation
+
+Attempted:
+
+- `rg "inline-team-creation-20260513|hide-internal-codes-20260615|auth-role-assignment-page\\.js\\?v=" ...` - passed; only the new version remains in active page/template/test references.
+- `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js` - passed; 2 tests passed.
+- `git diff --check` - passed.
+
+Not run:
+
+- Full repository validation suite, because the change is a narrow PR-review cache-key update with focused route-state coverage.
+- `npm test -- --ci tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js`, because the current npm script forwards `--ci` to Node and fails with `node: bad option: --ci`.
+
+## Residual Risk
+
+The local branch now has an approved `fix/` name, but its upstream still points
+at `origin/claude/lucid-ritchie-s7jjmz` until a remote branch or PR head update
+is pushed. The Codex thread has not yet been reacted to, replied to or resolved
+because the fix has not been committed and pushed to the PR branch in this step.

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
@@ -4,7 +4,7 @@
 **Trace type:** operational audit trace  
 **Branch:** `fix/role-assignment-check-answers`  
 **Trace required:** yes, because the branch starts with `fix/`  
-**Related work:** PR #401 Codex review comment
+**Related work:** PR #401 Codex review comment; replacement PR #402
 
 ## Task
 
@@ -18,6 +18,11 @@ clients do not continue to run the old success-message code.
 The work started on `claude/lucid-ritchie-s7jjmz`, which is not an approved
 work-branch prefix under the repository operating model. The local branch was
 renamed to `fix/role-assignment-check-answers`.
+
+After the first push, GitHub still showed PR #401 as headed by
+`claude/lucid-ritchie-s7jjmz`. The remote branch was renamed through GitHub to
+`fix/role-assignment-check-answers`. GitHub closed PR #401 when the old head ref
+was removed, so replacement PR #402 was opened from the approved `fix/` branch.
 
 Repository policy requires an auditable trace for repository-affecting work on
 `fix/` branches, so this trace is required even without the legacy `[reasoning]`
@@ -84,6 +89,10 @@ was still used by the rendered page and Nunjucks template after the success
 message privacy fix, while `/js/*` assets are cached. The requested work item
 was to bump the script version in both page and template.
 
+The thread was acknowledged with a thumbs-up reaction, replied to with the
+fixing commit and validation evidence, and resolved before PR #401 was closed by
+the remote branch rename.
+
 ## Implementation
 
 Updated the role-assignment script query string from
@@ -123,7 +132,6 @@ Not run:
 
 ## Residual Risk
 
-The local branch now has an approved `fix/` name, but its upstream still points
-at `origin/claude/lucid-ritchie-s7jjmz` until a remote branch or PR head update
-is pushed. The Codex thread has not yet been reacted to, replied to or resolved
-because the fix has not been committed and pushed to the PR branch in this step.
+PR #401 is closed because GitHub could not reopen it after the old `claude/`
+head ref was removed. Replacement PR #402 carries the same commits on the
+approved `fix/role-assignment-check-answers` branch.

--- a/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
+++ b/docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md
@@ -13,6 +13,11 @@ branch and inspect Codex review comments. PR #401 had one active Codex review
 thread requiring the role-assignment script cache key to be refreshed so cached
 clients do not continue to run the old success-message code.
 
+After local preview of replacement PR #402, the success message was accepted but
+the check-answers layout still wrapped first-column labels poorly. The follow-up
+fix ensures the check-answers summary list uses GOV.UK frontend component layout
+instead of page-specific CSS reimplementing `.govuk-summary-list` as a grid.
+
 ## Branch Trace Decision
 
 The work started on `claude/lucid-ritchie-s7jjmz`, which is not an approved
@@ -107,6 +112,14 @@ URL:
 - `tests/auth-role-assignment-ui-route-state.test.js`
 - `tests/auth-role-assignment-error-copy-route-state.test.js`
 
+For the check-answers layout follow-up:
+
+- Added `src/styles/auth-role-assignments.scss` as the Sass source for the role-assignment route stylesheet.
+- Registered `public/css/auth-role-assignments.css` in `scripts/styles/generated-css-targets.mjs`.
+- Regenerated `public/css/auth-role-assignments.css` from Sass.
+- Removed page-specific `.govuk-summary-list*` layout overrides so the GOV.UK frontend Summary list component owns the table, row, key, value and action layout.
+- Updated `tests/auth-role-assignment-ui-route-state.test.js` to assert the stylesheet is Sass-generated and does not define Summary list layout rules.
+
 Existing unrelated local changes were preserved and not reverted:
 
 - `infra/cloudflare/src/core/auth/passwordless.js`
@@ -123,6 +136,10 @@ Attempted:
 
 - `rg "inline-team-creation-20260513|hide-internal-codes-20260615|auth-role-assignment-page\\.js\\?v=" ...` - passed; only the new version remains in active page/template/test references.
 - `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js` - passed; 2 tests passed.
+- `npm run build:generated-css -- public/css/auth-role-assignments.css` - passed and regenerated the role-assignment route stylesheet from `src/styles/auth-role-assignments.scss`.
+- `npm run generated-css:check` - passed.
+- `node --test tests/sass-migration-route-state.test.js tests/govuk-frontend-integration-route-state.test.js` - passed.
+- Local browser preview on `http://127.0.0.1:4175/pages/team/role-assignments/` - passed; computed Summary list layout reported `table`, `table-row` and `table-cell`, with no grid template columns.
 - `git diff --check` - passed.
 
 Not run:

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -241,15 +241,22 @@
 	}
 
 .govuk-summary-list {
+	display: block;
+	width: 100%;
 	margin: 0 0 25px;
 	}
 
 .govuk-summary-list__row {
 	display: grid;
 	gap: 15px;
-	grid-template-columns: minmax(140px, 1fr) 2fr auto;
+	grid-template-columns: minmax(160px, 1fr) 2fr auto;
 	padding: 10px 0;
 	border-bottom: 1px solid #b1b4b6;
+	}
+
+.govuk-summary-list__key {
+	overflow-wrap: break-word;
+	word-break: normal;
 	}
 
 .govuk-summary-list__key {

--- a/public/js/auth-role-assignment-page.js
+++ b/public/js/auth-role-assignment-page.js
@@ -626,7 +626,6 @@ function showResult(data) {
 	if (!dom.result) return;
 	const role = data.role || {};
 	const targetUser = data.targetUser || {};
-	const assignment = data.assignment || {};
 	const membership = data.teamMembership || {};
 	const team = data.team || {};
 
@@ -637,8 +636,6 @@ function showResult(data) {
 ${team.created ? `<p class="govuk-body">The team <strong>${escapeHtml(teamLabel(team))}</strong> was created.</p>` : ""}
 <p class="govuk-body"><strong>${escapeHtml(role.label || role.key)}</strong> was assigned to ${escapeHtml(targetUser.displayName || targetUser.email || targetUser.id)} in ${escapeHtml(teamLabel(team))}.</p>
 ${membership.createdOrReactivated ? '<p class="govuk-body">They were also added as an active member of this team.</p>' : ""}
-<p class="govuk-body">Assignment ID: <code>${escapeHtml(assignment.id)}</code></p>
-<p class="govuk-body">Scope: <code>${escapeHtml(assignment.scopeId)}</code></p>
 `;
 	dom.result.focus?.();
 }

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -551,6 +551,6 @@
 		</main>
 		<x-include src="/partials/footer.html"></x-include>
 
-		<script type="module" src="/js/auth-role-assignment-page.js?v=inline-team-creation-20260513"></script>
+		<script type="module" src="/js/auth-role-assignment-page.js?v=hide-internal-codes-20260615"></script>
 	</body>
 </html>

--- a/scripts/styles/generated-css-targets.mjs
+++ b/scripts/styles/generated-css-targets.mjs
@@ -65,6 +65,11 @@ export const generatedCssTargets = [
 		source: 'src/styles/outcomes.scss',
 		output: 'public/css/outcomes.css',
 	},
+	{
+		name: 'Role assignment stylesheet',
+		source: 'src/styles/auth-role-assignments.scss',
+		output: 'public/css/auth-role-assignments.css',
+	},
 ];
 
 export const generatedCssPaths = generatedCssTargets.map((target) => target.output);

--- a/src/govuk/templates/pages/role-assignments.njk
+++ b/src/govuk/templates/pages/role-assignments.njk
@@ -607,6 +607,6 @@
 {% endblock %} {% block scripts %}
 <script
 	type="module"
-	src="/js/auth-role-assignment-page.js?v=inline-team-creation-20260513"
+	src="/js/auth-role-assignment-page.js?v=hide-internal-codes-20260615"
 ></script>
 {% endblock %}

--- a/src/styles/auth-role-assignments.scss
+++ b/src/styles/auth-role-assignments.scss
@@ -1,5 +1,3 @@
-@charset "UTF-8";
-
 /* ==========================================================================
    ResearchOps UI • Auth role assignment route stylesheet source
    Service:    Home Office Biometrics — ResearchOps
@@ -10,26 +8,28 @@
    License:    All rights reserved
    ========================================================================== */
 
-.govuk-\!-width-two-thirds, [class~="govuk-!-width-two-thirds"] {
+.govuk-\!-width-two-thirds,
+[class~='govuk-!-width-two-thirds'] {
 	width: 66.66% !important;
 	max-width: 100%;
-	}
+}
 
-.govuk-\!-width-one-half, [class~="govuk-!-width-one-half"] {
+.govuk-\!-width-one-half,
+[class~='govuk-!-width-one-half'] {
 	width: 50% !important;
 	max-width: 100%;
-	}
+}
 
 .govuk-list {
 	margin-top: 0;
 	margin-bottom: 15px;
 	padding-left: 0;
-	}
+}
 
 .govuk-list--bullet {
 	padding-left: 20px;
 	list-style-type: disc;
-	}
+}
 
 .govuk-visually-hidden {
 	position: absolute !important;
@@ -41,40 +41,40 @@
 	clip: rect(0 0 0 0) !important;
 	white-space: nowrap !important;
 	border: 0 !important;
-	}
+}
 
 .auth-role-assignment-page__header {
 	margin-bottom: 30px;
-	}
+}
 
 .auth-role-assignment-scope {
 	margin-bottom: 30px;
-	}
+}
 
 .auth-role-assignment-scope__panel {
 	max-width: 760px;
 	padding: 15px 20px;
 	border-left: 5px solid #1d70b8;
 	background: #f3f2f1;
-	}
+}
 
 .auth-role-assignment-scope__panel--blocked {
 	border-left-color: #d4351c;
 	background: #fff7f7;
-	}
+}
 
 .auth-role-assignment-scope__panel p:last-child {
 	margin-bottom: 0;
-	}
+}
 
 .auth-role-assignment-section {
 	margin-bottom: 35px;
-	}
+}
 
 .auth-role-assignment-details {
 	max-width: 760px;
 	margin-bottom: 25px;
-	}
+}
 
 .auth-role-assignment-details .govuk-details__summary {
 	position: relative;
@@ -84,53 +84,56 @@
 	color: #1d70b8;
 	cursor: pointer;
 	text-decoration: underline;
-	}
+}
 
 .auth-role-assignment-details .govuk-details__summary::-webkit-details-marker {
 	display: none;
-	}
+}
 
 .auth-role-assignment-details .govuk-details__summary::marker {
-	content: "";
-	}
+	content: '';
+}
 
 .auth-role-assignment-details .govuk-details__summary::before {
-	content: "";
+	content: '';
 	position: absolute;
 	top: 4px;
 	left: 0;
 	border-color: transparent transparent transparent currentColor;
 	border-style: solid;
 	border-width: 7px 0 7px 12px;
-	}
+}
 
 .auth-role-assignment-details[open] .govuk-details__summary::before {
 	top: 7px;
 	border-color: currentColor transparent transparent transparent;
 	border-width: 12px 7px 0;
-	}
+}
 
 .auth-role-assignment-details .govuk-details__summary:focus {
 	background-color: #ffdd00;
 	color: #0b0c0c;
 	outline: 3px solid #ffdd00;
 	outline-offset: 0;
-	box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+	box-shadow:
+		0 -2px #ffdd00,
+		0 4px #0b0c0c;
 	text-decoration: none;
-	}
+}
 
 .auth-role-assignment-details .govuk-details__text {
 	padding: 15px 20px;
 	border-left: 5px solid #b1b4b6;
-	}
+}
 
-.auth-role-assignment-radios, .auth-role-assignment-checkboxes {
+.auth-role-assignment-radios,
+.auth-role-assignment-checkboxes {
 	max-width: 760px;
-	}
+}
 
-.auth-role-assignment-radios .govuk-radios__hint[data-clicks-radio=true] {
+.auth-role-assignment-radios .govuk-radios__hint[data-clicks-radio='true'] {
 	cursor: pointer;
-	}
+}
 
 .auth-role-assignment-team-panel {
 	max-width: 760px;
@@ -138,11 +141,11 @@
 	padding: 20px;
 	border-left: 5px solid #b1b4b6;
 	background: #f3f2f1;
-	}
+}
 
 .auth-role-assignment-team-panel .govuk-form-group:last-child {
 	margin-bottom: 0;
-	}
+}
 
 .auth-role-assignment-summary {
 	max-width: 760px;
@@ -151,45 +154,45 @@
 	padding: 20px;
 	border-left: 5px solid #1d70b8;
 	background: #f3f2f1;
-	}
+}
 
 .auth-role-assignment-summary p:last-child {
 	margin-bottom: 0;
-	}
+}
 
 .auth-role-assignment-summary__abilities {
 	margin-bottom: 0;
-	}
+}
 
 .auth-role-assignment-custom-date {
 	max-width: 500px;
 	margin-top: 20px;
-	}
+}
 
 .auth-role-assignment-custom-date .govuk-date-input {
 	display: flex;
 	gap: 15px;
 	align-items: flex-start;
-	}
+}
 
 .auth-role-assignment-custom-date .govuk-date-input__item {
 	margin-right: 0;
-	}
+}
 
 .govuk-input--width-2 {
 	max-width: 4.5em;
-	}
+}
 
 .govuk-input--width-4 {
 	max-width: 6em;
-	}
+}
 
 .govuk-warning-text {
 	position: relative;
 	min-height: 35px;
 	margin-bottom: 20px;
 	padding-left: 45px;
-	}
+}
 
 .govuk-warning-text__icon {
 	position: absolute;
@@ -204,12 +207,12 @@
 	font-weight: 700;
 	line-height: 35px;
 	text-align: center;
-	}
+}
 
 .govuk-warning-text__text {
 	display: block;
 	font-weight: 700;
-	}
+}
 
 .govuk-warning-text__assistive {
 	position: absolute !important;
@@ -221,7 +224,7 @@
 	clip: rect(0 0 0 0) !important;
 	white-space: nowrap !important;
 	border: 0 !important;
-	}
+}
 
 .auth-role-assignment-sensitive {
 	max-width: 760px;
@@ -229,7 +232,7 @@
 	padding: 0;
 	border: 0;
 	background: transparent;
-	}
+}
 
 .auth-role-assignment-review {
 	max-width: 760px;
@@ -237,44 +240,47 @@
 	padding: 20px;
 	border: 2px solid #1d70b8;
 	background: #f3f2f1;
-	}
+}
 
 .auth-role-assignment-review .govuk-heading-l {
 	margin-top: 0;
-	}
+}
 
 .auth-role-assignment-result {
 	max-width: 760px;
 	margin-top: 30px;
 	padding: 20px;
 	border: 5px solid #1d70b8;
-	}
+}
 
 .auth-role-assignment-result--success {
 	border-color: #00703c;
 	background: #f3fff7;
-	}
+}
 
 .auth-role-assignment-result--error {
 	border-color: #d4351c;
 	background: #fff7f7;
-	}
+}
 
 .auth-role-assignment-result .govuk-heading-m {
 	margin-top: 0;
-	}
+}
 
 code {
 	padding: 2px 4px;
 	background: #f3f2f1;
-	font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+	font-family: ui-monospace, 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 	font-size: 0.95em;
-	}
+}
 
 @media (max-width: 640px) {
-	.govuk-\!-width-two-thirds, .govuk-\!-width-one-half, [class~="govuk-!-width-two-thirds"], [class~="govuk-!-width-one-half"] {
+	.govuk-\!-width-two-thirds,
+	.govuk-\!-width-one-half,
+	[class~='govuk-!-width-two-thirds'],
+	[class~='govuk-!-width-one-half'] {
 		width: 100% !important;
-		}
 	}
+}
 
 /* transparency begins in the cascade */

--- a/tests/auth-role-assignment-error-copy-route-state.test.js
+++ b/tests/auth-role-assignment-error-copy-route-state.test.js
@@ -31,7 +31,7 @@ function assertRoleAssignmentErrorsDoNotExposeProgrammaticTerms() {
 }
 
 function assertRoleAssignmentScriptCacheKeyWasRefreshed() {
-	assert.match(pageSource, /auth-role-assignment-page\.js\?v=inline-team-creation-20260513/);
+	assert.match(pageSource, /auth-role-assignment-page\.js\?v=hide-internal-codes-20260615/);
 }
 
 assertRoleAssignmentErrorsAreUserFacing();

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -49,7 +49,7 @@ function assertPageStructure() {
 	assert.match(pageSource, /id="confirm-role-assignment"/);
 	assert.match(pageSource, /Confirm and assign role/);
 	assert.match(pageSource, /id="role-assignment-result"/);
-	assert.match(pageSource, /\/js\/auth-role-assignment-page\.js\?v=inline-team-creation-20260513/);
+	assert.match(pageSource, /\/js\/auth-role-assignment-page\.js\?v=hide-internal-codes-20260615/);
 	assert.match(pageSource, /\/css\/auth-role-assignments\.css/);
 }
 
@@ -98,7 +98,7 @@ function assertRoleAssignmentPageIsGeneratedFromNunjucks() {
 	assert.match(templateSource, /{% block content %}/);
 	assert.match(templateSource, /id="role-assignment-form"/);
 	assert.match(templateSource, /{% block scripts %}/);
-	assert.match(templateSource, /\/js\/auth-role-assignment-page\.js\?v=inline-team-creation-20260513/);
+	assert.match(templateSource, /\/js\/auth-role-assignment-page\.js\?v=hide-internal-codes-20260615/);
 	assert.doesNotMatch(templateSource, /<html class="govuk-template"/);
 	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/header\.html"/);
 	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/footer\.html"/);

--- a/tests/auth-role-assignment-ui-route-state.test.js
+++ b/tests/auth-role-assignment-ui-route-state.test.js
@@ -4,7 +4,9 @@ import fs from 'node:fs';
 const pageSource = fs.readFileSync('public/pages/team/role-assignments/index.html', 'utf8');
 const scriptSource = fs.readFileSync('public/js/auth-role-assignment-page.js', 'utf8');
 const styleSource = fs.readFileSync('public/css/auth-role-assignments.css', 'utf8');
+const styleScssSource = fs.readFileSync('src/styles/auth-role-assignments.scss', 'utf8');
 const govukFrontendSource = fs.readFileSync('public/css/govuk/govuk-frontend-v6.css', 'utf8');
+const generatedCssTargetsSource = fs.readFileSync('scripts/styles/generated-css-targets.mjs', 'utf8');
 const rendererSource = fs.readFileSync('scripts/govuk/render-govuk-pages.mjs', 'utf8');
 const templateSource = fs.readFileSync('src/govuk/templates/pages/role-assignments.njk', 'utf8');
 const normalizedPageText = pageSource.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
@@ -102,6 +104,13 @@ function assertRoleAssignmentPageIsGeneratedFromNunjucks() {
 	assert.doesNotMatch(templateSource, /<html class="govuk-template"/);
 	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/header\.html"/);
 	assert.doesNotMatch(templateSource, /<x-include src="\/partials\/footer\.html"/);
+}
+
+function assertRoleAssignmentStylesAreGeneratedFromSass() {
+	assert.match(generatedCssTargetsSource, /source: 'src\/styles\/auth-role-assignments\.scss'/);
+	assert.match(generatedCssTargetsSource, /output: 'public\/css\/auth-role-assignments\.css'/);
+	assert.match(styleScssSource, /Repo:\s+\/src\/styles\/auth-role-assignments\.scss/);
+	assert.match(styleSource, /Repo:\s+\/src\/styles\/auth-role-assignments\.scss/);
 }
 
 function assertCurrentAccessPanelIsReducedToTeamScope() {
@@ -315,6 +324,22 @@ function assertGOVUKComponentMarkup() {
 	assert.match(scriptSource, /govuk-summary-list__actions/);
 }
 
+function assertSummaryListLayoutComesFromGOVUKFrontend() {
+	assert.match(govukFrontendSource, /\.govuk-summary-list\s*\{/);
+	assert.match(govukFrontendSource, /\.govuk-summary-list__row\s*\{/);
+	assert.doesNotMatch(styleScssSource, /\.govuk-summary-list\s*\{/);
+	assert.doesNotMatch(styleScssSource, /\.govuk-summary-list__row\s*\{/);
+	assert.doesNotMatch(styleScssSource, /\.govuk-summary-list__key\s*\{/);
+	assert.doesNotMatch(styleScssSource, /\.govuk-summary-list__value/);
+	assert.doesNotMatch(styleScssSource, /\.govuk-summary-list__actions\s*\{/);
+	assert.doesNotMatch(styleSource, /\.govuk-summary-list\s*\{/);
+	assert.doesNotMatch(styleSource, /\.govuk-summary-list__row\s*\{/);
+	assert.doesNotMatch(styleSource, /\.govuk-summary-list__key\s*\{/);
+	assert.doesNotMatch(styleSource, /\.govuk-summary-list__value/);
+	assert.doesNotMatch(styleSource, /\.govuk-summary-list__actions\s*\{/);
+	assert.doesNotMatch(styleSource, /grid-template-columns:\s*minmax\(160px,\s*1fr\)\s*2fr\s*auto/);
+}
+
 function assertStylesExist() {
 	assert.match(styleSource, /\.auth-role-assignment-scope__panel/);
 	assert.match(styleSource, /width-two-thirds/);
@@ -324,7 +349,6 @@ function assertStylesExist() {
 	assert.match(styleSource, /\.auth-role-assignment-team-panel/);
 	assert.match(styleSource, /\.auth-role-assignment-custom-date/);
 	assert.match(styleSource, /govuk-warning-text/);
-	assert.match(styleSource, /govuk-summary-list/);
 	assert.match(styleSource, /\.auth-role-assignment-result--success/);
 	assert.match(styleSource, /\.auth-role-assignment-result--error/);
 	assert.match(styleSource, /transparency begins in the cascade/);
@@ -334,6 +358,7 @@ assertPageStructure();
 assertTopLevelAdminInformationArchitecture();
 assertUsesFullGOVUKFrontendTemplate();
 assertRoleAssignmentPageIsGeneratedFromNunjucks();
+assertRoleAssignmentStylesAreGeneratedFromSass();
 assertCurrentAccessPanelIsReducedToTeamScope();
 assertExplicitTeamChoiceExists();
 assertMembershipCreationCopyExists();
@@ -350,4 +375,5 @@ assertClientValidatesBeforeReview();
 assertNoPostBeforeConfirm();
 assertRoleAbilitiesArePlainLanguage();
 assertGOVUKComponentMarkup();
+assertSummaryListLayoutComesFromGOVUKFrontend();
 assertStylesExist();


### PR DESCRIPTION
## What

Fixes the role-assignment check-and-confirm page and keeps the branch on the approved `fix/` prefix.

- Fixes the GOV.UK summary-list layout conflict on `/pages/team/role-assignments/` so keys no longer wrap character-by-character.
- Removes internal Assignment ID and Scope values from the success message.
- Bumps the role-assignment script cache key in the Nunjucks template and committed generated page so cached clients fetch the updated privacy fix.
- Adds the required audit trace for the `fix/` branch: `docs/agent-audit/reasoning/2026/06/15/role-assignment-cache-bust-codex-review.md`.

Supersedes closed PR #401, which was closed when the unapproved `claude/` branch was renamed to `fix/role-assignment-check-answers`.

## Testing

- `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/auth-role-assignment-ui-route-state.test.js tests/auth-role-assignment-error-copy-route-state.test.js`
- `git diff --check`
- `npm run trace:coverage`