### PR TITLE
Fix project create authentication in preview

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
@@ -146,6 +146,36 @@
       "command": "node tests/projects-route-contract.test.js",
       "status": "passed",
       "summary": "Confirmed authenticated GET and POST project routes pass with mocked D1 and Airtable."
+    },
+    {
+      "command": "python3 .../gh-address-comments/scripts/fetch_comments.py --repo . --pr 403",
+      "status": "passed",
+      "summary": "Found one unresolved GitHub Advanced Security thread for incomplete URL substring sanitization in tests/projects-route-contract.test.js."
+    },
+    {
+      "command": "python3 .../gh-fix-ci/scripts/inspect_pr_checks.py --repo . --pr 403 --json",
+      "status": "completed-with-finding",
+      "summary": "Confirmed the failing status was the CodeQL code-scanning alert; the GitHub Actions CodeQL workflow run itself completed successfully."
+    },
+    {
+      "command": "node tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed project route contract tests pass after replacing the unsafe hostname substring assertion."
+    },
+    {
+      "command": "npx prettier -c tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed the edited test file matches repository formatting."
+    }
+  ],
+  "reviewThreadDisposition": [
+    {
+      "tool": "GitHub Advanced Security",
+      "threadId": "PRRT_kwDOP3Td2M6Jr5D2",
+      "path": "tests/projects-route-contract.test.js",
+      "finding": "CodeQL / Incomplete URL substring sanitization",
+      "status": "addressed",
+      "resolution": "Replaced url.includes(\"raw.githubusercontent.com\") with URL parsing and strict https protocol plus raw.githubusercontent.com hostname checks."
     }
   ],
   "residualRisks": [

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
@@ -1,0 +1,155 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/project-create-auth-401",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "relatedWork": "Fix authenticated project creation from the Start a new research project check-answers step",
+  "task": "Investigate and fix a 401 authentication_required error shown to kevin.rapley@homeoffice.gov.uk when submitting the start-project check-answers flow.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: GOV.UK start-project form and check-answers flow"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: Cloudflare Pages Worker proxy and Worker authentication behaviour"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP tool, resource, prompt or consent work was in scope."
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "reason": "Airtable create behaviour was mocked in tests, but no Airtable API integration contract changed."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, surgical mutation and PR readiness.",
+    "ResearchOps Developer Control governed the start-project route and authenticated API conventions.",
+    "Multi-Functional Team governed public-sector assurance and residual-risk framing.",
+    "GOV.UK Design System governed the check-answers flow constraints and error presentation context.",
+    "Cloudflare governed Pages Worker proxy and Worker auth handling."
+  ],
+  "subAgents": [
+    {
+      "role": "RuntimeDev",
+      "result": "Identified that public/_worker.js stripped cf-access-jwt-assertion before forwarding preview API traffic."
+    },
+    {
+      "role": "TestDev",
+      "result": "Identified missing positive authenticated POST /api/projects coverage and suggested route contract assertions."
+    },
+    {
+      "role": "BranchGuard+TraceGuard",
+      "result": "Confirmed branch hygiene, trace requirement, trace location and unrelated local changes to exclude."
+    }
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    "/Users/kevin.rapley/.codex/config.toml",
+    "/Users/kevin.rapley/.codex/rules/default.rules",
+    "public/pages/start/start-new-project.js",
+    "public/_worker.js",
+    "public/js/auth-header-links.js",
+    "public/components/layout.js",
+    "infra/cloudflare/src/worker.js",
+    "infra/cloudflare/src/core/auth/access.js",
+    "infra/cloudflare/src/core/auth/access-scoped.js",
+    "infra/cloudflare/src/core/auth/passwordless.js",
+    "infra/cloudflare/src/service/project-record-routes.js",
+    "tests/start-project-step-1-defaults-route-state.test.js",
+    "tests/start-page-route-state.test.js",
+    "tests/projects-route-contract.test.js"
+  ],
+  "filesCreated": [
+    "tests/pages-advanced-worker-auth-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md",
+    "docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json"
+  ],
+  "filesModified": [
+    "public/_worker.js",
+    "public/pages/start/start-new-project.js",
+    "tests/projects-route-contract.test.js",
+    "tests/start-project-step-1-defaults-route-state.test.js"
+  ],
+  "preExistingLocalChangesLeftUnstaged": [
+    "infra/cloudflare/src/core/auth/passwordless.js",
+    "ResearchOps.sublime-workspace"
+  ],
+  "validation": [
+    {
+      "command": "node tests/pages-advanced-worker-auth-route-state.test.js",
+      "status": "passed",
+      "summary": "Confirmed the Pages advanced worker strips unsigned email Access headers but keeps cf-access-jwt-assertion."
+    },
+    {
+      "command": "node tests/start-project-step-1-defaults-route-state.test.js",
+      "status": "passed",
+      "summary": "Confirmed the start-project controller keeps same-origin API resolution and credentials."
+    },
+    {
+      "command": "node tests/start-page-route-state.test.js",
+      "status": "passed",
+      "summary": "Confirmed the start page route-state contract still passes."
+    },
+    {
+      "command": "node tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed authenticated GET and POST project routes pass with mocked D1 and Airtable."
+    }
+  ],
+  "residualRisks": [
+    "The local reproduction used repository mocks rather than the live Home Office account.",
+    "The fix preserves Worker-side JWT validation and forwards the signed Access JWT through the trusted Pages proxy."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
@@ -1,0 +1,156 @@
+# Agent trace - Project create authentication 401
+
+**Date:** 2026-06-15  
+**Trace type:** operational audit trace  
+**Branch:** `fix/project-create-auth-401`  
+**Trace required:** yes, because the branch starts with `fix/`  
+**Related work:** Fix authenticated project creation from the Start a new research project check-answers step
+
+## Task
+
+Investigate and fix a `401 authentication_required` error shown to
+`kevin.rapley@homeoffice.gov.uk` when submitting the Start a new research
+project flow from the check-answers step.
+
+The screenshot showed the shared header rendering the signed-in user while the
+project create POST returned `authentication_required`.
+
+## Branch Trace Decision
+
+The branch is `fix/project-create-auth-401`. Repository policy allows `fix/` as
+a work-branch prefix and requires an auditable trace for repository-affecting
+work on fix branches.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+The first three bundles are always-load bundles. `govuk-design-system` applies
+because the user-facing error is in the GOV.UK start-project form flow.
+`cloudflare` applies because the root cause is in Cloudflare Pages Worker proxy
+and Worker authentication behaviour.
+
+Skipped conditional bundles:
+
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP tool, resource, prompt or consent work was in scope.
+- `airtable-public-api` - Airtable create behaviour was mocked in tests, but no Airtable API integration contract changed.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, surgical mutation and PR readiness.
+- ResearchOps Developer Control governed the start-project route and authenticated API conventions.
+- Multi-Functional Team governed public-sector assurance and residual-risk framing.
+- GOV.UK Design System governed the check-answers flow constraints and error presentation context.
+- Cloudflare governed Pages Worker proxy and Worker auth handling.
+
+No bundle conflicts were identified.
+
+## Sub-Agent Coordination
+
+Custom sub-agent roles were loaded from `/Users/kevin.rapley/.codex/config.toml`.
+Three focused agents were used:
+
+- `RuntimeDev` inspected the browser JavaScript, Pages Worker proxy and Worker auth path. It identified that `public/_worker.js` stripped `cf-access-jwt-assertion` before forwarding preview API traffic.
+- `TestDev` identified the missing positive authenticated `POST /api/projects` regression and suggested assertions for Airtable project and detail create calls.
+- `BranchGuard` and `TraceGuard` confirmed the branch prefix, trace requirement, trace location and unrelated local changes to exclude from staging.
+
+## Implementation
+
+Updated `public/pages/start/start-new-project.js` so the start-project controller
+uses the same same-origin API convention as the authenticated project pages. The
+controller still supports an explicit `data-api-origin` or `window.API_ORIGIN`
+override, but no longer hardcodes a `workers.dev` API origin for Pages hosts.
+
+Updated `public/_worker.js` so the Pages advanced API proxy keeps the signed
+Cloudflare Access JWT when forwarding preview-host API requests. The proxy still
+strips unsigned email identity headers, and the upstream Worker continues to
+validate the signed JWT.
+
+Extended `tests/projects-route-contract.test.js` with a positive authenticated
+`POST /api/projects` regression. The test sends a realistic check-answers
+payload with the passwordless session cookie and asserts the route returns 201,
+creates the Airtable project with team fields, and creates linked project detail
+fields.
+
+Added `tests/pages-advanced-worker-auth-route-state.test.js` to guard against
+reintroducing `cf-access-jwt-assertion` stripping in the Pages advanced worker.
+
+Extended `tests/start-project-step-1-defaults-route-state.test.js` to ensure the
+start-project controller uses `resolveApiBase()`, includes credentials, and does
+not restore the hardcoded production Worker origin fallback.
+
+## Files
+
+Read:
+
+- `AGENTS.md`
+- operating-model files listed above
+- selected bundle prompt specs and bodies
+- `/Users/kevin.rapley/.codex/config.toml`
+- `/Users/kevin.rapley/.codex/rules/default.rules`
+- `public/pages/start/start-new-project.js`
+- `public/_worker.js`
+- `public/js/auth-header-links.js`
+- `public/components/layout.js`
+- `infra/cloudflare/src/worker.js`
+- `infra/cloudflare/src/core/auth/access.js`
+- `infra/cloudflare/src/core/auth/access-scoped.js`
+- `infra/cloudflare/src/core/auth/passwordless.js`
+- `infra/cloudflare/src/service/project-record-routes.js`
+- `tests/start-project-step-1-defaults-route-state.test.js`
+- `tests/start-page-route-state.test.js`
+- `tests/projects-route-contract.test.js`
+
+Created:
+
+- `tests/pages-advanced-worker-auth-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md`
+- `docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json`
+
+Modified:
+
+- `public/_worker.js`
+- `public/pages/start/start-new-project.js`
+- `tests/projects-route-contract.test.js`
+- `tests/start-project-step-1-defaults-route-state.test.js`
+
+Pre-existing local changes left unstaged:
+
+- `infra/cloudflare/src/core/auth/passwordless.js`
+- `ResearchOps.sublime-workspace`
+
+## Validation
+
+Completed:
+
+- `node tests/pages-advanced-worker-auth-route-state.test.js` - passed.
+- `node tests/start-project-step-1-defaults-route-state.test.js` - passed.
+- `node tests/start-page-route-state.test.js` - passed.
+- `node tests/projects-route-contract.test.js` - passed.
+
+## Residual Risk
+
+The local reproduction used repository mocks rather than the live Home Office
+account. The fix keeps the trusted, signed Access JWT available to the upstream
+Worker and preserves Worker-side JWT validation rather than relaxing API auth.

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
@@ -149,6 +149,21 @@ Completed:
 - `node tests/start-page-route-state.test.js` - passed.
 - `node tests/projects-route-contract.test.js` - passed.
 
+Follow-up after GitHub review:
+
+- `python3 .../gh-address-comments/scripts/fetch_comments.py --repo . --pr 403` - found one unresolved CodeQL review thread on `tests/projects-route-contract.test.js`.
+- `python3 .../gh-fix-ci/scripts/inspect_pr_checks.py --repo . --pr 403 --json` - confirmed the failing status was the CodeQL code-scanning alert, while the GitHub Actions CodeQL run completed successfully.
+- `node tests/projects-route-contract.test.js` - passed after replacing the unsafe hostname substring assertion.
+- `npx prettier -c tests/projects-route-contract.test.js` - passed.
+
+## Review Thread Disposition
+
+GitHub Advanced Security reported `CodeQL / Incomplete URL substring
+sanitization` because the test asserted `url.includes("raw.githubusercontent.com")`.
+The assertion now parses the URL and compares `protocol === "https:"` and
+`hostname === "raw.githubusercontent.com"`, avoiding arbitrary host-prefix or
+host-suffix matches.
+
 ## Residual Risk
 
 The local reproduction used repository mocks rather than the live Home Office

--- a/public/_worker.js
+++ b/public/_worker.js
@@ -70,7 +70,6 @@ function requestHeaders(request, target) {
 	headers.delete('cf-visitor');
 
 	if (target.stripAccessHeaders) {
-		headers.delete('cf-access-jwt-assertion');
 		headers.delete('cf-access-authenticated-user-email');
 		headers.delete('cf-access-user-email');
 	}
@@ -85,7 +84,7 @@ function addDiagnosticHeaders(headers, target) {
 	headers.set('x-researchops-api-upstream', target.origin);
 	headers.set('x-researchops-api-origin-source', target.source);
 	headers.set('x-researchops-pages-host', target.hostname);
-	headers.set('x-researchops-access-headers-forwarded', target.stripAccessHeaders ? 'false' : 'true');
+	headers.set('x-researchops-access-headers-forwarded', target.stripAccessHeaders ? 'jwt-only' : 'true');
 	return headers;
 }
 

--- a/public/pages/start/start-new-project.js
+++ b/public/pages/start/start-new-project.js
@@ -4,12 +4,12 @@
  * @summary Start → 4-step flow controller (navigation + validation + review + submit).
  */
 
-const API_ORIGIN =
-	document.documentElement?.dataset?.apiOrigin ||
-	window.API_ORIGIN ||
-	(location.hostname.endsWith("pages.dev") ?
-		"https://rops-api.digikev-kevin-rapley.workers.dev" :
-		location.origin);
+function resolveApiBase() {
+	const explicit = document.documentElement?.dataset?.apiOrigin || window.API_ORIGIN || "";
+	return String(explicit || "").trim().replace(/\/+$/, "");
+}
+
+const API_ORIGIN = resolveApiBase();
 
 function esc(value) {
 	return String(value ?? "").replace(/[&<>"']/g, c => ({

--- a/tests/pages-advanced-worker-auth-route-state.test.js
+++ b/tests/pages-advanced-worker-auth-route-state.test.js
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workerSource = fs.readFileSync("public/_worker.js", "utf8");
+
+function includes(source, text, label) {
+	assert.equal(source.includes(text), true, `Expected ${label} to include: ${text}`);
+}
+
+function excludes(source, text, label) {
+	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
+}
+
+includes(workerSource, "stripAccessHeaders: true", "Pages advanced worker");
+includes(workerSource, "headers.delete('cf-access-authenticated-user-email');", "Pages advanced worker");
+includes(workerSource, "headers.delete('cf-access-user-email');", "Pages advanced worker");
+includes(workerSource, "'jwt-only'", "Pages advanced worker");
+excludes(workerSource, "headers.delete('cf-access-jwt-assertion');", "Pages advanced worker");

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -48,6 +48,15 @@ function csvResponse(body) {
 	});
 }
 
+function isRawGitHubContentUrl(value) {
+	try {
+		const url = new URL(String(value));
+		return url.protocol === "https:" && url.hostname === "raw.githubusercontent.com";
+	} catch {
+		return false;
+	}
+}
+
 function authenticatedRequest(url) {
 	return new Request(url, {
 		headers: {
@@ -528,7 +537,7 @@ async function assertProjectsCsvRouteStillWorks() {
 		const body = await response.text();
 		assert.match(body, /LocalId,Name,CreatedAt/);
 		assert.equal(
-			calls.some(({ url }) => url.includes("raw.githubusercontent.com")),
+			calls.some(({ url }) => isRawGitHubContentUrl(url)),
 			true,
 		);
 	} finally {

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -266,9 +266,9 @@ function projectRecords() {
 }
 
 function createMockFetch(calls) {
-	return async (resource) => {
+	return async (resource, options = {}) => {
 		const url = String(resource);
-		calls.push(url);
+		calls.push({ url, options });
 
 		if (url.includes("/Projects/rec")) {
 			const recordId = decodeURIComponent(url.split("/Projects/")[1].split("?")[0]);
@@ -277,8 +277,34 @@ function createMockFetch(calls) {
 			return jsonResponse(record);
 		}
 
+		if (url.endsWith("/Projects") && options.method === "POST") {
+			const body = JSON.parse(String(options.body || "{}"));
+			return jsonResponse({
+				records: [
+					{
+						id: PROJECT_RECORD_IDS[0],
+						createdTime: "2026-06-15T10:00:00.000Z",
+						fields: body.records?.[0]?.fields || {},
+					},
+				],
+			});
+		}
+
 		if (url.includes("/Projects?")) {
 			return jsonResponse({ records: projectRecords() });
+		}
+
+		if (url.endsWith("/Project%20Details") && options.method === "POST") {
+			const body = JSON.parse(String(options.body || "{}"));
+			return jsonResponse({
+				records: [
+					{
+						id: "detailCreatedProject",
+						createdTime: "2026-06-15T10:01:00.000Z",
+						fields: body.records?.[0]?.fields || {},
+					},
+				],
+			});
 		}
 
 		if (url.includes("/Project%20Details?")) {
@@ -359,13 +385,87 @@ async function assertProjectsRouteUsesAirtableProjectsTable() {
 		assert.equal(Object.hasOwn(testProject, "notes"), false);
 
 		assert.equal(
-			calls.some((url) => url.includes("/Projects?")),
+			calls.some(({ url }) => url.includes("/Projects?")),
 			true,
 		);
 		assert.equal(
-			calls.some((url) => url.includes("/Project%20Details?")),
+			calls.some(({ url }) => url.includes("/Project%20Details?")),
 			false,
 		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
+async function assertAuthenticatedProjectCreateUsesSessionContext() {
+	const calls = [];
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = createMockFetch(calls);
+
+	try {
+		const response = await worker.fetch(
+			new Request("https://worker.test/api/projects", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					cookie: `rops_session=${TEST_SESSION_TOKEN}`,
+				},
+				body: JSON.stringify({
+					name: "Third Country National Discovery",
+					description: "Discovery research project",
+					phase: "Discovery",
+					status: "Goal setting & problem defining",
+					objectives: ["Understand the problem space", "Map end-to-end workflows"],
+					user_groups: ["Law enforcement", "Borders and immigration"],
+					stakeholders: [
+						{
+							name: "Pam Thethi",
+							role: "PSG - ILEC - Criminal Records Team",
+							email: "pam.thethi@homeoffice.gov.uk",
+						},
+					],
+					lead_researcher: "Amy Everett",
+					lead_researcher_email: "amy.everett@homeoffice.gov.uk",
+					notes: "Created from the start-project check answers flow",
+				}),
+			}),
+			env,
+			{},
+		);
+		assert.equal(response.status, 201);
+
+		const payload = await response.json();
+		assert.equal(payload.ok, true);
+		assert.notEqual(payload.error, "authentication_required");
+		assert.equal(payload.project.name, "Third Country National Discovery");
+		assert.equal(payload.project["rops:servicePhase"], "Discovery");
+		assert.equal(payload.project["rops:projectStatus"], "Goal setting & problem defining");
+		assert.equal(payload.project.teamName, TEST_TEAM_NAME);
+		assert.equal(payload.project.lead_researcher, "Amy Everett");
+		assert.equal(payload.project.lead_researcher_email, "amy.everett@homeoffice.gov.uk");
+		assert.equal(payload.project.notes, "Created from the start-project check answers flow");
+
+		const projectCreateCall = calls.find(({ url, options }) => url.endsWith("/Projects") && options.method === "POST");
+		assert.ok(projectCreateCall);
+		const projectCreateBody = JSON.parse(projectCreateCall.options.body);
+		const fields = projectCreateBody.records[0].fields;
+		assert.equal(fields.Name, "Third Country National Discovery");
+		assert.equal(fields.Description, "Discovery research project");
+		assert.equal(fields.Phase, "Discovery");
+		assert.equal(fields.Status, "Goal setting & problem defining");
+		assert.equal(fields.Objectives, "Understand the problem space\nMap end-to-end workflows");
+		assert.equal(fields.UserGroups, "Law enforcement, Borders and immigration");
+		assert.equal(fields["Team ID"], TEST_TEAM_ID);
+		assert.equal(fields["Team Name"], TEST_TEAM_NAME);
+		assert.match(fields.Stakeholders, /Pam Thethi/);
+
+		const detailCreateCall = calls.find(({ url, options }) => url.endsWith("/Project%20Details") && options.method === "POST");
+		assert.ok(detailCreateCall);
+		const detailCreateBody = JSON.parse(detailCreateCall.options.body);
+		assert.deepEqual(detailCreateBody.records[0].fields.Project, [PROJECT_RECORD_IDS[0]]);
+		assert.equal(detailCreateBody.records[0].fields["Lead Researcher"], "Amy Everett");
+		assert.equal(detailCreateBody.records[0].fields["Lead Researcher Email"], "amy.everett@homeoffice.gov.uk");
+		assert.equal(detailCreateBody.records[0].fields.Notes, "Created from the start-project check answers flow");
 	} finally {
 		globalThis.fetch = originalFetch;
 	}
@@ -387,11 +487,11 @@ async function assertProjectReadResolvesAirtableRecordId() {
 		assert.equal(project.name, "Test Project 1");
 		assert.equal(project.lead_researcher, "Lead Test");
 		assert.equal(
-			calls.some((url) => url.includes(`/Projects/${PROJECT_RECORD_IDS[2]}`)),
+			calls.some(({ url }) => url.includes(`/Projects/${PROJECT_RECORD_IDS[2]}`)),
 			true,
 		);
 		assert.equal(
-			calls.some((url) => url.includes("/Projects?") && !url.includes("/Project%20Details?")),
+			calls.some(({ url }) => url.includes("/Projects?") && !url.includes("/Project%20Details?")),
 			false,
 		);
 	} finally {
@@ -428,7 +528,7 @@ async function assertProjectsCsvRouteStillWorks() {
 		const body = await response.text();
 		assert.match(body, /LocalId,Name,CreatedAt/);
 		assert.equal(
-			calls.some((url) => url.includes("raw.githubusercontent.com")),
+			calls.some(({ url }) => url.includes("raw.githubusercontent.com")),
 			true,
 		);
 	} finally {
@@ -444,6 +544,7 @@ function assertLegacyProjectsDirectHandlerIsAbsent() {
 
 await assertProjectsRouteFailsClosedWithoutSession();
 await assertProjectsRouteUsesAirtableProjectsTable();
+await assertAuthenticatedProjectCreateUsesSessionContext();
 await assertProjectReadResolvesAirtableRecordId();
 await assertNonRecordProjectIdIsNotFound();
 await assertProjectsCsvRouteStillWorks();

--- a/tests/start-project-step-1-defaults-route-state.test.js
+++ b/tests/start-project-step-1-defaults-route-state.test.js
@@ -42,6 +42,11 @@ includes(
 includes(startController, 'phase: DEFAULT_PROJECT_PHASE,', 'start controller');
 includes(startController, 'status: DEFAULT_PROJECT_STATUS,', 'start controller');
 includes(startController, 'Set by default', 'start controller');
+includes(startController, 'function resolveApiBase()', 'start controller');
+includes(startController, 'const API_ORIGIN = resolveApiBase();', 'start controller');
+includes(startController, 'credentials: "include"', 'start controller');
+excludes(startController, 'rops-api.digikev-kevin-rapley.workers.dev', 'start controller');
+excludes(startController, 'location.hostname.endsWith("pages.dev")', 'start controller');
 excludes(startController, 'document.querySelector("#p_phase")', 'start controller');
 excludes(startController, 'document.querySelector("#p_status")', 'start controller');
 


### PR DESCRIPTION
## Summary

Fixes the `401 authentication_required` error when a signed-in user submits the Start a new research project check-answers step.

Root cause: the Pages advanced API proxy stripped the signed Cloudflare Access JWT before forwarding preview-host API requests to the Worker. The header could show a signed-in user, but `/api/projects` could not resolve authenticated context when creating the project.

## Changes

- Keep `cf-access-jwt-assertion` when proxying preview API traffic, while still removing unsigned Access email headers.
- Make the start-project controller use the same same-origin API resolution pattern as authenticated project pages, with explicit API-origin overrides still supported.
- Add a positive authenticated `POST /api/projects` regression covering the check-answers payload and Airtable create fields.
- Add a route-state guard so the Pages advanced worker does not strip the signed JWT again.
- Add required branch trace: `docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md`.

## Validation

- `npm test -- tests/pages-advanced-worker-auth-route-state.test.js tests/start-project-step-1-defaults-route-state.test.js tests/start-page-route-state.test.js tests/projects-route-contract.test.js`
- `npx prettier -c public/_worker.js public/pages/start/start-new-project.js tests/projects-route-contract.test.js tests/start-project-step-1-defaults-route-state.test.js tests/pages-advanced-worker-auth-route-state.test.js docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json`
- `npm run trace:coverage`
- `git diff --check`