### PR TITLE
Allow project create without Airtable team fields

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
@@ -1,9 +1,9 @@
 {
   "date": "2026-06-15",
   "traceType": "operational-audit-trace",
-  "branch": "fix/project-create-auth-401",
+  "branch": "fix/project-create-team-fields-nonblocking",
   "traceRequired": true,
-  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace. PR #403 was merged before the Airtable team-field fallback reached main, so the follow-up fix was carried onto replacement branch fix/project-create-team-fields-nonblocking from current origin/main.",
   "relatedWork": "Fix authenticated project creation from the Start a new research project check-answers step",
   "task": "Investigate and fix a 401 authentication_required error shown to kevin.rapley@homeoffice.gov.uk when submitting the start-project check-answers flow.",
   "selectedBundles": [
@@ -31,6 +31,11 @@
       "id": "cloudflare",
       "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
       "selectionBasis": "conditional: Cloudflare Pages Worker proxy and Worker authentication behaviour"
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "selectionBasis": "conditional: Airtable rejected configured project team fields during record creation"
     }
   ],
   "skippedBundles": [
@@ -45,11 +50,6 @@
       "reason": "No MCP tool, resource, prompt or consent work was in scope."
     },
     {
-      "id": "airtable-public-api",
-      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
-      "reason": "Airtable create behaviour was mocked in tests, but no Airtable API integration contract changed."
-    },
-    {
       "id": "mural-public-api",
       "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
       "reason": "No Mural API or collaboration integration work was in scope."
@@ -60,7 +60,8 @@
     "ResearchOps Developer Control governed the start-project route and authenticated API conventions.",
     "Multi-Functional Team governed public-sector assurance and residual-risk framing.",
     "GOV.UK Design System governed the check-answers flow constraints and error presentation context.",
-    "Cloudflare governed Pages Worker proxy and Worker auth handling."
+    "Cloudflare governed Pages Worker proxy and Worker auth handling.",
+    "Airtable Public API governed the record-create fallback boundary for optional team fields."
   ],
   "subAgents": [
     {
@@ -96,6 +97,8 @@
     ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
     ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
     ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    ".agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml",
+    ".agent-operating-model/bundles/airtable-public-api/prompt.body.xml",
     "/Users/kevin.rapley/.codex/config.toml",
     "/Users/kevin.rapley/.codex/rules/default.rules",
     "public/pages/start/start-new-project.js",
@@ -119,6 +122,7 @@
   "filesModified": [
     "public/_worker.js",
     "public/pages/start/start-new-project.js",
+    "infra/cloudflare/src/service/project-record-routes.js",
     "tests/projects-route-contract.test.js",
     "tests/start-project-step-1-defaults-route-state.test.js"
   ],
@@ -166,6 +170,24 @@
       "command": "npx prettier -c tests/projects-route-contract.test.js",
       "status": "passed",
       "summary": "Confirmed the edited test file matches repository formatting."
+    },
+    {
+      "command": "node tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed project create retries without optional team fields when Airtable rejects those configured fields and still returns 201."
+    },
+    {
+      "command": "npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed the Airtable fallback service edit and route-contract test match repository formatting."
+    }
+  ],
+  "followUps": [
+    {
+      "trigger": "Screenshot showed Error 500: Airtable rejected the configured project team fields.",
+      "status": "addressed",
+      "resolution": "Project creation now retries once without the optional configured project team fields when Airtable reports an unknown-field error for a create request that included those fields.",
+      "evidence": "tests/projects-route-contract.test.js asserts the first create includes Team ID and Team Name, the retry omits them, and the response is 201 with projectWarning project_team_fields_missing."
     }
   ],
   "reviewThreadDisposition": [

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json
@@ -180,6 +180,26 @@
       "command": "npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js",
       "status": "passed",
       "summary": "Confirmed the Airtable fallback service edit and route-contract test match repository formatting."
+    },
+    {
+      "command": "python3 .../gh-address-comments/scripts/fetch_comments.py --repo . --pr 404",
+      "status": "passed",
+      "summary": "Found one unresolved Codex review thread on infra/cloudflare/src/service/project-record-routes.js about preserving supported team metadata on fallback."
+    },
+    {
+      "command": "node tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed the project create fallback removes only the named rejected team field and preserves Team Name when Team ID is rejected."
+    },
+    {
+      "command": "npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed the Codex review follow-up service edit and test update match repository formatting."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "Confirmed no whitespace errors in the Codex review follow-up diff."
     }
   ],
   "followUps": [
@@ -188,6 +208,12 @@
       "status": "addressed",
       "resolution": "Project creation now retries once without the optional configured project team fields when Airtable reports an unknown-field error for a create request that included those fields.",
       "evidence": "tests/projects-route-contract.test.js asserts the first create includes Team ID and Team Name, the retry omits them, and the response is 201 with projectWarning project_team_fields_missing."
+    },
+    {
+      "trigger": "PR #404 Codex review reported that dropping both configured team fields on fallback could remove all team metadata when Airtable rejected only one field.",
+      "status": "addressed",
+      "resolution": "The retry now removes only the configured project team field named in the Airtable unknown-field error, preserving any remaining supported team metadata.",
+      "evidence": "tests/projects-route-contract.test.js asserts that when Airtable rejects Team ID, the retry omits Team ID, keeps Team Name, returns 201 and maps teamName on the response project."
     }
   ],
   "reviewThreadDisposition": [
@@ -198,6 +224,14 @@
       "finding": "CodeQL / Incomplete URL substring sanitization",
       "status": "addressed",
       "resolution": "Replaced url.includes(\"raw.githubusercontent.com\") with URL parsing and strict https protocol plus raw.githubusercontent.com hostname checks."
+    },
+    {
+      "tool": "Codex Review",
+      "threadId": "PRRT_kwDOP3Td2M6JsVQI",
+      "path": "infra/cloudflare/src/service/project-record-routes.js",
+      "finding": "Fallback create removed both configured project team fields even when Airtable rejected only one, risking invisible projects for team-scoped creators.",
+      "status": "addressed",
+      "resolution": "Added rejectedProjectTeamFieldNames() and changed withoutProjectTeamFields() so named unknown team fields are removed individually while supported team fields are preserved."
     }
   ],
   "residualRisks": [

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-15  
 **Trace type:** operational audit trace  
-**Branch:** `fix/project-create-auth-401`  
+**Branch:** `fix/project-create-team-fields-nonblocking`
 **Trace required:** yes, because the branch starts with `fix/`  
 **Related work:** Fix authenticated project creation from the Start a new research project check-answers step
 
@@ -17,9 +17,14 @@ project create POST returned `authentication_required`.
 
 ## Branch Trace Decision
 
-The branch is `fix/project-create-auth-401`. Repository policy allows `fix/` as
-a work-branch prefix and requires an auditable trace for repository-affecting
-work on fix branches.
+The active replacement branch is `fix/project-create-team-fields-nonblocking`.
+Repository policy allows `fix/` as a work-branch prefix and requires an
+auditable trace for repository-affecting work on fix branches.
+
+PR #403 was merged before the later Airtable team-field fallback was included
+in `main`. The follow-up commit was therefore carried onto this replacement
+branch from current `origin/main` without force-updating or reopening the merged
+branch.
 
 ## Operating Model
 
@@ -43,17 +48,19 @@ Selected bundle stack:
 - `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
 - `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
 - `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+- `airtable-public-api` at `.agent-operating-model/bundles/airtable-public-api/`
 
 The first three bundles are always-load bundles. `govuk-design-system` applies
 because the user-facing error is in the GOV.UK start-project form flow.
 `cloudflare` applies because the root cause is in Cloudflare Pages Worker proxy
-and Worker authentication behaviour.
+and Worker authentication behaviour. `airtable-public-api` applies to the
+follow-up because Airtable rejected configured project team fields during record
+creation.
 
 Skipped conditional bundles:
 
 - `openai-platform` - no OpenAI API, model or eval implementation was in scope.
 - `mcp-agent-tooling` - no MCP tool, resource, prompt or consent work was in scope.
-- `airtable-public-api` - Airtable create behaviour was mocked in tests, but no Airtable API integration contract changed.
 - `mural-public-api` - no Mural API or collaboration integration work was in scope.
 
 Precedence decisions:
@@ -63,6 +70,7 @@ Precedence decisions:
 - Multi-Functional Team governed public-sector assurance and residual-risk framing.
 - GOV.UK Design System governed the check-answers flow constraints and error presentation context.
 - Cloudflare governed Pages Worker proxy and Worker auth handling.
+- Airtable Public API governed the record-create fallback boundary for optional team fields.
 
 No bundle conflicts were identified.
 
@@ -100,6 +108,12 @@ Extended `tests/start-project-step-1-defaults-route-state.test.js` to ensure the
 start-project controller uses `resolveApiBase()`, includes credentials, and does
 not restore the hardcoded production Worker origin fallback.
 
+Follow-up implementation: updated `infra/cloudflare/src/service/project-record-routes.js`
+so a project create is not blocked when Airtable rejects only the configured
+project team fields. The route now retries once without those optional fields
+and returns `201` with `projectWarning: "project_team_fields_missing"` when the
+fallback succeeds. Other Airtable create errors still surface as failures.
+
 ## Files
 
 Read:
@@ -118,6 +132,8 @@ Read:
 - `infra/cloudflare/src/core/auth/access-scoped.js`
 - `infra/cloudflare/src/core/auth/passwordless.js`
 - `infra/cloudflare/src/service/project-record-routes.js`
+- `.agent-operating-model/bundles/airtable-public-api/prompt.spec.yaml`
+- `.agent-operating-model/bundles/airtable-public-api/prompt.body.xml`
 - `tests/start-project-step-1-defaults-route-state.test.js`
 - `tests/start-page-route-state.test.js`
 - `tests/projects-route-contract.test.js`
@@ -132,6 +148,7 @@ Modified:
 
 - `public/_worker.js`
 - `public/pages/start/start-new-project.js`
+- `infra/cloudflare/src/service/project-record-routes.js`
 - `tests/projects-route-contract.test.js`
 - `tests/start-project-step-1-defaults-route-state.test.js`
 
@@ -155,6 +172,14 @@ Follow-up after GitHub review:
 - `python3 .../gh-fix-ci/scripts/inspect_pr_checks.py --repo . --pr 403 --json` - confirmed the failing status was the CodeQL code-scanning alert, while the GitHub Actions CodeQL run completed successfully.
 - `node tests/projects-route-contract.test.js` - passed after replacing the unsafe hostname substring assertion.
 - `npx prettier -c tests/projects-route-contract.test.js` - passed.
+- `node tests/projects-route-contract.test.js` - passed after adding the Airtable team-field fallback.
+- `npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js` - passed.
+
+Follow-up for non-blocking Airtable team fields:
+
+- Screenshot showed `Error 500: Airtable rejected the configured project team fields.`
+- Added a retry path that removes only the configured team fields when Airtable reports an unknown-field error for a project create that included team fields.
+- Added route-contract coverage proving the first Airtable create attempt includes `Team ID` and `Team Name`, the retry omits them, and the route still returns `201`.
 
 ## Review Thread Disposition
 

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md
@@ -114,6 +114,12 @@ project team fields. The route now retries once without those optional fields
 and returns `201` with `projectWarning: "project_team_fields_missing"` when the
 fallback succeeds. Other Airtable create errors still surface as failures.
 
+Codex review follow-up: refined the Airtable fallback so the retry removes only
+the configured project team field named in the Airtable unknown-field error.
+This preserves remaining supported team metadata, for example keeping
+`Team Name` when only `Team ID` is rejected, so the created project remains
+visible to team-scoped creators.
+
 ## Files
 
 Read:
@@ -181,6 +187,13 @@ Follow-up for non-blocking Airtable team fields:
 - Added a retry path that removes only the configured team fields when Airtable reports an unknown-field error for a project create that included team fields.
 - Added route-contract coverage proving the first Airtable create attempt includes `Team ID` and `Team Name`, the retry omits them, and the route still returns `201`.
 
+Codex review follow-up:
+
+- `python3 .../gh-address-comments/scripts/fetch_comments.py --repo . --pr 404` - found one unresolved Codex review thread on `infra/cloudflare/src/service/project-record-routes.js`.
+- `node tests/projects-route-contract.test.js` - passed after changing the retry to preserve team metadata that Airtable did not reject.
+- `npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js` - passed.
+- `git diff --check` - passed.
+
 ## Review Thread Disposition
 
 GitHub Advanced Security reported `CodeQL / Incomplete URL substring
@@ -188,6 +201,11 @@ sanitization` because the test asserted `url.includes("raw.githubusercontent.com
 The assertion now parses the URL and compares `protocol === "https:"` and
 `hostname === "raw.githubusercontent.com"`, avoiding arbitrary host-prefix or
 host-suffix matches.
+
+PR #404 Codex review reported that dropping both configured team fields on
+fallback could make a newly created project invisible when Airtable rejected only
+one field. The fallback now removes named rejected team fields only, preserving
+supported team metadata on the retry.
 
 ## Residual Risk
 

--- a/infra/cloudflare/src/service/project-record-routes.js
+++ b/infra/cloudflare/src/service/project-record-routes.js
@@ -270,9 +270,15 @@ function hasProjectTeamFields(fields = {}, env = {}) {
 	return projectTeamFieldNames(env).some((field) => Object.hasOwn(fields, field));
 }
 
-function withoutProjectTeamFields(fields = {}, env = {}) {
+function rejectedProjectTeamFieldNames(error, env = {}) {
+	const text = `${error?.message || ""} ${error?.body || ""}`;
+	return projectTeamFieldNames(env).filter((field) => text.includes(field));
+}
+
+function withoutProjectTeamFields(fields = {}, env = {}, rejectedFields = []) {
 	const next = { ...fields };
-	for (const field of projectTeamFieldNames(env)) {
+	const fieldsToRemove = rejectedFields.length ? rejectedFields : projectTeamFieldNames(env);
+	for (const field of fieldsToRemove) {
 		delete next[field];
 	}
 	return next;
@@ -481,7 +487,7 @@ export async function createProjectRecord(request, env, authContext = {}) {
 		} catch (error) {
 			if (!isUnknownFieldError(error) || !hasProjectTeamFields(fields, env)) throw error;
 			projectWarning = "project_team_fields_missing";
-			record = await createProjectInAirtable(env, table, withoutProjectTeamFields(fields, env));
+			record = await createProjectInAirtable(env, table, withoutProjectTeamFields(fields, env, rejectedProjectTeamFieldNames(error, env)));
 		}
 		if (!record?.id) return json({ ok: false, error: "Project create failed" }, 502);
 

--- a/infra/cloudflare/src/service/project-record-routes.js
+++ b/infra/cloudflare/src/service/project-record-routes.js
@@ -262,6 +262,22 @@ function buildProjectFields(payload = {}, authContext = {}, env = {}) {
 	return fields;
 }
 
+function projectTeamFieldNames(env = {}) {
+	return [env.AIRTABLE_PROJECT_TEAM_NAME_FIELD || "Team Name", env.AIRTABLE_PROJECT_TEAM_ID_FIELD || "Team ID"];
+}
+
+function hasProjectTeamFields(fields = {}, env = {}) {
+	return projectTeamFieldNames(env).some((field) => Object.hasOwn(fields, field));
+}
+
+function withoutProjectTeamFields(fields = {}, env = {}) {
+	const next = { ...fields };
+	for (const field of projectTeamFieldNames(env)) {
+		delete next[field];
+	}
+	return next;
+}
+
 function buildProjectDetailFields(payload = {}, projectRecordId) {
 	const fields = {
 		Project: [projectRecordId],
@@ -430,6 +446,15 @@ function sourceHeaders(source, warning = null) {
 	};
 }
 
+async function createProjectInAirtable(env, table, fields) {
+	const data = await airtableJson(env, `https://api.airtable.com/v0/${env.AIRTABLE_BASE_ID}/${table}`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ records: [{ fields }] }),
+	});
+	return data.records?.[0] || null;
+}
+
 export async function createProjectRecord(request, env, authContext = {}) {
 	requireEnv(env, ["AIRTABLE_BASE_ID", "AIRTABLE_TABLE_PROJECTS", "AIRTABLE_API_KEY"]);
 	if (!canStartProject(authContext)) return json({ ok: false, error: "forbidden", detail: "You do not have permission to start a research project." }, 403);
@@ -449,12 +474,15 @@ export async function createProjectRecord(request, env, authContext = {}) {
 
 	try {
 		const table = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
-		const data = await airtableJson(env, `https://api.airtable.com/v0/${env.AIRTABLE_BASE_ID}/${table}`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ records: [{ fields }] }),
-		});
-		const record = data.records?.[0];
+		let record = null;
+		let projectWarning = null;
+		try {
+			record = await createProjectInAirtable(env, table, fields);
+		} catch (error) {
+			if (!isUnknownFieldError(error) || !hasProjectTeamFields(fields, env)) throw error;
+			projectWarning = "project_team_fields_missing";
+			record = await createProjectInAirtable(env, table, withoutProjectTeamFields(fields, env));
+		}
 		if (!record?.id) return json({ ok: false, error: "Project create failed" }, 502);
 
 		let detailRecord = null;
@@ -476,13 +504,13 @@ export async function createProjectRecord(request, env, authContext = {}) {
 					lead_researcher_email: displayText(detailFields["Lead Researcher Email"] || payload.lead_researcher_email || payload["Lead Researcher Email"] || ""),
 					notes: displayText(detailFields.Notes || payload.notes || payload.Notes || ""),
 				},
+				projectWarning,
 				detailWarning,
 			},
 			201,
 			sourceHeaders("airtable"),
 		);
 	} catch (error) {
-		if (isUnknownFieldError(error)) return json({ ok: false, error: "project_team_fields_missing", detail: "Airtable rejected the configured project team fields." }, 500);
 		return json({ ok: false, error: `Airtable ${error?.status || 500}`, detail: displayText(error?.message || error) }, error?.status || 500);
 	}
 }

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -274,7 +274,7 @@ function projectRecords() {
 	];
 }
 
-function createMockFetch(calls, { rejectProjectTeamFields = false } = {}) {
+function createMockFetch(calls, { rejectProjectTeamField = "" } = {}) {
 	let projectTeamFieldRejections = 0;
 	return async (resource, options = {}) => {
 		const url = String(resource);
@@ -290,13 +290,13 @@ function createMockFetch(calls, { rejectProjectTeamFields = false } = {}) {
 		if (url.endsWith("/Projects") && options.method === "POST") {
 			const body = JSON.parse(String(options.body || "{}"));
 			const fields = body.records?.[0]?.fields || {};
-			if (rejectProjectTeamFields && projectTeamFieldRejections === 0 && (Object.hasOwn(fields, "Team ID") || Object.hasOwn(fields, "Team Name"))) {
+			if (rejectProjectTeamField && projectTeamFieldRejections === 0 && Object.hasOwn(fields, rejectProjectTeamField)) {
 				projectTeamFieldRejections += 1;
 				return jsonResponse(
 					{
 						error: {
 							type: "UNKNOWN_FIELD_NAME",
-							message: "Unknown field name: Team ID",
+							message: `Unknown field name: ${rejectProjectTeamField}`,
 						},
 					},
 					{ status: 422 },
@@ -497,7 +497,7 @@ async function assertAuthenticatedProjectCreateUsesSessionContext() {
 async function assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing() {
 	const calls = [];
 	const originalFetch = globalThis.fetch;
-	globalThis.fetch = createMockFetch(calls, { rejectProjectTeamFields: true });
+	globalThis.fetch = createMockFetch(calls, { rejectProjectTeamField: "Team ID" });
 
 	try {
 		const response = await worker.fetch(
@@ -525,6 +525,7 @@ async function assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing() {
 		assert.equal(payload.ok, true);
 		assert.equal(payload.projectWarning, "project_team_fields_missing");
 		assert.equal(payload.project.name, "Third Country National Discovery");
+		assert.equal(payload.project.teamName, TEST_TEAM_NAME);
 
 		const projectCreateCalls = calls.filter(({ url, options }) => url.endsWith("/Projects") && options.method === "POST");
 		assert.equal(projectCreateCalls.length, 2);
@@ -535,7 +536,7 @@ async function assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing() {
 
 		const retriedFields = JSON.parse(projectCreateCalls[1].options.body).records[0].fields;
 		assert.equal(Object.hasOwn(retriedFields, "Team ID"), false);
-		assert.equal(Object.hasOwn(retriedFields, "Team Name"), false);
+		assert.equal(retriedFields["Team Name"], TEST_TEAM_NAME);
 		assert.equal(retriedFields.Name, "Third Country National Discovery");
 	} finally {
 		globalThis.fetch = originalFetch;

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -274,7 +274,8 @@ function projectRecords() {
 	];
 }
 
-function createMockFetch(calls) {
+function createMockFetch(calls, { rejectProjectTeamFields = false } = {}) {
+	let projectTeamFieldRejections = 0;
 	return async (resource, options = {}) => {
 		const url = String(resource);
 		calls.push({ url, options });
@@ -288,12 +289,25 @@ function createMockFetch(calls) {
 
 		if (url.endsWith("/Projects") && options.method === "POST") {
 			const body = JSON.parse(String(options.body || "{}"));
+			const fields = body.records?.[0]?.fields || {};
+			if (rejectProjectTeamFields && projectTeamFieldRejections === 0 && (Object.hasOwn(fields, "Team ID") || Object.hasOwn(fields, "Team Name"))) {
+				projectTeamFieldRejections += 1;
+				return jsonResponse(
+					{
+						error: {
+							type: "UNKNOWN_FIELD_NAME",
+							message: "Unknown field name: Team ID",
+						},
+					},
+					{ status: 422 },
+				);
+			}
 			return jsonResponse({
 				records: [
 					{
 						id: PROJECT_RECORD_IDS[0],
 						createdTime: "2026-06-15T10:00:00.000Z",
-						fields: body.records?.[0]?.fields || {},
+						fields,
 					},
 				],
 			});
@@ -480,6 +494,54 @@ async function assertAuthenticatedProjectCreateUsesSessionContext() {
 	}
 }
 
+async function assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing() {
+	const calls = [];
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = createMockFetch(calls, { rejectProjectTeamFields: true });
+
+	try {
+		const response = await worker.fetch(
+			new Request("https://worker.test/api/projects", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					cookie: `rops_session=${TEST_SESSION_TOKEN}`,
+				},
+				body: JSON.stringify({
+					name: "Third Country National Discovery",
+					description: "Discovery research project",
+					phase: "Discovery",
+					status: "Goal setting & problem defining",
+					objectives: ["Understand the problem space"],
+					user_groups: ["Law enforcement"],
+				}),
+			}),
+			env,
+			{},
+		);
+		assert.equal(response.status, 201);
+
+		const payload = await response.json();
+		assert.equal(payload.ok, true);
+		assert.equal(payload.projectWarning, "project_team_fields_missing");
+		assert.equal(payload.project.name, "Third Country National Discovery");
+
+		const projectCreateCalls = calls.filter(({ url, options }) => url.endsWith("/Projects") && options.method === "POST");
+		assert.equal(projectCreateCalls.length, 2);
+
+		const rejectedFields = JSON.parse(projectCreateCalls[0].options.body).records[0].fields;
+		assert.equal(rejectedFields["Team ID"], TEST_TEAM_ID);
+		assert.equal(rejectedFields["Team Name"], TEST_TEAM_NAME);
+
+		const retriedFields = JSON.parse(projectCreateCalls[1].options.body).records[0].fields;
+		assert.equal(Object.hasOwn(retriedFields, "Team ID"), false);
+		assert.equal(Object.hasOwn(retriedFields, "Team Name"), false);
+		assert.equal(retriedFields.Name, "Third Country National Discovery");
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
 async function assertProjectReadResolvesAirtableRecordId() {
 	const calls = [];
 	const originalFetch = globalThis.fetch;
@@ -554,6 +616,7 @@ function assertLegacyProjectsDirectHandlerIsAbsent() {
 await assertProjectsRouteFailsClosedWithoutSession();
 await assertProjectsRouteUsesAirtableProjectsTable();
 await assertAuthenticatedProjectCreateUsesSessionContext();
+await assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing();
 await assertProjectReadResolvesAirtableRecordId();
 await assertNonRecordProjectIdIsNotFound();
 await assertProjectsCsvRouteStillWorks();


### PR DESCRIPTION
## Summary

- retries project creation once without the optional configured Airtable team fields when Airtable reports them as unknown fields
- keeps other Airtable create errors as failures
- adds route-contract coverage proving the retry returns 201 with `projectWarning: "project_team_fields_missing"`
- updates the audit trace for replacement branch `fix/project-create-team-fields-nonblocking` after PR #403 was merged before this follow-up reached `main`

## Validation

- `node tests/projects-route-contract.test.js`
- `npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json`
- `npm run trace:coverage`
- `git diff --check`

## Trace

- `docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.md`
- `docs/agent-audit/reasoning/2026/06/15/project-create-auth-401.json`