### PR TITLE
Handle quoted project team field errors

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json
@@ -1,0 +1,108 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/project-create-team-id-quoted-field",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "task": "Fix remaining project create failure where Airtable returns Error 422: Unknown field name: \"Team ID\".",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: GOV.UK start-project check-answers form flow"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: Cloudflare Worker route behaviour"
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "selectionBasis": "conditional: Airtable record create unknown field response"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP tool, resource, prompt or consent work was in scope."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, surgical mutation and PR readiness.",
+    "ResearchOps Developer Control governed the project-create route contract.",
+    "Multi-Functional Team governed public-sector assurance and residual-risk framing.",
+    "GOV.UK Design System governed the user-facing check-answers context.",
+    "Cloudflare governed Worker route behaviour and deployment evidence.",
+    "Airtable Public API governed the record-create retry boundary."
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    "infra/cloudflare/src/service/project-record-routes.js",
+    "tests/projects-route-contract.test.js"
+  ],
+  "filesModified": [
+    "infra/cloudflare/src/service/project-record-routes.js",
+    "tests/projects-route-contract.test.js"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md",
+    "docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json"
+  ],
+  "validation": [
+    {
+      "command": "node tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed project create handles quoted Team ID and sequential team field unknown errors."
+    },
+    {
+      "command": "npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirmed changed service and test files match repository formatting."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "Confirmed no whitespace errors in the diff."
+    }
+  ],
+  "residualRisks": [
+    "The reproduction uses Worker route mocks rather than a live Airtable write.",
+    "The retry is bounded by configured team-field count and does not retry non-team Airtable errors."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md
@@ -1,0 +1,109 @@
+# Agent trace - Project create quoted Team ID fallback
+
+**Date:** 2026-06-15
+**Trace type:** operational audit trace
+**Branch:** `fix/project-create-team-id-quoted-field`
+**Trace required:** yes, because the branch starts with `fix/`
+
+## Task
+
+Fix the remaining Start a new research project create failure where Airtable
+returns `Error 422: Unknown field name: "Team ID"` from the check-answers step.
+
+## Branch Trace Decision
+
+The branch is `fix/project-create-team-id-quoted-field`. Repository policy
+allows `fix/` as a work-branch prefix and requires an auditable trace for
+repository-affecting work on fix branches.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+- `airtable-public-api` at `.agent-operating-model/bundles/airtable-public-api/`
+
+Skipped conditional bundles:
+
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP tool, resource, prompt or consent work was in scope.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, surgical mutation and PR readiness.
+- ResearchOps Developer Control governed the project-create route contract.
+- GOV.UK Design System governed the user-facing form flow context.
+- Cloudflare governed Worker route behaviour and deployment evidence.
+- Airtable Public API governed the record-create retry boundary.
+
+No bundle conflicts were identified.
+
+## Implementation
+
+Updated `infra/cloudflare/src/service/project-record-routes.js` so project
+creation uses a bounded fallback loop for configured team fields. If Airtable
+reports an unknown team field, the route removes the named rejected field and
+retries. If Airtable then rejects another configured team field, the route
+removes that field too and retries again. Other Airtable errors still fail.
+
+Updated `tests/projects-route-contract.test.js` to cover quoted Airtable unknown
+field messages. The tests verify that:
+
+- when only `Team ID` is rejected, the retry preserves `Team Name`
+- when `Team ID` and then `Team Name` are both rejected, the route still returns
+  `201` after retrying without configured team fields
+
+## Files
+
+Read:
+
+- `infra/cloudflare/src/service/project-record-routes.js`
+- `tests/projects-route-contract.test.js`
+- operating-model files listed above
+- selected bundle prompt specs and bodies
+
+Modified:
+
+- `infra/cloudflare/src/service/project-record-routes.js`
+- `tests/projects-route-contract.test.js`
+
+Created:
+
+- `docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md`
+- `docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json`
+
+Pre-existing local changes were temporarily stashed before branching from
+current `main` and are not part of this PR.
+
+## Validation
+
+Completed:
+
+- `node tests/projects-route-contract.test.js` - passed.
+- `npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js` - passed.
+- `git diff --check` - passed.
+
+## Residual Risk
+
+This is covered with Worker route mocks rather than a live Airtable write. The
+retry is bounded by the configured team-field count so it cannot loop
+indefinitely.

--- a/infra/cloudflare/src/service/project-record-routes.js
+++ b/infra/cloudflare/src/service/project-record-routes.js
@@ -284,6 +284,31 @@ function withoutProjectTeamFields(fields = {}, env = {}, rejectedFields = []) {
 	return next;
 }
 
+async function createProjectWithTeamFieldFallback(env, table, fields) {
+	let nextFields = fields;
+	let projectWarning = null;
+	const removedFields = new Set();
+
+	for (let attempt = 0; attempt <= projectTeamFieldNames(env).length; attempt += 1) {
+		try {
+			return {
+				record: await createProjectInAirtable(env, table, nextFields),
+				projectWarning,
+			};
+		} catch (error) {
+			if (!isUnknownFieldError(error) || !hasProjectTeamFields(nextFields, env)) throw error;
+			projectWarning = "project_team_fields_missing";
+			const rejectedFields = rejectedProjectTeamFieldNames(error, env).filter((field) => Object.hasOwn(nextFields, field));
+			const fieldsToRemove = rejectedFields.length ? rejectedFields : projectTeamFieldNames(env).filter((field) => Object.hasOwn(nextFields, field) && !removedFields.has(field));
+			if (!fieldsToRemove.length) throw error;
+			fieldsToRemove.forEach((field) => removedFields.add(field));
+			nextFields = withoutProjectTeamFields(nextFields, env, fieldsToRemove);
+		}
+	}
+
+	return { record: null, projectWarning };
+}
+
 function buildProjectDetailFields(payload = {}, projectRecordId) {
 	const fields = {
 		Project: [projectRecordId],
@@ -478,18 +503,10 @@ export async function createProjectRecord(request, env, authContext = {}) {
 	const fields = buildProjectFields(payload, authContext, env);
 	if (!fields.Name) return json({ ok: false, error: "Project name is required" }, 400);
 
-	try {
-		const table = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
-		let record = null;
-		let projectWarning = null;
 		try {
-			record = await createProjectInAirtable(env, table, fields);
-		} catch (error) {
-			if (!isUnknownFieldError(error) || !hasProjectTeamFields(fields, env)) throw error;
-			projectWarning = "project_team_fields_missing";
-			record = await createProjectInAirtable(env, table, withoutProjectTeamFields(fields, env, rejectedProjectTeamFieldNames(error, env)));
-		}
-		if (!record?.id) return json({ ok: false, error: "Project create failed" }, 502);
+			const table = encodeURIComponent(env.AIRTABLE_TABLE_PROJECTS);
+			const { record, projectWarning } = await createProjectWithTeamFieldFallback(env, table, fields);
+			if (!record?.id) return json({ ok: false, error: "Project create failed" }, 502);
 
 		let detailRecord = null;
 		let detailWarning = null;

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -274,7 +274,7 @@ function projectRecords() {
 	];
 }
 
-function createMockFetch(calls, { rejectProjectTeamField = "" } = {}) {
+function createMockFetch(calls, { rejectProjectTeamFields = [] } = {}) {
 	let projectTeamFieldRejections = 0;
 	return async (resource, options = {}) => {
 		const url = String(resource);
@@ -290,13 +290,14 @@ function createMockFetch(calls, { rejectProjectTeamField = "" } = {}) {
 		if (url.endsWith("/Projects") && options.method === "POST") {
 			const body = JSON.parse(String(options.body || "{}"));
 			const fields = body.records?.[0]?.fields || {};
-			if (rejectProjectTeamField && projectTeamFieldRejections === 0 && Object.hasOwn(fields, rejectProjectTeamField)) {
+			const rejectedField = rejectProjectTeamFields[projectTeamFieldRejections] || "";
+			if (rejectedField && Object.hasOwn(fields, rejectedField)) {
 				projectTeamFieldRejections += 1;
 				return jsonResponse(
 					{
 						error: {
 							type: "UNKNOWN_FIELD_NAME",
-							message: `Unknown field name: ${rejectProjectTeamField}`,
+							message: `Unknown field name: "${rejectedField}"`,
 						},
 					},
 					{ status: 422 },
@@ -497,7 +498,7 @@ async function assertAuthenticatedProjectCreateUsesSessionContext() {
 async function assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing() {
 	const calls = [];
 	const originalFetch = globalThis.fetch;
-	globalThis.fetch = createMockFetch(calls, { rejectProjectTeamField: "Team ID" });
+	globalThis.fetch = createMockFetch(calls, { rejectProjectTeamFields: ["Team ID", "Team Name"] });
 
 	try {
 		const response = await worker.fetch(
@@ -525,19 +526,65 @@ async function assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing() {
 		assert.equal(payload.ok, true);
 		assert.equal(payload.projectWarning, "project_team_fields_missing");
 		assert.equal(payload.project.name, "Third Country National Discovery");
-		assert.equal(payload.project.teamName, TEST_TEAM_NAME);
 
 		const projectCreateCalls = calls.filter(({ url, options }) => url.endsWith("/Projects") && options.method === "POST");
-		assert.equal(projectCreateCalls.length, 2);
+		assert.equal(projectCreateCalls.length, 3);
 
 		const rejectedFields = JSON.parse(projectCreateCalls[0].options.body).records[0].fields;
 		assert.equal(rejectedFields["Team ID"], TEST_TEAM_ID);
 		assert.equal(rejectedFields["Team Name"], TEST_TEAM_NAME);
 
+		const firstRetryFields = JSON.parse(projectCreateCalls[1].options.body).records[0].fields;
+		assert.equal(Object.hasOwn(firstRetryFields, "Team ID"), false);
+		assert.equal(firstRetryFields["Team Name"], TEST_TEAM_NAME);
+
+		const secondRetryFields = JSON.parse(projectCreateCalls[2].options.body).records[0].fields;
+		assert.equal(Object.hasOwn(secondRetryFields, "Team ID"), false);
+		assert.equal(Object.hasOwn(secondRetryFields, "Team Name"), false);
+		assert.equal(secondRetryFields.Name, "Third Country National Discovery");
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
+async function assertProjectCreatePreservesSupportedTeamFields() {
+	const calls = [];
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = createMockFetch(calls, { rejectProjectTeamFields: ["Team ID"] });
+
+	try {
+		const response = await worker.fetch(
+			new Request("https://worker.test/api/projects", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					cookie: `rops_session=${TEST_SESSION_TOKEN}`,
+				},
+				body: JSON.stringify({
+					name: "Third Country National Discovery",
+					description: "Discovery research project",
+					phase: "Discovery",
+					status: "Goal setting & problem defining",
+					objectives: ["Understand the problem space"],
+					user_groups: ["Law enforcement"],
+				}),
+			}),
+			env,
+			{},
+		);
+		assert.equal(response.status, 201);
+
+		const payload = await response.json();
+		assert.equal(payload.ok, true);
+		assert.equal(payload.projectWarning, "project_team_fields_missing");
+		assert.equal(payload.project.teamName, TEST_TEAM_NAME);
+
+		const projectCreateCalls = calls.filter(({ url, options }) => url.endsWith("/Projects") && options.method === "POST");
+		assert.equal(projectCreateCalls.length, 2);
+
 		const retriedFields = JSON.parse(projectCreateCalls[1].options.body).records[0].fields;
 		assert.equal(Object.hasOwn(retriedFields, "Team ID"), false);
 		assert.equal(retriedFields["Team Name"], TEST_TEAM_NAME);
-		assert.equal(retriedFields.Name, "Third Country National Discovery");
 	} finally {
 		globalThis.fetch = originalFetch;
 	}
@@ -618,6 +665,7 @@ await assertProjectsRouteFailsClosedWithoutSession();
 await assertProjectsRouteUsesAirtableProjectsTable();
 await assertAuthenticatedProjectCreateUsesSessionContext();
 await assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing();
+await assertProjectCreatePreservesSupportedTeamFields();
 await assertProjectReadResolvesAirtableRecordId();
 await assertNonRecordProjectIdIsNotFound();
 await assertProjectsCsvRouteStillWorks();


### PR DESCRIPTION
## Summary

- handles quoted Airtable unknown-field messages such as `Unknown field name: "Team ID"` during project creation
- replaces the single team-field retry with a bounded fallback loop over configured project team fields
- preserves supported team metadata when only one configured team field is rejected
- continues without configured team fields if Airtable rejects both `Team ID` and `Team Name`

## Validation

- `node tests/projects-route-contract.test.js`
- `npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json`
- `npm run trace:coverage`
- `git diff --check`

## Trace

- `docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md`
- `docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json`