### PR TITLE
Preserve project team visibility after create

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json
@@ -4,7 +4,7 @@
   "branch": "fix/project-create-team-id-quoted-field",
   "traceRequired": true,
   "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
-  "task": "Fix remaining project create failure where Airtable returns Error 422: Unknown field name: \"Team ID\".",
+  "task": "Fix remaining project create failure where Airtable returns Error 422: Unknown field name: \"Team ID\", and ensure created projects remain assigned to the authenticated user's DaaS team.",
   "selectedBundles": [
     {
       "id": "github-diamond",
@@ -79,6 +79,11 @@
   "filesModified": [
     "infra/cloudflare/src/service/project-record-routes.js",
     "tests/projects-route-contract.test.js"
+  ],
+  "implementationNotes": [
+    "Project creation now writes the authenticated active team name to Org as a stable ownership field.",
+    "The configured Team Name and Team ID fields remain best-effort and can be removed individually when Airtable rejects them.",
+    "The contract test models the authenticated team as DaaS and verifies Org is preserved across all team-field fallback retries."
   ],
   "filesCreated": [
     "docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md",

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json
@@ -83,7 +83,9 @@
   "implementationNotes": [
     "Project creation now writes the authenticated active team name to Org as a stable ownership field.",
     "The configured Team Name and Team ID fields remain best-effort and can be removed individually when Airtable rejects them.",
-    "The contract test models the authenticated team as DaaS and verifies Org is preserved across all team-field fallback retries."
+    "The contract test models the authenticated team as DaaS and verifies Org is preserved across team-field fallback retries.",
+    "Codex review identified that Org must not be an unconditional blocker on deployments without a writable Org column.",
+    "The ownership fallback field is now configurable through AIRTABLE_PROJECT_TEAM_FALLBACK_FIELD and removed by the bounded retry path if Airtable rejects it."
   ],
   "filesCreated": [
     "docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md",
@@ -93,7 +95,7 @@
     {
       "command": "node tests/projects-route-contract.test.js",
       "status": "passed",
-      "summary": "Confirmed project create handles quoted Team ID and sequential team field unknown errors."
+      "summary": "Confirmed project create handles quoted Team ID, sequential team field unknown errors, DaaS ownership mapping and Org unknown-field fallback."
     },
     {
       "command": "npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js",

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md
@@ -9,6 +9,8 @@
 
 Fix the remaining Start a new research project create failure where Airtable
 returns `Error 422: Unknown field name: "Team ID"` from the check-answers step.
+Follow-up: ensure a successfully created project remains assigned to Kevin
+Rapley's DaaS team and is visible on `/pages/projects/` after redirect.
 
 ## Branch Trace Decision
 
@@ -65,12 +67,20 @@ reports an unknown team field, the route removes the named rejected field and
 retries. If Airtable then rejects another configured team field, the route
 removes that field too and retries again. Other Airtable errors still fail.
 
+Updated the create payload to also set `Org` from the authenticated user's
+active team. `Org` is already read as a project team name by the list route, so
+the DaaS assignment survives even if the configured `Team ID` and `Team Name`
+fields are rejected by Airtable.
+
 Updated `tests/projects-route-contract.test.js` to cover quoted Airtable unknown
 field messages. The tests verify that:
 
 - when only `Team ID` is rejected, the retry preserves `Team Name`
 - when `Team ID` and then `Team Name` are both rejected, the route still returns
   `201` after retrying without configured team fields
+- the project create contract models the authenticated team as DaaS
+- `Org` is included on the original create request and every retry, and maps
+  back as the visible project team
 
 ## Files
 

--- a/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md
+++ b/docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md
@@ -11,6 +11,8 @@ Fix the remaining Start a new research project create failure where Airtable
 returns `Error 422: Unknown field name: "Team ID"` from the check-answers step.
 Follow-up: ensure a successfully created project remains assigned to Kevin
 Rapley's DaaS team and is visible on `/pages/projects/` after redirect.
+Review follow-up: address Codex feedback that the fallback ownership field must
+not make project creation fail on deployments without a writable `Org` column.
 
 ## Branch Trace Decision
 
@@ -72,6 +74,12 @@ active team. `Org` is already read as a project team name by the list route, so
 the DaaS assignment survives even if the configured `Team ID` and `Team Name`
 fields are rejected by Airtable.
 
+After Codex review, made the ownership field configurable through
+`AIRTABLE_PROJECT_TEAM_FALLBACK_FIELD` and managed it through the same bounded
+Airtable unknown-field fallback as the configured team fields. If a deployment
+does not have a writable `Org` column, project creation now retries without that
+field instead of surfacing Airtable's `422` response.
+
 Updated `tests/projects-route-contract.test.js` to cover quoted Airtable unknown
 field messages. The tests verify that:
 
@@ -81,6 +89,8 @@ field messages. The tests verify that:
 - the project create contract models the authenticated team as DaaS
 - `Org` is included on the original create request and every retry, and maps
   back as the visible project team
+- if `Org` is rejected by Airtable, the retry removes `Org` while preserving
+  supported `Team Name` and `Team ID` fields
 
 ## Files
 

--- a/infra/cloudflare/src/service/project-record-routes.js
+++ b/infra/cloudflare/src/service/project-record-routes.js
@@ -257,7 +257,10 @@ function buildProjectFields(payload = {}, authContext = {}, env = {}) {
 	const teamId = displayText(team?.id || team?.teamId || team?.team_id || payload.teamId || payload.team_id || "");
 	const teamNameField = env.AIRTABLE_PROJECT_TEAM_NAME_FIELD || "Team Name";
 	const teamIdField = env.AIRTABLE_PROJECT_TEAM_ID_FIELD || "Team ID";
-	if (teamName) fields[teamNameField] = teamName;
+	if (teamName) {
+		fields.Org = teamName;
+		fields[teamNameField] = teamName;
+	}
 	if (teamId) fields[teamIdField] = teamId;
 	return fields;
 }

--- a/infra/cloudflare/src/service/project-record-routes.js
+++ b/infra/cloudflare/src/service/project-record-routes.js
@@ -257,8 +257,9 @@ function buildProjectFields(payload = {}, authContext = {}, env = {}) {
 	const teamId = displayText(team?.id || team?.teamId || team?.team_id || payload.teamId || payload.team_id || "");
 	const teamNameField = env.AIRTABLE_PROJECT_TEAM_NAME_FIELD || "Team Name";
 	const teamIdField = env.AIRTABLE_PROJECT_TEAM_ID_FIELD || "Team ID";
+	const teamFallbackField = displayText(env.AIRTABLE_PROJECT_TEAM_FALLBACK_FIELD || "Org");
 	if (teamName) {
-		fields.Org = teamName;
+		if (teamFallbackField) fields[teamFallbackField] = teamName;
 		fields[teamNameField] = teamName;
 	}
 	if (teamId) fields[teamIdField] = teamId;
@@ -269,18 +270,22 @@ function projectTeamFieldNames(env = {}) {
 	return [env.AIRTABLE_PROJECT_TEAM_NAME_FIELD || "Team Name", env.AIRTABLE_PROJECT_TEAM_ID_FIELD || "Team ID"];
 }
 
+function projectTeamCreateFieldNames(env = {}) {
+	return unique([...projectTeamFieldNames(env), env.AIRTABLE_PROJECT_TEAM_FALLBACK_FIELD || "Org"]);
+}
+
 function hasProjectTeamFields(fields = {}, env = {}) {
-	return projectTeamFieldNames(env).some((field) => Object.hasOwn(fields, field));
+	return projectTeamCreateFieldNames(env).some((field) => Object.hasOwn(fields, field));
 }
 
 function rejectedProjectTeamFieldNames(error, env = {}) {
 	const text = `${error?.message || ""} ${error?.body || ""}`;
-	return projectTeamFieldNames(env).filter((field) => text.includes(field));
+	return projectTeamCreateFieldNames(env).filter((field) => text.includes(field));
 }
 
 function withoutProjectTeamFields(fields = {}, env = {}, rejectedFields = []) {
 	const next = { ...fields };
-	const fieldsToRemove = rejectedFields.length ? rejectedFields : projectTeamFieldNames(env);
+	const fieldsToRemove = rejectedFields.length ? rejectedFields : projectTeamCreateFieldNames(env);
 	for (const field of fieldsToRemove) {
 		delete next[field];
 	}
@@ -292,7 +297,7 @@ async function createProjectWithTeamFieldFallback(env, table, fields) {
 	let projectWarning = null;
 	const removedFields = new Set();
 
-	for (let attempt = 0; attempt <= projectTeamFieldNames(env).length; attempt += 1) {
+	for (let attempt = 0; attempt <= projectTeamCreateFieldNames(env).length; attempt += 1) {
 		try {
 			return {
 				record: await createProjectInAirtable(env, table, nextFields),
@@ -302,7 +307,7 @@ async function createProjectWithTeamFieldFallback(env, table, fields) {
 			if (!isUnknownFieldError(error) || !hasProjectTeamFields(nextFields, env)) throw error;
 			projectWarning = "project_team_fields_missing";
 			const rejectedFields = rejectedProjectTeamFieldNames(error, env).filter((field) => Object.hasOwn(nextFields, field));
-			const fieldsToRemove = rejectedFields.length ? rejectedFields : projectTeamFieldNames(env).filter((field) => Object.hasOwn(nextFields, field) && !removedFields.has(field));
+			const fieldsToRemove = rejectedFields.length ? rejectedFields : projectTeamCreateFieldNames(env).filter((field) => Object.hasOwn(nextFields, field) && !removedFields.has(field));
 			if (!fieldsToRemove.length) throw error;
 			fieldsToRemove.forEach((field) => removedFields.add(field));
 			nextFields = withoutProjectTeamFields(nextFields, env, fieldsToRemove);

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import worker from "../infra/cloudflare/src/worker.js";
 
-const TEST_TEAM_ID = "team_researchops_core";
-const TEST_TEAM_NAME = "ResearchOps Core";
+const TEST_TEAM_ID = "team_daas";
+const TEST_TEAM_NAME = "DaaS";
 const TEST_USER_ID = "usr_project_contract";
 const TEST_SESSION_TOKEN = "project-contract-session";
 
@@ -479,6 +479,7 @@ async function assertAuthenticatedProjectCreateUsesSessionContext() {
 		assert.equal(fields.Status, "Goal setting & problem defining");
 		assert.equal(fields.Objectives, "Understand the problem space\nMap end-to-end workflows");
 		assert.equal(fields.UserGroups, "Law enforcement, Borders and immigration");
+		assert.equal(fields.Org, TEST_TEAM_NAME);
 		assert.equal(fields["Team ID"], TEST_TEAM_ID);
 		assert.equal(fields["Team Name"], TEST_TEAM_NAME);
 		assert.match(fields.Stakeholders, /Pam Thethi/);
@@ -526,19 +527,23 @@ async function assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing() {
 		assert.equal(payload.ok, true);
 		assert.equal(payload.projectWarning, "project_team_fields_missing");
 		assert.equal(payload.project.name, "Third Country National Discovery");
+		assert.equal(payload.project.teamName, TEST_TEAM_NAME);
 
 		const projectCreateCalls = calls.filter(({ url, options }) => url.endsWith("/Projects") && options.method === "POST");
 		assert.equal(projectCreateCalls.length, 3);
 
 		const rejectedFields = JSON.parse(projectCreateCalls[0].options.body).records[0].fields;
+		assert.equal(rejectedFields.Org, TEST_TEAM_NAME);
 		assert.equal(rejectedFields["Team ID"], TEST_TEAM_ID);
 		assert.equal(rejectedFields["Team Name"], TEST_TEAM_NAME);
 
 		const firstRetryFields = JSON.parse(projectCreateCalls[1].options.body).records[0].fields;
+		assert.equal(firstRetryFields.Org, TEST_TEAM_NAME);
 		assert.equal(Object.hasOwn(firstRetryFields, "Team ID"), false);
 		assert.equal(firstRetryFields["Team Name"], TEST_TEAM_NAME);
 
 		const secondRetryFields = JSON.parse(projectCreateCalls[2].options.body).records[0].fields;
+		assert.equal(secondRetryFields.Org, TEST_TEAM_NAME);
 		assert.equal(Object.hasOwn(secondRetryFields, "Team ID"), false);
 		assert.equal(Object.hasOwn(secondRetryFields, "Team Name"), false);
 		assert.equal(secondRetryFields.Name, "Third Country National Discovery");
@@ -583,6 +588,7 @@ async function assertProjectCreatePreservesSupportedTeamFields() {
 		assert.equal(projectCreateCalls.length, 2);
 
 		const retriedFields = JSON.parse(projectCreateCalls[1].options.body).records[0].fields;
+		assert.equal(retriedFields.Org, TEST_TEAM_NAME);
 		assert.equal(Object.hasOwn(retriedFields, "Team ID"), false);
 		assert.equal(retriedFields["Team Name"], TEST_TEAM_NAME);
 	} finally {

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -596,6 +596,55 @@ async function assertProjectCreatePreservesSupportedTeamFields() {
 	}
 }
 
+async function assertProjectCreateDoesNotBlockWhenOrgFieldIsMissing() {
+	const calls = [];
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = createMockFetch(calls, { rejectProjectTeamFields: ["Org"] });
+
+	try {
+		const response = await worker.fetch(
+			new Request("https://worker.test/api/projects", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					cookie: `rops_session=${TEST_SESSION_TOKEN}`,
+				},
+				body: JSON.stringify({
+					name: "Third Country National Discovery",
+					description: "Discovery research project",
+					phase: "Discovery",
+					status: "Goal setting & problem defining",
+					objectives: ["Understand the problem space"],
+					user_groups: ["Law enforcement"],
+				}),
+			}),
+			env,
+			{},
+		);
+		assert.equal(response.status, 201);
+
+		const payload = await response.json();
+		assert.equal(payload.ok, true);
+		assert.equal(payload.projectWarning, "project_team_fields_missing");
+		assert.equal(payload.project.teamName, TEST_TEAM_NAME);
+
+		const projectCreateCalls = calls.filter(({ url, options }) => url.endsWith("/Projects") && options.method === "POST");
+		assert.equal(projectCreateCalls.length, 2);
+
+		const rejectedFields = JSON.parse(projectCreateCalls[0].options.body).records[0].fields;
+		assert.equal(rejectedFields.Org, TEST_TEAM_NAME);
+		assert.equal(rejectedFields["Team ID"], TEST_TEAM_ID);
+		assert.equal(rejectedFields["Team Name"], TEST_TEAM_NAME);
+
+		const retriedFields = JSON.parse(projectCreateCalls[1].options.body).records[0].fields;
+		assert.equal(Object.hasOwn(retriedFields, "Org"), false);
+		assert.equal(retriedFields["Team ID"], TEST_TEAM_ID);
+		assert.equal(retriedFields["Team Name"], TEST_TEAM_NAME);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
 async function assertProjectReadResolvesAirtableRecordId() {
 	const calls = [];
 	const originalFetch = globalThis.fetch;
@@ -672,6 +721,7 @@ await assertProjectsRouteUsesAirtableProjectsTable();
 await assertAuthenticatedProjectCreateUsesSessionContext();
 await assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing();
 await assertProjectCreatePreservesSupportedTeamFields();
+await assertProjectCreateDoesNotBlockWhenOrgFieldIsMissing();
 await assertProjectReadResolvesAirtableRecordId();
 await assertNonRecordProjectIdIsNotFound();
 await assertProjectsCsvRouteStillWorks();


### PR DESCRIPTION
## Summary
- write the authenticated active team to the existing Org project ownership field during project creation
- preserve Org across Airtable fallback retries when configured Team ID / Team Name fields are rejected
- model the create-route contract with the DaaS team so a non-core user can see their newly created project

## Validation
- node tests/projects-route-contract.test.js
- npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.md docs/agent-audit/reasoning/2026/06/15/project-create-team-id-quoted-field.json
- npm run trace:coverage
- git diff --check