### PR TITLE
Sync created project details into cache

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json
+++ b/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json
@@ -1,0 +1,72 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/sync-created-project-cache-details",
+  "traceRequired": true,
+  "task": "Sync newly created project cache details into D1 immediately after Airtable create.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: D1 cache write behaviour"
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "selectionBasis": "conditional: Airtable create route data mapping"
+    }
+  ],
+  "implementationNotes": [
+    "Created projects are now synced to D1 with the same project object returned by the create response.",
+    "Single-record D1 sync no longer deactivates the full Airtable project cache.",
+    "The route contract test verifies objectives, user groups, stakeholders and lead researcher are preserved in payload_json."
+  ],
+  "filesModified": [
+    "infra/cloudflare/src/service/project-record-routes.js",
+    "tests/projects-route-contract.test.js"
+  ],
+  "filesCreated": [
+    "docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md",
+    "docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json"
+  ],
+  "validation": [
+    {
+      "command": "node tests/projects-route-contract.test.js",
+      "status": "passed",
+      "summary": "Confirm project create caches full project details without deactivating the cache."
+    },
+    {
+      "command": "npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json",
+      "status": "passed",
+      "summary": "Confirm changed files use repository formatting."
+    },
+    {
+      "command": "npm run trace:coverage",
+      "status": "passed",
+      "summary": "Confirm audit trace coverage for the fix branch."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "Confirm there are no whitespace errors."
+    }
+  ],
+  "residualRisks": [
+    "The test uses route mocks rather than a live Airtable write."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json
+++ b/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json
@@ -34,7 +34,10 @@
   "implementationNotes": [
     "Created projects are now synced to D1 with the same project object returned by the create response.",
     "Single-record D1 sync no longer deactivates the full Airtable project cache.",
-    "The route contract test verifies objectives, user groups, stakeholders and lead researcher are preserved in payload_json."
+    "Create-time single-project cache writes use the airtable-partial source so list reads do not treat them as a complete cache.",
+    "Project-by-ID Airtable refresh joins Project Details before syncing to D1 so lead researcher, email and notes stay in payload_json.",
+    "The route contract test verifies objectives, user groups, stakeholders and lead researcher are preserved in payload_json.",
+    "The route contract test verifies partial cache rows do not short-circuit the project list."
   ],
   "filesModified": [
     "infra/cloudflare/src/service/project-record-routes.js",

--- a/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md
+++ b/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md
@@ -1,0 +1,66 @@
+# Agent trace - Sync created project cache details
+
+**Date:** 2026-06-15
+**Trace type:** operational audit trace
+**Branch:** `fix/sync-created-project-cache-details`
+**Trace required:** yes, because the branch starts with `fix/`
+
+## Task
+
+Fix the create-project forward path so newly created projects are immediately
+cached with user groups, stakeholders, objectives and lead researcher details.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+- `airtable-public-api` at `.agent-operating-model/bundles/airtable-public-api/`
+
+## Implementation
+
+Updated the project create route to sync the created project into D1 immediately
+after Airtable and Project Details creation. The cached payload now includes the
+mapped project fields plus lead researcher, lead researcher email and notes.
+
+Updated D1 sync so single-record syncs do not mark the whole Airtable cache
+inactive. Full list refreshes still replace the active Airtable set.
+
+## Files
+
+Modified:
+
+- `infra/cloudflare/src/service/project-record-routes.js`
+- `tests/projects-route-contract.test.js`
+
+Created:
+
+- `docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md`
+- `docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json`
+
+## Validation
+
+Passed:
+
+- `node tests/projects-route-contract.test.js`
+- `npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json`
+- `npm run trace:coverage`
+- `git diff --check`
+
+## Residual Risk
+
+The test uses Worker route mocks rather than a live Airtable write. The
+operational repair for the existing project was performed separately through a
+temporary branch-only workflow.

--- a/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md
+++ b/docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md
@@ -38,6 +38,14 @@ mapped project fields plus lead researcher, lead researcher email and notes.
 Updated D1 sync so single-record syncs do not mark the whole Airtable cache
 inactive. Full list refreshes still replace the active Airtable set.
 
+Handled Codex review comments by marking create-time single-project cache writes
+as `airtable-partial`. Project list reads treat partial rows as an incomplete
+cache and query Airtable instead of returning a partial list. Project-by-ID
+reads still allow partial rows as a fallback.
+
+Updated project-by-ID Airtable refresh to join Project Details before syncing to
+D1, so lead researcher, email and notes are preserved in the cached payload.
+
 ## Files
 
 Modified:

--- a/infra/cloudflare/src/service/project-record-routes.js
+++ b/infra/cloudflare/src/service/project-record-routes.js
@@ -416,24 +416,32 @@ async function ensureProjectCache(db) {
 	}
 }
 
+async function sourceForProjectCacheWrite(db, projectId, mode) {
+	if (mode !== "preserve-full") return mode === "full" ? "airtable" : "airtable-partial";
+	const row = await db.prepare("SELECT source FROM rops_projects_cache WHERE id = ? LIMIT 1").bind(projectId).first();
+	return row?.source === "airtable" ? "airtable" : "airtable-partial";
+}
+
 async function syncActiveProjectsToD1(env, projects = [], options = {}) {
 	const db = env.RESEARCHOPS_D1;
 	if (!db?.prepare) return;
 	const currentProjects = projects.filter((project) => isAirtableRecordId(project.id));
 	if (!currentProjects.length) return;
 	const replaceActiveSet = options.replaceActiveSet !== false;
+	const cacheMode = options.cacheMode || (replaceActiveSet ? "full" : "partial");
 
 	try {
 		await ensureProjectCache(db);
 		if (replaceActiveSet) {
-			await db.prepare("UPDATE rops_projects_cache SET active = 0 WHERE source = 'airtable'").run();
+			await db.prepare("UPDATE rops_projects_cache SET active = 0 WHERE source IN ('airtable', 'airtable-partial')").run();
 		}
 
 		const updatedAt = new Date().toISOString();
 		for (const project of currentProjects) {
+			const source = await sourceForProjectCacheWrite(db, project.id, cacheMode);
 			await db
-				.prepare("INSERT INTO rops_projects_cache (id, name, org, phase, status, active, source, updated_at, payload_json) VALUES (?, ?, ?, ?, ?, 1, 'airtable', ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, org = excluded.org, phase = excluded.phase, status = excluded.status, active = excluded.active, source = excluded.source, updated_at = excluded.updated_at, payload_json = excluded.payload_json")
-				.bind(project.id, project.name || "", project.org || "", project["rops:servicePhase"] || "", project["rops:projectStatus"] || "", updatedAt, JSON.stringify(project))
+				.prepare("INSERT INTO rops_projects_cache (id, name, org, phase, status, active, source, updated_at, payload_json) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, org = excluded.org, phase = excluded.phase, status = excluded.status, active = excluded.active, source = excluded.source, updated_at = excluded.updated_at, payload_json = excluded.payload_json")
+				.bind(project.id, project.name || "", project.org || "", project["rops:servicePhase"] || "", project["rops:projectStatus"] || "", source, updatedAt, JSON.stringify(project))
 				.run();
 		}
 	} catch {
@@ -445,8 +453,17 @@ async function readD1ProjectCache(env) {
 	const db = env.RESEARCHOPS_D1;
 	if (!db?.prepare) throw Object.assign(new Error("RESEARCHOPS_D1 binding not available"), { source: "d1" });
 	await ensureProjectCache(db);
-	const response = await db.prepare("SELECT * FROM rops_projects_cache WHERE active = 1 ORDER BY updated_at DESC").all();
+	const partial = await db.prepare("SELECT id FROM rops_projects_cache WHERE active = 1 AND source = 'airtable-partial' LIMIT 1").first();
+	const response = await db.prepare("SELECT * FROM rops_projects_cache WHERE active = 1 AND source = 'airtable' ORDER BY updated_at DESC").all();
 	const rows = response?.results || [];
+	if (partial) {
+		return {
+			projects: [],
+			activeProjectCount: rows.length,
+			invalidProjectCount: 0,
+			incomplete: true,
+		};
+	}
 	const projects = rows.map(mapD1Project).filter(isRenderable);
 	return {
 		projects,
@@ -459,7 +476,7 @@ async function getD1ProjectRecord(env, projectId) {
 	const db = env.RESEARCHOPS_D1;
 	if (!db?.prepare) throw Object.assign(new Error("RESEARCHOPS_D1 binding not available"), { source: "d1" });
 	await ensureProjectCache(db);
-	const row = await db.prepare("SELECT * FROM rops_projects_cache WHERE active = 1 AND id = ? LIMIT 1").bind(projectId).first();
+	const row = await db.prepare("SELECT * FROM rops_projects_cache WHERE active = 1 AND source IN ('airtable', 'airtable-partial') AND id = ? LIMIT 1").bind(projectId).first();
 	const project = mapD1Project(row || {});
 	return isRenderable(project) ? project : null;
 }
@@ -640,8 +657,8 @@ export async function getProjectRecord(_request, env, projectId, authContext = {
 			if (!hasProjectShape(projectRecord)) return json({ ok: false, error: "Project not found" }, 404);
 			const project = mapProject(projectRecord);
 			if (!isRenderable(project) || !userCanSee(project, authContext)) return json({ ok: false, error: "Project not found" }, 404);
-			await syncActiveProjectsToD1(env, [project], { replaceActiveSet: false });
 			const joined = await joinDetails(env, [project]);
+			await syncActiveProjectsToD1(env, [joined[0]], { replaceActiveSet: false, cacheMode: "preserve-full" });
 			return json(joined[0], 200, sourceHeaders("airtable"));
 		} catch (error) {
 			if (error?.status === 404) return json({ ok: false, error: "Project not found" }, 404);

--- a/infra/cloudflare/src/service/project-record-routes.js
+++ b/infra/cloudflare/src/service/project-record-routes.js
@@ -416,15 +416,18 @@ async function ensureProjectCache(db) {
 	}
 }
 
-async function syncActiveProjectsToD1(env, projects = []) {
+async function syncActiveProjectsToD1(env, projects = [], options = {}) {
 	const db = env.RESEARCHOPS_D1;
 	if (!db?.prepare) return;
 	const currentProjects = projects.filter((project) => isAirtableRecordId(project.id));
 	if (!currentProjects.length) return;
+	const replaceActiveSet = options.replaceActiveSet !== false;
 
 	try {
 		await ensureProjectCache(db);
-		await db.prepare("UPDATE rops_projects_cache SET active = 0 WHERE source = 'airtable'").run();
+		if (replaceActiveSet) {
+			await db.prepare("UPDATE rops_projects_cache SET active = 0 WHERE source = 'airtable'").run();
+		}
 
 		const updatedAt = new Date().toISOString();
 		for (const project of currentProjects) {
@@ -524,17 +527,18 @@ export async function createProjectRecord(request, env, authContext = {}) {
 			detailWarning = isUnknownFieldError(error) ? "project_detail_fields_missing" : "project_detail_create_failed";
 		}
 
-		const project = mapProject(record);
 		const detailFields = detailRecord?.fields || {};
+		const project = {
+			...mapProject(record),
+			lead_researcher: displayText(detailFields["Lead Researcher"] || payload.lead_researcher || payload["Lead Researcher"] || ""),
+			lead_researcher_email: displayText(detailFields["Lead Researcher Email"] || payload.lead_researcher_email || payload["Lead Researcher Email"] || ""),
+			notes: displayText(detailFields.Notes || payload.notes || payload.Notes || ""),
+		};
+		await syncActiveProjectsToD1(env, [project], { replaceActiveSet: false });
 		return json(
 			{
 				ok: true,
-				project: {
-					...project,
-					lead_researcher: displayText(detailFields["Lead Researcher"] || payload.lead_researcher || payload["Lead Researcher"] || ""),
-					lead_researcher_email: displayText(detailFields["Lead Researcher Email"] || payload.lead_researcher_email || payload["Lead Researcher Email"] || ""),
-					notes: displayText(detailFields.Notes || payload.notes || payload.Notes || ""),
-				},
+				project,
 				projectWarning,
 				detailWarning,
 			},
@@ -636,7 +640,7 @@ export async function getProjectRecord(_request, env, projectId, authContext = {
 			if (!hasProjectShape(projectRecord)) return json({ ok: false, error: "Project not found" }, 404);
 			const project = mapProject(projectRecord);
 			if (!isRenderable(project) || !userCanSee(project, authContext)) return json({ ok: false, error: "Project not found" }, 404);
-			await syncActiveProjectsToD1(env, [project]);
+			await syncActiveProjectsToD1(env, [project], { replaceActiveSet: false });
 			const joined = await joinDetails(env, [project]);
 			return json(joined[0], 200, sourceHeaders("airtable"));
 		} catch (error) {

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -7,6 +7,7 @@ const TEST_TEAM_NAME = "DaaS";
 const TEST_USER_ID = "usr_project_contract";
 const TEST_SESSION_TOKEN = "project-contract-session";
 const d1RunCalls = [];
+let d1HasPartialProject = false;
 
 const PROJECT_RECORD_IDS = [
 	"recMtdmBbaFilF2Tm",
@@ -165,6 +166,10 @@ function firstRowForSql(sql) {
 
 	if (sql.includes("SELECT ra.id") && sql.includes("ResearchOps Core Team")) {
 		return { id: "ra_core_admin" };
+	}
+
+	if (sql.includes("SELECT id FROM rops_projects_cache") && sql.includes("source = 'airtable-partial'")) {
+		return d1HasPartialProject ? { id: PROJECT_RECORD_IDS[0] } : null;
 	}
 
 	return null;
@@ -423,6 +428,30 @@ async function assertProjectsRouteUsesAirtableProjectsTable() {
 	}
 }
 
+async function assertPartialProjectCacheDoesNotShortCircuitProjectList() {
+	const calls = [];
+	const originalFetch = globalThis.fetch;
+	d1HasPartialProject = true;
+	globalThis.fetch = createMockFetch(calls);
+
+	try {
+		const response = await worker.fetch(authenticatedRequest("https://worker.test/api/projects"), env, {});
+		assert.equal(response.status, 200);
+
+		const payload = await response.json();
+		assert.equal(payload.ok, true);
+		assert.equal(payload.projects.length, 5);
+		assert.equal(response.headers.get("x-rops-source"), "airtable");
+		assert.equal(
+			calls.some(({ url }) => url.includes("/Projects?")),
+			true,
+		);
+	} finally {
+		d1HasPartialProject = false;
+		globalThis.fetch = originalFetch;
+	}
+}
+
 async function assertAuthenticatedProjectCreateUsesSessionContext() {
 	const calls = [];
 	const originalFetch = globalThis.fetch;
@@ -501,7 +530,8 @@ async function assertAuthenticatedProjectCreateUsesSessionContext() {
 		);
 		const cacheInsertCall = d1RunCalls.find((call) => call.sql.includes("INSERT INTO rops_projects_cache"));
 		assert.ok(cacheInsertCall);
-		const cachedProject = JSON.parse(cacheInsertCall.args[6]);
+		assert.equal(cacheInsertCall.args[5], "airtable-partial");
+		const cachedProject = JSON.parse(cacheInsertCall.args[7]);
 		assert.deepEqual(cachedProject.objectives, ["Understand the problem space", "Map end-to-end workflows"]);
 		assert.deepEqual(cachedProject.user_groups, ["Law enforcement", "Borders and immigration"]);
 		assert.equal(cachedProject.stakeholders.length, 1);
@@ -665,6 +695,7 @@ async function assertProjectCreateDoesNotBlockWhenOrgFieldIsMissing() {
 async function assertProjectReadResolvesAirtableRecordId() {
 	const calls = [];
 	const originalFetch = globalThis.fetch;
+	d1RunCalls.length = 0;
 	globalThis.fetch = createMockFetch(calls);
 
 	try {
@@ -677,6 +708,8 @@ async function assertProjectReadResolvesAirtableRecordId() {
 		assert.equal(project.recordId, PROJECT_RECORD_IDS[2]);
 		assert.equal(project.name, "Test Project 1");
 		assert.equal(project.lead_researcher, "Lead Test");
+		assert.equal(project.lead_researcher_email, "lead.test@example.test");
+		assert.equal(project.notes, "Joined detail notes");
 		assert.equal(
 			calls.some(({ url }) => url.includes(`/Projects/${PROJECT_RECORD_IDS[2]}`)),
 			true,
@@ -685,6 +718,13 @@ async function assertProjectReadResolvesAirtableRecordId() {
 			calls.some(({ url }) => url.includes("/Projects?") && !url.includes("/Project%20Details?")),
 			false,
 		);
+		const cacheInsertCall = d1RunCalls.find((call) => call.sql.includes("INSERT INTO rops_projects_cache"));
+		assert.ok(cacheInsertCall);
+		assert.equal(cacheInsertCall.args[5], "airtable-partial");
+		const cachedProject = JSON.parse(cacheInsertCall.args[7]);
+		assert.equal(cachedProject.lead_researcher, "Lead Test");
+		assert.equal(cachedProject.lead_researcher_email, "lead.test@example.test");
+		assert.equal(cachedProject.notes, "Joined detail notes");
 	} finally {
 		globalThis.fetch = originalFetch;
 	}
@@ -735,6 +775,7 @@ function assertLegacyProjectsDirectHandlerIsAbsent() {
 
 await assertProjectsRouteFailsClosedWithoutSession();
 await assertProjectsRouteUsesAirtableProjectsTable();
+await assertPartialProjectCacheDoesNotShortCircuitProjectList();
 await assertAuthenticatedProjectCreateUsesSessionContext();
 await assertProjectCreateDoesNotBlockWhenTeamFieldsAreMissing();
 await assertProjectCreatePreservesSupportedTeamFields();

--- a/tests/projects-route-contract.test.js
+++ b/tests/projects-route-contract.test.js
@@ -6,6 +6,7 @@ const TEST_TEAM_ID = "team_daas";
 const TEST_TEAM_NAME = "DaaS";
 const TEST_USER_ID = "usr_project_contract";
 const TEST_SESSION_TOKEN = "project-contract-session";
+const d1RunCalls = [];
 
 const PROJECT_RECORD_IDS = [
 	"recMtdmBbaFilF2Tm",
@@ -181,6 +182,7 @@ function createMockStatement(sql, args = []) {
 			return { results: allRowsForSql(sql) };
 		},
 		async run() {
+			d1RunCalls.push({ sql, args });
 			return { success: true, meta: { changes: 1 }, args };
 		},
 	};
@@ -424,6 +426,7 @@ async function assertProjectsRouteUsesAirtableProjectsTable() {
 async function assertAuthenticatedProjectCreateUsesSessionContext() {
 	const calls = [];
 	const originalFetch = globalThis.fetch;
+	d1RunCalls.length = 0;
 	globalThis.fetch = createMockFetch(calls);
 
 	try {
@@ -491,6 +494,20 @@ async function assertAuthenticatedProjectCreateUsesSessionContext() {
 		assert.equal(detailCreateBody.records[0].fields["Lead Researcher"], "Amy Everett");
 		assert.equal(detailCreateBody.records[0].fields["Lead Researcher Email"], "amy.everett@homeoffice.gov.uk");
 		assert.equal(detailCreateBody.records[0].fields.Notes, "Created from the start-project check answers flow");
+
+		assert.equal(
+			d1RunCalls.some((call) => call.sql.includes("UPDATE rops_projects_cache SET active = 0")),
+			false,
+		);
+		const cacheInsertCall = d1RunCalls.find((call) => call.sql.includes("INSERT INTO rops_projects_cache"));
+		assert.ok(cacheInsertCall);
+		const cachedProject = JSON.parse(cacheInsertCall.args[6]);
+		assert.deepEqual(cachedProject.objectives, ["Understand the problem space", "Map end-to-end workflows"]);
+		assert.deepEqual(cachedProject.user_groups, ["Law enforcement", "Borders and immigration"]);
+		assert.equal(cachedProject.stakeholders.length, 1);
+		assert.equal(cachedProject.stakeholders[0].name, "Pam Thethi");
+		assert.equal(cachedProject.lead_researcher, "Amy Everett");
+		assert.equal(cachedProject.lead_researcher_email, "amy.everett@homeoffice.gov.uk");
 	} finally {
 		globalThis.fetch = originalFetch;
 	}


### PR DESCRIPTION
## Summary
- cache newly created projects into D1 with objectives, user groups, stakeholders, lead researcher and notes
- avoid marking the whole Airtable cache inactive during single-project syncs
- add a route contract assertion for the cached create-project payload

## Existing data repair
- repaired `Third Country National Discovery` separately through a branch-only workflow
- verified Airtable project fields, Project Details record, and D1 cache now include DaaS, 7 user groups, 3 objectives, 3 stakeholders, Amy Everett, and amy.everett@homeoffice.gov.uk

## Validation
- `node tests/projects-route-contract.test.js`
- `npx prettier -c infra/cloudflare/src/service/project-record-routes.js tests/projects-route-contract.test.js docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.md docs/agent-audit/reasoning/2026/06/15/sync-created-project-cache-details.json`
- `npm run trace:coverage`
- `git diff --check`