### PR TITLE
Fix start page Nunjucks and Sass ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ public/pages/repository/
 
 # OS/editor noise
 .DS_Store
+*.sublime-workspace

--- a/.prettierignore
+++ b/.prettierignore
@@ -47,6 +47,7 @@ assets/researchops/researchops-home.css
 *.jpeg
 *.gif
 *.svg
+*.sublime-workspace
 
 # Repository operating model control files are validated by agent:model:validate.
 .agent-operating-model/**

--- a/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json
+++ b/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json
@@ -244,6 +244,11 @@
       "command": "Browser smoke check http://127.0.0.1:4173/pages/start/",
       "status": "passed",
       "summary": "Confirmed page title, H1, project form, four steps, generated GOV.UK CSS, start route CSS and no legacy forms fragment stylesheet."
+    },
+    {
+      "command": "node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/start-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/start-project-step-1-defaults-route-state.test.js tests/sass-migration-route-state.test.js",
+      "status": "passed",
+      "summary": "Focused start page checks passed after addressing the Codex review comment about the hidden utility."
     }
   ],
   "validationPendingAtUpdate": [],
@@ -267,6 +272,10 @@
     {
       "issue": "Direct validate checks failed on brittle exact-string assertions after generated HTML wrapped attributes.",
       "pivot": "Changed the assertions to check ID and class contracts independently."
+    },
+    {
+      "issue": "Codex review noted that the AI assist panels still used the hidden utility after /css/screen.css was removed.",
+      "pivot": "Added a route-local .hidden display rule to src/styles/start.scss, regenerated public/css/start.css and covered it in tests/start-page-route-state.test.js."
     }
   ],
   "residualRisks": [

--- a/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json
+++ b/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json
@@ -1,0 +1,276 @@
+{
+  "date": "2026-06-15",
+  "traceType": "operational-audit-trace",
+  "branch": "fix/pages-start-nunjucks-sass",
+  "traceRequired": true,
+  "traceDecision": "Required because repository-affecting work on branches starting with fix/ must have an auditable trace.",
+  "relatedWork": "/pages/start/ Nunjucks and Sass source ownership",
+  "task": "Fix /pages/start/ so the page is owned by the repository GOV.UK Nunjucks renderer and generated Sass pipeline.",
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/",
+      "selectionBasis": "always-load"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/",
+      "selectionBasis": "conditional: GOV.UK page template, generated HTML, form markup and Sass"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/",
+      "selectionBasis": "conditional: Cloudflare Pages publishes committed public/ generated output"
+    }
+  ],
+  "skippedBundles": [
+    {
+      "id": "openai-platform",
+      "canonicalPath": ".agent-operating-model/bundles/openai/",
+      "reason": "No OpenAI API, model or eval implementation was in scope."
+    },
+    {
+      "id": "mcp-agent-tooling",
+      "canonicalPath": ".agent-operating-model/bundles/mcp-agent-tooling/",
+      "reason": "No MCP server, tool, resource, prompt or consent work was in scope."
+    },
+    {
+      "id": "airtable-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/airtable-public-api/",
+      "reason": "No Airtable API or data integration work was in scope."
+    },
+    {
+      "id": "mural-public-api",
+      "canonicalPath": ".agent-operating-model/bundles/mural-public-api/",
+      "reason": "No Mural API or collaboration integration work was in scope."
+    }
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace coverage, surgical mutation, validation evidence and PR readiness.",
+    "ResearchOps Developer Control governed repository conventions, generated page ownership and route-state test expectations.",
+    "Multi-Functional Team governed public-sector service assurance and residual-risk framing.",
+    "GOV.UK Design System governed shared frontend layout, form component markup, input width decisions and page affordance checks.",
+    "Cloudflare context governed the decision to keep regenerated public/ output in the change set while the deployment contract publishes committed files."
+  ],
+  "selectedSubAgents": [
+    {
+      "role": "TemplateDev",
+      "agent": "Mendel",
+      "reason": "Nunjucks source ownership and renderer registration"
+    },
+    {
+      "role": "StyleDev",
+      "agent": "Hooke",
+      "reason": "Sass source ownership and generated CSS target coverage"
+    },
+    {
+      "role": "TestDev",
+      "agent": "Franklin",
+      "reason": "Route-state and generated-output contract coverage"
+    },
+    {
+      "role": "RenderGuard",
+      "agent": "Bernoulli",
+      "reason": "Source-to-generated-output drift checks"
+    },
+    {
+      "role": "CheckGuard",
+      "agent": "Pauli",
+      "reason": "Focused validation lane selection and blockers"
+    },
+    {
+      "role": "ReviewGuard",
+      "agent": "Faraday",
+      "reason": "Changed-file plausibility, trace and PR readiness"
+    }
+  ],
+  "filesRead": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md",
+    ".agent-operating-model/bundles/github/prompt.spec.yaml",
+    ".agent-operating-model/bundles/github/prompt.body.xml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.spec.yaml",
+    ".agent-operating-model/bundles/researchops-developer-control/prompt.body.xml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.spec.yaml",
+    ".agent-operating-model/bundles/multi-functional-team/prompt.body.xml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.spec.yaml",
+    ".agent-operating-model/bundles/govuk-design-system/prompt.body.xml",
+    ".agent-operating-model/bundles/cloudflare/prompt.spec.yaml",
+    ".agent-operating-model/bundles/cloudflare/prompt.body.xml",
+    "/Users/kevin.rapley/.codex/config.toml",
+    "src/govuk/templates/layouts/researchops.njk",
+    "src/govuk/templates/pages/start-overview.njk",
+    "public/pages/start/index.html",
+    "public/css/start.css",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "scripts/styles/generated-css-targets.mjs",
+    "tests/start-page-route-state.test.js",
+    "tests/govuk-forms-application-route-state.test.js",
+    "tests/start-project-step-1-defaults-route-state.test.js",
+    "tests/govuk-pages-render-workflow-state.test.js",
+    "tests/sass-migration-route-state.test.js",
+    "tests/govuk-frontend-integration-route-state.test.js"
+  ],
+  "filesCreated": [
+    "src/govuk/templates/pages/start.njk",
+    "src/styles/start.scss",
+    "docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.md",
+    "docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json"
+  ],
+  "filesModified": [
+    ".gitignore",
+    ".prettierignore",
+    "public/css/start.css",
+    "public/pages/start/index.html",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "scripts/styles/generated-css-targets.mjs",
+    "tests/govuk-forms-application-route-state.test.js",
+    "tests/govuk-frontend-integration-route-state.test.js",
+    "tests/govuk-pages-render-workflow-state.test.js",
+    "tests/start-page-route-state.test.js"
+  ],
+  "excludedLocalChanges": [
+    "infra/cloudflare/src/core/auth/passwordless.js",
+    "ResearchOps.sublime-workspace"
+  ],
+  "generatedOutput": [
+    {
+      "path": "public/pages/start/index.html",
+      "source": "src/govuk/templates/pages/start.njk",
+      "reasonCommitted": "Cloudflare Pages currently publishes committed public/ files."
+    },
+    {
+      "path": "public/css/start.css",
+      "source": "src/styles/start.scss",
+      "reasonCommitted": "Route stylesheet is committed generated output and guarded by generated-css checks."
+    }
+  ],
+  "validation": [
+    {
+      "command": "npm run build:generated-css -- public/css/start.css",
+      "status": "passed",
+      "summary": "Generated public/css/start.css from src/styles/start.scss."
+    },
+    {
+      "command": "npm run build:generated-css",
+      "status": "passed",
+      "summary": "Generated all registered CSS targets, including the new start route target."
+    },
+    {
+      "command": "npm run build:govuk-pages",
+      "status": "passed",
+      "summary": "Rendered GOV.UK pages and regenerated public/pages/start/index.html from src/govuk/templates/pages/start.njk."
+    },
+    {
+      "command": "npm run generated-css:check",
+      "status": "passed",
+      "summary": "Generated CSS formatting check passed."
+    },
+    {
+      "command": "node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/start-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/start-project-step-1-defaults-route-state.test.js tests/govuk-pages-render-workflow-state.test.js tests/sass-migration-route-state.test.js tests/govuk-frontend-integration-route-state.test.js",
+      "status": "passed",
+      "summary": "Focused start, GOV.UK renderer and Sass migration route-state tests passed."
+    },
+    {
+      "command": "node -e JSON parse check for docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json",
+      "status": "passed",
+      "summary": "Trace JSON parsed successfully."
+    },
+    {
+      "command": "npm run trace:validate",
+      "status": "passed",
+      "summary": "Trace validation passed."
+    },
+    {
+      "command": "npm run trace:coverage",
+      "status": "passed",
+      "summary": "Trace coverage confirmed for the fix/ branch."
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "summary": "No whitespace errors were found."
+    },
+    {
+      "command": "npm run format:check",
+      "status": "passed",
+      "summary": "Repository formatting and generated CSS checks passed after ignoring local Sublime workspace files."
+    },
+    {
+      "command": "npm run lint",
+      "status": "passed",
+      "summary": "Lint passed with existing repository warnings. The generated CSS step produced an out-of-scope Home Office stylesheet diff that was removed from the worktree."
+    },
+    {
+      "command": "npm test",
+      "status": "passed",
+      "summary": "Full local Node test suite passed: 222 tests."
+    },
+    {
+      "command": "npm run build",
+      "status": "passed",
+      "summary": "Built GOV.UK assets, generated CSS and GOV.UK pages."
+    },
+    {
+      "command": "node --test tests/start-page-route-state.test.js tests/govuk-forms-application-route-state.test.js",
+      "status": "passed",
+      "summary": "Direct route-state tests passed against committed generated output."
+    },
+    {
+      "command": "npm run validate",
+      "status": "passed",
+      "summary": "Repository validation completed successfully after route-state assertions were made robust to generated attribute wrapping."
+    },
+    {
+      "command": "Browser smoke check http://127.0.0.1:4173/pages/start/",
+      "status": "passed",
+      "summary": "Confirmed page title, H1, project form, four steps, generated GOV.UK CSS, start route CSS and no legacy forms fragment stylesheet."
+    }
+  ],
+  "validationPendingAtUpdate": [],
+  "issuesAndPivots": [
+    {
+      "issue": "Initial Sass source imported GOV.UK Frontend and generated a full GOV.UK stylesheet into public/css/start.css.",
+      "pivot": "Kept start.scss as a narrow route stylesheet because the shared layout already loads /assets/govuk/govuk-frontend.css."
+    },
+    {
+      "issue": "Focused tests initially expected legacy GOV.UK fragment styles on /pages/start/.",
+      "pivot": "Updated tests to assert the new shared layout and full GOV.UK Frontend CSS contract."
+    },
+    {
+      "issue": "Untracked ResearchOps.sublime-workspace was a known formatting and commit hygiene blocker.",
+      "pivot": "Added *.sublime-workspace to .gitignore and .prettierignore so the editor workspace file remains local."
+    },
+    {
+      "issue": "npm run lint runs the full generated CSS build and temporarily reintroduced an unrelated public/css/brands/home-office.css diff.",
+      "pivot": "Removed that out-of-scope generated side-effect from the worktree before staging."
+    },
+    {
+      "issue": "Direct validate checks failed on brittle exact-string assertions after generated HTML wrapped attributes.",
+      "pivot": "Changed the assertions to check ID and class contracts independently."
+    }
+  ],
+  "residualRisks": [
+    "public/pages/start/index.html has a larger generated diff because the page moved from static HTML to the shared Nunjucks renderer.",
+    "The worktree contains unrelated local edits to infra/cloudflare/src/core/auth/passwordless.js that must not be staged for this PR."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.md
+++ b/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.md
@@ -205,6 +205,21 @@ asserted exact one-line generated attributes. Those assertions were updated to
 check the same `id` and class contracts independently, then `npm run validate`
 passed.
 
+## Codex Review Follow-Up
+
+Codex review left one unresolved, non-outdated comment on
+`src/govuk/templates/pages/start.njk`. The comment was legitimate: moving the
+start page to the shared GOV.UK layout removed `/css/screen.css`, but the AI
+assistance panels still use the old `hidden` utility class.
+
+Disposition:
+
+- Added a route-local `.hidden { display: none; }` rule to `src/styles/start.scss`.
+- Regenerated `public/css/start.css`.
+- Added a route-state assertion that the generated start stylesheet includes
+  the `.hidden` rule.
+- Re-ran focused start page checks.
+
 ## Residual Risk
 
 `public/pages/start/index.html` has a larger generated diff because the page

--- a/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.md
+++ b/docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.md
@@ -1,0 +1,217 @@
+# Agent trace - Start page Nunjucks and Sass ownership
+
+**Date:** 2026-06-15  
+**Trace type:** operational audit trace  
+**Branch:** `fix/pages-start-nunjucks-sass`  
+**Trace required:** yes, because the branch starts with `fix/`  
+**Related work:** `/pages/start/` Nunjucks and Sass source ownership
+
+## Task
+
+Fix `/pages/start/` so the page is owned by the repository GOV.UK Nunjucks
+renderer and generated Sass pipeline instead of being maintained only as
+committed static HTML and CSS.
+
+The unit of work also required choosing the most suitable 6 roles from the 10
+configured sub-agent roles, confirming the work locally, pushing the branch to
+GitHub and opening a ready-for-review pull request.
+
+## Branch Trace Decision
+
+The branch is `fix/pages-start-nunjucks-sass`. Repository policy allows `fix/`
+as a work-branch prefix and requires an auditable trace for repository-affecting
+work on `fix/` branches. This trace is required even though the prompt did not
+include the legacy `[reasoning]` token.
+
+## Operating Model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/bundles/`
+
+Selected bundle stack:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+The first three bundles are always-load bundles. `govuk-design-system` applies
+because this task changes GOV.UK page templates, form markup, generated HTML and
+Sass. `cloudflare` applies because Cloudflare Pages currently publishes the
+committed `public/` output.
+
+Skipped conditional bundles:
+
+- `openai-platform` - no OpenAI API, model or eval implementation was in scope.
+- `mcp-agent-tooling` - no MCP server, tool, resource, prompt or consent work was in scope.
+- `airtable-public-api` - no Airtable API or data integration work was in scope.
+- `mural-public-api` - no Mural API or collaboration integration work was in scope.
+
+Precedence decisions:
+
+- GitHub Diamond governed branch naming, trace coverage, surgical mutation,
+  validation evidence and PR readiness.
+- ResearchOps Developer Control governed repository conventions, generated page
+  ownership and route-state test expectations.
+- Multi-Functional Team governed public-sector service assurance and residual
+  risk framing.
+- GOV.UK Design System governed the shared frontend layout, form component
+  markup, input width decisions and page affordance checks.
+- Cloudflare context governed the decision to keep regenerated `public/` output
+  in the change set while the deployment contract publishes committed files.
+
+No bundle conflicts were identified.
+
+## Sub-Agent Selection
+
+Selected 6 roles from the configured 10:
+
+- `TemplateDev` for Nunjucks source ownership and renderer registration.
+- `StyleDev` for Sass source ownership and generated CSS target coverage.
+- `TestDev` for route-state and generated-output contract coverage.
+- `RenderGuard` for source-to-generated-output drift checks.
+- `CheckGuard` for focused validation lane selection and blockers.
+- `ReviewGuard` for changed-file plausibility, trace and PR readiness.
+
+Skipped roles:
+
+- `BranchGuard` - branch hygiene was checked directly and by ReviewGuard for this
+  narrow unit.
+- `RuntimeDev` - no Worker runtime, auth flow or browser controller logic was in scope.
+- `TraceGuard` - trace obligations were handled directly and by ReviewGuard.
+- `DocsDev` - no product-note or documentation content change was needed beyond
+  the required trace artefacts.
+
+## Implementation
+
+Created `src/govuk/templates/pages/start.njk` as the Nunjucks source for
+`/pages/start/`. The template extends `layouts/researchops.njk`, keeps the start
+route stylesheet in the `head` block, preserves the four-step form flow and
+keeps the existing start route JavaScript modules in the `scripts` block.
+
+Registered the page in `scripts/govuk/render-govuk-pages.mjs` so it renders to
+`public/pages/start/index.html`.
+
+Created `src/styles/start.scss` as the Sass source for `public/css/start.css`
+and registered it in `scripts/styles/generated-css-targets.mjs`.
+
+Regenerated `public/css/start.css` and `public/pages/start/index.html`. The
+generated page now uses the shared GOV.UK layout shell and full
+`/assets/govuk/govuk-frontend.css` instead of legacy GOV.UK fragment styles.
+
+Added `*.sublime-workspace` to `.gitignore` and `.prettierignore` so local
+editor workspace files are excluded from commits and repository-wide format
+checks. This addresses the pre-existing validation blocker reported by the
+sub-agents without committing `ResearchOps.sublime-workspace`.
+
+Updated focused route-state tests so they verify:
+
+- `/pages/start/` is registered in the GOV.UK renderer.
+- `src/govuk/templates/pages/start.njk` extends the shared layout.
+- `src/styles/start.scss` is the source for `public/css/start.css`.
+- Generated start page output preserves form IDs, step IDs, AI-assist hooks,
+  default project phase/status copy and the check-answers summary list.
+- The start route no longer depends on legacy GOV.UK fragment styles.
+
+## Files
+
+Read:
+
+- operating-model files listed above
+- selected bundle prompt specs and bodies
+- selected GOV.UK, ResearchOps, GitHub and Cloudflare reference files
+- `/Users/kevin.rapley/.codex/config.toml`
+- `src/govuk/templates/layouts/researchops.njk`
+- `src/govuk/templates/pages/start-overview.njk`
+- `public/pages/start/index.html`
+- `public/css/start.css`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `scripts/styles/generated-css-targets.mjs`
+- start, GOV.UK frontend, Sass migration and render workflow tests
+
+Created:
+
+- `src/govuk/templates/pages/start.njk`
+- `src/styles/start.scss`
+- `docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.md`
+- `docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json`
+
+Modified:
+
+- `.gitignore`
+- `.prettierignore`
+- `public/css/start.css`
+- `public/pages/start/index.html`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `scripts/styles/generated-css-targets.mjs`
+- `tests/govuk-forms-application-route-state.test.js`
+- `tests/govuk-frontend-integration-route-state.test.js`
+- `tests/govuk-pages-render-workflow-state.test.js`
+- `tests/start-page-route-state.test.js`
+
+Unrelated local files deliberately excluded from this unit:
+
+- `infra/cloudflare/src/core/auth/passwordless.js`
+- `ResearchOps.sublime-workspace`
+
+## Validation
+
+Passed:
+
+- `npm run build:generated-css -- public/css/start.css`
+- `npm run build:generated-css`
+- `npm run build:govuk-pages`
+- `npm run generated-css:check`
+- `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/start-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/start-project-step-1-defaults-route-state.test.js tests/govuk-pages-render-workflow-state.test.js tests/sass-migration-route-state.test.js tests/govuk-frontend-integration-route-state.test.js`
+- `node -e` JSON parse check for `docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json`
+- `npm run trace:validate`
+- `npm run trace:coverage`
+- `git diff --check`
+- `npm run format:check`
+- `npm run lint`
+- `npm run build`
+- `npm test`
+- `node --test tests/start-page-route-state.test.js tests/govuk-forms-application-route-state.test.js`
+- `npm run validate`
+- Browser smoke check at `http://127.0.0.1:4173/pages/start/`, which confirmed
+  the page title, H1, project form, four steps, generated GOV.UK CSS, start CSS
+  and absence of the legacy GOV.UK forms fragment stylesheet.
+
+Earlier focused test run failed before test-contract updates because the start
+page no longer loads legacy GOV.UK fragment styles after moving under the shared
+Nunjucks layout. The affected tests were updated to assert the intended new
+contract.
+
+`npm run lint` passed with existing repository warnings. Its generated CSS build
+step temporarily produced an out-of-scope `public/css/brands/home-office.css`
+diff; that generator side-effect was removed from the worktree and is not part
+of this unit.
+
+The first `npm run validate` attempt failed because two direct route-state tests
+asserted exact one-line generated attributes. Those assertions were updated to
+check the same `id` and class contracts independently, then `npm run validate`
+passed.
+
+## Residual Risk
+
+`public/pages/start/index.html` has a larger generated diff because the page
+moved from hand-maintained static HTML to the shared Nunjucks renderer. Review
+should focus on the new template, generated page registration, Sass target and
+route-state assertions, while still checking the regenerated public output.
+
+The worktree contains unrelated local edits to
+`infra/cloudflare/src/core/auth/passwordless.js`; they must not be staged for
+this PR.

--- a/public/css/start.css
+++ b/public/css/start.css
@@ -25,6 +25,10 @@
 	display: none;
 	}
 
+.hidden {
+	display: none;
+	}
+
 .start-step .lede, .start-step .govuk-body {
 	max-width: 760px;
 	}

--- a/public/pages/start/index.html
+++ b/public/pages/start/index.html
@@ -1,209 +1,280 @@
 <!doctype html>
 <html class="govuk-template" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Start a new research project - ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<meta name="sda-auto" content="true" />
-	<title>Start a new research project — ResearchOps Demo Suite</title>
+		<link rel="stylesheet" href="/css/start.css" media="screen" />
 
-	<link rel="stylesheet" href="/css/govuk/govuk-typography.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-colours.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-page-chrome.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-buttons.css" media="screen" />
-	<link rel="stylesheet" href="/css/govuk/govuk-forms.css" media="screen" />
-	<link rel="stylesheet" href="/css/screen.css" media="screen" />
-	<link rel="stylesheet" href="/css/start.css" media="screen" />
+		<script type="module" src="/components/layout.js" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js" defer></script>
+	</head>
+	<body class="govuk-template__body">
+		<script>
+			document.body.className +=
+				" js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
+		</script>
+		<x-include src="/partials/header.html" vars='{"active":"Start Research Project"}'></x-include>
+		<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
+			<div class="govuk-width-container">
+				<div class="page-intro">
+					<div class="govuk-grid-row">
+						<div class="govuk-grid-column-two-thirds">
+							<h1 class="govuk-heading-xl page-title" id="start-title">Start a new research project</h1>
+							<p class="lede">
+								Define the project, then capture stakeholders, initial objectives, user groups and ownership.
+							</p>
+							<p class="govuk-body">
+								Use this guided process to create the project record that will later hold studies, participants,
+								sessions, notes, evidence, insights and recommendations.
+							</p>
+						</div>
+					</div>
+				</div>
 
-	<!-- Components/layout first -->
-	<script type="module" src="/components/layout.js" defer></script>
-
-	<!-- Step 1 owner: imports copilot-suggester internally and sets window.__descAssistActive -->
-	<script type="module" src="/js/start-description-assist.js" defer></script>
-
-	<!-- Step 2 owner: wires objectives AI & rule suggestions -->
-	<script type="module" src="/js/start-objectives-assist.js" defer></script>
-
-	<!-- Main page controller: respects window.__descAssistActive and will not double-wire Step 1 -->
-	<script type="module" src="start-new-project.js" defer></script>
-	<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen">
-	<script type="module" src="/js/govuk-frontend-init.js" defer></script>
-</head>
-
-<body class="govuk-template__body">
-	<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-
-	<x-include src="/partials/debug.html" debug-only></x-include>
-	<x-include
-		src="/partials/header.html"
-		vars='{
-			"active":"Start Research Project",
-			"subtitle":"Define the project, add research framing and set ownership"
-		}'>
-	</x-include>
-
-	<main class="govuk-main-wrapper" id="main-content" role="main" tabindex="-1">
-		<div class="govuk-width-container">
-			<div class="page-intro">
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
-						<h1 class="govuk-heading-xl page-title" id="start-title">Start a new research project</h1>
-						<p class="lede">
-							Define the project, then capture stakeholders, initial objectives, user groups and ownership.
-						</p>
-						<p class="govuk-body">
-							Use this guided process to create the project record that will later hold studies, participants, sessions, notes, evidence, insights and recommendations.
-						</p>
-					</div>
-				</div>
-			</div>
-
-			<div class="govuk-grid-row">
-				<div class="govuk-grid-column-two-thirds">
-					<div class="card start-card">
-						<div id="error-summary" class="govuk-error-summary start-panel" aria-labelledby="error-summary-title" role="alert" tabindex="-1" hidden>
-							<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>
-							<div class="govuk-error-summary__body">
-								<ul id="error-list" class="govuk-list govuk-error-summary__list"></ul>
+						<div class="card start-card">
+							<div
+								id="error-summary"
+								class="govuk-error-summary start-panel"
+								aria-labelledby="error-summary-title"
+								role="alert"
+								tabindex="-1"
+								hidden
+							>
+								<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>
+								<div class="govuk-error-summary__body">
+									<ul id="error-list" class="govuk-list govuk-error-summary__list"></ul>
+								</div>
 							</div>
-						</div>
 
-						<!-- Step 1 -->
-						<section id="step1" class="start-step" aria-labelledby="step1-title">
-							<p class="govuk-caption-l">Step 1 of 4</p>
-							<h2 class="govuk-heading-m" id="step1-title">Define the project</h2>
-							<p class="govuk-body">Give the project a name and description.</p>
-							<p class="govuk-body">ResearchOps will start the project in Discovery with the status Goal setting &amp; problem defining.</p>
+							<section id="step1" class="start-step" aria-labelledby="step1-title">
+								<p class="govuk-caption-l">Step 1 of 4</p>
+								<h2 class="govuk-heading-m" id="step1-title">Define the project</h2>
+								<p class="govuk-body">Give the project a name and description.</p>
+								<p class="govuk-body">
+									ResearchOps will start the project in Discovery with the status Goal setting &amp; problem defining.
+								</p>
 
-							<form id="projectForm" class="start-form" novalidate>
-								<div id="p_name_group" class="govuk-form-group">
-									<label class="govuk-label" for="p_name">Project name</label>
-									<p id="p_name_hint" class="govuk-hint">Use a short name the research team and stakeholders will recognise.</p>
-									<p id="p_name_error" class="govuk-error-message start-error" hidden></p>
-									<input id="p_name" name="name" class="govuk-input" required aria-required="true" aria-invalid="false" aria-describedby="p_name_hint" />
-								</div>
-
-								<div id="p_desc_group" class="govuk-form-group">
-									<label class="govuk-label" for="p_desc">Description</label>
-									<p id="p_desc_help" class="govuk-hint">Write what you plan to research. Do not include participant personal data.</p>
-									<p id="p_desc_error" class="govuk-error-message start-error" hidden></p>
-									<textarea id="p_desc" name="description" class="govuk-textarea" required aria-required="true" aria-invalid="false" aria-describedby="p_desc_help"></textarea>
-								</div>
-
-								<div id="ai-tools" class="toolbar mt-2 hidden start-assist" aria-label="Description assistance">
-									<p id="ai-rewrite-help" class="govuk-hint">
-										This sends the description you entered to an AI service to suggest improvements. Do not include participant personal data.
-									</p>
-									<button class="govuk-button govuk-button--secondary" id="btn-ai-rewrite" type="button" aria-describedby="ai-rewrite-help">Try AI rewrite</button>
-									<small id="ai-rewrite-status" class="mono muted" aria-live="polite"></small>
-								</div>
-
-								<div id="description-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
-								<div id="ai-rewrite-output" class="mt-2 start-assist-output" aria-live="polite"></div>
-
-								<div class="govuk-button-group cta">
-									<button class="govuk-button" id="next2" type="submit">Continue</button>
-								</div>
-							</form>
-						</section>
-
-						<!-- Step 2 -->
-						<section id="step2" class="start-step" hidden aria-labelledby="step2-title">
-							<p class="govuk-caption-l">Step 2 of 4</p>
-							<h2 class="govuk-heading-m" id="step2-title">Add stakeholders, objectives and user groups</h2>
-							<p class="govuk-body">Add the people involved, what the research needs to learn and who the research should include.</p>
-
-							<form id="targetForm" class="start-form" novalidate>
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="p_stakeholders">Stakeholders</label>
-									<p id="p_stakeholders_help" class="govuk-hint">Enter one stakeholder per line using the format: name | role | work email. Staff contact details should only be added where needed for project ownership.</p>
-									<textarea id="p_stakeholders" class="govuk-textarea" aria-describedby="p_stakeholders_help"></textarea>
-								</div>
-
-								<div id="p_objectives_group" class="govuk-form-group">
-									<label class="govuk-label" for="p_objectives">Initial objectives</label>
-									<p id="p_objectives_help" class="govuk-hint">List at least one research objective. Keep objectives action-oriented and linked to decisions the team needs to make. Do not include participant personal data.</p>
-									<p id="p_objectives_error" class="govuk-error-message start-error" hidden></p>
-									<textarea id="p_objectives" name="p_objectives" class="govuk-textarea" rows="5" required aria-required="true" aria-invalid="false" aria-describedby="p_objectives_help"></textarea>
-									<div id="ai-objectives-tools" class="toolbar mt-2 hidden start-assist" aria-label="Objectives assistance">
-										<p id="ai-objectives-help" class="govuk-hint">
-											This sends the objectives you entered to an AI service to suggest improvements. Do not include participant personal data.
+								<form id="projectForm" class="start-form" novalidate>
+									<div id="p_name_group" class="govuk-form-group">
+										<label class="govuk-label" for="p_name">Project name</label>
+										<p id="p_name_hint" class="govuk-hint">
+											Use a short name the research team and stakeholders will recognise.
 										</p>
-										<button class="govuk-button govuk-button--secondary" id="btn-obj-suggestions" type="button">Get suggestions</button>
-										<button class="govuk-button govuk-button--secondary" id="btn-obj-ai-rewrite" type="button" aria-describedby="ai-objectives-help">Try AI rewrite</button>
-										<small id="ai-obj-status" class="mono muted" aria-live="polite"></small>
+										<p id="p_name_error" class="govuk-error-message start-error" hidden></p>
+										<input
+											id="p_name"
+											name="name"
+											class="govuk-input govuk-!-width-two-thirds"
+											required
+											aria-required="true"
+											aria-invalid="false"
+											aria-describedby="p_name_hint"
+										/>
 									</div>
-								</div>
 
-								<div id="objectives-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
-								<div id="ai-objectives-output" class="mt-2 start-assist-output" aria-live="polite"></div>
+									<div id="p_desc_group" class="govuk-form-group">
+										<label class="govuk-label" for="p_desc">Description</label>
+										<p id="p_desc_help" class="govuk-hint">
+											Write what you plan to research. Do not include participant personal data.
+										</p>
+										<p id="p_desc_error" class="govuk-error-message start-error" hidden></p>
+										<textarea
+											id="p_desc"
+											name="description"
+											class="govuk-textarea"
+											required
+											aria-required="true"
+											aria-invalid="false"
+											aria-describedby="p_desc_help"
+										></textarea>
+									</div>
 
-								<div id="p_usergroups_group" class="govuk-form-group">
-									<label class="govuk-label" for="p_usergroups">User groups</label>
-									<p id="p_usergroups_help" class="govuk-hint">Enter at least one user group as a comma-separated list.</p>
-									<p id="p_usergroups_error" class="govuk-error-message start-error" hidden></p>
-									<input id="p_usergroups" class="govuk-input" required aria-required="true" aria-invalid="false" aria-describedby="p_usergroups_help" />
-								</div>
+									<div id="ai-tools" class="toolbar mt-2 hidden start-assist" aria-label="Description assistance">
+										<p id="ai-rewrite-help" class="govuk-hint">
+											This sends the description you entered to an AI service to suggest improvements. Do not include
+											participant personal data.
+										</p>
+										<button
+											class="govuk-button govuk-button--secondary"
+											id="btn-ai-rewrite"
+											type="button"
+											aria-describedby="ai-rewrite-help"
+										>
+											Try AI rewrite
+										</button>
+										<small id="ai-rewrite-status" class="mono muted" aria-live="polite"></small>
+									</div>
+
+									<div id="description-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
+									<div id="ai-rewrite-output" class="mt-2 start-assist-output" aria-live="polite"></div>
+
+									<div class="govuk-button-group cta">
+										<button class="govuk-button" id="next2" type="submit">Continue</button>
+									</div>
+								</form>
+							</section>
+
+							<section id="step2" class="start-step" hidden aria-labelledby="step2-title">
+								<p class="govuk-caption-l">Step 2 of 4</p>
+								<h2 class="govuk-heading-m" id="step2-title">Add stakeholders, objectives and user groups</h2>
+								<p class="govuk-body">
+									Add the people involved, what the research needs to learn and who the research should include.
+								</p>
+
+								<form id="targetForm" class="start-form" novalidate>
+									<div class="govuk-form-group">
+										<label class="govuk-label" for="p_stakeholders">Stakeholders</label>
+										<p id="p_stakeholders_help" class="govuk-hint">
+											Enter one stakeholder per line using the format: name | role | work email. Staff contact details
+											should only be added where needed for project ownership.
+										</p>
+										<textarea
+											id="p_stakeholders"
+											class="govuk-textarea"
+											aria-describedby="p_stakeholders_help"
+										></textarea>
+									</div>
+
+									<div id="p_objectives_group" class="govuk-form-group">
+										<label class="govuk-label" for="p_objectives">Initial objectives</label>
+										<p id="p_objectives_help" class="govuk-hint">
+											List at least one research objective. Keep objectives action-oriented and linked to decisions the
+											team needs to make. Do not include participant personal data.
+										</p>
+										<p id="p_objectives_error" class="govuk-error-message start-error" hidden></p>
+										<textarea
+											id="p_objectives"
+											name="p_objectives"
+											class="govuk-textarea"
+											rows="5"
+											required
+											aria-required="true"
+											aria-invalid="false"
+											aria-describedby="p_objectives_help"
+										></textarea>
+										<div
+											id="ai-objectives-tools"
+											class="toolbar mt-2 hidden start-assist"
+											aria-label="Objectives assistance"
+										>
+											<p id="ai-objectives-help" class="govuk-hint">
+												This sends the objectives you entered to an AI service to suggest improvements. Do not include
+												participant personal data.
+											</p>
+											<button class="govuk-button govuk-button--secondary" id="btn-obj-suggestions" type="button">
+												Get suggestions
+											</button>
+											<button
+												class="govuk-button govuk-button--secondary"
+												id="btn-obj-ai-rewrite"
+												type="button"
+												aria-describedby="ai-objectives-help"
+											>
+												Try AI rewrite
+											</button>
+											<small id="ai-obj-status" class="mono muted" aria-live="polite"></small>
+										</div>
+									</div>
+
+									<div id="objectives-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
+									<div id="ai-objectives-output" class="mt-2 start-assist-output" aria-live="polite"></div>
+
+									<div id="p_usergroups_group" class="govuk-form-group">
+										<label class="govuk-label" for="p_usergroups">User groups</label>
+										<p id="p_usergroups_help" class="govuk-hint">
+											Enter at least one user group as a comma-separated list.
+										</p>
+										<p id="p_usergroups_error" class="govuk-error-message start-error" hidden></p>
+										<input
+											id="p_usergroups"
+											class="govuk-input govuk-!-width-two-thirds"
+											required
+											aria-required="true"
+											aria-invalid="false"
+											aria-describedby="p_usergroups_help"
+										/>
+									</div>
+
+									<div class="govuk-button-group cta">
+										<button class="govuk-button govuk-button--secondary" id="prev1" type="button">Back</button>
+										<button class="govuk-button" id="next3" type="button">Continue</button>
+									</div>
+								</form>
+							</section>
+
+							<section id="step3" class="start-step" hidden aria-labelledby="step3-title">
+								<p class="govuk-caption-l">Step 3 of 4</p>
+								<h2 class="govuk-heading-m" id="step3-title">Add project ownership and notes</h2>
+								<p class="govuk-body">
+									Add supplementary information about who owns the research and anything the team should know before the
+									project is created.
+								</p>
+
+								<form id="researchForm" class="start-form" novalidate>
+									<div class="govuk-form-group">
+										<label class="govuk-label" for="lead_name">Lead researcher</label>
+										<input id="lead_name" class="govuk-input govuk-!-width-two-thirds" value="" />
+									</div>
+
+									<div id="lead_email_group" class="govuk-form-group">
+										<label class="govuk-label" for="lead_email">Researcher&rsquo;s email</label>
+										<p id="lead_email_hint" class="govuk-hint">Use a work email address.</p>
+										<p id="lead_email_error" class="govuk-error-message start-error" hidden></p>
+										<input
+											id="lead_email"
+											type="email"
+											class="govuk-input govuk-!-width-two-thirds"
+											value=""
+											aria-invalid="false"
+											aria-describedby="lead_email_hint"
+										/>
+									</div>
+
+									<div class="govuk-form-group">
+										<label class="govuk-label" for="p_notes">Notes</label>
+										<p id="p_notes_help" class="govuk-hint">
+											Add project notes that will help the team start the work. Do not include participant personal
+											data.
+										</p>
+										<textarea id="p_notes" class="govuk-textarea" aria-describedby="p_notes_help"></textarea>
+									</div>
+
+									<div class="govuk-button-group cta">
+										<button class="govuk-button govuk-button--secondary" id="prev2" type="button">Back</button>
+										<button class="govuk-button" id="next4" type="button">Continue</button>
+									</div>
+								</form>
+							</section>
+
+							<section id="step4" class="start-step" hidden aria-labelledby="step4-title">
+								<p class="govuk-caption-l">Step 4 of 4</p>
+								<h2 class="govuk-heading-m" id="step4-title">Check your answers before creating the project</h2>
+								<p class="govuk-body">
+									Review the project setup before it is saved. You can go back to change anything that is missing or
+									unclear.
+								</p>
+
+								<dl id="check-answers-list" class="govuk-summary-list start-summary-list" aria-live="polite"></dl>
 
 								<div class="govuk-button-group cta">
-									<button class="govuk-button govuk-button--secondary" id="prev1" type="button">Back</button>
-									<button class="govuk-button" id="next3" type="button">Continue</button>
+									<button class="govuk-button govuk-button--secondary" id="prev3" type="button">Back</button>
+									<button class="govuk-button" id="finish" type="button">Create project</button>
 								</div>
-							</form>
-						</section>
-
-						<!-- Step 3 -->
-						<section id="step3" class="start-step" hidden aria-labelledby="step3-title">
-							<p class="govuk-caption-l">Step 3 of 4</p>
-							<h2 class="govuk-heading-m" id="step3-title">Add project ownership and notes</h2>
-							<p class="govuk-body">Add supplementary information about who owns the research and anything the team should know before the project is created.</p>
-
-							<form id="researchForm" class="start-form" novalidate>
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="lead_name">Lead researcher</label>
-									<input id="lead_name" class="govuk-input" value="" />
-								</div>
-
-								<div id="lead_email_group" class="govuk-form-group">
-									<label class="govuk-label" for="lead_email">Researcher&rsquo;s email</label>
-									<p id="lead_email_hint" class="govuk-hint">Use a work email address.</p>
-									<p id="lead_email_error" class="govuk-error-message start-error" hidden></p>
-									<input id="lead_email" type="email" class="govuk-input" value="" aria-invalid="false" aria-describedby="lead_email_hint" />
-								</div>
-
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="p_notes">Notes</label>
-									<p id="p_notes_help" class="govuk-hint">Add project notes that will help the team start the work. Do not include participant personal data.</p>
-									<textarea id="p_notes" class="govuk-textarea" aria-describedby="p_notes_help"></textarea>
-								</div>
-
-								<div class="govuk-button-group cta">
-									<button class="govuk-button govuk-button--secondary" id="prev2" type="button">Back</button>
-									<button class="govuk-button" id="next4" type="button">Continue</button>
-								</div>
-							</form>
-						</section>
-
-						<!-- Step 4 -->
-						<section id="step4" class="start-step" hidden aria-labelledby="step4-title">
-							<p class="govuk-caption-l">Step 4 of 4</p>
-							<h2 class="govuk-heading-m" id="step4-title">Check your answers before creating the project</h2>
-							<p class="govuk-body">Review the project setup before it is saved. You can go back to change anything that is missing or unclear.</p>
-
-							<dl id="check-answers-list" class="govuk-summary-list start-summary-list" aria-live="polite"></dl>
-
-							<div class="govuk-button-group cta">
-								<button class="govuk-button govuk-button--secondary" id="prev3" type="button">Back</button>
-								<button class="govuk-button" id="finish" type="button">Create project</button>
-							</div>
-						</section>
+							</section>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-	</main>
+		</main>
+		<x-include src="/partials/footer.html"></x-include>
 
-	<x-include src="/partials/footer.html"></x-include>
-</body>
-
+		<script type="module" src="/js/start-description-assist.js" defer></script>
+		<script type="module" src="/js/start-objectives-assist.js" defer></script>
+		<script type="module" src="start-new-project.js" defer></script>
+	</body>
 </html>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -197,6 +197,19 @@ export const govukPages = [
 		},
 	},
 	{
+		template: 'pages/start.njk',
+		output: 'public/pages/start/index.html',
+		context: {
+			pageTitle: 'Start a new research project - ResearchOps Demo Suite',
+			serviceName: 'ResearchOps Demo Suite',
+			activeNavigation: 'Start Research Project',
+			navigation: navigation.map((item) => ({
+				...item,
+				active: item.href === '/pages/start/overview/',
+			})),
+		},
+	},
+	{
 		template: 'pages/account.njk',
 		output: 'public/pages/account/index.html',
 		context: {

--- a/scripts/styles/generated-css-targets.mjs
+++ b/scripts/styles/generated-css-targets.mjs
@@ -31,6 +31,11 @@ export const generatedCssTargets = [
 		output: 'public/css/projects.css',
 	},
 	{
+		name: 'Start research project stylesheet',
+		source: 'src/styles/start.scss',
+		output: 'public/css/start.css',
+	},
+	{
 		name: 'Research repository stylesheet',
 		source: 'src/styles/repository.scss',
 		output: 'public/css/repository.css',

--- a/src/govuk/templates/pages/start.njk
+++ b/src/govuk/templates/pages/start.njk
@@ -1,0 +1,168 @@
+{% extends "layouts/researchops.njk" %}
+
+{% block head %}
+	<link rel="stylesheet" href="/css/start.css" media="screen">
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+	<div class="page-intro">
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+				<h1 class="govuk-heading-xl page-title" id="start-title">Start a new research project</h1>
+				<p class="lede">
+					Define the project, then capture stakeholders, initial objectives, user groups and ownership.
+				</p>
+				<p class="govuk-body">
+					Use this guided process to create the project record that will later hold studies, participants, sessions, notes, evidence, insights and recommendations.
+				</p>
+			</div>
+		</div>
+	</div>
+
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds">
+			<div class="card start-card">
+				<div id="error-summary" class="govuk-error-summary start-panel" aria-labelledby="error-summary-title" role="alert" tabindex="-1" hidden>
+					<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>
+					<div class="govuk-error-summary__body">
+						<ul id="error-list" class="govuk-list govuk-error-summary__list"></ul>
+					</div>
+				</div>
+
+				<section id="step1" class="start-step" aria-labelledby="step1-title">
+					<p class="govuk-caption-l">Step 1 of 4</p>
+					<h2 class="govuk-heading-m" id="step1-title">Define the project</h2>
+					<p class="govuk-body">Give the project a name and description.</p>
+					<p class="govuk-body">ResearchOps will start the project in Discovery with the status Goal setting &amp; problem defining.</p>
+
+					<form id="projectForm" class="start-form" novalidate>
+						<div id="p_name_group" class="govuk-form-group">
+							<label class="govuk-label" for="p_name">Project name</label>
+							<p id="p_name_hint" class="govuk-hint">Use a short name the research team and stakeholders will recognise.</p>
+							<p id="p_name_error" class="govuk-error-message start-error" hidden></p>
+							<input id="p_name" name="name" class="govuk-input govuk-!-width-two-thirds" required aria-required="true" aria-invalid="false" aria-describedby="p_name_hint">
+						</div>
+
+						<div id="p_desc_group" class="govuk-form-group">
+							<label class="govuk-label" for="p_desc">Description</label>
+							<p id="p_desc_help" class="govuk-hint">Write what you plan to research. Do not include participant personal data.</p>
+							<p id="p_desc_error" class="govuk-error-message start-error" hidden></p>
+							<textarea id="p_desc" name="description" class="govuk-textarea" required aria-required="true" aria-invalid="false" aria-describedby="p_desc_help"></textarea>
+						</div>
+
+						<div id="ai-tools" class="toolbar mt-2 hidden start-assist" aria-label="Description assistance">
+							<p id="ai-rewrite-help" class="govuk-hint">
+								This sends the description you entered to an AI service to suggest improvements. Do not include participant personal data.
+							</p>
+							<button class="govuk-button govuk-button--secondary" id="btn-ai-rewrite" type="button" aria-describedby="ai-rewrite-help">Try AI rewrite</button>
+							<small id="ai-rewrite-status" class="mono muted" aria-live="polite"></small>
+						</div>
+
+						<div id="description-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
+						<div id="ai-rewrite-output" class="mt-2 start-assist-output" aria-live="polite"></div>
+
+						<div class="govuk-button-group cta">
+							<button class="govuk-button" id="next2" type="submit">Continue</button>
+						</div>
+					</form>
+				</section>
+
+				<section id="step2" class="start-step" hidden aria-labelledby="step2-title">
+					<p class="govuk-caption-l">Step 2 of 4</p>
+					<h2 class="govuk-heading-m" id="step2-title">Add stakeholders, objectives and user groups</h2>
+					<p class="govuk-body">Add the people involved, what the research needs to learn and who the research should include.</p>
+
+					<form id="targetForm" class="start-form" novalidate>
+						<div class="govuk-form-group">
+							<label class="govuk-label" for="p_stakeholders">Stakeholders</label>
+							<p id="p_stakeholders_help" class="govuk-hint">Enter one stakeholder per line using the format: name | role | work email. Staff contact details should only be added where needed for project ownership.</p>
+							<textarea id="p_stakeholders" class="govuk-textarea" aria-describedby="p_stakeholders_help"></textarea>
+						</div>
+
+						<div id="p_objectives_group" class="govuk-form-group">
+							<label class="govuk-label" for="p_objectives">Initial objectives</label>
+							<p id="p_objectives_help" class="govuk-hint">List at least one research objective. Keep objectives action-oriented and linked to decisions the team needs to make. Do not include participant personal data.</p>
+							<p id="p_objectives_error" class="govuk-error-message start-error" hidden></p>
+							<textarea id="p_objectives" name="p_objectives" class="govuk-textarea" rows="5" required aria-required="true" aria-invalid="false" aria-describedby="p_objectives_help"></textarea>
+							<div id="ai-objectives-tools" class="toolbar mt-2 hidden start-assist" aria-label="Objectives assistance">
+								<p id="ai-objectives-help" class="govuk-hint">
+									This sends the objectives you entered to an AI service to suggest improvements. Do not include participant personal data.
+								</p>
+								<button class="govuk-button govuk-button--secondary" id="btn-obj-suggestions" type="button">Get suggestions</button>
+								<button class="govuk-button govuk-button--secondary" id="btn-obj-ai-rewrite" type="button" aria-describedby="ai-objectives-help">Try AI rewrite</button>
+								<small id="ai-obj-status" class="mono muted" aria-live="polite"></small>
+							</div>
+						</div>
+
+						<div id="objectives-suggestions" class="mt-2 start-assist-output" aria-live="polite"></div>
+						<div id="ai-objectives-output" class="mt-2 start-assist-output" aria-live="polite"></div>
+
+						<div id="p_usergroups_group" class="govuk-form-group">
+							<label class="govuk-label" for="p_usergroups">User groups</label>
+							<p id="p_usergroups_help" class="govuk-hint">Enter at least one user group as a comma-separated list.</p>
+							<p id="p_usergroups_error" class="govuk-error-message start-error" hidden></p>
+							<input id="p_usergroups" class="govuk-input govuk-!-width-two-thirds" required aria-required="true" aria-invalid="false" aria-describedby="p_usergroups_help">
+						</div>
+
+						<div class="govuk-button-group cta">
+							<button class="govuk-button govuk-button--secondary" id="prev1" type="button">Back</button>
+							<button class="govuk-button" id="next3" type="button">Continue</button>
+						</div>
+					</form>
+				</section>
+
+				<section id="step3" class="start-step" hidden aria-labelledby="step3-title">
+					<p class="govuk-caption-l">Step 3 of 4</p>
+					<h2 class="govuk-heading-m" id="step3-title">Add project ownership and notes</h2>
+					<p class="govuk-body">Add supplementary information about who owns the research and anything the team should know before the project is created.</p>
+
+					<form id="researchForm" class="start-form" novalidate>
+						<div class="govuk-form-group">
+							<label class="govuk-label" for="lead_name">Lead researcher</label>
+							<input id="lead_name" class="govuk-input govuk-!-width-two-thirds" value="">
+						</div>
+
+						<div id="lead_email_group" class="govuk-form-group">
+							<label class="govuk-label" for="lead_email">Researcher&rsquo;s email</label>
+							<p id="lead_email_hint" class="govuk-hint">Use a work email address.</p>
+							<p id="lead_email_error" class="govuk-error-message start-error" hidden></p>
+							<input id="lead_email" type="email" class="govuk-input govuk-!-width-two-thirds" value="" aria-invalid="false" aria-describedby="lead_email_hint">
+						</div>
+
+						<div class="govuk-form-group">
+							<label class="govuk-label" for="p_notes">Notes</label>
+							<p id="p_notes_help" class="govuk-hint">Add project notes that will help the team start the work. Do not include participant personal data.</p>
+							<textarea id="p_notes" class="govuk-textarea" aria-describedby="p_notes_help"></textarea>
+						</div>
+
+						<div class="govuk-button-group cta">
+							<button class="govuk-button govuk-button--secondary" id="prev2" type="button">Back</button>
+							<button class="govuk-button" id="next4" type="button">Continue</button>
+						</div>
+					</form>
+				</section>
+
+				<section id="step4" class="start-step" hidden aria-labelledby="step4-title">
+					<p class="govuk-caption-l">Step 4 of 4</p>
+					<h2 class="govuk-heading-m" id="step4-title">Check your answers before creating the project</h2>
+					<p class="govuk-body">Review the project setup before it is saved. You can go back to change anything that is missing or unclear.</p>
+
+					<dl id="check-answers-list" class="govuk-summary-list start-summary-list" aria-live="polite"></dl>
+
+					<div class="govuk-button-group cta">
+						<button class="govuk-button govuk-button--secondary" id="prev3" type="button">Back</button>
+						<button class="govuk-button" id="finish" type="button">Create project</button>
+					</div>
+				</section>
+			</div>
+		</div>
+	</div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+	<script type="module" src="/js/start-description-assist.js" defer></script>
+	<script type="module" src="/js/start-objectives-assist.js" defer></script>
+	<script type="module" src="start-new-project.js" defer></script>
+{% endblock %}

--- a/src/styles/start.scss
+++ b/src/styles/start.scss
@@ -25,6 +25,10 @@
 	display: none;
 }
 
+.hidden {
+	display: none;
+}
+
 .start-step .lede,
 .start-step .govuk-body {
 	max-width: 760px;

--- a/src/styles/start.scss
+++ b/src/styles/start.scss
@@ -11,83 +11,86 @@
 
 .start-card {
 	margin-bottom: 24px;
-	}
+}
 
 .start-step {
 	margin-top: 24px;
-	}
+}
 
 .start-step:first-of-type {
 	margin-top: 0;
-	}
+}
 
 .start-step[hidden] {
 	display: none;
-	}
+}
 
-.start-step .lede, .start-step .govuk-body {
+.start-step .lede,
+.start-step .govuk-body {
 	max-width: 760px;
-	}
+}
 
 .start-form {
 	display: grid;
 	gap: 12px;
-	}
+}
 
 .start-form label {
 	margin: 0;
-	}
+}
 
 .start-form textarea {
 	min-height: 140px;
 	resize: vertical;
-	}
+}
 
-.start-form select, .start-form textarea {
+.start-form select,
+.start-form textarea {
 	border: 2px solid #0b0c0c;
 	padding: 8px;
 	font: inherit;
-	}
+}
 
 .start-form .hint {
 	margin: 0;
-	}
+}
 
-.start-form .cta, .start-step .cta {
+.start-form .cta,
+.start-step .cta {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
 	margin-top: 8px;
-	}
+}
 
 .start-panel {
 	margin: 12px 0 24px;
-	}
+}
 
 .start-assist {
 	margin-top: 8px;
-	}
+}
 
 .start-assist-output {
 	margin-top: 8px;
-	}
+}
 
 .start-error {
 	margin: 12px 0;
-	}
+}
 
 .start-summary-list {
 	margin-bottom: 24px;
-	}
+}
 
 .start-summary-list .govuk-summary-list__value {
 	word-break: break-word;
-	}
+}
 
 @media (min-width: 40.0625em) {
 	.start-summary-list .govuk-summary-list__actions {
 		width: 20%;
-		}
 	}
+}
 
 /* transparency begins in the cascade */

--- a/tests/govuk-forms-application-route-state.test.js
+++ b/tests/govuk-forms-application-route-state.test.js
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const legacyFormRoutes = [
-	"public/pages/start/index.html",
 	"public/pages/search/index.html",
 	"public/pages/notes/index.html",
 	"public/pages/consent/index.html",
@@ -36,7 +35,10 @@ for (const route of legacyFormRoutes) {
 }
 
 const startPage = read("public/pages/start/index.html");
-includes(startPage, "id=\"error-summary\" class=\"govuk-error-summary start-panel\"", "Start route");
+includes(startPage, "href=\"/assets/govuk/govuk-frontend.css\"", "Start route");
+excludes(startPage, "href=\"/css/govuk/govuk-forms.css\"", "Start route");
+includes(startPage, "id=\"error-summary\"", "Start route");
+includes(startPage, "class=\"govuk-error-summary start-panel\"", "Start route");
 includes(startPage, "class=\"govuk-textarea\"", "Start route");
 includes(startPage, "class=\"govuk-button-group cta\"", "Start route");
 includes(startPage, "Give the project a name and description.", "Start route");

--- a/tests/govuk-frontend-integration-route-state.test.js
+++ b/tests/govuk-frontend-integration-route-state.test.js
@@ -58,6 +58,8 @@ assert.equal(
 );
 assert.match(generatedCssTargets, /source: 'src\/styles\/projects\.scss'/);
 assert.match(generatedCssTargets, /output: 'public\/css\/projects\.css'/);
+assert.match(generatedCssTargets, /source: 'src\/styles\/start\.scss'/);
+assert.match(generatedCssTargets, /output: 'public\/css\/start\.css'/);
 assert.match(generatedCssTargets, /source: 'src\/styles\/project-dashboard\.scss'/);
 assert.match(generatedCssTargets, /output: 'public\/css\/project-dashboard\.css'/);
 assert.match(generatedCssTargets, /source: 'src\/styles\/outcomes\.scss'/);

--- a/tests/govuk-pages-render-workflow-state.test.js
+++ b/tests/govuk-pages-render-workflow-state.test.js
@@ -82,6 +82,8 @@ assert.equal(
 
 includes(renderer, "output: 'public/pages/projects/journals/index.html'", 'GOV.UK pages renderer');
 includes(renderer, "template: 'pages/projects-journals.njk'", 'GOV.UK pages renderer');
+includes(renderer, "output: 'public/pages/start/index.html'", 'GOV.UK pages renderer');
+includes(renderer, "template: 'pages/start.njk'", 'GOV.UK pages renderer');
 
 for (const snippet of [
 	'Cloudflare Pages currently publishes the committed `public/` directory',

--- a/tests/start-page-route-state.test.js
+++ b/tests/start-page-route-state.test.js
@@ -73,6 +73,7 @@ includes(buttonCssSource, ".govuk-button--warning", "GOV.UK button stylesheet");
 includes(stylesheetSource, ".start-card", "start stylesheet");
 includes(stylesheetSource, ".start-step", "start stylesheet");
 includes(stylesheetSource, ".start-step[hidden]", "start stylesheet");
+includes(stylesheetSource, ".hidden", "start stylesheet");
 includes(stylesheetSource, ".start-form", "start stylesheet");
 includes(stylesheetSource, ".start-panel", "start stylesheet");
 includes(stylesheetSource, ".start-assist", "start stylesheet");

--- a/tests/start-page-route-state.test.js
+++ b/tests/start-page-route-state.test.js
@@ -3,6 +3,10 @@ import fs from "node:fs";
 
 const pageSource = fs.readFileSync("public/pages/start/index.html", "utf8");
 const stylesheetSource = fs.readFileSync("public/css/start.css", "utf8");
+const startTemplateSource = fs.readFileSync("src/govuk/templates/pages/start.njk", "utf8");
+const startSassSource = fs.readFileSync("src/styles/start.scss", "utf8");
+const generatedCssTargets = fs.readFileSync("scripts/styles/generated-css-targets.mjs", "utf8");
+const govukPageRenderer = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "utf8");
 const buttonCssSource = fs.readFileSync("public/css/govuk/govuk-buttons.css", "utf8");
 
 function includes(source, text, label) {
@@ -13,19 +17,21 @@ function excludes(source, text, label) {
   assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
-includes(pageSource, "href=\"/css/govuk/govuk-page-chrome.css\"", "start page");
-includes(pageSource, "href=\"/css/screen.css\"", "start page");
-includes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "start page");
+includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "start page");
 includes(pageSource, "href=\"/css/start.css\"", "start page");
 includes(pageSource, "src=\"/components/layout.js\" defer", "start page");
 includes(pageSource, "src=\"/js/start-description-assist.js\" defer", "start page");
 includes(pageSource, "src=\"/js/start-objectives-assist.js\" defer", "start page");
 includes(pageSource, "src=\"start-new-project.js\" defer", "start page");
+excludes(pageSource, "href=\"/css/govuk/govuk-page-chrome.css\"", "start page");
+excludes(pageSource, "href=\"/css/govuk/govuk-buttons.css\"", "start page");
+excludes(pageSource, "href=\"/css/govuk/govuk-forms.css\"", "start page");
 includes(pageSource, "<main class=\"govuk-main-wrapper\" id=\"main-content\" role=\"main\" tabindex=\"-1\">", "start page");
 includes(pageSource, "<div class=\"govuk-width-container\">", "start page");
 includes(pageSource, "<div class=\"govuk-grid-column-two-thirds\">", "start page");
 includes(pageSource, "class=\"card start-card\"", "start page");
-includes(pageSource, "id=\"error-summary\" class=\"govuk-error-summary start-panel\"", "start page");
+includes(pageSource, "id=\"error-summary\"", "start page");
+includes(pageSource, "class=\"govuk-error-summary start-panel\"", "start page");
 includes(pageSource, "id=\"error-list\" class=\"govuk-list govuk-error-summary__list\"", "start page");
 includes(pageSource, "class=\"start-step\"", "start page");
 includes(pageSource, "class=\"start-form\"", "start page");
@@ -74,3 +80,16 @@ includes(stylesheetSource, ".start-assist-output", "start stylesheet");
 includes(stylesheetSource, ".start-error", "start stylesheet");
 includes(stylesheetSource, ".start-summary-list", "start stylesheet");
 includes(stylesheetSource, "/* transparency begins in the cascade */", "start stylesheet");
+
+includes(startTemplateSource, '{% extends "layouts/researchops.njk" %}', "start template");
+includes(startTemplateSource, 'href="/css/start.css"', "start template");
+includes(startTemplateSource, 'id="projectForm"', "start template");
+includes(startTemplateSource, 'id="step4"', "start template");
+includes(startTemplateSource, 'src="start-new-project.js"', "start template");
+includes(startSassSource, ".start-card", "start Sass source");
+includes(startSassSource, "margin-bottom: 24px", "start Sass source");
+includes(startSassSource, "border: 2px solid #0b0c0c", "start Sass source");
+includes(generatedCssTargets, "source: 'src/styles/start.scss'", "generated CSS targets");
+includes(generatedCssTargets, "output: 'public/css/start.css'", "generated CSS targets");
+includes(govukPageRenderer, "template: 'pages/start.njk'", "GOV.UK page renderer");
+includes(govukPageRenderer, "output: 'public/pages/start/index.html'", "GOV.UK page renderer");


### PR DESCRIPTION
## Summary

- Add `src/govuk/templates/pages/start.njk` and register `/pages/start/` in the GOV.UK page renderer.
- Add `src/styles/start.scss` and register it as the generated source for `public/css/start.css`.
- Regenerate `public/pages/start/index.html` and `public/css/start.css` from those sources.
- Update route-state tests to assert the new Nunjucks/Sass ownership and shared GOV.UK Frontend layout contract.
- Ignore local Sublime workspace files so editor state is not picked up by commits or formatting checks.

## Why

`/pages/start/` was still maintained as static committed HTML and CSS, while adjacent GOV.UK pages use checked-in Nunjucks templates and registered Sass-generated styles. This made the start page harder to regenerate consistently and left tests protecting only the public artefacts rather than the source ownership path.

## Validation

- `npm run build:generated-css -- public/css/start.css`
- `npm run build:generated-css`
- `npm run build:govuk-pages`
- `npm run generated-css:check`
- `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/start-page-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/start-project-step-1-defaults-route-state.test.js tests/govuk-pages-render-workflow-state.test.js tests/sass-migration-route-state.test.js tests/govuk-frontend-integration-route-state.test.js`
- `node -e` JSON parse check for `docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json`
- `npm run trace:validate`
- `npm run trace:coverage`
- `git diff --check`
- `npm run format:check`
- `npm run lint` passed with existing repository warnings
- `npm test` passed, 222 tests

## Trace

Required for `fix/` branch policy:

- `docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.md`
- `docs/agent-audit/reasoning/2026/06/15/pages-start-nunjucks-sass.json`

## Risk and rollout

The generated HTML diff for `public/pages/start/index.html` is larger because the page now comes from the shared Nunjucks layout. Review should focus on the source template, renderer registration, Sass target and route-state assertions, while checking the regenerated output for deployment shape.

A pre-existing local change to `infra/cloudflare/src/core/auth/passwordless.js` was deliberately not included in this PR.
