### PR TITLE
Adjust home hero desktop column widths

### DIFF
--- a/assets/researchops/researchops-home.css
+++ b/assets/researchops/researchops-home.css
@@ -120,6 +120,17 @@
 	padding: 25px 0 0;
 	}
 
+.researchops-home-hero__content-column, .researchops-home-hero__image-column {
+	box-sizing: border-box;
+	}
+
+.researchops-home-hero__image {
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	height: auto;
+	}
+
 .researchops-home-masthead .govuk-heading-xl, .researchops-home-masthead .govuk-body-l, .researchops-home-masthead .govuk-body {
 	color: #ffffff;
 	}
@@ -206,6 +217,14 @@
 	}
 
 @media (min-width: 40.0625em) {
+	.researchops-home-hero__content-column {
+		width: 55%;
+		}
+	.researchops-home-hero__image-column {
+		width: 45%;
+		padding-right: 0;
+		padding-left: 0;
+		}
 	.researchops-highlight-panel, .researchops-journey-map {
 		padding: 30px;
 		}

--- a/docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.json
+++ b/docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.json
@@ -1,0 +1,66 @@
+{
+	"date": "2026-06-16",
+	"branch": "feature/domain-brand-routing",
+	"traceRequired": true,
+	"repository": "kevinrapley/ResearchOps",
+	"task": "Update the ResearchOps home page masthead desktop layout so the hero text column is 55% and the SVG column is 45%.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		".agent-operating-model/bundles/github/",
+		".agent-operating-model/bundles/researchops-developer-control/",
+		".agent-operating-model/bundles/multi-functional-team/",
+		".agent-operating-model/bundles/govuk-design-system/"
+	],
+	"skippedBundles": [
+		".agent-operating-model/bundles/cloudflare/",
+		".agent-operating-model/bundles/openai/",
+		".agent-operating-model/bundles/mcp-agent-tooling/",
+		".agent-operating-model/bundles/airtable-public-api/",
+		".agent-operating-model/bundles/mural-public-api/"
+	],
+	"filesRead": [
+		"src/govuk/templates/pages/home.njk",
+		"src/styles/researchops-home.scss",
+		"public/index.html",
+		"assets/researchops/researchops-home.css",
+		"public/assets/researchops/researchops-home.css",
+		"tests/deploy-asset-paths.test.js",
+		"scripts/styles/build-generated-css.mjs",
+		"scripts/styles/generated-css-targets.mjs"
+	],
+	"filesModified": [
+		"src/govuk/templates/pages/home.njk",
+		"src/styles/researchops-home.scss",
+		"public/index.html",
+		"assets/researchops/researchops-home.css",
+		"public/assets/researchops/researchops-home.css",
+		"tests/researchops-home-hero-layout-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.md",
+		"docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.json"
+	],
+	"decisions": [
+		"Add a route-specific content-column class to the home hero text column.",
+		"Override GOV.UK desktop grid widths to 55% and 45% at the existing desktop breakpoint.",
+		"Remove desktop horizontal padding from the image column so the SVG fills the 45% column.",
+		"Keep mobile behaviour unchanged by scoping layout overrides to the desktop media query.",
+		"Regenerate committed home CSS outputs and public/index.html."
+	],
+	"validationAttempted": [
+		"node --test tests/researchops-home-hero-layout-route-state.test.js tests/deploy-asset-paths.test.js",
+		"npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/index.html public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css",
+		"Browser measurement at 1280px viewport: text column 55%, image column 45%, SVG fills image column",
+		"npm test -- --test-reporter=spec"
+	],
+	"residualRisks": [
+		"npm run validate was not run during this pass."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.md
+++ b/docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.md
@@ -1,0 +1,91 @@
+# Home hero desktop columns
+
+## Task summary
+
+Update the ResearchOps home page masthead so the desktop hero text column is 55% wide and the adjacent SVG illustration column is 45% wide, with the SVG fitting that 45% space.
+
+## Run metadata
+
+- Date: 2026-06-16
+- Branch: `feature/domain-brand-routing`
+- Trace required: yes, because `feature/` branches require an auditable trace.
+- Repository: `kevinrapley/ResearchOps`
+
+## Operating model loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Bundles selected
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+## Bundles skipped
+
+- `.agent-operating-model/bundles/cloudflare/`: no Worker, Pages routing, binding or deployment behaviour changed.
+- `.agent-operating-model/bundles/openai/`: no OpenAI API, model or AI route behaviour changed.
+- `.agent-operating-model/bundles/mcp-agent-tooling/`: no MCP protocol or agent tooling changed.
+- `.agent-operating-model/bundles/airtable-public-api/`: no Airtable API behaviour changed.
+- `.agent-operating-model/bundles/mural-public-api/`: no Mural API behaviour changed.
+
+## Precedence decisions
+
+- GitHub Diamond governed branch naming, trace requirement, surgical mutation and validation evidence.
+- ResearchOps Developer Control governed source-first changes to Nunjucks and Sass plus generated deploy assets.
+- Multi-Functional Team governed public-sector service usability and readability of the home page hero.
+- GOV.UK Design System governed preserving the GOV.UK grid structure while applying route-specific desktop width overrides.
+
+## Files read
+
+- `src/govuk/templates/pages/home.njk`
+- `src/styles/researchops-home.scss`
+- `public/index.html`
+- `assets/researchops/researchops-home.css`
+- `public/assets/researchops/researchops-home.css`
+- `tests/deploy-asset-paths.test.js`
+- `scripts/styles/build-generated-css.mjs`
+- `scripts/styles/generated-css-targets.mjs`
+
+## Files created or modified
+
+- `src/govuk/templates/pages/home.njk`
+- `src/styles/researchops-home.scss`
+- `public/index.html`
+- `assets/researchops/researchops-home.css`
+- `public/assets/researchops/researchops-home.css`
+- `tests/researchops-home-hero-layout-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.md`
+- `docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.json`
+
+## Decisions
+
+- Added a dedicated `researchops-home-hero__content-column` class to the existing GOV.UK two-thirds text column.
+- Kept the existing `researchops-home-hero__image-column` and `researchops-home-hero__image` hooks for the SVG column and image.
+- Overrode the GOV.UK desktop grid widths at `40.0625em` so the content column is `55%` and the image column is `45%`.
+- Removed desktop horizontal padding from the image column so the SVG fills the 45% column rather than only the padded inner area.
+- Kept mobile behaviour unchanged by applying the width and padding overrides only inside the desktop media query.
+- Regenerated both committed home stylesheet outputs and the rendered home page.
+
+## Validation attempted
+
+- `node --test tests/researchops-home-hero-layout-route-state.test.js tests/deploy-asset-paths.test.js` passed.
+- `npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/index.html public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css` passed.
+- Browser measurement at 1280px viewport passed: text column `55%`, image column `45%`, SVG fills image column.
+- `npm test -- --test-reporter=spec` passed with 227 tests.
+
+## Existing local changes
+
+- `infra/cloudflare/src/core/auth/passwordless.js` was already modified locally and was left untouched and unstaged.
+
+## Residual risks
+
+- `npm run validate` was not run during this pass.

--- a/public/assets/researchops/researchops-home.css
+++ b/public/assets/researchops/researchops-home.css
@@ -120,6 +120,17 @@
 	padding: 25px 0 0;
 	}
 
+.researchops-home-hero__content-column, .researchops-home-hero__image-column {
+	box-sizing: border-box;
+	}
+
+.researchops-home-hero__image {
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	height: auto;
+	}
+
 .researchops-home-masthead .govuk-heading-xl, .researchops-home-masthead .govuk-body-l, .researchops-home-masthead .govuk-body {
 	color: #ffffff;
 	}
@@ -206,6 +217,14 @@
 	}
 
 @media (min-width: 40.0625em) {
+	.researchops-home-hero__content-column {
+		width: 55%;
+		}
+	.researchops-home-hero__image-column {
+		width: 45%;
+		padding-right: 0;
+		padding-left: 0;
+		}
 	.researchops-highlight-panel, .researchops-journey-map {
 		padding: 30px;
 		}

--- a/public/index.html
+++ b/public/index.html
@@ -22,11 +22,12 @@
 				<section class="researchops-home-hero" aria-labelledby="home-title">
 					<div class="govuk-width-container">
 						<div class="govuk-grid-row">
-							<div class="govuk-grid-column-two-thirds">
+							<div class="govuk-grid-column-two-thirds researchops-home-hero__content-column">
 								<h1 class="govuk-heading-xl" id="home-title">Home Office Digital ResearchOps</h1>
 								<p class="govuk-body-l">Research operations for public services.</p>
 								<p class="govuk-body">
-									Plan, approve, run and reuse user research. Keep a clear record of ethics, evidence, risks and decisions, so teams can see what is known, what is uncertain and what needs to happen next.
+									Plan, approve, run and reuse user research. Keep a clear record of ethics, evidence, risks and
+									decisions, so teams can see what is known, what is uncertain and what needs to happen next.
 								</p>
 							</div>
 							<div class="govuk-grid-column-one-third researchops-home-hero__image-column">

--- a/src/govuk/templates/pages/home.njk
+++ b/src/govuk/templates/pages/home.njk
@@ -12,7 +12,7 @@
 	<section class="researchops-home-hero" aria-labelledby="home-title">
 		<div class="govuk-width-container">
 			<div class="govuk-grid-row">
-				<div class="govuk-grid-column-two-thirds">
+				<div class="govuk-grid-column-two-thirds researchops-home-hero__content-column">
 					<h1 class="govuk-heading-xl" id="home-title">Home Office Digital ResearchOps</h1>
 					<p class="govuk-body-l">Research operations for public services.</p>
 					<p class="govuk-body">Plan, approve, run and reuse user research. Keep a clear record of ethics, evidence, risks and decisions, so teams can see what is known, what is uncertain and what needs to happen next.</p>

--- a/src/styles/researchops-home.scss
+++ b/src/styles/researchops-home.scss
@@ -119,6 +119,18 @@
 	padding: govuk-spacing(5) 0 0;
 }
 
+.researchops-home-hero__content-column,
+.researchops-home-hero__image-column {
+	box-sizing: border-box;
+}
+
+.researchops-home-hero__image {
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	height: auto;
+}
+
 .researchops-home-masthead .govuk-heading-xl,
 .researchops-home-masthead .govuk-body-l,
 .researchops-home-masthead .govuk-body {
@@ -207,6 +219,16 @@
 }
 
 @media (min-width: 40.0625em) {
+	.researchops-home-hero__content-column {
+		width: 55%;
+	}
+
+	.researchops-home-hero__image-column {
+		width: 45%;
+		padding-right: 0;
+		padding-left: 0;
+	}
+
 	.researchops-highlight-panel,
 	.researchops-journey-map {
 		padding: govuk-spacing(6);

--- a/tests/researchops-home-hero-layout-route-state.test.js
+++ b/tests/researchops-home-hero-layout-route-state.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const homeTemplate = fs.readFileSync('src/govuk/templates/pages/home.njk', 'utf8');
+const homePage = fs.readFileSync('public/index.html', 'utf8');
+const homeCss = fs.readFileSync('public/assets/researchops/researchops-home.css', 'utf8');
+
+assert.match(
+	homeTemplate,
+	/class="govuk-grid-column-two-thirds researchops-home-hero__content-column"/
+);
+assert.match(homePage, /class="govuk-grid-column-two-thirds researchops-home-hero__content-column"/);
+assert.match(homePage, /class="govuk-grid-column-one-third researchops-home-hero__image-column"/);
+assert.match(homePage, /class="researchops-home-hero__image"/);
+
+assert.match(
+	homeCss,
+	/@media \(min-width: 40\.0625em\) \{[\s\S]*?\.researchops-home-hero__content-column \{[\s\S]*?width: 55%;[\s\S]*?\.researchops-home-hero__image-column \{[\s\S]*?width: 45%;[\s\S]*?padding-right: 0;[\s\S]*?padding-left: 0;/
+);
+assert.match(
+	homeCss,
+	/\.researchops-home-hero__image \{[\s\S]*?width: 100%;[\s\S]*?max-width: 100%;[\s\S]*?height: auto;/
+);


### PR DESCRIPTION
## Summary
- Set the home page hero text column to 55% and the SVG column to 45% on desktop
- Make the SVG fill the 45% image column while preserving mobile behaviour
- Add a route-state regression test and required trace evidence

## Validation
- node --test tests/researchops-home-hero-layout-route-state.test.js tests/deploy-asset-paths.test.js
- npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/index.html public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css
- Browser measurement at 1280px: text column 55%, image column 45%, SVG fills image column
- npm test -- --test-reporter=spec

## Trace
- docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.md
- docs/agent-audit/reasoning/2026/06/16/home-hero-desktop-columns.json