### PR TITLE
Cap home hero SVG on mobile

### DIFF
--- a/assets/researchops/researchops-home.css
+++ b/assets/researchops/researchops-home.css
@@ -126,7 +126,7 @@
 
 .researchops-home-hero__image {
 	display: block;
-	width: 100%;
+	width: 320px;
 	max-width: 100%;
 	height: auto;
 	}
@@ -224,6 +224,9 @@
 		width: 45%;
 		padding-right: 0;
 		padding-left: 0;
+		}
+	.researchops-home-hero__image {
+		width: 100%;
 		}
 	.researchops-highlight-panel, .researchops-journey-map {
 		padding: 30px;

--- a/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.json
+++ b/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.json
@@ -29,12 +29,16 @@
 	],
 	"filesRead": [
 		"src/styles/researchops-home.scss",
+		"src/govuk/templates/pages/home.njk",
+		"public/index.html",
 		"tests/researchops-home-hero-layout-route-state.test.js",
 		"assets/researchops/researchops-home.css",
 		"public/assets/researchops/researchops-home.css"
 	],
 	"filesModified": [
 		"src/styles/researchops-home.scss",
+		"src/govuk/templates/pages/home.njk",
+		"public/index.html",
 		"assets/researchops/researchops-home.css",
 		"public/assets/researchops/researchops-home.css",
 		"tests/researchops-home-hero-layout-route-state.test.js",
@@ -45,13 +49,15 @@
 		"Treat the Codex review comment as legitimate.",
 		"Set the mobile/default SVG width to 320px with max-width 100%.",
 		"Keep SVG width 100% scoped to the desktop media query.",
-		"Update route-state coverage for both mobile/default and desktop image sizing."
+		"Update route-state coverage for both mobile/default and desktop image sizing.",
+		"Bump the home stylesheet query string to home-masthead-mobile-svg-20260616 so deployed clients request the updated CSS."
 	],
 	"validationAttempted": [
 		"node --test tests/researchops-home-hero-layout-route-state.test.js tests/deploy-asset-paths.test.js",
 		"npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css",
 		"Browser measurements at 360px, 640px and 1280px viewports",
-		"npm test -- --test-reporter=spec"
+		"npm test -- --test-reporter=spec",
+		"npm run build:govuk-pages"
 	],
 	"residualRisks": [
 		"npm run validate was not run during this pass."

--- a/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.json
+++ b/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.json
@@ -1,0 +1,59 @@
+{
+	"date": "2026-06-16",
+	"branch": "fix/home-hero-mobile-svg",
+	"traceRequired": true,
+	"repository": "kevinrapley/ResearchOps",
+	"task": "Fix the home hero SVG mobile sizing regression raised by Codex review feedback.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		".agent-operating-model/bundles/github/",
+		".agent-operating-model/bundles/researchops-developer-control/",
+		".agent-operating-model/bundles/multi-functional-team/",
+		".agent-operating-model/bundles/govuk-design-system/"
+	],
+	"skippedBundles": [
+		".agent-operating-model/bundles/cloudflare/",
+		".agent-operating-model/bundles/openai/",
+		".agent-operating-model/bundles/mcp-agent-tooling/",
+		".agent-operating-model/bundles/airtable-public-api/",
+		".agent-operating-model/bundles/mural-public-api/"
+	],
+	"filesRead": [
+		"src/styles/researchops-home.scss",
+		"tests/researchops-home-hero-layout-route-state.test.js",
+		"assets/researchops/researchops-home.css",
+		"public/assets/researchops/researchops-home.css"
+	],
+	"filesModified": [
+		"src/styles/researchops-home.scss",
+		"assets/researchops/researchops-home.css",
+		"public/assets/researchops/researchops-home.css",
+		"tests/researchops-home-hero-layout-route-state.test.js",
+		"docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.md",
+		"docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.json"
+	],
+	"decisions": [
+		"Treat the Codex review comment as legitimate.",
+		"Set the mobile/default SVG width to 320px with max-width 100%.",
+		"Keep SVG width 100% scoped to the desktop media query.",
+		"Update route-state coverage for both mobile/default and desktop image sizing."
+	],
+	"validationAttempted": [
+		"node --test tests/researchops-home-hero-layout-route-state.test.js tests/deploy-asset-paths.test.js",
+		"npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css",
+		"Browser measurements at 360px, 640px and 1280px viewports",
+		"npm test -- --test-reporter=spec"
+	],
+	"residualRisks": [
+		"npm run validate was not run during this pass."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.md
+++ b/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.md
@@ -47,6 +47,8 @@ Address a Codex review finding after the home hero column-width change: prevent 
 ## Files read
 
 - `src/styles/researchops-home.scss`
+- `src/govuk/templates/pages/home.njk`
+- `public/index.html`
 - `tests/researchops-home-hero-layout-route-state.test.js`
 - `assets/researchops/researchops-home.css`
 - `public/assets/researchops/researchops-home.css`
@@ -54,6 +56,8 @@ Address a Codex review finding after the home hero column-width change: prevent 
 ## Files created or modified
 
 - `src/styles/researchops-home.scss`
+- `src/govuk/templates/pages/home.njk`
+- `public/index.html`
 - `assets/researchops/researchops-home.css`
 - `public/assets/researchops/researchops-home.css`
 - `tests/researchops-home-hero-layout-route-state.test.js`
@@ -66,6 +70,7 @@ Address a Codex review finding after the home hero column-width change: prevent 
 - Set the mobile/default SVG width to `320px` with `max-width: 100%`, so the image respects the intended intrinsic width while still fitting narrower screens.
 - Keep `width: 100%` only inside the desktop media query so the SVG fills the 45% desktop image column.
 - Update the route-state test to assert separate mobile/default and desktop image-width contracts.
+- Bump the home stylesheet query string to `home-masthead-mobile-svg-20260616` so clients and CDN edges request the updated CSS rather than a previously cached URL.
 
 ## Validation attempted
 
@@ -73,6 +78,7 @@ Address a Codex review finding after the home hero column-width change: prevent 
 - `npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css` passed.
 - Browser measurements passed: 360px and 640px viewports kept the SVG at `320px`; 1280px viewport kept text at `55%`, image column at `45%`, and SVG filling that column.
 - `npm test -- --test-reporter=spec` passed with 227 tests.
+- After the Codex cache-key comment, `npm run build:govuk-pages` regenerated `public/index.html` from the updated template.
 
 ## Existing local changes
 

--- a/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.md
+++ b/docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.md
@@ -1,0 +1,83 @@
+# Home hero mobile SVG cap
+
+## Task summary
+
+Address a Codex review finding after the home hero column-width change: prevent the decorative SVG from expanding to the full stacked mobile column while preserving the desktop 45% image-column fill.
+
+## Run metadata
+
+- Date: 2026-06-16
+- Branch: `fix/home-hero-mobile-svg`
+- Trace required: yes, because `fix/` branches require an auditable trace.
+- Repository: `kevinrapley/ResearchOps`
+
+## Operating model loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Bundles selected
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+## Bundles skipped
+
+- `.agent-operating-model/bundles/cloudflare/`: no Cloudflare runtime or deployment behaviour changed.
+- `.agent-operating-model/bundles/openai/`: no OpenAI API, model or AI route behaviour changed.
+- `.agent-operating-model/bundles/mcp-agent-tooling/`: no MCP protocol or agent tooling changed.
+- `.agent-operating-model/bundles/airtable-public-api/`: no Airtable API behaviour changed.
+- `.agent-operating-model/bundles/mural-public-api/`: no Mural API behaviour changed.
+
+## Precedence decisions
+
+- GitHub Diamond governed branch naming, trace requirement, automated review-comment disposition and validation evidence.
+- ResearchOps Developer Control governed source-first Sass edits and generated CSS outputs.
+- Multi-Functional Team governed public-sector service usability and avoiding unnecessary masthead height on mobile.
+- GOV.UK Design System governed preserving the stacked mobile grid and desktop breakpoint behaviour.
+
+## Files read
+
+- `src/styles/researchops-home.scss`
+- `tests/researchops-home-hero-layout-route-state.test.js`
+- `assets/researchops/researchops-home.css`
+- `public/assets/researchops/researchops-home.css`
+
+## Files created or modified
+
+- `src/styles/researchops-home.scss`
+- `assets/researchops/researchops-home.css`
+- `public/assets/researchops/researchops-home.css`
+- `tests/researchops-home-hero-layout-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.md`
+- `docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.json`
+
+## Decisions
+
+- Treat the Codex review comment as legitimate.
+- Set the mobile/default SVG width to `320px` with `max-width: 100%`, so the image respects the intended intrinsic width while still fitting narrower screens.
+- Keep `width: 100%` only inside the desktop media query so the SVG fills the 45% desktop image column.
+- Update the route-state test to assert separate mobile/default and desktop image-width contracts.
+
+## Validation attempted
+
+- `node --test tests/researchops-home-hero-layout-route-state.test.js tests/deploy-asset-paths.test.js` passed.
+- `npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css` passed.
+- Browser measurements passed: 360px and 640px viewports kept the SVG at `320px`; 1280px viewport kept text at `55%`, image column at `45%`, and SVG filling that column.
+- `npm test -- --test-reporter=spec` passed with 227 tests.
+
+## Existing local changes
+
+- `infra/cloudflare/src/core/auth/passwordless.js` existed as an unrelated local edit before this task and was temporarily stashed while creating the clean fix branch.
+
+## Residual risks
+
+- `npm run validate` was not run during this pass.

--- a/public/assets/researchops/researchops-home.css
+++ b/public/assets/researchops/researchops-home.css
@@ -126,7 +126,7 @@
 
 .researchops-home-hero__image {
 	display: block;
-	width: 100%;
+	width: 320px;
 	max-width: 100%;
 	height: auto;
 	}
@@ -224,6 +224,9 @@
 		width: 45%;
 		padding-right: 0;
 		padding-left: 0;
+		}
+	.researchops-home-hero__image {
+		width: 100%;
 		}
 	.researchops-highlight-panel, .researchops-journey-map {
 		padding: 30px;

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,11 @@
 		<title>ResearchOps Demo Suite</title>
 		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-		<link rel="stylesheet" href="/assets/researchops/researchops-home.css?v=home-masthead-20260608" media="screen" />
+		<link
+			rel="stylesheet"
+			href="/assets/researchops/researchops-home.css?v=home-masthead-mobile-svg-20260616"
+			media="screen"
+		/>
 
 		<script type="module" src="/components/layout.js" defer></script>
 		<script type="module" src="/js/govuk-frontend-init.js" defer></script>

--- a/src/govuk/templates/pages/home.njk
+++ b/src/govuk/templates/pages/home.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% block head %}
-	<link rel="stylesheet" href="/assets/researchops/researchops-home.css?v=home-masthead-20260608" media="screen">
+	<link rel="stylesheet" href="/assets/researchops/researchops-home.css?v=home-masthead-mobile-svg-20260616" media="screen">
 {% endblock %}
 
 {% block content %}

--- a/src/styles/researchops-home.scss
+++ b/src/styles/researchops-home.scss
@@ -126,7 +126,7 @@
 
 .researchops-home-hero__image {
 	display: block;
-	width: 100%;
+	width: 320px;
 	max-width: 100%;
 	height: auto;
 }
@@ -227,6 +227,10 @@
 		width: 45%;
 		padding-right: 0;
 		padding-left: 0;
+	}
+
+	.researchops-home-hero__image {
+		width: 100%;
 	}
 
 	.researchops-highlight-panel,

--- a/tests/researchops-home-hero-layout-route-state.test.js
+++ b/tests/researchops-home-hero-layout-route-state.test.js
@@ -19,5 +19,9 @@ assert.match(
 );
 assert.match(
 	homeCss,
-	/\.researchops-home-hero__image \{[\s\S]*?width: 100%;[\s\S]*?max-width: 100%;[\s\S]*?height: auto;/
+	/\.researchops-home-hero__image \{[\s\S]*?width: 320px;[\s\S]*?max-width: 100%;[\s\S]*?height: auto;/
+);
+assert.match(
+	homeCss,
+	/@media \(min-width: 40\.0625em\) \{[\s\S]*?\.researchops-home-hero__image \{[\s\S]*?width: 100%;/
 );

--- a/tests/researchops-home-hero-layout-route-state.test.js
+++ b/tests/researchops-home-hero-layout-route-state.test.js
@@ -12,6 +12,8 @@ assert.match(
 assert.match(homePage, /class="govuk-grid-column-two-thirds researchops-home-hero__content-column"/);
 assert.match(homePage, /class="govuk-grid-column-one-third researchops-home-hero__image-column"/);
 assert.match(homePage, /class="researchops-home-hero__image"/);
+assert.match(homePage, /researchops-home\.css\?v=home-masthead-mobile-svg-20260616/);
+assert.match(homeTemplate, /researchops-home\.css\?v=home-masthead-mobile-svg-20260616/);
 
 assert.match(
 	homeCss,


### PR DESCRIPTION
## Summary
- Keep the home hero SVG capped at 320px by default so it does not expand across stacked mobile columns
- Keep the desktop/tablet override so the SVG still fills the 45% image column
- Update route-state coverage for mobile/default and desktop image sizing

## Validation
- node --test tests/researchops-home-hero-layout-route-state.test.js tests/deploy-asset-paths.test.js
- npx prettier -c src/styles/researchops-home.scss tests/researchops-home-hero-layout-route-state.test.js public/assets/researchops/researchops-home.css assets/researchops/researchops-home.css
- Browser measurements: 360px and 640px keep SVG at 320px; 1280px keeps text 55%, image column 45%, SVG fills image column
- npm test -- --test-reporter=spec

## Trace
- docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.md
- docs/agent-audit/reasoning/2026/06/16/home-hero-mobile-svg-cap.json