### PR TITLE
Fix main QA smoke CI

### DIFF
--- a/.github/workflows/qa-e2e.yml
+++ b/.github/workflows/qa-e2e.yml
@@ -28,12 +28,12 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx --yes playwright@1.56.1 install --with-deps chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
         env:
           NODE_OPTIONS: --max-old-space-size=2048
-        run: npx --yes playwright@1.56.1 test
+        run: npm run test:e2e
 
       - name: Upload Playwright report (HTML)
         if: always()

--- a/docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.json
+++ b/docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.json
@@ -1,0 +1,75 @@
+{
+  "date": "2026-06-16",
+  "branch": "fix/qa-bdd-main-ci",
+  "task": "Fix main branch QA BDD and Playwright E2E failures after authenticated walkthrough merge",
+  "operatingModel": {
+    "loaded": [
+      "AGENTS.md",
+      ".agent-operating-model/orchestration.xml",
+      ".agent-operating-model/bundle-registry.json",
+      ".agent-operating-model/task-signal-catalog.json",
+      ".agent-operating-model/selection-rules.json",
+      ".agent-operating-model/github-mutation-policy.md",
+      ".agent-operating-model/precedence-policy.md"
+    ],
+    "selectedBundles": [
+      ".agent-operating-model/bundles/github/",
+      ".agent-operating-model/bundles/researchops-developer-control/",
+      ".agent-operating-model/bundles/multi-functional-team/"
+    ],
+    "skippedBundles": [
+      ".agent-operating-model/bundles/govuk-design-system/",
+      ".agent-operating-model/bundles/cloudflare/",
+      ".agent-operating-model/bundles/openai/",
+      ".agent-operating-model/bundles/mcp-agent-tooling/",
+      ".agent-operating-model/bundles/airtable-public-api/",
+      ".agent-operating-model/bundles/mural-public-api/"
+    ]
+  },
+  "failureEvidence": [
+    {
+      "run": 27645142118,
+      "workflow": "qa-bdd",
+      "job": "bdd-smoke",
+      "result": "failed",
+      "details": "Projects smoke scenario hit deployed authenticated realm and received the sign-in page title."
+    },
+    {
+      "run": 27645201722,
+      "workflow": "QA \u2022 Playwright E2E",
+      "job": "e2e",
+      "result": "failed",
+      "details": "Workflow forced playwright@1.56.1 while the repository lockfile installs Playwright 1.60.0."
+    }
+  ],
+  "changes": [
+    "Default Cucumber smoke checks public sign-in instead of protected Projects route.",
+    "Playwright E2E smoke checks public sign-in instead of protected Projects route.",
+    "QA E2E workflow uses repository-installed Playwright commands.",
+    "Focused route-state test covers the main QA CI contract."
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/main-qa-ci-route-state.test.js tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "npx prettier -c .github/workflows/qa-e2e.yml tests/e2e/smoke.spec.js tests/main-qa-ci-route-state.test.js docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.md docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.json",
+      "result": "passed"
+    },
+    {
+      "command": "npm run trace:coverage",
+      "result": "passed"
+    },
+    {
+      "command": "BASE_URL=http://127.0.0.1:8792 npm run qa:cucumber:ci",
+      "result": "passed",
+      "details": "3 scenarios passed, 11 steps passed"
+    },
+    {
+      "command": "BASE_URL=http://127.0.0.1:8792 npm run test:e2e",
+      "result": "passed",
+      "details": "4 tests passed"
+    }
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.md
+++ b/docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.md
@@ -1,0 +1,64 @@
+# Main QA BDD CI Fix Trace
+
+Date: 2026-06-16
+Branch: `fix/qa-bdd-main-ci`
+Task: Fix the main-branch QA BDD and Playwright E2E failures after the authenticated walkthrough merge.
+
+## Operating Model Bootstrap
+
+- Loaded `AGENTS.md`.
+- Loaded `.agent-operating-model/orchestration.xml`.
+- Loaded `.agent-operating-model/bundle-registry.json`.
+- Loaded `.agent-operating-model/task-signal-catalog.json`.
+- Loaded `.agent-operating-model/selection-rules.json`.
+- Loaded `.agent-operating-model/github-mutation-policy.md`.
+- Loaded `.agent-operating-model/precedence-policy.md`.
+- Verified selected bundle directories contain `prompt.spec.yaml` and `prompt.body.xml`.
+
+## Selected Bundles
+
+- `.agent-operating-model/bundles/github/` (`github-diamond`)
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+
+Skipped:
+
+- `govuk-design-system`: no UI implementation or content-pattern change beyond CI smoke route selection.
+- `cloudflare`: no Cloudflare runtime or deployment code change.
+- OpenAI, MCP agent tooling, Airtable public API and Mural public API were not involved.
+
+## Failure Evidence
+
+- Main push workflow `qa-bdd`, run `27645142118`, failed in `bdd-smoke`.
+- Failing scenario: `Projects page loads`.
+- Observed title: `Sign in to ResearchOps - ResearchOps Demo Suite`.
+- Expected title: `/Projects/i`.
+- Main workflow used deployed `BASE_URL=https://researchops.pages.dev/`, where the Projects route is inside the authenticated realm.
+- Follow-on `QA • Playwright E2E`, run `27645201722`, failed because the workflow forced `npx playwright@1.56.1 test` while the repository lockfile installs Playwright `1.60.0`.
+
+## Implementation Summary
+
+- Replaced the default public BDD smoke scenario for `/pages/projects/index.html` with a public sign-in page check.
+- Replaced the E2E smoke route for `/pages/projects/index.html` with `/pages/account/sign-in/index.html`.
+- Updated `.github/workflows/qa-e2e.yml` to use the repository-installed Playwright binary through `npx playwright install --with-deps chromium` and `npm run test:e2e`.
+- Added `tests/main-qa-ci-route-state.test.js` to lock the CI contract.
+
+## Validation Plan
+
+- Focused route-state tests passed:
+  - `node --test tests/main-qa-ci-route-state.test.js tests/qa-bdd-authenticated-walkthrough-route-state.test.js`
+- Formatting check passed:
+  - `npx prettier -c .github/workflows/qa-e2e.yml tests/e2e/smoke.spec.js tests/main-qa-ci-route-state.test.js docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.md docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.json`
+- Trace coverage passed:
+  - `npm run trace:coverage`
+- Cucumber smoke passed against a local static server:
+  - `BASE_URL=http://127.0.0.1:8792 npm run qa:cucumber:ci`
+  - Result: 3 scenarios passed, 11 steps passed.
+- Playwright E2E passed against the same local static server:
+  - `BASE_URL=http://127.0.0.1:8792 npm run test:e2e`
+  - Result: 4 tests passed.
+
+## Residual Risk
+
+- The deployed main smoke suite now checks only public pages. Authenticated page coverage remains in the dedicated walkthrough profile and visual walkthrough catalogue.
+- Local validation uses a static server; GitHub Actions will confirm the deployed main workflow behaviour after the fix PR is merged.

--- a/features/smoke.feature
+++ b/features/smoke.feature
@@ -5,10 +5,10 @@ Feature: Smoke
     When I visit "/"
     Then the page should contain "Research" within 5s
 
-  Scenario: Projects page loads
+  Scenario: Sign-in page loads
     Given the site base URL
-    When I visit "/pages/projects/index.html"
-    Then the page should have a <title> containing "Projects"
+    When I visit "/pages/account/sign-in/index.html"
+    Then the page should have a <title> containing "Sign in"
 
   Scenario: Start page has main landmarks
     Given the site base URL

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,7 +1,7 @@
 // tests/e2e/smoke.spec.js
 import { test, expect } from '@playwright/test';
 
-const paths = ['/', '/index.html', '/pages/start/index.html', '/pages/projects/index.html'];
+const paths = ['/', '/index.html', '/pages/start/index.html', '/pages/account/sign-in/index.html'];
 
 for (const p of paths) {
 	test(`smoke: GET ${p} should render`, async ({ page, baseURL }) => {
@@ -24,8 +24,8 @@ for (const p of paths) {
 		await expect(page.locator('body')).toBeVisible();
 
 		// Optional: very light content sanity per route
-		if (p === '/pages/projects/index.html') {
-			await expect(page).toHaveTitle(/projects/i);
+		if (p === '/pages/account/sign-in/index.html') {
+			await expect(page).toHaveTitle(/sign in/i);
 		}
 		if (p === '/' || p === '/index.html') {
 			// Expect some hallmark text on the homepage without being brittle.

--- a/tests/main-qa-ci-route-state.test.js
+++ b/tests/main-qa-ci-route-state.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const smokeFeature = fs.readFileSync('features/smoke.feature', 'utf8');
+const e2eSmoke = fs.readFileSync('tests/e2e/smoke.spec.js', 'utf8');
+const e2eWorkflow = fs.readFileSync('.github/workflows/qa-e2e.yml', 'utf8');
+
+assert.match(smokeFeature, /Scenario: Sign-in page loads/);
+assert.match(smokeFeature, /\/pages\/account\/sign-in\/index\.html/);
+assert.doesNotMatch(smokeFeature, /Scenario: Projects page loads/);
+
+assert.match(e2eSmoke, /\/pages\/account\/sign-in\/index\.html/);
+assert.match(e2eSmoke, /toHaveTitle\(\/sign in\/i\)/);
+assert.doesNotMatch(e2eSmoke, /\/pages\/projects\/index\.html/);
+
+assert.match(e2eWorkflow, /run: npx playwright install --with-deps chromium/);
+assert.match(e2eWorkflow, /run: npm run test:e2e/);
+assert.doesNotMatch(e2eWorkflow, /playwright@1\.56\.1/);


### PR DESCRIPTION
## Summary
- keep default BDD and E2E smoke checks on public routes by replacing the protected Projects route with the public sign-in page
- run Playwright E2E with the repository-installed Playwright version instead of forcing playwright@1.56.1
- add route-state coverage and trace evidence for the main QA CI contract

## Validation
- node --test tests/main-qa-ci-route-state.test.js tests/qa-bdd-authenticated-walkthrough-route-state.test.js
- npx prettier -c .github/workflows/qa-e2e.yml tests/e2e/smoke.spec.js tests/main-qa-ci-route-state.test.js docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.md docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.json
- npm run trace:coverage
- BASE_URL=http://127.0.0.1:8792 npm run qa:cucumber:ci
- BASE_URL=http://127.0.0.1:8792 npm run test:e2e

Trace: docs/agent-audit/reasoning/2026/06/16/main-qa-bdd-ci-fix-trace.md