### PR TITLE
Fix QA BDD walkthrough execution path

### DIFF
--- a/.github/workflows/qa-bdd.yml
+++ b/.github/workflows/qa-bdd.yml
@@ -221,11 +221,7 @@ jobs:
     if: >-
       ${{
         needs.bdd-smoke.result == 'success' &&
-        (
-          github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/main' ||
-          github.event.workflow_run.head_branch == 'main'
-        )
+        github.event_name == 'workflow_dispatch'
       }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -297,6 +293,9 @@ jobs:
             || echo "BASE_URL did not respond during preflight. Continuing so the visual walkthrough can produce the authoritative result."
 
       - name: Run application visual walkthrough
+        env:
+          RESEARCHOPS_QA_BDD_AUTH_EMAIL: qa-bdd.walkthrough@example.gov.uk
+          RESEARCHOPS_QA_BDD_AUTH_CODE: ${{ secrets.RESEARCHOPS_QA_BDD_AUTH_CODE }}
         run: npm run qa:visual-walkthrough
 
       - name: Sync source-derived acceptance criteria

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json
@@ -1,0 +1,71 @@
+{
+  "traceId": "qa-bdd-manual-walkthrough-auth",
+  "date": "2026-06-16",
+  "branch": "fix/qa-bdd-repository-walkthrough",
+  "task": "Fix post-merge qa-bdd failure by keeping visual walkthrough manual and adding QA auth for protected deployed pages",
+  "operatingModelFiles": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    ".agent-operating-model/bundles/github/",
+    ".agent-operating-model/bundles/researchops-developer-control/",
+    ".agent-operating-model/bundles/multi-functional-team/"
+  ],
+  "evidence": [
+    {
+      "type": "github-actions",
+      "details": "Main qa-bdd walkthrough failed on repository/default desktop and mobile captures after PR #415 merge."
+    },
+    {
+      "type": "live-route-check",
+      "details": "/pages/repository/ and /pages/repository/index.html redirect to sign-in; generated child repository pages remain reachable."
+    },
+    {
+      "type": "configuration-check",
+      "details": "GitHub repository secrets currently include Cloudflare deploy secrets but no RESEARCHOPS_QA_BDD_AUTH_CODE secret."
+    }
+  ],
+  "filesModified": [
+    ".github/workflows/qa-bdd.yml",
+    "docs/qa/visual-walkthrough.md",
+    "scripts/visual-walkthrough.mjs",
+    "tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+    "visual-walkthrough.config.mjs"
+  ],
+  "filesAdded": [
+    "docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md",
+    "docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json"
+  ],
+  "decisions": [
+    "Normal main smoke remains fast and public-route only.",
+    "The heavyweight walkthrough now runs through manual workflow dispatch.",
+    "Protected deployed pages use a real QA auth session when the matching secret and Cloudflare Worker bypass are configured."
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/visual-walkthrough-registry-coverage.test.js tests/main-qa-ci-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "npx prettier -c .github/workflows/qa-bdd.yml docs/qa/visual-walkthrough.md scripts/visual-walkthrough.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js visual-walkthrough.config.mjs docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json",
+      "result": "passed"
+    },
+    {
+      "command": "npm run trace:coverage",
+      "result": "passed"
+    },
+    {
+      "command": "npm run lint",
+      "result": "passed with existing warnings and no errors"
+    }
+  ],
+  "residualRisk": "Manual protected-page capture requires RESEARCHOPS_QA_BDD_AUTH_CODE to be configured in GitHub Actions and to match the deployed Cloudflare Worker QA BDD bypass."
+}

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json
@@ -36,6 +36,7 @@
   "filesModified": [
     ".github/workflows/qa-bdd.yml",
     "docs/qa/visual-walkthrough.md",
+    "infra/cloudflare/wrangler.toml",
     "scripts/visual-walkthrough.mjs",
     "tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
     "visual-walkthrough.config.mjs"
@@ -47,6 +48,7 @@
   "decisions": [
     "Normal main smoke remains fast and public-route only.",
     "The heavyweight walkthrough now runs through manual workflow dispatch.",
+    "The non-secret Cloudflare Worker enable flag and allowed QA email live in wrangler.toml.",
     "Protected deployed pages use a real QA auth session when the matching secret and Cloudflare Worker bypass are configured."
   ],
   "validation": [
@@ -65,6 +67,14 @@
     {
       "command": "npm run lint",
       "result": "passed with existing warnings and no errors"
+    },
+    {
+      "command": "node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "result": "passed after adding Cloudflare Worker QA BDD vars"
+    },
+    {
+      "command": "npx prettier -c infra/cloudflare/wrangler.toml tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "result": "passed"
     }
   ],
   "residualRisk": "Manual protected-page capture requires RESEARCHOPS_QA_BDD_AUTH_CODE to be configured in GitHub Actions and to match the deployed Cloudflare Worker QA BDD bypass."

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md
@@ -1,0 +1,65 @@
+# QA BDD manual walkthrough auth trace
+
+Date: 2026-06-16
+Branch: `fix/qa-bdd-repository-walkthrough`
+Task: Fix the post-merge `qa-bdd` failure where the visual walkthrough ran on main and could not capture the protected repository front page.
+
+## Operating model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+
+The selected bundle directories had their registered `prompt.spec.yaml` and `prompt.body.xml` files.
+
+## Evidence
+
+- Main `qa-bdd` failed in the `walkthrough` job after PR #415 was merged.
+- The failure happened on `repository/default` desktop and mobile captures.
+- Live checks showed `/pages/repository/` and `/pages/repository/index.html` redirect to `/pages/account/sign-in/`.
+- Other generated repository routes, such as `/pages/repository/service-areas/`, were reachable and already captured.
+- Repository secrets currently list Cloudflare deploy secrets but no `RESEARCHOPS_QA_BDD_AUTH_CODE` secret.
+
+## Changes
+
+- Restricted the heavyweight visual walkthrough job to manual `workflow_dispatch` runs.
+- Kept the smoke BDD path available for normal main and PR checks.
+- Added QA auth secret wiring to the manual visual walkthrough step.
+- Added server-side QA sign-in support in `scripts/visual-walkthrough.mjs` so protected pages can receive a real session cookie before navigation.
+- Updated the repository front-page visual state to wait for the server-rendered repository shell.
+- Added route-state tests for the manual-job boundary, secret wiring and protected-page sign-in helper.
+- Updated `docs/qa/visual-walkthrough.md` to explain the required GitHub secret and deployed Worker QA bypass alignment.
+
+## Validation
+
+Attempted before the final fix:
+
+- `BASE_URL=https://researchops.pages.dev/ npm run qa:visual-walkthrough` failed on the protected repository page because the live route redirected to sign-in.
+- Targeted repository capture without QA auth failed for the same protected-route reason.
+
+Completed after the fix:
+
+- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/visual-walkthrough-registry-coverage.test.js tests/main-qa-ci-route-state.test.js` passed.
+- `npx prettier -c .github/workflows/qa-bdd.yml docs/qa/visual-walkthrough.md scripts/visual-walkthrough.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js visual-walkthrough.config.mjs docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json` passed.
+- `npm run trace:coverage` passed.
+- `npm run lint` passed with existing repository warnings and no errors.
+
+GitHub Actions still needs to run on the PR to prove the normal main smoke path no longer runs the heavyweight walkthrough automatically.
+
+## Residual risk
+
+The manual walkthrough cannot capture protected deployed pages until `RESEARCHOPS_QA_BDD_AUTH_CODE` is configured as a GitHub Actions secret and matches the deployed Cloudflare Worker QA BDD bypass code for `qa-bdd.walkthrough@example.gov.uk`.

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md
@@ -40,6 +40,7 @@ The selected bundle directories had their registered `prompt.spec.yaml` and `pro
 - Kept the smoke BDD path available for normal main and PR checks.
 - Added QA auth secret wiring to the manual visual walkthrough step.
 - Added server-side QA sign-in support in `scripts/visual-walkthrough.mjs` so protected pages can receive a real session cookie before navigation.
+- Added the non-secret Cloudflare Worker vars `RESEARCHOPS_QA_BDD_AUTH_ENABLED=true` and `RESEARCHOPS_QA_BDD_AUTH_EMAILS=qa-bdd.walkthrough@example.gov.uk` to `infra/cloudflare/wrangler.toml`.
 - Updated the repository front-page visual state to wait for the server-rendered repository shell.
 - Added route-state tests for the manual-job boundary, secret wiring and protected-page sign-in helper.
 - Updated `docs/qa/visual-walkthrough.md` to explain the required GitHub secret and deployed Worker QA bypass alignment.
@@ -57,6 +58,8 @@ Completed after the fix:
 - `npx prettier -c .github/workflows/qa-bdd.yml docs/qa/visual-walkthrough.md scripts/visual-walkthrough.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js visual-walkthrough.config.mjs docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json` passed.
 - `npm run trace:coverage` passed.
 - `npm run lint` passed with existing repository warnings and no errors.
+- Follow-up check after adding the Cloudflare Worker non-secret vars: `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js` passed.
+- Follow-up formatting check: `npx prettier -c infra/cloudflare/wrangler.toml tests/qa-bdd-authenticated-walkthrough-route-state.test.js` passed.
 
 GitHub Actions still needs to run on the PR to prove the normal main smoke path no longer runs the heavyweight walkthrough automatically.
 

--- a/docs/qa/visual-walkthrough.md
+++ b/docs/qa/visual-walkthrough.md
@@ -15,7 +15,7 @@ The walkthrough writes to `reports-site/`:
 - `screenshots/desktop/*.png` — desktop captured page and state evidence
 - `screenshots/mobile/*.png` — mobile captured page and state evidence
 
-The generated report is uploaded as the `visual-walkthrough-site` workflow artifact. On main branch runs, `reports-site/` is committed back to the repository when generated output changes.
+The generated report is uploaded as the `visual-walkthrough-site` workflow artifact. The heavyweight walkthrough is run from the dedicated manual `qa-bdd` workflow dispatch so normal smoke checks stay quick and stable.
 
 ## Registry
 
@@ -219,7 +219,7 @@ npm run qa:visual-walkthrough
 
 The command uses `BASE_URL`, `PAGES_URL` or `PREVIEW_URL` when provided. Otherwise it falls back to `https://researchops.pages.dev/`.
 
-For the authenticated walkthrough, run the dedicated walkthrough profile/job against the deployed preview or production URL. That run is expected to provide the QA auth settings and any required manual-run environment values, including the QA auth bypass and local asset behaviour if you deliberately want a local capture.
+For the authenticated walkthrough, run the dedicated walkthrough profile/job against the deployed preview or production URL. Protected deployed pages need `RESEARCHOPS_QA_BDD_AUTH_CODE` configured as a GitHub Actions secret, and the deployed auth Worker must allow `qa-bdd.walkthrough@example.gov.uk` with the same 6 digit code through its QA BDD bypass settings.
 
 The command runs the same registered page and state catalogue for each configured profile. It then writes one report with a screenshot switcher and profile-specific screenshot directories.
 
@@ -227,7 +227,7 @@ The command runs the same registered page and state catalogue for each configure
 
 The `qa-bdd` workflow still runs the Cucumber smoke suite first.
 
-If smoke passes, the walkthrough job runs the application visual walkthrough. The workflow then:
+When the manual walkthrough job runs, it first completes the smoke suite and then runs the application visual walkthrough. The workflow then:
 
 1. uploads `reports-site/` as an artifact
 2. checks whether the run is allowed to persist to `main`

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -29,6 +29,8 @@ MODEL = "@cf/meta/llama-3.1-8b-instruct"
 AUDIT = "true"
 RESEARCHOPS_BUILD_SHA = "local"
 RESEARCHOPS_BUILD_BRANCH = "local"
+RESEARCHOPS_QA_BDD_AUTH_ENABLED = "true"
+RESEARCHOPS_QA_BDD_AUTH_EMAILS = "qa-bdd.walkthrough@example.gov.uk"
 
 ALLOWED_ORIGINS = "https://researchops.pages.dev,https://rops-api.digikev-kevin-rapley.workers.dev,http://localhost:8080,https://reops-sourcebook.pages.dev"
 

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -5,7 +5,7 @@
  * @summary Generate the application visual walkthrough report from a registered page/state catalogue.
  */
 
-import { chromium } from 'playwright';
+import { chromium, request as playwrightRequest } from 'playwright';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -20,6 +20,7 @@ import {
 } from '../visual-walkthrough.participant-consent-states.mjs';
 import { buildStateAcceptanceGherkin } from './researchops-state-acceptance.mjs';
 import {
+	SIGN_IN_EMAIL,
 	registerLocalAssetRoutes,
 	registerMockRoutes,
 	walkthroughMockRoutes,
@@ -90,6 +91,10 @@ const baseURL = normalizeBaseURL(
 	process.env.BASE_URL || process.env.PAGES_URL || process.env.PREVIEW_URL || DEFAULT_BASE_URL
 );
 const useLocalAssets = process.env.WALKTHROUGH_LOCAL_ASSETS === 'true';
+const qaBddAuthEmail = process.env.RESEARCHOPS_QA_BDD_AUTH_EMAIL || SIGN_IN_EMAIL;
+const qaBddAuthCode = String(process.env.RESEARCHOPS_QA_BDD_AUTH_CODE || '').replace(/\s+/g, '');
+const SERVER_PROTECTED_PAGE_IDS = new Set(['repository']);
+let qaBddStorageStatePromise = null;
 const captureProfiles = (visualWalkthroughConfig.profiles || DEFAULT_PROFILES).map((profile) => ({
 	...profile,
 	id: slugify(profile.id || profile.title || 'profile'),
@@ -273,10 +278,70 @@ async function runAction(page, action) {
 	throw new Error(`Unsupported visual walkthrough action type: ${action.type}`);
 }
 
+function needsServerAuth(pageConfig) {
+	const hostname = new URL(baseURL).hostname;
+	const localHostnames = new Set(['localhost', '127.0.0.1', '::1']);
+	return (
+		!useLocalAssets &&
+		!localHostnames.has(hostname) &&
+		pageConfig.authenticated !== false &&
+		SERVER_PROTECTED_PAGE_IDS.has(pageConfig.id)
+	);
+}
+
+function canUseQaBddAuth() {
+	return qaBddAuthEmail && /^\d{6}$/.test(qaBddAuthCode);
+}
+
+async function createQaBddStorageState() {
+	if (!canUseQaBddAuth()) {
+		throw new Error(
+			'Protected visual walkthrough pages require RESEARCHOPS_QA_BDD_AUTH_CODE to match the deployed QA BDD auth bypass code.'
+		);
+	}
+
+	const api = await playwrightRequest.newContext({
+		baseURL,
+		ignoreHTTPSErrors: true,
+	});
+
+	try {
+		const startResponse = await api.post('/api/auth/email/start', {
+			data: { email: qaBddAuthEmail },
+		});
+		const startBody = await startResponse.json().catch(() => ({}));
+		if (!startResponse.ok() || !startBody?.challengeId) {
+			throw new Error(`QA BDD sign-in start failed with HTTP ${startResponse.status()}.`);
+		}
+
+		const verifyResponse = await api.post('/api/auth/email/verify', {
+			data: {
+				challengeId: startBody.challengeId,
+				code: qaBddAuthCode,
+			},
+		});
+		const verifyBody = await verifyResponse.json().catch(() => ({}));
+		if (!verifyResponse.ok() || !verifyBody?.ok) {
+			throw new Error(`QA BDD sign-in verify failed with HTTP ${verifyResponse.status()}.`);
+		}
+
+		return api.storageState();
+	} finally {
+		await api.dispose();
+	}
+}
+
+async function qaBddStorageState() {
+	qaBddStorageStatePromise ||= createQaBddStorageState();
+	return qaBddStorageStatePromise;
+}
+
 async function captureState(browser, pageConfig, stateConfig, profile) {
+	const storageState = needsServerAuth(pageConfig) ? await qaBddStorageState() : undefined;
 	const context = await browser.newContext({
 		ignoreHTTPSErrors: true,
 		reducedMotion: 'reduce',
+		...(storageState ? { storageState } : {}),
 		...profile.contextOptions,
 	});
 	const page = await context.newPage();

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -14,6 +14,7 @@ const visualWalkthroughSource = fs.readFileSync('scripts/visual-walkthrough.mjs'
 const helperSource = fs.readFileSync('scripts/walkthrough-playwright.mjs', 'utf8');
 const passwordlessSource = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
 const participantConsentSource = fs.readFileSync('public/js/participant-consent-page.js', 'utf8');
+const qaBddWorkflowSource = fs.readFileSync('.github/workflows/qa-bdd.yml', 'utf8');
 
 test('QA BDD walkthrough captures sign-in code and authenticated page states', () => {
 	assert.match(featureSource, /@walkthrough/);
@@ -36,15 +37,34 @@ test('visual walkthrough uses local assets and deterministic authenticated mocks
 	assert.match(visualWalkthroughSource, /registerLocalAssetRoutes/);
 	assert.match(visualWalkthroughSource, /walkthroughMockRoutes/);
 	assert.match(visualWalkthroughSource, /process\.env\.WALKTHROUGH_LOCAL_ASSETS === 'true'/);
+	assert.match(visualWalkthroughSource, /playwrightRequest\.newContext/);
+	assert.match(visualWalkthroughSource, /RESEARCHOPS_QA_BDD_AUTH_CODE/);
+	assert.match(visualWalkthroughSource, /SERVER_PROTECTED_PAGE_IDS = new Set\(\['repository'\]\)/);
 	assert.match(helperSource, /operationalMockRoutes/);
 	assert.match(helperSource, /typeof body === 'function'/);
 	assert.match(helperSource, /SIGN_IN_EMAIL = 'qa-bdd\.walkthrough@example\.gov\.uk'/);
 });
 
+test('visual walkthrough is a manual job with QA auth secret wiring', () => {
+	const walkthroughJobIndex = qaBddWorkflowSource.indexOf('  walkthrough:');
+	const walkthroughJob = qaBddWorkflowSource.slice(walkthroughJobIndex);
+
+	assert.ok(walkthroughJobIndex > -1);
+	assert.match(walkthroughJob, /github\.event_name == 'workflow_dispatch'/);
+	assert.doesNotMatch(walkthroughJob, /github\.ref == 'refs\/heads\/main'/);
+	assert.doesNotMatch(walkthroughJob, /github\.event\.workflow_run\.head_branch == 'main'/);
+	assert.match(walkthroughJob, /RESEARCHOPS_QA_BDD_AUTH_EMAIL: qa-bdd\.walkthrough@example\.gov\.uk/);
+	assert.match(walkthroughJob, /RESEARCHOPS_QA_BDD_AUTH_CODE: \$\{\{ secrets\.RESEARCHOPS_QA_BDD_AUTH_CODE \}\}/);
+});
+
 test('visual walkthrough registers Cloudflare-generated repository pages', () => {
 	const registeredPaths = new Set(visualWalkthroughConfig.pages.map((page) => page.path));
+	const repositoryPage = visualWalkthroughConfig.pages.find((page) => page.id === 'repository');
 
 	assert.equal(registeredPaths.has('/pages/repository/index.html'), true);
+	assert.deepEqual(repositoryPage.defaultState.actions, [
+		{ type: 'waitForSelector', selector: '[data-repository-page]' },
+	]);
 	for (const page of repositoryStaticPages) {
 		assert.equal(
 			registeredPaths.has(`/pages/repository/${page.slug}/index.html`),

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -15,6 +15,7 @@ const helperSource = fs.readFileSync('scripts/walkthrough-playwright.mjs', 'utf8
 const passwordlessSource = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
 const participantConsentSource = fs.readFileSync('public/js/participant-consent-page.js', 'utf8');
 const qaBddWorkflowSource = fs.readFileSync('.github/workflows/qa-bdd.yml', 'utf8');
+const cloudflareWranglerSource = fs.readFileSync('infra/cloudflare/wrangler.toml', 'utf8');
 
 test('QA BDD walkthrough captures sign-in code and authenticated page states', () => {
 	assert.match(featureSource, /@walkthrough/);
@@ -102,6 +103,15 @@ test('passwordless QA BDD bypass is env gated and reuses the normal session path
 	assert.match(passwordlessSource, /qaBddCodeAccepted/);
 	assert.match(passwordlessSource, /INSERT INTO auth_sessions/);
 	assert.doesNotMatch(passwordlessSource, /qa-bdd\.walkthrough@example\.gov\.uk/);
+});
+
+test('Cloudflare Worker config enables QA BDD auth without storing the code', () => {
+	assert.match(cloudflareWranglerSource, /RESEARCHOPS_QA_BDD_AUTH_ENABLED = "true"/);
+	assert.match(
+		cloudflareWranglerSource,
+		/RESEARCHOPS_QA_BDD_AUTH_EMAILS = "qa-bdd\.walkthrough@example\.gov\.uk"/,
+	);
+	assert.doesNotMatch(cloudflareWranglerSource, /RESEARCHOPS_QA_BDD_AUTH_CODE/);
 });
 
 test('participant consent same-origin API URLs are valid during walkthrough capture', () => {

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -203,17 +203,21 @@ function repositoryStaticPageEntry(page) {
 }
 
 const repositoryPages = [
-	statefulPage(
-		'repository',
-		'Research repository',
-		'Research repository',
-		'/pages/repository/index.html',
-		'Cloudflare-generated research repository front page.',
-		'Repository front page with published artefacts',
-		'Repository front page captured from the deployed generated page with deterministic repository data.',
-		'/pages/repository/',
-		'Staff need clearer evidence boundaries before accepting recommendations'
-	),
+	{
+		id: 'repository',
+		title: 'Research repository',
+		group: 'Research repository',
+		path: '/pages/repository/index.html',
+		description: 'Cloudflare-generated research repository front page.',
+		defaultState: {
+			id: 'default',
+			title: 'Repository front page with published artefacts',
+			description:
+				'Repository front page captured from the deployed generated page after the server-rendered repository shell is available.',
+			path: '/pages/repository/',
+			actions: [{ type: 'waitForSelector', selector: '[data-repository-page]' }],
+		},
+	},
 	...repositoryStaticPages.map(repositoryStaticPageEntry),
 ];
 


### PR DESCRIPTION
## Summary
- keep the heavyweight visual walkthrough on manual qa-bdd workflow dispatch instead of normal main CI
- add QA BDD sign-in storage state support so protected deployed pages can be captured when the auth code secret is configured
- update repository front-page capture state, docs, tests and audit trace

## Validation
- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/visual-walkthrough-registry-coverage.test.js tests/main-qa-ci-route-state.test.js`
- `npx prettier -c .github/workflows/qa-bdd.yml docs/qa/visual-walkthrough.md scripts/visual-walkthrough.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js visual-walkthrough.config.mjs docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.md docs/agent-audit/reasoning/2026/06/16/qa-bdd-manual-walkthrough-auth-trace.json`
- `npm run trace:coverage`
- `npm run lint`

## Notes
Manual protected-page walkthrough capture requires a GitHub Actions secret named `RESEARCHOPS_QA_BDD_AUTH_CODE` that matches the deployed Cloudflare Worker QA BDD bypass code for `qa-bdd.walkthrough@example.gov.uk`.