### PR TITLE
Fix QA BDD Worker auth secret deploy

### DIFF
--- a/.github/workflows/deploy-passwordless-preview-worker.yml
+++ b/.github/workflows/deploy-passwordless-preview-worker.yml
@@ -153,6 +153,7 @@ jobs:
           RESEARCHOPS_EMAIL_WEBHOOK_URL: ${{ secrets.RESEARCHOPS_EMAIL_WEBHOOK_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}
+          RESEARCHOPS_QA_BDD_AUTH_CODE: ${{ secrets.RESEARCHOPS_QA_BDD_AUTH_CODE }}
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           MURAL_CLIENT_SECRET: ${{ secrets.MURAL_CLIENT_SECRET }}
@@ -179,6 +180,11 @@ jobs:
 
           if [ -z "${MURAL_CLIENT_SECRET}" ]; then
             echo "Missing required secret: MURAL_CLIENT_SECRET"
+            exit 1
+          fi
+
+          if [ -z "${RESEARCHOPS_QA_BDD_AUTH_CODE}" ]; then
+            echo "Missing required secret: RESEARCHOPS_QA_BDD_AUTH_CODE"
             exit 1
           fi
 

--- a/.github/workflows/deploy-passwordless-preview-worker.yml
+++ b/.github/workflows/deploy-passwordless-preview-worker.yml
@@ -189,6 +189,7 @@ jobs:
           RESEARCHOPS_EMAIL_WEBHOOK_TOKEN: ${{ secrets.RESEARCHOPS_EMAIL_WEBHOOK_TOKEN }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}
+          RESEARCHOPS_QA_BDD_AUTH_CODE: ${{ secrets.RESEARCHOPS_QA_BDD_AUTH_CODE }}
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           MURAL_CLIENT_SECRET: ${{ secrets.MURAL_CLIENT_SECRET }}
@@ -203,6 +204,7 @@ jobs:
               "RESEARCHOPS_EMAIL_WEBHOOK_TOKEN",
               "RESEND_API_KEY",
               "RESEARCHOPS_EMAIL_FROM",
+              "RESEARCHOPS_QA_BDD_AUTH_CODE",
               "AIRTABLE_BASE_ID",
               "AIRTABLE_API_KEY",
               "MURAL_CLIENT_SECRET",

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -71,6 +71,7 @@ jobs:
           RESEARCHOPS_AUTH_SECRET: ${{ secrets.RESEARCHOPS_AUTH_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}
+          RESEARCHOPS_QA_BDD_AUTH_CODE: ${{ secrets.RESEARCHOPS_QA_BDD_AUTH_CODE }}
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           MURAL_CLIENT_SECRET: ${{ secrets.MURAL_CLIENT_SECRET }}
@@ -79,6 +80,7 @@ jobs:
           if [ -z "${RESEARCHOPS_AUTH_SECRET}" ]; then missing="${missing} RESEARCHOPS_AUTH_SECRET"; fi
           if [ -z "${RESEND_API_KEY}" ]; then missing="${missing} RESEND_API_KEY"; fi
           if [ -z "${RESEARCHOPS_EMAIL_FROM}" ]; then missing="${missing} RESEARCHOPS_EMAIL_FROM"; fi
+          if [ -z "${RESEARCHOPS_QA_BDD_AUTH_CODE}" ]; then missing="${missing} RESEARCHOPS_QA_BDD_AUTH_CODE"; fi
           if [ -z "${AIRTABLE_BASE_ID}" ]; then missing="${missing} AIRTABLE_BASE_ID"; fi
           if [ -z "${AIRTABLE_API_KEY}" ]; then missing="${missing} AIRTABLE_API_KEY"; fi
           if [ -z "${MURAL_CLIENT_SECRET}" ]; then missing="${missing} MURAL_CLIENT_SECRET"; fi
@@ -133,6 +135,7 @@ jobs:
             RESEARCHOPS_AUTH_SECRET
             RESEND_API_KEY
             RESEARCHOPS_EMAIL_FROM
+            RESEARCHOPS_QA_BDD_AUTH_CODE
             AIRTABLE_BASE_ID
             AIRTABLE_API_KEY
             MURAL_CLIENT_SECRET
@@ -140,6 +143,7 @@ jobs:
           RESEARCHOPS_AUTH_SECRET: ${{ secrets.RESEARCHOPS_AUTH_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}
+          RESEARCHOPS_QA_BDD_AUTH_CODE: ${{ secrets.RESEARCHOPS_QA_BDD_AUTH_CODE }}
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           MURAL_CLIENT_SECRET: ${{ secrets.MURAL_CLIENT_SECRET }}
@@ -170,6 +174,7 @@ jobs:
           RESEARCHOPS_AUTH_SECRET: ${{ secrets.RESEARCHOPS_AUTH_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}
+          RESEARCHOPS_QA_BDD_AUTH_CODE: ${{ secrets.RESEARCHOPS_QA_BDD_AUTH_CODE }}
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           MURAL_CLIENT_SECRET: ${{ secrets.MURAL_CLIENT_SECRET }}
@@ -180,6 +185,7 @@ jobs:
           if [ -z "${RESEARCHOPS_AUTH_SECRET}" ]; then missing="${missing} RESEARCHOPS_AUTH_SECRET"; fi
           if [ -z "${RESEND_API_KEY}" ]; then missing="${missing} RESEND_API_KEY"; fi
           if [ -z "${RESEARCHOPS_EMAIL_FROM}" ]; then missing="${missing} RESEARCHOPS_EMAIL_FROM"; fi
+          if [ -z "${RESEARCHOPS_QA_BDD_AUTH_CODE}" ]; then missing="${missing} RESEARCHOPS_QA_BDD_AUTH_CODE"; fi
           if [ -z "${AIRTABLE_BASE_ID}" ]; then missing="${missing} AIRTABLE_BASE_ID"; fi
           if [ -z "${AIRTABLE_API_KEY}" ]; then missing="${missing} AIRTABLE_API_KEY"; fi
           if [ -z "${MURAL_CLIENT_SECRET}" ]; then missing="${missing} MURAL_CLIENT_SECRET"; fi
@@ -397,6 +403,7 @@ jobs:
             RESEARCHOPS_AUTH_SECRET
             RESEND_API_KEY
             RESEARCHOPS_EMAIL_FROM
+            RESEARCHOPS_QA_BDD_AUTH_CODE
             AIRTABLE_BASE_ID
             AIRTABLE_API_KEY
             MURAL_CLIENT_SECRET
@@ -404,6 +411,7 @@ jobs:
           RESEARCHOPS_AUTH_SECRET: ${{ secrets.RESEARCHOPS_AUTH_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEARCHOPS_EMAIL_FROM: ${{ secrets.RESEARCHOPS_EMAIL_FROM }}
+          RESEARCHOPS_QA_BDD_AUTH_CODE: ${{ secrets.RESEARCHOPS_QA_BDD_AUTH_CODE }}
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           MURAL_CLIENT_SECRET: ${{ secrets.MURAL_CLIENT_SECRET }}

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.json
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.json
@@ -47,6 +47,7 @@
   "decisions": [
     "Keep the QA auth code secret out of checked-in Wrangler config.",
     "Pass the QA auth code to all Worker deploy paths that can serve deployed walkthrough auth.",
+    "Fail the passwordless preview Worker deploy early when RESEARCHOPS_QA_BDD_AUTH_CODE is missing.",
     "Enable the passwordless preview Worker QA BDD allow-list vars so preview auth behaves like production."
   ],
   "validation": [

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.json
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.json
@@ -1,0 +1,67 @@
+{
+  "traceId": "qa-bdd-worker-auth-secret-deploy",
+  "date": "2026-06-16",
+  "branch": "fix/qa-bdd-auth-secret-deploy",
+  "task": "Fix the manual qa-bdd walkthrough failure where deployed protected-page sign-in rejected the QA BDD auth code.",
+  "operatingModelFiles": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    ".agent-operating-model/bundles/github/",
+    ".agent-operating-model/bundles/researchops-developer-control/",
+    ".agent-operating-model/bundles/multi-functional-team/",
+    ".agent-operating-model/bundles/cloudflare/"
+  ],
+  "evidence": [
+    {
+      "type": "github-actions",
+      "details": "Manual qa-bdd run 27648926080 failed only repository/default desktop and mobile captures."
+    },
+    {
+      "type": "runtime-auth",
+      "details": "Both failed captures reported QA BDD sign-in verify failed with HTTP 400."
+    },
+    {
+      "type": "configuration-check",
+      "details": "The qa-bdd workflow supplied RESEARCHOPS_QA_BDD_AUTH_CODE, but the production Worker deploy workflow did not pass that secret to Cloudflare."
+    }
+  ],
+  "filesModified": [
+    ".github/workflows/deploy-worker.yml",
+    ".github/workflows/deploy-passwordless-preview-worker.yml",
+    "infra/cloudflare/wrangler.passwordless-preview.toml",
+    "tests/qa-bdd-authenticated-walkthrough-route-state.test.js"
+  ],
+  "filesAdded": [
+    "docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.md",
+    "docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.json"
+  ],
+  "decisions": [
+    "Keep the QA auth code secret out of checked-in Wrangler config.",
+    "Pass the QA auth code to all Worker deploy paths that can serve deployed walkthrough auth.",
+    "Enable the passwordless preview Worker QA BDD allow-list vars so preview auth behaves like production."
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "npx prettier -c .github/workflows/deploy-worker.yml .github/workflows/deploy-passwordless-preview-worker.yml infra/cloudflare/wrangler.passwordless-preview.toml tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "npm run trace:coverage",
+      "result": "passed"
+    }
+  ],
+  "residualRisk": "The next production deploy must complete before the manual walkthrough can benefit from this change. The GitHub Actions secret and Cloudflare Worker secret must remain the same six-digit code."
+}

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.md
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.md
@@ -38,6 +38,7 @@ Selected bundles:
 - Added `RESEARCHOPS_QA_BDD_AUTH_CODE` to production Worker deploy secret checks and Wrangler action secret uploads.
 - Added the same secret wiring to the shared preview Worker deploy path in `.github/workflows/deploy-worker.yml`.
 - Added the same secret to the passwordless preview Worker secret bulk upload.
+- Added an early passwordless preview Worker secret check so missing `RESEARCHOPS_QA_BDD_AUTH_CODE` fails before deploy.
 - Enabled the QA BDD auth allow-list vars in `infra/cloudflare/wrangler.passwordless-preview.toml` without storing the secret code in source.
 - Added route-state tests so deploy workflow secret wiring and preview Worker QA auth vars remain covered.
 

--- a/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.md
+++ b/docs/agent-audit/reasoning/2026/06/16/qa-bdd-worker-auth-secret-deploy-trace.md
@@ -1,0 +1,52 @@
+# QA BDD Worker auth secret deploy trace
+
+Date: 2026-06-16
+Branch: `fix/qa-bdd-auth-secret-deploy`
+Task: Fix the manual `qa-bdd` walkthrough failure where deployed protected-page sign-in rejected the QA BDD auth code.
+
+## Operating model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/cloudflare/`
+
+## Evidence
+
+- Manual GitHub Actions run `27648926080` for `qa-bdd` reached deployed pages and captured most walkthrough states.
+- The only walkthrough failures were `repository/default/desktop` and `repository/default/mobile`.
+- Both failed at QA BDD sign-in verify with HTTP 400, which means the deployed Worker did not accept the code sent by the walkthrough job.
+- The `qa-bdd` workflow already passes `RESEARCHOPS_QA_BDD_AUTH_CODE` to the walkthrough step.
+- The production Worker deploy workflow did not pass `RESEARCHOPS_QA_BDD_AUTH_CODE` to Cloudflare.
+
+## Changes
+
+- Added `RESEARCHOPS_QA_BDD_AUTH_CODE` to production Worker deploy secret checks and Wrangler action secret uploads.
+- Added the same secret wiring to the shared preview Worker deploy path in `.github/workflows/deploy-worker.yml`.
+- Added the same secret to the passwordless preview Worker secret bulk upload.
+- Enabled the QA BDD auth allow-list vars in `infra/cloudflare/wrangler.passwordless-preview.toml` without storing the secret code in source.
+- Added route-state tests so deploy workflow secret wiring and preview Worker QA auth vars remain covered.
+
+## Validation
+
+- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js` passed.
+- `npx prettier -c .github/workflows/deploy-worker.yml .github/workflows/deploy-passwordless-preview-worker.yml infra/cloudflare/wrangler.passwordless-preview.toml tests/qa-bdd-authenticated-walkthrough-route-state.test.js` passed.
+- `npm run trace:coverage` passed.
+
+## Residual risk
+
+The next production deploy must run before the manual walkthrough can benefit from this change. The GitHub Actions secret and Cloudflare Worker secret must remain the same six-digit code.

--- a/infra/cloudflare/wrangler.passwordless-preview.toml
+++ b/infra/cloudflare/wrangler.passwordless-preview.toml
@@ -17,6 +17,8 @@ binding = "AI"
 [vars]
 MODEL = "@cf/meta/llama-3.1-8b-instruct"
 AUDIT = "true"
+RESEARCHOPS_QA_BDD_AUTH_ENABLED = "true"
+RESEARCHOPS_QA_BDD_AUTH_EMAILS = "qa-bdd.walkthrough@example.gov.uk"
 
 ALLOWED_ORIGINS = "https://chore-govuk-frontend-integra.researchops.pages.dev,https://fix-projects-team-scoped-acc.researchops.pages.dev,https://fix-team-admin-sign-in-journ.researchops.pages.dev,https://researchops.pages.dev,https://rops-api-passwordless-preview.digikev-kevin-rapley.workers.dev,https://rops-api.digikev-kevin-rapley.workers.dev,http://localhost:8080,https://reops-sourcebook.pages.dev"
 

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -143,6 +143,10 @@ test('Cloudflare deploy workflows pass the QA BDD auth code secret to Workers', 
 		passwordlessPreviewWorkflowSource,
 		/RESEARCHOPS_QA_BDD_AUTH_CODE: \$\{\{ secrets\.RESEARCHOPS_QA_BDD_AUTH_CODE \}\}/,
 	);
+	assert.match(
+		passwordlessPreviewWorkflowSource,
+		/Missing required secret: RESEARCHOPS_QA_BDD_AUTH_CODE/,
+	);
 	assert.match(passwordlessPreviewWorkflowSource, /"RESEARCHOPS_QA_BDD_AUTH_CODE"/);
 });
 

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -15,7 +15,16 @@ const helperSource = fs.readFileSync('scripts/walkthrough-playwright.mjs', 'utf8
 const passwordlessSource = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
 const participantConsentSource = fs.readFileSync('public/js/participant-consent-page.js', 'utf8');
 const qaBddWorkflowSource = fs.readFileSync('.github/workflows/qa-bdd.yml', 'utf8');
+const deployWorkerWorkflowSource = fs.readFileSync('.github/workflows/deploy-worker.yml', 'utf8');
+const passwordlessPreviewWorkflowSource = fs.readFileSync(
+	'.github/workflows/deploy-passwordless-preview-worker.yml',
+	'utf8',
+);
 const cloudflareWranglerSource = fs.readFileSync('infra/cloudflare/wrangler.toml', 'utf8');
+const passwordlessPreviewWranglerSource = fs.readFileSync(
+	'infra/cloudflare/wrangler.passwordless-preview.toml',
+	'utf8',
+);
 
 test('QA BDD walkthrough captures sign-in code and authenticated page states', () => {
 	assert.match(featureSource, /@walkthrough/);
@@ -112,6 +121,29 @@ test('Cloudflare Worker config enables QA BDD auth without storing the code', ()
 		/RESEARCHOPS_QA_BDD_AUTH_EMAILS = "qa-bdd\.walkthrough@example\.gov\.uk"/,
 	);
 	assert.doesNotMatch(cloudflareWranglerSource, /RESEARCHOPS_QA_BDD_AUTH_CODE/);
+	assert.match(passwordlessPreviewWranglerSource, /RESEARCHOPS_QA_BDD_AUTH_ENABLED = "true"/);
+	assert.match(
+		passwordlessPreviewWranglerSource,
+		/RESEARCHOPS_QA_BDD_AUTH_EMAILS = "qa-bdd\.walkthrough@example\.gov\.uk"/,
+	);
+	assert.doesNotMatch(passwordlessPreviewWranglerSource, /RESEARCHOPS_QA_BDD_AUTH_CODE/);
+});
+
+test('Cloudflare deploy workflows pass the QA BDD auth code secret to Workers', () => {
+	assert.match(
+		deployWorkerWorkflowSource,
+		/RESEARCHOPS_QA_BDD_AUTH_CODE: \$\{\{ secrets\.RESEARCHOPS_QA_BDD_AUTH_CODE \}\}/,
+	);
+	assert.match(deployWorkerWorkflowSource, /missing="\$\{missing\} RESEARCHOPS_QA_BDD_AUTH_CODE"/);
+	assert.match(
+		deployWorkerWorkflowSource,
+		/secrets: \|\n(?: {12}[A-Z0-9_]+\n)* {12}RESEARCHOPS_QA_BDD_AUTH_CODE/,
+	);
+	assert.match(
+		passwordlessPreviewWorkflowSource,
+		/RESEARCHOPS_QA_BDD_AUTH_CODE: \$\{\{ secrets\.RESEARCHOPS_QA_BDD_AUTH_CODE \}\}/,
+	);
+	assert.match(passwordlessPreviewWorkflowSource, /"RESEARCHOPS_QA_BDD_AUTH_CODE"/);
 });
 
 test('participant consent same-origin API URLs are valid during walkthrough capture', () => {


### PR DESCRIPTION
## Summary
- pass RESEARCHOPS_QA_BDD_AUTH_CODE through production and preview Worker deploy paths
- enable QA BDD auth allow-list vars for the passwordless preview Worker without storing the code in source
- add route-state coverage and audit trace for the deploy wiring

## Validation
- node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js
- npx prettier -c .github/workflows/deploy-worker.yml .github/workflows/deploy-passwordless-preview-worker.yml infra/cloudflare/wrangler.passwordless-preview.toml tests/qa-bdd-authenticated-walkthrough-route-state.test.js
- npm run trace:coverage