### PR TITLE
Fix project dashboard areas nav layout

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, move Objectives into a separate Project Objectives panel beneath Stakeholder management, treat a no-studies studies_unavailable response in Research outcomes as a normal empty state instead of surfacing a system-style failure message, and apply govuk-body-s to non-navigation panel content with dl.govuk-body-s summary lists.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, move Objectives into a separate Project Objectives panel beneath Stakeholder management, treat a no-studies studies_unavailable response in Research outcomes as a normal empty state instead of surfacing a system-style failure message, apply govuk-body-s to non-navigation panel content with dl.govuk-body-s summary lists, address PR review feedback by keeping the dashboard header and h1 before the Project areas navigation in DOM order while preserving the desktop layout, and fix the Project details summary-list cascade so dl.govuk-body-s, dt and dd compute to the expected smaller GOV.UK body size.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -49,7 +49,9 @@
     "public/js/project-dashboard.js",
     "tests/studies-route-contract.test.js",
     "infra/cloudflare/src/service/studies.js",
-    "package.json"
+    "package.json",
+    "GitHub PR #423 review thread PRRT_kwDOP3Td2M6LkMtl",
+    "public/assets/govuk/govuk-frontend.css"
   ],
   "filesModified": [
     "src/govuk/templates/pages/project-dashboard.njk",
@@ -96,7 +98,14 @@
     "Kept genuine study load failures visible as a non-technical retry message.",
     "Added govuk-body-s to every non-navigation dashboard panel content wrapper, leaving the Project areas navigation at its existing size.",
     "Added govuk-body-s directly to the Mural and Project details dl.govuk-summary-list elements so their dt and dd content inherit from the list.",
-    "Added scoped dashboard Sass so lists, labels, hints, summary-list keys and summary-list values inherit the smaller typography inside non-navigation panel content."
+    "Added scoped dashboard Sass so lists, labels, hints, summary-list keys and summary-list values inherit the smaller typography inside non-navigation panel content.",
+    "Classified the PR review comment about source order as useful because the single-column/mobile reading order placed the Project areas navigation before the dashboard heading.",
+    "Moved .rops-dashboard-header before .rops-dashboard-sidebar in the template and generated page so keyboard and screen-reader users encounter the project heading before the section navigation.",
+    "Placed .rops-dashboard-header and .rops-dashboard-content in the right grid column on desktop so the visual two-column layout is preserved despite the improved DOM order.",
+    "Replaced the dashboard layout shorthand gap with column-gap and row-gap so desktop column spacing and vertical panel spacing remain explicit after the grid placement change.",
+    "Added route-state assertions for the header-before-sidebar and project-title-before-project-areas-nav DOM order in both source and generated HTML.",
+    "Fixed the Project details summary-list typography cascade by making non-navigation panel dl.govuk-body-s elements inherit from the govuk-body-s panel content wrapper before their keys and values inherit from the dl.",
+    "Added .govuk-body to the non-navigation panel typography inheritance rule so medium body paragraphs inside smaller panel content do not override the intended panel text size."
   ],
   "validationAttempted": [
     "npm run build:project-dashboard && npm run build:govuk-pages passed",
@@ -129,7 +138,16 @@
     "node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js passed after updating the broader summary-list contracts",
     "npm run lint passed after the panel typography change with existing repository warnings and no errors",
     "npm test passed after the panel typography change with 245 tests and 0 failures",
-    "npm run validate passed after the panel typography change"
+    "npm run validate passed after the panel typography change",
+    "npm run build:generated-css && npm run build:govuk-pages passed after the review source-order and Project details summary-list typography fixes",
+    "node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js passed after the review source-order and Project details summary-list typography fixes",
+    "Browser computed-style check confirmed the Project details dl, summary-list keys and summary-list values compute to 16px font size and 20px line height, while the Project areas navigation remains at 19px",
+    "Browser layout check confirmed the dashboard header precedes the Project areas navigation in DOM/mobile order and remains aligned with the main content column on desktop",
+    "npm run format:check passed after formatting the dashboard Sass",
+    "npm run lint passed after the review source-order and Project details summary-list typography fixes with existing repository warnings and no errors",
+    "npm test passed after the review source-order and Project details summary-list typography fixes with 245 tests and 0 failures",
+    "npm run validate passed after the review source-order and Project details summary-list typography fixes",
+    "Final browser computed-style check after validation rebuilt assets confirmed the Project details summary-list key still computes to 16px font size and 20px line height, and the dashboard header still precedes the Project areas navigation in DOM order"
   ],
   "residualRisks": [
     "Final deployed appearance still depends on the generated static assets being served without stale cache.",

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, move Objectives into a separate Project Objectives panel beneath Stakeholder management, and treat a no-studies studies_unavailable response in Research outcomes as a normal empty state instead of surfacing a system-style failure message.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, move Objectives into a separate Project Objectives panel beneath Stakeholder management, treat a no-studies studies_unavailable response in Research outcomes as a normal empty state instead of surfacing a system-style failure message, and apply govuk-body-s to non-navigation panel content with dl.govuk-body-s summary lists.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -93,7 +93,10 @@
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks.",
     "Changed the dashboard studies loader so the known studies_unavailable response maps to an empty studies array and renders No studies have been created for this project yet.",
     "Removed the user-facing Could not load studies, Study records could not be loaded for this project. and study technical-detail copy from the Research outcomes panel.",
-    "Kept genuine study load failures visible as a non-technical retry message."
+    "Kept genuine study load failures visible as a non-technical retry message.",
+    "Added govuk-body-s to every non-navigation dashboard panel content wrapper, leaving the Project areas navigation at its existing size.",
+    "Added govuk-body-s directly to the Mural and Project details dl.govuk-summary-list elements so their dt and dd content inherit from the list.",
+    "Added scoped dashboard Sass so lists, labels, hints, summary-list keys and summary-list values inherit the smaller typography inside non-navigation panel content."
   ],
   "validationAttempted": [
     "npm run build:project-dashboard && npm run build:govuk-pages passed",
@@ -118,7 +121,15 @@
     "npm run format:check passed after generated CSS was rebuilt by the lint script",
     "npm run lint passed after the no-studies empty-state change with existing repository warnings and no errors",
     "npm test passed after the no-studies empty-state change with 245 tests and 0 failures",
-    "npm run validate passed after the no-studies empty-state change"
+    "npm run validate passed after the no-studies empty-state change",
+    "npm run build:generated-css and npm run build:govuk-pages passed after the panel typography change",
+    "node --test tests/project-dashboard-route-state.test.js passed after the panel typography change",
+    "Initial full validation exposed two broader GOV.UK route-state assertions that still expected a bare govuk-summary-list class",
+    "Updated those broader route-state assertions to expect govuk-summary-list govuk-body-s",
+    "node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js passed after updating the broader summary-list contracts",
+    "npm run lint passed after the panel typography change with existing repository warnings and no errors",
+    "npm test passed after the panel typography change with 245 tests and 0 failures",
+    "npm run validate passed after the panel typography change"
   ],
   "residualRisks": [
     "Final deployed appearance still depends on the generated static assets being served without stale cache.",

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, then keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, and make the lower main-column panel gaps match the gap between Project details and Stakeholder management.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -21,20 +21,21 @@
     ".agent-operating-model/bundles/github/",
     ".agent-operating-model/bundles/researchops-developer-control/",
     ".agent-operating-model/bundles/multi-functional-team/",
-    ".agent-operating-model/bundles/govuk-design-system/"
+    ".agent-operating-model/bundles/govuk-design-system/",
+    ".agent-operating-model/bundles/mural-public-api/"
   ],
   "skippedBundles": [
     ".agent-operating-model/bundles/cloudflare/",
     ".agent-operating-model/bundles/openai/",
     ".agent-operating-model/bundles/mcp-agent-tooling/",
-    ".agent-operating-model/bundles/airtable-public-api/",
-    ".agent-operating-model/bundles/mural-public-api/"
+    ".agent-operating-model/bundles/airtable-public-api/"
   ],
   "precedenceDecisions": [
     "GitHub Diamond governed branch naming, trace requirement, surgical mutation, changed-file review and PR readiness.",
     "ResearchOps Developer Control governed the project dashboard route, generated GOV.UK page output, generated CSS output and route-state test style.",
     "Multi-Functional Team governed public-sector product assurance and the need to keep the project hub usable for researchers and product team members.",
     "GOV.UK Design System governed preserving semantic navigation, GOV.UK summary-card structure and responsive behaviour.",
+    "Mural Public API governed keeping Mural integration state bounded to presentation behaviour without changing endpoint contracts, scopes or OAuth flow.",
     "No instruction conflicts were found."
   ],
   "filesRead": [
@@ -42,7 +43,9 @@
     "src/styles/project-dashboard.scss",
     "public/pages/project-dashboard/index.html",
     "public/css/project-dashboard.css",
+    "public/components/mural-integration.js",
     "tests/project-dashboard-route-state.test.js",
+    "tests/mural-ui-route-state.test.js",
     "package.json"
   ],
   "filesModified": [
@@ -51,6 +54,7 @@
     "public/css/project-dashboard.css",
     "public/pages/project-dashboard/index.html",
     "tests/project-dashboard-route-state.test.js",
+    "tests/mural-ui-route-state.test.js",
     "docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md",
     "docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json"
   ],
@@ -77,11 +81,14 @@
     "Added a scoped .rops-link-panel .govuk-button rule so the journal button keeps an 8px bottom margin inside the link panel.",
     "Removed the #mural-status paragraph from the dashboard template and deleted its now-unused .rops-mural-status stylesheet rule.",
     "Changed the Mural integration disabled/default state to hide the existing #mural-connect button until a disconnected or recoverable-error path shows it.",
+    "Added an initial hidden attribute to the rendered #mural-connect button so it is not visible before the Mural state script completes.",
+    "Added a scoped #mural-connect[hidden] { display: none; } rule because GOV.UK button styling otherwise gave the hidden button visible dimensions.",
+    "Set the main dashboard grid gap to 30px and reset direct summary-card bottom margins in that grid so Stakeholder management, Research planning and Research outcomes gaps match the measured Project details to Stakeholder management gap.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
     "npm run build:project-dashboard && npm run build:govuk-pages passed",
-    "node --test tests/project-dashboard-route-state.test.js passed",
+    "node --test tests/project-dashboard-route-state.test.js tests/mural-ui-route-state.test.js passed",
     "npm run format:check passed",
     "npm run lint passed with existing repository warnings and no errors",
     "Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths",
@@ -89,6 +96,9 @@
     "Route-state checks confirm the rops-link-panel button bottom margin rule is present in both Sass and generated CSS",
     "Route-state checks confirm the #mural-status paragraph and .rops-mural-status style no longer render",
     "Route-state checks confirm the Mural disabled/default state hides the existing Connect Mural button",
+    "Browser connected-state check confirmed the existing #mural-connect button remains in the DOM while hidden, disabled, display: none, and measuring 0px by 0px",
+    "Browser disconnected-state check confirmed the same #mural-connect button becomes visible and enabled when Mural verification returns a disconnected response",
+    "Browser spacing check confirmed Project details to Stakeholder management, Stakeholder management to Research planning, and Research planning to Research outcomes each measure 30px",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, and move Objectives into a separate Project Objectives panel beneath Stakeholder management.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, move Objectives into a separate Project Objectives panel beneath Stakeholder management, and treat a no-studies studies_unavailable response in Research outcomes as a normal empty state instead of surfacing a system-style failure message.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -46,6 +46,9 @@
     "public/components/mural-integration.js",
     "tests/project-dashboard-route-state.test.js",
     "tests/mural-ui-route-state.test.js",
+    "public/js/project-dashboard.js",
+    "tests/studies-route-contract.test.js",
+    "infra/cloudflare/src/service/studies.js",
     "package.json"
   ],
   "filesModified": [
@@ -53,6 +56,7 @@
     "src/styles/project-dashboard.scss",
     "public/css/project-dashboard.css",
     "public/pages/project-dashboard/index.html",
+    "public/js/project-dashboard.js",
     "tests/project-dashboard-route-state.test.js",
     "tests/mural-ui-route-state.test.js",
     "docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md",
@@ -86,7 +90,10 @@
     "Set the main dashboard grid gap to 30px and reset direct summary-card bottom margins in that grid so Stakeholder management, Research planning and Research outcomes gaps match the measured Project details to Stakeholder management gap.",
     "Moved the existing objectives list, add-objective button and add-objective form into a new Project Objectives summary-card immediately after Stakeholder management.",
     "Added a Project Objectives link to the Project areas navigation.",
-    "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
+    "Preserved existing dashboard cards, links, IDs and JavaScript hooks.",
+    "Changed the dashboard studies loader so the known studies_unavailable response maps to an empty studies array and renders No studies have been created for this project yet.",
+    "Removed the user-facing Could not load studies, Study records could not be loaded for this project. and study technical-detail copy from the Research outcomes panel.",
+    "Kept genuine study load failures visible as a non-technical retry message."
   ],
   "validationAttempted": [
     "npm run build:project-dashboard && npm run build:govuk-pages passed",
@@ -106,9 +113,15 @@
     "Route-state checks confirm Project Objectives renders after Stakeholder management and before Research planning, with the existing objectives DOM hooks preserved",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
-    "npm run validate passed"
+    "npm run validate passed",
+    "node --test tests/project-dashboard-route-state.test.js tests/studies-route-contract.test.js passed after the no-studies empty-state change",
+    "npm run format:check passed after generated CSS was rebuilt by the lint script",
+    "npm run lint passed after the no-studies empty-state change with existing repository warnings and no errors",
+    "npm test passed after the no-studies empty-state change with 245 tests and 0 failures",
+    "npm run validate passed after the no-studies empty-state change"
   ],
   "residualRisks": [
-    "Final deployed appearance still depends on the generated static assets being served without stale cache."
+    "Final deployed appearance still depends on the generated static assets being served without stale cache.",
+    "Genuine study API outages now use generic user-facing copy on the dashboard; detailed diagnosis remains available in logs and API responses rather than in the Research outcomes panel."
   ]
 }

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -1,0 +1,84 @@
+{
+  "date": "2026-06-23",
+  "branch": "fix/project-dashboard-areas-nav-layout",
+  "traceRequired": true,
+  "repository": "kevinrapley/ResearchOps",
+  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    ".agent-operating-model/bundles/github/",
+    ".agent-operating-model/bundles/researchops-developer-control/",
+    ".agent-operating-model/bundles/multi-functional-team/",
+    ".agent-operating-model/bundles/govuk-design-system/"
+  ],
+  "skippedBundles": [
+    ".agent-operating-model/bundles/cloudflare/",
+    ".agent-operating-model/bundles/openai/",
+    ".agent-operating-model/bundles/mcp-agent-tooling/",
+    ".agent-operating-model/bundles/airtable-public-api/",
+    ".agent-operating-model/bundles/mural-public-api/"
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch naming, trace requirement, surgical mutation, changed-file review and PR readiness.",
+    "ResearchOps Developer Control governed the project dashboard route, generated GOV.UK page output, generated CSS output and route-state test style.",
+    "Multi-Functional Team governed public-sector product assurance and the need to keep the project hub usable for researchers and product team members.",
+    "GOV.UK Design System governed preserving semantic navigation, GOV.UK summary-card structure and responsive behaviour.",
+    "No instruction conflicts were found."
+  ],
+  "filesRead": [
+    "src/govuk/templates/pages/project-dashboard.njk",
+    "src/styles/project-dashboard.scss",
+    "public/pages/project-dashboard/index.html",
+    "public/css/project-dashboard.css",
+    "tests/project-dashboard-route-state.test.js",
+    "package.json"
+  ],
+  "filesModified": [
+    "src/govuk/templates/pages/project-dashboard.njk",
+    "src/styles/project-dashboard.scss",
+    "public/css/project-dashboard.css",
+    "public/pages/project-dashboard/index.html",
+    "tests/project-dashboard-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md",
+    "docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json"
+  ],
+  "existingLocalChanges": [
+    {
+      "path": "infra/cloudflare/src/core/auth/passwordless.js",
+      "disposition": "pre-existing unrelated local edit, not staged for this PR"
+    }
+  ],
+  "decisions": [
+    "Moved {{ daasBrandPanel() }} before the new dashboard layout wrapper so the DaaS panel remains full width.",
+    "Added .rops-dashboard-layout around the project-area nav and the rest of the dashboard content.",
+    "Kept the navigation as a semantic nav with aria-labelledby=\"project-areas-title\".",
+    "Added .rops-project-areas-nav for the left column and .rops-dashboard-content for the right column.",
+    "Used a responsive CSS grid that stays single-column by default and becomes minmax(0, 1fr) minmax(0, 3fr) from the existing desktop breakpoint.",
+    "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
+  ],
+  "validationAttempted": [
+    "npm run build:project-dashboard && npm run build:govuk-pages passed",
+    "node --test tests/project-dashboard-route-state.test.js passed",
+    "npm run format:check passed",
+    "npm run lint passed with existing repository warnings and no errors",
+    "Browser layout check with Playwright passed at 1280px desktop and 390px mobile widths",
+    "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
+    "npm test passed with 245 tests and 0 failures",
+    "npm run validate passed"
+  ],
+  "residualRisks": [
+    "Final deployed appearance still depends on the generated static assets being served without stale cache."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel.",
+  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, then make that navigation sticky after scrolling beyond it.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -66,6 +66,8 @@
     "Kept the navigation as a semantic nav with aria-labelledby=\"project-areas-title\".",
     "Added .rops-project-areas-nav for the left column and .rops-dashboard-content for the right column.",
     "Used a responsive CSS grid that stays single-column by default and becomes minmax(0, 1fr) minmax(0, 3fr) from the existing desktop breakpoint.",
+    "Made .rops-project-areas-nav sticky only from the desktop layout breakpoint.",
+    "Used top: 1rem for the sticky offset, matching the DaaS brand panel bottom spacing.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
@@ -73,7 +75,7 @@
     "node --test tests/project-dashboard-route-state.test.js passed",
     "npm run format:check passed",
     "npm run lint passed with existing repository warnings and no errors",
-    "Browser layout check with Playwright passed at 1280px desktop and 390px mobile widths",
+    "Browser layout and sticky navigation check with Playwright passed at 1280px desktop and 390px mobile widths",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, then make the sidebar one third width and the main content column two thirds width.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, then keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -74,6 +74,9 @@
     "Added align-self: start to .rops-dashboard-sidebar so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.",
     "Reset direct .govuk-summary-card bottom margins inside .rops-dashboard-sidebar so the sidebar grid gap defines the visible spacing between the nav and journal panels.",
     "Adjusted the desktop dashboard grid from a one-quarter/three-quarter split to a one-third/two-thirds split while keeping the DaaS brand panel outside the two-column area.",
+    "Added a scoped .rops-link-panel .govuk-button rule so the journal button keeps an 8px bottom margin inside the link panel.",
+    "Removed the #mural-status paragraph from the dashboard template and deleted its now-unused .rops-mural-status stylesheet rule.",
+    "Changed the Mural integration disabled/default state to hide the existing #mural-connect button until a disconnected or recoverable-error path shows it.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
@@ -83,6 +86,9 @@
     "npm run lint passed with existing repository warnings and no errors",
     "Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths",
     "Browser layout ratio check with Playwright passed at 1280px desktop width, confirming the sidebar is one third and the main content column is two thirds of the dashboard grid",
+    "Route-state checks confirm the rops-link-panel button bottom margin rule is present in both Sass and generated CSS",
+    "Route-state checks confirm the #mural-status paragraph and .rops-mural-status style no longer render",
+    "Route-state checks confirm the Mural disabled/default state hides the existing Connect Mural button",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, then move the Reflexive journal panel into the left column underneath the Project areas navigation.",
+  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, then make the left sidebar sticky as a group.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -66,10 +66,12 @@
     "Kept the navigation as a semantic nav with aria-labelledby=\"project-areas-title\".",
     "Added .rops-project-areas-nav for the left column and .rops-dashboard-content for the right column.",
     "Used a responsive CSS grid that stays single-column by default and becomes minmax(0, 1fr) minmax(0, 3fr) from the existing desktop breakpoint.",
-    "Made .rops-project-areas-nav sticky only from the desktop layout breakpoint.",
+    "Kept sticky behaviour desktop-only from the dashboard layout breakpoint.",
     "Used top: 1rem for the sticky offset, matching the DaaS brand panel bottom spacing.",
     "Added .rops-dashboard-sidebar to stack the Project areas navigation and Reflexive journal panel in the left column.",
     "Moved the existing Reflexive journal markup out of the main dashboard content grid without changing its IDs, links or Mural integration hooks.",
+    "Moved the sticky positioning from .rops-project-areas-nav to .rops-dashboard-sidebar so the left column sticks as one stack.",
+    "Added align-self: start to .rops-dashboard-sidebar so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
@@ -77,7 +79,7 @@
     "node --test tests/project-dashboard-route-state.test.js passed",
     "npm run format:check passed",
     "npm run lint passed with existing repository warnings and no errors",
-    "Browser layout, sticky navigation and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths",
+    "Browser layout, sticky sidebar and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, and make the lower main-column panel gaps match the gap between Project details and Stakeholder management.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, and move Objectives into a separate Project Objectives panel beneath Stakeholder management.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -84,6 +84,8 @@
     "Added an initial hidden attribute to the rendered #mural-connect button so it is not visible before the Mural state script completes.",
     "Added a scoped #mural-connect[hidden] { display: none; } rule because GOV.UK button styling otherwise gave the hidden button visible dimensions.",
     "Set the main dashboard grid gap to 30px and reset direct summary-card bottom margins in that grid so Stakeholder management, Research planning and Research outcomes gaps match the measured Project details to Stakeholder management gap.",
+    "Moved the existing objectives list, add-objective button and add-objective form into a new Project Objectives summary-card immediately after Stakeholder management.",
+    "Added a Project Objectives link to the Project areas navigation.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
@@ -99,6 +101,9 @@
     "Browser connected-state check confirmed the existing #mural-connect button remains in the DOM while hidden, disabled, display: none, and measuring 0px by 0px",
     "Browser disconnected-state check confirmed the same #mural-connect button becomes visible and enabled when Mural verification returns a disconnected response",
     "Browser spacing check confirmed Project details to Stakeholder management, Stakeholder management to Research planning, and Research planning to Research outcomes each measure 30px",
+    "npm run build:govuk-pages passed after moving objectives into their own panel",
+    "node --test tests/project-dashboard-route-state.test.js tests/platform-heading-hierarchy-sentence-case.test.js passed",
+    "Route-state checks confirm Project Objectives renders after Stakeholder management and before Research planning, with the existing objectives DOM hooks preserved",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, move Objectives into a separate Project Objectives panel beneath Stakeholder management, treat a no-studies studies_unavailable response in Research outcomes as a normal empty state instead of surfacing a system-style failure message, apply govuk-body-s to non-navigation panel content with dl.govuk-body-s summary lists, address PR review feedback by keeping the dashboard header and h1 before the Project areas navigation in DOM order while preserving the desktop layout, and fix the Project details summary-list cascade so dl.govuk-body-s, dt and dd compute to the expected smaller GOV.UK body size.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, make the sidebar one third width and the main content column two thirds width, add an 8px bottom margin to the button at the bottom of the rops-link-panel, remove the #mural-status paragraph element, keep the Connect Mural button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active, fix the rendered disabled Connect Mural button still being visible, make the lower main-column panel gaps match the gap between Project details and Stakeholder management, move Objectives into a separate Project Objectives panel beneath Stakeholder management, treat a no-studies studies_unavailable response in Research outcomes as a normal empty state instead of surfacing a system-style failure message, apply govuk-body-s to non-navigation panel content with dl.govuk-body-s summary lists, address PR review feedback by keeping the dashboard header and h1 before the Project areas navigation in DOM order while preserving the desktop layout, fix the Project details summary-list cascade so dl.govuk-body-s, dt and dd compute to the expected smaller GOV.UK body size, and render Project Objectives from simple Markdown-style numbered and dashed list text.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -51,7 +51,11 @@
     "infra/cloudflare/src/service/studies.js",
     "package.json",
     "GitHub PR #423 review thread PRRT_kwDOP3Td2M6LkMtl",
-    "public/assets/govuk/govuk-frontend.css"
+    "public/assets/govuk/govuk-frontend.css",
+    "public/js/project-dashboard.js",
+    "src/govuk/templates/pages/project-dashboard.njk",
+    "src/styles/project-dashboard.scss",
+    "tests/project-dashboard-route-state.test.js"
   ],
   "filesModified": [
     "src/govuk/templates/pages/project-dashboard.njk",
@@ -105,7 +109,14 @@
     "Replaced the dashboard layout shorthand gap with column-gap and row-gap so desktop column spacing and vertical panel spacing remain explicit after the grid placement change.",
     "Added route-state assertions for the header-before-sidebar and project-title-before-project-areas-nav DOM order in both source and generated HTML.",
     "Fixed the Project details summary-list typography cascade by making non-navigation panel dl.govuk-body-s elements inherit from the govuk-body-s panel content wrapper before their keys and values inherit from the dl.",
-    "Added .govuk-body to the non-navigation panel typography inheritance rule so medium body paragraphs inside smaller panel content do not override the intended panel text size."
+    "Added .govuk-body to the non-navigation panel typography inheritance rule so medium body paragraphs inside smaller panel content do not override the intended panel text size.",
+    "Replaced the static Project Objectives ul placeholder with a neutral .rops-objectives-list container so the client renderer can emit a valid ol when objectives are loaded.",
+    "Added a lightweight Project Objectives parser that recognises numbered lines such as 1. Objective or 1) Objective as top-level ordered-list items.",
+    "Added support for dashed, starred or plus-prefixed lines as nested unordered-list items beneath the current numbered objective.",
+    "Preserved escaping for all objective text before insertion into generated HTML.",
+    "Added .rops-objective-list styles so top-level objective items have divider lines while .rops-objective-list__sublist > li explicitly has no divider line.",
+    "Kept plain legacy objective strings supported by rendering them as top-level ordered-list items when no Markdown-style numbering is present.",
+    "Added route-state assertions for the neutral objectives container, Markdown-style parser hooks, ordered-list classes, nested-list classes and top-level/nested divider styling."
   ],
   "validationAttempted": [
     "npm run build:project-dashboard && npm run build:govuk-pages passed",
@@ -147,7 +158,16 @@
     "npm run lint passed after the review source-order and Project details summary-list typography fixes with existing repository warnings and no errors",
     "npm test passed after the review source-order and Project details summary-list typography fixes with 245 tests and 0 failures",
     "npm run validate passed after the review source-order and Project details summary-list typography fixes",
-    "Final browser computed-style check after validation rebuilt assets confirmed the Project details summary-list key still computes to 16px font size and 20px line height, and the dashboard header still precedes the Project areas navigation in DOM order"
+    "Final browser computed-style check after validation rebuilt assets confirmed the Project details summary-list key still computes to 16px font size and 20px line height, and the dashboard header still precedes the Project areas navigation in DOM order",
+    "npm run build:generated-css && npm run build:govuk-pages passed after the Project Objectives Markdown-style rendering change",
+    "node --test tests/project-dashboard-route-state.test.js passed after the Project Objectives Markdown-style rendering change",
+    "Browser mock-data check confirmed the sample objectives render as 3 top-level ordered objectives with nested unordered-list counts of 3, 4 and 3",
+    "Browser computed-style check confirmed top-level objective items have divider lines except the final item, and nested bullet items have no divider lines",
+    "node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js passed after the Project Objectives Markdown-style rendering change",
+    "npm run format:check passed after the Project Objectives Markdown-style rendering change",
+    "npm run lint passed after the Project Objectives Markdown-style rendering change with existing repository warnings and no errors",
+    "npm test passed after the Project Objectives Markdown-style rendering change with 245 tests and 0 failures",
+    "npm run validate passed after the Project Objectives Markdown-style rendering change"
   ],
   "residualRisks": [
     "Final deployed appearance still depends on the generated static assets being served without stale cache.",

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, then make the left sidebar sticky as a group.",
+  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, then reduce the visible gap between the nav and journal panels to match other dashboard panel gaps.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -72,6 +72,7 @@
     "Moved the existing Reflexive journal markup out of the main dashboard content grid without changing its IDs, links or Mural integration hooks.",
     "Moved the sticky positioning from .rops-project-areas-nav to .rops-dashboard-sidebar so the left column sticks as one stack.",
     "Added align-self: start to .rops-dashboard-sidebar so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.",
+    "Reset direct .govuk-summary-card bottom margins inside .rops-dashboard-sidebar so the sidebar grid gap defines the visible spacing between the nav and journal panels.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
@@ -79,7 +80,7 @@
     "node --test tests/project-dashboard-route-state.test.js passed",
     "npm run format:check passed",
     "npm run lint passed with existing repository warnings and no errors",
-    "Browser layout, sticky sidebar and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths",
+    "Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, then reduce the visible gap between the nav and journal panels to match other dashboard panel gaps.",
+  "task": "Move the Project Dashboard Project areas navigation into a left column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, move the Reflexive journal panel into the left column underneath the Project areas navigation, make the left sidebar sticky as a group, reduce the visible gap between the nav and journal panels to match other dashboard panel gaps, then make the sidebar one third width and the main content column two thirds width.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -65,7 +65,7 @@
     "Added .rops-dashboard-layout around the project-area nav and the rest of the dashboard content.",
     "Kept the navigation as a semantic nav with aria-labelledby=\"project-areas-title\".",
     "Added .rops-project-areas-nav for the left column and .rops-dashboard-content for the right column.",
-    "Used a responsive CSS grid that stays single-column by default and becomes minmax(0, 1fr) minmax(0, 3fr) from the existing desktop breakpoint.",
+    "Used a responsive CSS grid that stays single-column by default and becomes minmax(0, 1fr) minmax(0, 2fr) from the existing desktop breakpoint.",
     "Kept sticky behaviour desktop-only from the dashboard layout breakpoint.",
     "Used top: 1rem for the sticky offset, matching the DaaS brand panel bottom spacing.",
     "Added .rops-dashboard-sidebar to stack the Project areas navigation and Reflexive journal panel in the left column.",
@@ -73,6 +73,7 @@
     "Moved the sticky positioning from .rops-project-areas-nav to .rops-dashboard-sidebar so the left column sticks as one stack.",
     "Added align-self: start to .rops-dashboard-sidebar so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.",
     "Reset direct .govuk-summary-card bottom margins inside .rops-dashboard-sidebar so the sidebar grid gap defines the visible spacing between the nav and journal panels.",
+    "Adjusted the desktop dashboard grid from a one-quarter/three-quarter split to a one-third/two-thirds split while keeping the DaaS brand panel outside the two-column area.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
@@ -81,6 +82,7 @@
     "npm run format:check passed",
     "npm run lint passed with existing repository warnings and no errors",
     "Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths",
+    "Browser layout ratio check with Playwright passed at 1280px desktop width, confirming the sidebar is one third and the main content column is two thirds of the dashboard grid",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json
@@ -3,7 +3,7 @@
   "branch": "fix/project-dashboard-areas-nav-layout",
   "traceRequired": true,
   "repository": "kevinrapley/ResearchOps",
-  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, then make that navigation sticky after scrolling beyond it.",
+  "task": "Move the Project Dashboard Project areas navigation into a one-quarter left column with remaining content in a three-quarter right column after the full-width DaaS brand panel, make that navigation sticky after scrolling beyond it, then move the Reflexive journal panel into the left column underneath the Project areas navigation.",
   "operatingModelFilesLoaded": [
     "AGENTS.md",
     ".agent-operating-model/orchestration.xml",
@@ -68,6 +68,8 @@
     "Used a responsive CSS grid that stays single-column by default and becomes minmax(0, 1fr) minmax(0, 3fr) from the existing desktop breakpoint.",
     "Made .rops-project-areas-nav sticky only from the desktop layout breakpoint.",
     "Used top: 1rem for the sticky offset, matching the DaaS brand panel bottom spacing.",
+    "Added .rops-dashboard-sidebar to stack the Project areas navigation and Reflexive journal panel in the left column.",
+    "Moved the existing Reflexive journal markup out of the main dashboard content grid without changing its IDs, links or Mural integration hooks.",
     "Preserved existing dashboard cards, links, IDs and JavaScript hooks."
   ],
   "validationAttempted": [
@@ -75,7 +77,7 @@
     "node --test tests/project-dashboard-route-state.test.js passed",
     "npm run format:check passed",
     "npm run lint passed with existing repository warnings and no errors",
-    "Browser layout and sticky navigation check with Playwright passed at 1280px desktop and 390px mobile widths",
+    "Browser layout, sticky navigation and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths",
     "npm test -- --ci could not run because the current script passes --ci through to Node, which exits with node: bad option: --ci",
     "npm test passed with 245 tests and 0 failures",
     "npm run validate passed"

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -4,6 +4,8 @@
 
 Move the Project Dashboard `Project areas` navigation into a left column that takes one quarter of the desktop width, with the remaining dashboard content in a three-quarter column to the right. Keep the DaaS brand panel full width before the two-column dashboard layout.
 
+Follow-up: make the `Project areas` navigation sticky after users scroll beyond it, with the same visible top spacing as the space between the navigation panel and the DaaS brand panel.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -79,6 +81,8 @@ Move the Project Dashboard `Project areas` navigation into a left column that ta
 - Kept the navigation as a semantic `nav` with `aria-labelledby="project-areas-title"`.
 - Added `.rops-project-areas-nav` for the left column and `.rops-dashboard-content` for the right column.
 - Used a responsive CSS grid that stays single-column by default and becomes `minmax(0, 1fr) minmax(0, 3fr)` from the existing desktop breakpoint.
+- Made `.rops-project-areas-nav` sticky only from the desktop layout breakpoint.
+- Used `top: 1rem` for the sticky offset, matching the DaaS brand panel bottom spacing.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
@@ -87,7 +91,7 @@ Move the Project Dashboard `Project areas` navigation into a left column that ta
 - `node --test tests/project-dashboard-route-state.test.js` passed.
 - `npm run format:check` passed.
 - `npm run lint` passed with existing repository warnings and no errors.
-- Browser layout check with Playwright passed at 1280px desktop and 390px mobile widths.
+- Browser layout and sticky navigation check with Playwright passed at 1280px desktop and 390px mobile widths.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -14,6 +14,12 @@ Follow-up: reduce the visible gap between `Project areas` and `Reflexive journal
 
 Follow-up: make the sidebar with `Project areas` and `Reflexive journal` one third width and the main content column two thirds width within the GOV.UK width container.
 
+Follow-up: add an 8px bottom margin to the button at the bottom of the `rops-link-panel`.
+
+Follow-up: remove the `#mural-status` paragraph element from the Mural board panel.
+
+Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -97,6 +103,9 @@ Follow-up: make the sidebar with `Project areas` and `Reflexive journal` one thi
 - Added `align-self: start` to `.rops-dashboard-sidebar` so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.
 - Reset direct `.govuk-summary-card` bottom margins inside `.rops-dashboard-sidebar` so the sidebar grid gap defines the visible spacing between the nav and journal panels.
 - Adjusted the desktop dashboard grid from a one-quarter/three-quarter split to a one-third/two-thirds split while keeping the DaaS brand panel outside the two-column area.
+- Added a scoped `.rops-link-panel .govuk-button` rule so the journal button keeps an 8px bottom margin inside the link panel.
+- Removed the `#mural-status` paragraph from the dashboard template and deleted its now-unused `.rops-mural-status` stylesheet rule.
+- Changed the Mural integration disabled/default state to hide the existing `#mural-connect` button until a disconnected or recoverable-error path shows it.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
@@ -107,6 +116,9 @@ Follow-up: make the sidebar with `Project areas` and `Reflexive journal` one thi
 - `npm run lint` passed with existing repository warnings and no errors.
 - Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths.
 - Browser layout ratio check with Playwright passed at 1280px desktop width, confirming the sidebar is one third and the main content column is two thirds of the dashboard grid.
+- Route-state checks confirm the `rops-link-panel` button bottom margin rule is present in both Sass and generated CSS.
+- Route-state checks confirm the `#mural-status` paragraph and `.rops-mural-status` style no longer render.
+- Route-state checks confirm the Mural disabled/default state hides the existing Connect Mural button.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -24,6 +24,8 @@ Follow-up: fix the rendered disabled `Connect Mural` button still being visible 
 
 Follow-up: make the gaps between `Stakeholder management`, `Research planning` and `Research outcomes` match the gap between `Project details` and `Stakeholder management`.
 
+Follow-up: move `Objectives` out of the `Stakeholder management` panel into a separate `Project Objectives` panel directly beneath it.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -117,6 +119,8 @@ Follow-up: make the gaps between `Stakeholder management`, `Research planning` a
 - Added an initial `hidden` attribute to the rendered `#mural-connect` button so it is not visible before the Mural state script completes.
 - Added a scoped `#mural-connect[hidden] { display: none; }` rule because GOV.UK button styling otherwise gave the hidden button visible dimensions.
 - Set the main dashboard grid gap to 30px and reset direct summary-card bottom margins in that grid so `Stakeholder management`, `Research planning` and `Research outcomes` gaps match the measured `Project details` to `Stakeholder management` gap.
+- Moved the existing objectives list, add-objective button and add-objective form into a new `Project Objectives` summary-card immediately after `Stakeholder management`.
+- Added a `Project Objectives` link to the `Project areas` navigation.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
@@ -133,6 +137,9 @@ Follow-up: make the gaps between `Stakeholder management`, `Research planning` a
 - Browser connected-state check confirmed the existing `#mural-connect` button remains in the DOM while hidden, disabled, `display: none`, and measuring 0px by 0px.
 - Browser disconnected-state check confirmed the same `#mural-connect` button becomes visible and enabled when Mural verification returns a disconnected response.
 - Browser spacing check confirmed `Project details` to `Stakeholder management`, `Stakeholder management` to `Research planning`, and `Research planning` to `Research outcomes` each measure 30px.
+- `npm run build:govuk-pages` passed after moving objectives into their own panel.
+- `node --test tests/project-dashboard-route-state.test.js tests/platform-heading-hierarchy-sentence-case.test.js` passed.
+- Route-state checks confirm `Project Objectives` renders after `Stakeholder management` and before `Research planning`, with the existing objectives DOM hooks preserved.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -20,6 +20,10 @@ Follow-up: remove the `#mural-status` paragraph element from the Mural board pan
 
 Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI while Mural is connected or the disabled default state is active.
 
+Follow-up: fix the rendered disabled `Connect Mural` button still being visible by making the initial hidden state effective against GOV.UK button styling.
+
+Follow-up: make the gaps between `Stakeholder management`, `Research planning` and `Research outcomes` match the gap between `Project details` and `Stakeholder management`.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -47,6 +51,7 @@ Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI w
 - `.agent-operating-model/bundles/researchops-developer-control/`
 - `.agent-operating-model/bundles/multi-functional-team/`
 - `.agent-operating-model/bundles/govuk-design-system/`
+- `.agent-operating-model/bundles/mural-public-api/`
 
 ## Bundles skipped
 
@@ -54,7 +59,6 @@ Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI w
 - `.agent-operating-model/bundles/openai/`: no OpenAI API, model or AI route behaviour changed.
 - `.agent-operating-model/bundles/mcp-agent-tooling/`: no MCP protocol or agent tooling changed.
 - `.agent-operating-model/bundles/airtable-public-api/`: no Airtable API behaviour changed.
-- `.agent-operating-model/bundles/mural-public-api/`: no Mural API behaviour changed.
 
 ## Precedence decisions
 
@@ -62,6 +66,7 @@ Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI w
 - ResearchOps Developer Control governed the project dashboard route, generated GOV.UK page output, generated CSS output and route-state test style.
 - Multi-Functional Team governed public-sector product assurance and the need to keep the project hub usable for researchers and product team members.
 - GOV.UK Design System governed preserving semantic navigation, GOV.UK summary-card structure and responsive behaviour.
+- Mural Public API governed keeping Mural integration state bounded to presentation behaviour without changing endpoint contracts, scopes or OAuth flow.
 - No instruction conflicts were found.
 
 ## Files read
@@ -70,7 +75,9 @@ Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI w
 - `src/styles/project-dashboard.scss`
 - `public/pages/project-dashboard/index.html`
 - `public/css/project-dashboard.css`
+- `public/components/mural-integration.js`
 - `tests/project-dashboard-route-state.test.js`
+- `tests/mural-ui-route-state.test.js`
 - `package.json`
 
 ## Files created or modified
@@ -80,6 +87,7 @@ Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI w
 - `public/css/project-dashboard.css`
 - `public/pages/project-dashboard/index.html`
 - `tests/project-dashboard-route-state.test.js`
+- `tests/mural-ui-route-state.test.js`
 - `docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md`
 - `docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json`
 
@@ -106,12 +114,15 @@ Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI w
 - Added a scoped `.rops-link-panel .govuk-button` rule so the journal button keeps an 8px bottom margin inside the link panel.
 - Removed the `#mural-status` paragraph from the dashboard template and deleted its now-unused `.rops-mural-status` stylesheet rule.
 - Changed the Mural integration disabled/default state to hide the existing `#mural-connect` button until a disconnected or recoverable-error path shows it.
+- Added an initial `hidden` attribute to the rendered `#mural-connect` button so it is not visible before the Mural state script completes.
+- Added a scoped `#mural-connect[hidden] { display: none; }` rule because GOV.UK button styling otherwise gave the hidden button visible dimensions.
+- Set the main dashboard grid gap to 30px and reset direct summary-card bottom margins in that grid so `Stakeholder management`, `Research planning` and `Research outcomes` gaps match the measured `Project details` to `Stakeholder management` gap.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
 
 - `npm run build:project-dashboard && npm run build:govuk-pages` passed.
-- `node --test tests/project-dashboard-route-state.test.js` passed.
+- `node --test tests/project-dashboard-route-state.test.js tests/mural-ui-route-state.test.js` passed.
 - `npm run format:check` passed.
 - `npm run lint` passed with existing repository warnings and no errors.
 - Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths.
@@ -119,6 +130,9 @@ Follow-up: keep the `Connect Mural` button in the HTML but hide it from the UI w
 - Route-state checks confirm the `rops-link-panel` button bottom margin rule is present in both Sass and generated CSS.
 - Route-state checks confirm the `#mural-status` paragraph and `.rops-mural-status` style no longer render.
 - Route-state checks confirm the Mural disabled/default state hides the existing Connect Mural button.
+- Browser connected-state check confirmed the existing `#mural-connect` button remains in the DOM while hidden, disabled, `display: none`, and measuring 0px by 0px.
+- Browser disconnected-state check confirmed the same `#mural-connect` button becomes visible and enabled when Mural verification returns a disconnected response.
+- Browser spacing check confirmed `Project details` to `Stakeholder management`, `Stakeholder management` to `Research planning`, and `Research planning` to `Research outcomes` each measure 30px.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -10,6 +10,8 @@ Follow-up: move the `Reflexive journal` panel into the left column underneath th
 
 Follow-up: make the left sidebar sticky as a group so the `Project areas` navigation and `Reflexive journal` panel remain in view together.
 
+Follow-up: reduce the visible gap between `Project areas` and `Reflexive journal` so it matches the other dashboard panel gaps.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -91,6 +93,7 @@ Follow-up: make the left sidebar sticky as a group so the `Project areas` naviga
 - Moved the existing `Reflexive journal` markup out of the main dashboard content grid without changing its IDs, links or Mural integration hooks.
 - Moved the sticky positioning from `.rops-project-areas-nav` to `.rops-dashboard-sidebar` so the left column sticks as one stack.
 - Added `align-self: start` to `.rops-dashboard-sidebar` so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.
+- Reset direct `.govuk-summary-card` bottom margins inside `.rops-dashboard-sidebar` so the sidebar grid gap defines the visible spacing between the nav and journal panels.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
@@ -99,7 +102,7 @@ Follow-up: make the left sidebar sticky as a group so the `Project areas` naviga
 - `node --test tests/project-dashboard-route-state.test.js` passed.
 - `npm run format:check` passed.
 - `npm run lint` passed with existing repository warnings and no errors.
-- Browser layout, sticky sidebar and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths.
+- Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -8,6 +8,8 @@ Follow-up: make the `Project areas` navigation sticky after users scroll beyond 
 
 Follow-up: move the `Reflexive journal` panel into the left column underneath the `Project areas` navigation.
 
+Follow-up: make the left sidebar sticky as a group so the `Project areas` navigation and `Reflexive journal` panel remain in view together.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -83,10 +85,12 @@ Follow-up: move the `Reflexive journal` panel into the left column underneath th
 - Kept the navigation as a semantic `nav` with `aria-labelledby="project-areas-title"`.
 - Added `.rops-project-areas-nav` for the left column and `.rops-dashboard-content` for the right column.
 - Used a responsive CSS grid that stays single-column by default and becomes `minmax(0, 1fr) minmax(0, 3fr)` from the existing desktop breakpoint.
-- Made `.rops-project-areas-nav` sticky only from the desktop layout breakpoint.
+- Kept sticky behaviour desktop-only from the dashboard layout breakpoint.
 - Used `top: 1rem` for the sticky offset, matching the DaaS brand panel bottom spacing.
 - Added `.rops-dashboard-sidebar` to stack the `Project areas` navigation and `Reflexive journal` panel in the left column.
 - Moved the existing `Reflexive journal` markup out of the main dashboard content grid without changing its IDs, links or Mural integration hooks.
+- Moved the sticky positioning from `.rops-project-areas-nav` to `.rops-dashboard-sidebar` so the left column sticks as one stack.
+- Added `align-self: start` to `.rops-dashboard-sidebar` so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
@@ -95,7 +99,7 @@ Follow-up: move the `Reflexive journal` panel into the left column underneath th
 - `node --test tests/project-dashboard-route-state.test.js` passed.
 - `npm run format:check` passed.
 - `npm run lint` passed with existing repository warnings and no errors.
-- Browser layout, sticky navigation and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths.
+- Browser layout, sticky sidebar and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -1,0 +1,97 @@
+# Project dashboard areas nav layout
+
+## Task summary
+
+Move the Project Dashboard `Project areas` navigation into a left column that takes one quarter of the desktop width, with the remaining dashboard content in a three-quarter column to the right. Keep the DaaS brand panel full width before the two-column dashboard layout.
+
+## Run metadata
+
+- Date: 2026-06-23
+- Branch: `fix/project-dashboard-areas-nav-layout`
+- Trace required: yes, because `fix/` branches require an auditable trace.
+- Repository: `kevinrapley/ResearchOps`
+
+## Operating model loaded
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+## Bundles selected
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+## Bundles skipped
+
+- `.agent-operating-model/bundles/cloudflare/`: no Worker, Pages runtime, binding or deployment behaviour changed.
+- `.agent-operating-model/bundles/openai/`: no OpenAI API, model or AI route behaviour changed.
+- `.agent-operating-model/bundles/mcp-agent-tooling/`: no MCP protocol or agent tooling changed.
+- `.agent-operating-model/bundles/airtable-public-api/`: no Airtable API behaviour changed.
+- `.agent-operating-model/bundles/mural-public-api/`: no Mural API behaviour changed.
+
+## Precedence decisions
+
+- GitHub Diamond governed branch naming, trace requirement, surgical mutation, changed-file review and PR readiness.
+- ResearchOps Developer Control governed the project dashboard route, generated GOV.UK page output, generated CSS output and route-state test style.
+- Multi-Functional Team governed public-sector product assurance and the need to keep the project hub usable for researchers and product team members.
+- GOV.UK Design System governed preserving semantic navigation, GOV.UK summary-card structure and responsive behaviour.
+- No instruction conflicts were found.
+
+## Files read
+
+- `src/govuk/templates/pages/project-dashboard.njk`
+- `src/styles/project-dashboard.scss`
+- `public/pages/project-dashboard/index.html`
+- `public/css/project-dashboard.css`
+- `tests/project-dashboard-route-state.test.js`
+- `package.json`
+
+## Files created or modified
+
+- `src/govuk/templates/pages/project-dashboard.njk`
+- `src/styles/project-dashboard.scss`
+- `public/css/project-dashboard.css`
+- `public/pages/project-dashboard/index.html`
+- `tests/project-dashboard-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md`
+- `docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json`
+
+## Existing local changes
+
+- The checkout already had an unrelated local edit in `infra/cloudflare/src/core/auth/passwordless.js`.
+- That file was not staged for this PR.
+
+## Decisions
+
+- Moved `{{ daasBrandPanel() }}` before the new dashboard layout wrapper so the DaaS panel remains full width.
+- Added `.rops-dashboard-layout` around the project-area nav and the rest of the dashboard content.
+- Kept the navigation as a semantic `nav` with `aria-labelledby="project-areas-title"`.
+- Added `.rops-project-areas-nav` for the left column and `.rops-dashboard-content` for the right column.
+- Used a responsive CSS grid that stays single-column by default and becomes `minmax(0, 1fr) minmax(0, 3fr)` from the existing desktop breakpoint.
+- Preserved existing dashboard cards, links, IDs and JavaScript hooks.
+
+## Validation attempted
+
+- `npm run build:project-dashboard && npm run build:govuk-pages` passed.
+- `node --test tests/project-dashboard-route-state.test.js` passed.
+- `npm run format:check` passed.
+- `npm run lint` passed with existing repository warnings and no errors.
+- Browser layout check with Playwright passed at 1280px desktop and 390px mobile widths.
+- `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
+- `npm test` passed with 245 tests and 0 failures.
+- `npm run validate` passed.
+
+## Residual risks
+
+- Final deployed appearance still depends on the generated static assets being served without stale cache.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -6,6 +6,8 @@ Move the Project Dashboard `Project areas` navigation into a left column that ta
 
 Follow-up: make the `Project areas` navigation sticky after users scroll beyond it, with the same visible top spacing as the space between the navigation panel and the DaaS brand panel.
 
+Follow-up: move the `Reflexive journal` panel into the left column underneath the `Project areas` navigation.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -83,6 +85,8 @@ Follow-up: make the `Project areas` navigation sticky after users scroll beyond 
 - Used a responsive CSS grid that stays single-column by default and becomes `minmax(0, 1fr) minmax(0, 3fr)` from the existing desktop breakpoint.
 - Made `.rops-project-areas-nav` sticky only from the desktop layout breakpoint.
 - Used `top: 1rem` for the sticky offset, matching the DaaS brand panel bottom spacing.
+- Added `.rops-dashboard-sidebar` to stack the `Project areas` navigation and `Reflexive journal` panel in the left column.
+- Moved the existing `Reflexive journal` markup out of the main dashboard content grid without changing its IDs, links or Mural integration hooks.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
@@ -91,7 +95,7 @@ Follow-up: make the `Project areas` navigation sticky after users scroll beyond 
 - `node --test tests/project-dashboard-route-state.test.js` passed.
 - `npm run format:check` passed.
 - `npm run lint` passed with existing repository warnings and no errors.
-- Browser layout and sticky navigation check with Playwright passed at 1280px desktop and 390px mobile widths.
+- Browser layout, sticky navigation and left-column journal placement check with Playwright passed at 1280px desktop and 390px mobile widths.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -28,6 +28,8 @@ Follow-up: move `Objectives` out of the `Stakeholder management` panel into a se
 
 Follow-up: in the `Research outcomes` panel, treat a no-studies `studies_unavailable` response as a normal empty state instead of surfacing a system-style failure message to users.
 
+Follow-up: apply `govuk-body-s` to Project Dashboard panel content, excluding the `Project areas` navigation, and use `dl.govuk-body-s` so summary-list keys and values inherit the smaller body size.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -131,6 +133,9 @@ Follow-up: in the `Research outcomes` panel, treat a no-studies `studies_unavail
 - Changed the dashboard studies loader so the known `studies_unavailable` response maps to an empty studies array and renders `No studies have been created for this project yet.`
 - Removed the user-facing `Could not load studies`, `Study records could not be loaded for this project.` and study technical-detail copy from the Research outcomes panel.
 - Kept genuine study load failures visible as a non-technical retry message.
+- Added `govuk-body-s` to every non-navigation dashboard panel content wrapper, leaving the `Project areas` navigation at its existing size.
+- Added `govuk-body-s` directly to the Mural and Project details `dl.govuk-summary-list` elements so their `dt` and `dd` content inherit from the list.
+- Added scoped dashboard Sass so lists, labels, hints, summary-list keys and summary-list values inherit the smaller typography inside non-navigation panel content.
 
 ## Validation attempted
 
@@ -157,6 +162,14 @@ Follow-up: in the `Research outcomes` panel, treat a no-studies `studies_unavail
 - `npm run lint` passed after the no-studies empty-state change with existing repository warnings and no errors.
 - `npm test` passed after the no-studies empty-state change with 245 tests and 0 failures.
 - `npm run validate` passed after the no-studies empty-state change.
+- `npm run build:generated-css` and `npm run build:govuk-pages` passed after the panel typography change.
+- `node --test tests/project-dashboard-route-state.test.js` passed after the panel typography change.
+- Initial full validation exposed two broader GOV.UK route-state assertions that still expected a bare `govuk-summary-list` class.
+- Updated those broader route-state assertions to expect `govuk-summary-list govuk-body-s`.
+- `node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js` passed after updating the broader summary-list contracts.
+- `npm run lint` passed after the panel typography change with existing repository warnings and no errors.
+- `npm test` passed after the panel typography change with 245 tests and 0 failures.
+- `npm run validate` passed after the panel typography change.
 
 ## Residual risks
 

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -34,6 +34,8 @@ Follow-up: address PR review feedback by keeping the dashboard header and `<h1>`
 
 Follow-up: fix the Project details summary list cascade so `dl.govuk-body-s`, `dt` and `dd` compute to the expected smaller GOV.UK body size.
 
+Follow-up: render Project Objectives from simple Markdown-style numbered and dashed list text, producing an ordered list with nested unordered lists and divider lines only between top-level objectives.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -94,6 +96,10 @@ Follow-up: fix the Project details summary list cascade so `dl.govuk-body-s`, `d
 - `package.json`
 - GitHub PR #423 review thread `PRRT_kwDOP3Td2M6LkMtl`
 - `public/assets/govuk/govuk-frontend.css`
+- `public/js/project-dashboard.js`
+- `src/govuk/templates/pages/project-dashboard.njk`
+- `src/styles/project-dashboard.scss`
+- `tests/project-dashboard-route-state.test.js`
 
 ## Files created or modified
 
@@ -149,6 +155,13 @@ Follow-up: fix the Project details summary list cascade so `dl.govuk-body-s`, `d
 - Added route-state assertions for the header-before-sidebar and project-title-before-project-areas-nav DOM order in both source and generated HTML.
 - Fixed the Project details summary-list typography cascade by making non-navigation panel `dl.govuk-body-s` elements inherit from the `govuk-body-s` panel content wrapper before their keys and values inherit from the `dl`.
 - Added `.govuk-body` to the non-navigation panel typography inheritance rule so medium body paragraphs inside smaller panel content do not override the intended panel text size.
+- Replaced the static Project Objectives `<ul>` placeholder with a neutral `.rops-objectives-list` container so the client renderer can emit a valid `<ol>` when objectives are loaded.
+- Added a lightweight Project Objectives parser that recognises numbered lines such as `1. Objective` or `1) Objective` as top-level ordered-list items.
+- Added support for dashed, starred or plus-prefixed lines as nested unordered-list items beneath the current numbered objective.
+- Preserved escaping for all objective text before insertion into generated HTML.
+- Added `.rops-objective-list` styles so top-level objective items have divider lines while `.rops-objective-list__sublist > li` explicitly has no divider line.
+- Kept plain legacy objective strings supported by rendering them as top-level ordered-list items when no Markdown-style numbering is present.
+- Added route-state assertions for the neutral objectives container, Markdown-style parser hooks, ordered-list classes, nested-list classes and top-level/nested divider styling.
 
 ## Validation attempted
 
@@ -192,6 +205,15 @@ Follow-up: fix the Project details summary list cascade so `dl.govuk-body-s`, `d
 - `npm test` passed after the review source-order and Project details summary-list typography fixes with 245 tests and 0 failures.
 - `npm run validate` passed after the review source-order and Project details summary-list typography fixes.
 - Final browser computed-style check after validation rebuilt assets confirmed the Project details summary-list key still computes to `16px` font size and `20px` line height, and the dashboard header still precedes the `Project areas` navigation in DOM order.
+- `npm run build:generated-css && npm run build:govuk-pages` passed after the Project Objectives Markdown-style rendering change.
+- `node --test tests/project-dashboard-route-state.test.js` passed after the Project Objectives Markdown-style rendering change.
+- Browser mock-data check confirmed the sample objectives render as 3 top-level ordered objectives with nested unordered-list counts of 3, 4 and 3.
+- Browser computed-style check confirmed top-level objective items have divider lines except the final item, and nested bullet items have no divider lines.
+- `node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js` passed after the Project Objectives Markdown-style rendering change.
+- `npm run format:check` passed after the Project Objectives Markdown-style rendering change.
+- `npm run lint` passed after the Project Objectives Markdown-style rendering change with existing repository warnings and no errors.
+- `npm test` passed after the Project Objectives Markdown-style rendering change with 245 tests and 0 failures.
+- `npm run validate` passed after the Project Objectives Markdown-style rendering change.
 
 ## Residual risks
 

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -26,6 +26,8 @@ Follow-up: make the gaps between `Stakeholder management`, `Research planning` a
 
 Follow-up: move `Objectives` out of the `Stakeholder management` panel into a separate `Project Objectives` panel directly beneath it.
 
+Follow-up: in the `Research outcomes` panel, treat a no-studies `studies_unavailable` response as a normal empty state instead of surfacing a system-style failure message to users.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -80,6 +82,9 @@ Follow-up: move `Objectives` out of the `Stakeholder management` panel into a se
 - `public/components/mural-integration.js`
 - `tests/project-dashboard-route-state.test.js`
 - `tests/mural-ui-route-state.test.js`
+- `public/js/project-dashboard.js`
+- `tests/studies-route-contract.test.js`
+- `infra/cloudflare/src/service/studies.js`
 - `package.json`
 
 ## Files created or modified
@@ -90,6 +95,7 @@ Follow-up: move `Objectives` out of the `Stakeholder management` panel into a se
 - `public/pages/project-dashboard/index.html`
 - `tests/project-dashboard-route-state.test.js`
 - `tests/mural-ui-route-state.test.js`
+- `public/js/project-dashboard.js`
 - `docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md`
 - `docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json`
 
@@ -122,6 +128,9 @@ Follow-up: move `Objectives` out of the `Stakeholder management` panel into a se
 - Moved the existing objectives list, add-objective button and add-objective form into a new `Project Objectives` summary-card immediately after `Stakeholder management`.
 - Added a `Project Objectives` link to the `Project areas` navigation.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
+- Changed the dashboard studies loader so the known `studies_unavailable` response maps to an empty studies array and renders `No studies have been created for this project yet.`
+- Removed the user-facing `Could not load studies`, `Study records could not be loaded for this project.` and study technical-detail copy from the Research outcomes panel.
+- Kept genuine study load failures visible as a non-technical retry message.
 
 ## Validation attempted
 
@@ -143,7 +152,13 @@ Follow-up: move `Objectives` out of the `Stakeholder management` panel into a se
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.
+- `node --test tests/project-dashboard-route-state.test.js tests/studies-route-contract.test.js` passed after the no-studies empty-state change.
+- `npm run format:check` passed after generated CSS was rebuilt by the lint script.
+- `npm run lint` passed after the no-studies empty-state change with existing repository warnings and no errors.
+- `npm test` passed after the no-studies empty-state change with 245 tests and 0 failures.
+- `npm run validate` passed after the no-studies empty-state change.
 
 ## Residual risks
 
 - Final deployed appearance still depends on the generated static assets being served without stale cache.
+- Genuine study API outages now use generic user-facing copy on the dashboard; detailed diagnosis remains available in logs and API responses rather than in the Research outcomes panel.

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -30,6 +30,10 @@ Follow-up: in the `Research outcomes` panel, treat a no-studies `studies_unavail
 
 Follow-up: apply `govuk-body-s` to Project Dashboard panel content, excluding the `Project areas` navigation, and use `dl.govuk-body-s` so summary-list keys and values inherit the smaller body size.
 
+Follow-up: address PR review feedback by keeping the dashboard header and `<h1>` before the `Project areas` navigation in DOM order, while preserving the desktop two-column visual layout with CSS grid placement.
+
+Follow-up: fix the Project details summary list cascade so `dl.govuk-body-s`, `dt` and `dd` compute to the expected smaller GOV.UK body size.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -88,6 +92,8 @@ Follow-up: apply `govuk-body-s` to Project Dashboard panel content, excluding th
 - `tests/studies-route-contract.test.js`
 - `infra/cloudflare/src/service/studies.js`
 - `package.json`
+- GitHub PR #423 review thread `PRRT_kwDOP3Td2M6LkMtl`
+- `public/assets/govuk/govuk-frontend.css`
 
 ## Files created or modified
 
@@ -136,6 +142,13 @@ Follow-up: apply `govuk-body-s` to Project Dashboard panel content, excluding th
 - Added `govuk-body-s` to every non-navigation dashboard panel content wrapper, leaving the `Project areas` navigation at its existing size.
 - Added `govuk-body-s` directly to the Mural and Project details `dl.govuk-summary-list` elements so their `dt` and `dd` content inherit from the list.
 - Added scoped dashboard Sass so lists, labels, hints, summary-list keys and summary-list values inherit the smaller typography inside non-navigation panel content.
+- Classified the PR review comment about source order as useful because the single-column/mobile reading order placed the `Project areas` navigation before the dashboard heading.
+- Moved `.rops-dashboard-header` before `.rops-dashboard-sidebar` in the template and generated page so keyboard and screen-reader users encounter the project heading before the section navigation.
+- Placed `.rops-dashboard-header` and `.rops-dashboard-content` in the right grid column on desktop so the visual two-column layout is preserved despite the improved DOM order.
+- Replaced the dashboard layout shorthand `gap` with `column-gap` and `row-gap` so desktop column spacing and vertical panel spacing remain explicit after the grid placement change.
+- Added route-state assertions for the header-before-sidebar and project-title-before-project-areas-nav DOM order in both source and generated HTML.
+- Fixed the Project details summary-list typography cascade by making non-navigation panel `dl.govuk-body-s` elements inherit from the `govuk-body-s` panel content wrapper before their keys and values inherit from the `dl`.
+- Added `.govuk-body` to the non-navigation panel typography inheritance rule so medium body paragraphs inside smaller panel content do not override the intended panel text size.
 
 ## Validation attempted
 
@@ -170,6 +183,15 @@ Follow-up: apply `govuk-body-s` to Project Dashboard panel content, excluding th
 - `npm run lint` passed after the panel typography change with existing repository warnings and no errors.
 - `npm test` passed after the panel typography change with 245 tests and 0 failures.
 - `npm run validate` passed after the panel typography change.
+- `npm run build:generated-css && npm run build:govuk-pages` passed after the review source-order and Project details summary-list typography fixes.
+- `node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js` passed after the review source-order and Project details summary-list typography fixes.
+- Browser computed-style check confirmed the Project details `dl`, summary-list keys and summary-list values compute to `16px` font size and `20px` line height, while the `Project areas` navigation remains at `19px`.
+- Browser layout check confirmed the dashboard header precedes the `Project areas` navigation in DOM/mobile order and remains aligned with the main content column on desktop.
+- `npm run format:check` passed after formatting the dashboard Sass.
+- `npm run lint` passed after the review source-order and Project details summary-list typography fixes with existing repository warnings and no errors.
+- `npm test` passed after the review source-order and Project details summary-list typography fixes with 245 tests and 0 failures.
+- `npm run validate` passed after the review source-order and Project details summary-list typography fixes.
+- Final browser computed-style check after validation rebuilt assets confirmed the Project details summary-list key still computes to `16px` font size and `20px` line height, and the dashboard header still precedes the `Project areas` navigation in DOM order.
 
 ## Residual risks
 

--- a/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
+++ b/docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
@@ -12,6 +12,8 @@ Follow-up: make the left sidebar sticky as a group so the `Project areas` naviga
 
 Follow-up: reduce the visible gap between `Project areas` and `Reflexive journal` so it matches the other dashboard panel gaps.
 
+Follow-up: make the sidebar with `Project areas` and `Reflexive journal` one third width and the main content column two thirds width within the GOV.UK width container.
+
 ## Run metadata
 
 - Date: 2026-06-23
@@ -86,7 +88,7 @@ Follow-up: reduce the visible gap between `Project areas` and `Reflexive journal
 - Added `.rops-dashboard-layout` around the project-area nav and the rest of the dashboard content.
 - Kept the navigation as a semantic `nav` with `aria-labelledby="project-areas-title"`.
 - Added `.rops-project-areas-nav` for the left column and `.rops-dashboard-content` for the right column.
-- Used a responsive CSS grid that stays single-column by default and becomes `minmax(0, 1fr) minmax(0, 3fr)` from the existing desktop breakpoint.
+- Used a responsive CSS grid that stays single-column by default and becomes `minmax(0, 1fr) minmax(0, 2fr)` from the existing desktop breakpoint.
 - Kept sticky behaviour desktop-only from the dashboard layout breakpoint.
 - Used `top: 1rem` for the sticky offset, matching the DaaS brand panel bottom spacing.
 - Added `.rops-dashboard-sidebar` to stack the `Project areas` navigation and `Reflexive journal` panel in the left column.
@@ -94,6 +96,7 @@ Follow-up: reduce the visible gap between `Project areas` and `Reflexive journal
 - Moved the sticky positioning from `.rops-project-areas-nav` to `.rops-dashboard-sidebar` so the left column sticks as one stack.
 - Added `align-self: start` to `.rops-dashboard-sidebar` so the sticky grid item uses the sidebar stack height instead of stretching to the full content column height.
 - Reset direct `.govuk-summary-card` bottom margins inside `.rops-dashboard-sidebar` so the sidebar grid gap defines the visible spacing between the nav and journal panels.
+- Adjusted the desktop dashboard grid from a one-quarter/three-quarter split to a one-third/two-thirds split while keeping the DaaS brand panel outside the two-column area.
 - Preserved existing dashboard cards, links, IDs and JavaScript hooks.
 
 ## Validation attempted
@@ -103,6 +106,7 @@ Follow-up: reduce the visible gap between `Project areas` and `Reflexive journal
 - `npm run format:check` passed.
 - `npm run lint` passed with existing repository warnings and no errors.
 - Browser layout, sticky sidebar, left-column journal placement and 20px nav-to-journal panel gap check with Playwright passed at 1280px desktop and 390px mobile widths.
+- Browser layout ratio check with Playwright passed at 1280px desktop width, confirming the sidebar is one third and the main content column is two thirds of the dashboard grid.
 - `npm test -- --ci` could not run because the current script passes `--ci` through to Node, which exits with `node: bad option: --ci`.
 - `npm test` passed with 245 tests and 0 failures.
 - `npm run validate` passed.

--- a/public/components/mural-integration.js
+++ b/public/components/mural-integration.js
@@ -183,7 +183,7 @@
 	};
 
 	function disableAll() {
-		showConnectButton();
+		hideConnectButton();
 		if (els.btnSetup) els.btnSetup.disabled = true;
 		setOpenLinkState(false);
 	}

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -70,6 +70,12 @@
 	min-width: 0;
 	}
 
+.rops-dashboard-sidebar {
+	align-content: start;
+	display: grid;
+	gap: 20px;
+	}
+
 .rops-project-areas-nav {
 	align-self: start;
 	}

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -10,7 +10,7 @@
    ============================================================================ */
 
 .rops-dashboard-header {
-	margin-bottom: 30px;
+	margin-bottom: 0;
 	}
 
 .rops-dashboard-description {
@@ -65,9 +65,10 @@
 	}
 
 .rops-dashboard-layout {
+	column-gap: 20px;
 	display: grid;
-	gap: 20px;
 	grid-template-columns: 1fr;
+	row-gap: 30px;
 	}
 
 .rops-dashboard-layout > * {
@@ -89,7 +90,12 @@
 	align-self: start;
 	}
 
-.govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-list, .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-label, .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-hint {
+.govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-body, .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-list, .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-label, .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-hint {
+	font-size: inherit;
+	line-height: inherit;
+	}
+
+.govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s dl.govuk-body-s {
 	font-size: inherit;
 	line-height: inherit;
 	}
@@ -113,9 +119,19 @@
 	.rops-dashboard-layout {
 		grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
 		}
+	.rops-dashboard-header {
+		grid-column: 2;
+		grid-row: 1;
+		}
 	.rops-dashboard-sidebar {
+		grid-column: 1;
+		grid-row: 1/span 2;
 		position: sticky;
 		top: 1rem;
+		}
+	.rops-dashboard-content {
+		grid-column: 2;
+		grid-row: 2;
 		}
 	.rops-two-column {
 		grid-template-columns: 1fr 1fr;

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -72,6 +72,7 @@
 
 .rops-dashboard-sidebar {
 	align-content: start;
+	align-self: start;
 	display: grid;
 	gap: 20px;
 	}
@@ -94,7 +95,7 @@
 	.rops-dashboard-layout {
 		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
 		}
-	.rops-project-areas-nav {
+	.rops-dashboard-sidebar {
 		position: sticky;
 		top: 1rem;
 		}

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -89,6 +89,16 @@
 	align-self: start;
 	}
 
+.govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-list, .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-label, .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-hint {
+	font-size: inherit;
+	line-height: inherit;
+	}
+
+.govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s .govuk-summary-list__key, .govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s .govuk-summary-list__value {
+	font-size: inherit;
+	line-height: inherit;
+	}
+
 .rops-two-column {
 	display: grid;
 	gap: 20px;

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -88,6 +88,10 @@
 	.rops-dashboard-layout {
 		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
 		}
+	.rops-project-areas-nav {
+		position: sticky;
+		top: 1rem;
+		}
 	.rops-two-column {
 		grid-template-columns: 1fr 1fr;
 		}

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -161,6 +161,37 @@
 	padding-bottom: 0;
 	}
 
+.rops-objective-list {
+	margin-bottom: 20px;
+	}
+
+.rops-objective-list > li {
+	border-bottom: 1px solid #b1b4b6;
+	margin-bottom: 15px;
+	padding-bottom: 15px;
+	}
+
+.rops-objective-list > li:last-child {
+	border-bottom: 0;
+	margin-bottom: 0;
+	padding-bottom: 0;
+	}
+
+.rops-objective-list__title {
+	display: block;
+	}
+
+.rops-objective-list__sublist {
+	margin-bottom: 0;
+	margin-top: 10px;
+	}
+
+.rops-objective-list__sublist > li {
+	border-bottom: 0;
+	margin-bottom: 5px;
+	padding-bottom: 0;
+	}
+
 .rops-study-list {
 	margin-bottom: 20px;
 	}

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -56,8 +56,12 @@
 
 .rops-dashboard-grid {
 	display: grid;
-	gap: 20px;
+	gap: 30px;
 	grid-template-columns: 1fr;
+	}
+
+.rops-dashboard-grid > .govuk-summary-card {
+	margin-bottom: 0;
 	}
 
 .rops-dashboard-layout {
@@ -165,6 +169,10 @@
 
 .rops-mural-actions {
 	margin-top: 20px;
+	}
+
+#mural-connect[hidden] {
+	display: none;
 	}
 
 .rops-disabled-button {

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -60,6 +60,20 @@
 	grid-template-columns: 1fr;
 	}
 
+.rops-dashboard-layout {
+	display: grid;
+	gap: 20px;
+	grid-template-columns: 1fr;
+	}
+
+.rops-dashboard-layout > * {
+	min-width: 0;
+	}
+
+.rops-project-areas-nav {
+	align-self: start;
+	}
+
 .rops-two-column {
 	display: grid;
 	gap: 20px;
@@ -71,6 +85,9 @@
 	}
 
 @media (min-width: 48.0625em) {
+	.rops-dashboard-layout {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
+		}
 	.rops-two-column {
 		grid-template-columns: 1fr 1fr;
 		}

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -97,7 +97,7 @@
 
 @media (min-width: 48.0625em) {
 	.rops-dashboard-layout {
-		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
+		grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
 		}
 	.rops-dashboard-sidebar {
 		position: sticky;

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -159,8 +159,8 @@
 	padding-left: 15px;
 	}
 
-.rops-mural-status {
-	margin: 0 0 12px;
+.rops-link-panel .govuk-button {
+	margin-bottom: 8px;
 	}
 
 .rops-mural-actions {

--- a/public/css/project-dashboard.css
+++ b/public/css/project-dashboard.css
@@ -77,6 +77,10 @@
 	gap: 20px;
 	}
 
+.rops-dashboard-sidebar > .govuk-summary-card {
+	margin-bottom: 0;
+	}
+
 .rops-project-areas-nav {
 	align-self: start;
 	}

--- a/public/js/project-dashboard.js
+++ b/public/js/project-dashboard.js
@@ -312,7 +312,45 @@ function renderStakeholders(stakeholders = []) {
 function renderObjectives(objectives = []) {
 	const list = document.getElementById("objectives-list");
 	if (!list) return;
-	list.innerHTML = objectives.length ? objectives.map((objective) => `<li>${escapeHtml(objective)}</li>`).join("") : "<li>No objectives yet.</li>";
+	const parsedObjectives = parseObjectiveMarkdownList(objectives);
+	list.innerHTML = parsedObjectives.length ? objectiveListHtml(parsedObjectives) : '<p class="govuk-body-s">No objectives yet.</p>';
+}
+
+function parseObjectiveMarkdownList(objectives = []) {
+	const lines = objectiveLines(objectives);
+	const items = [];
+	let currentItem = null;
+	for (const line of lines) {
+		const numberedMatch = line.match(/^\d+[.)]\s+(.+)$/);
+		const bulletMatch = line.match(/^[-*+]\s+(.+)$/);
+		if (numberedMatch) {
+			currentItem = { text: numberedMatch[1].trim(), children: [] };
+			items.push(currentItem);
+		} else if (bulletMatch && currentItem) {
+			currentItem.children.push(bulletMatch[1].trim());
+		} else {
+			currentItem = { text: (bulletMatch?.[1] || line).trim(), children: [] };
+			items.push(currentItem);
+		}
+	}
+	return items.filter((item) => item.text);
+}
+
+function objectiveLines(objectives = []) {
+	return (Array.isArray(objectives) ? objectives : [objectives])
+		.flatMap((objective) => String(objective || "").split(/\r?\n/))
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+function objectiveListHtml(objectives = []) {
+	const items = objectives.map((objective) => {
+		const children = objective.children.length
+			? `<ul class="govuk-list govuk-list--bullet rops-objective-list__sublist">${objective.children.map((child) => `<li>${escapeHtml(child)}</li>`).join("")}</ul>`
+			: "";
+		return `<li><span class="rops-objective-list__title">${escapeHtml(objective.text)}</span>${children}</li>`;
+	});
+	return `<ol class="govuk-list govuk-list--number rops-objective-list">${items.join("")}</ol>`;
 }
 
 function renderUserGroups(userGroups = []) {

--- a/public/js/project-dashboard.js
+++ b/public/js/project-dashboard.js
@@ -173,7 +173,13 @@ async function loadStudies(projectId) {
 		cache: "no-store",
 		credentials: "include",
 	}, 15000);
-	const json = await readJsonResponse(response, "Studies");
+	let json;
+	try {
+		json = await readJsonResponse(response, "Studies");
+	} catch (error) {
+		if (isStudiesUnavailableError(error)) return [];
+		throw error;
+	}
 	return (json.studies || []).map((study) => ({
 		id: study.id || "",
 		method: study.method || "",
@@ -198,6 +204,10 @@ async function loadParticipantsForStudy(study) {
 		studyId: study.id,
 		studyTitle,
 	}));
+}
+
+function isStudiesUnavailableError(error) {
+	return String(error?.upstreamBody?.error || error?.message || "").trim() === "studies_unavailable";
 }
 
 async function loadParticipantsForStudies(studies = []) {
@@ -323,7 +333,7 @@ function renderStudies(project, studies) {
 	const list = document.getElementById("studies-list");
 	if (!list) return;
 	if (!studies.length) {
-		list.innerHTML = "<li>No studies yet.</li>";
+		renderNoStudiesMessage(list);
 		return;
 	}
 	const projectId = projectIdFromUrl(project);
@@ -339,6 +349,10 @@ ${description ? `<p class="govuk-body-s rops-study-description">${escapeHtml(des
 ${status ? `<strong class="govuk-tag ${studyStatusTagClass(status)}">${escapeHtml(status)}</strong>` : ""}
 </li>`;
 	}).join("");
+}
+
+function renderNoStudiesMessage(list) {
+	list.innerHTML = "<li>No studies have been created for this project yet.</li>";
 }
 
 function participantPlanningPanel() {
@@ -392,8 +406,11 @@ function renderParticipantsLoadError(project, error) {
 function renderStudiesLoadError(error) {
 	const list = document.getElementById("studies-list");
 	if (!list) return;
-	const reason = String(error?.message || error || "Unknown error").trim();
-	list.innerHTML = `<li role="alert"><strong>Could not load studies</strong><br><span>Study records could not be loaded for this project.</span><br><span><strong>Technical detail:</strong> <code>${escapeHtml(reason)}</code></span></li>`;
+	if (isStudiesUnavailableError(error)) {
+		renderNoStudiesMessage(list);
+		return;
+	}
+	list.innerHTML = '<li role="alert"><strong>Studies are not available right now</strong><br><span>Try refreshing this page or opening research outcomes.</span></li>';
 }
 
 function togglePanel(toggle, panel, forceOpen = null) {

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -305,9 +305,9 @@
 									<h2 class="govuk-summary-card__title">Project Objectives</h2>
 								</div>
 								<div class="govuk-summary-card__content govuk-body-s">
-									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list">
-										<li>No objectives yet.</li>
-									</ul>
+									<div class="rops-objectives-list" id="objectives-list">
+										<p class="govuk-body-s">No objectives yet.</p>
+									</div>
 
 									<button
 										type="button"

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -55,6 +55,20 @@
 				</div>
 
 				<div class="rops-dashboard-layout">
+					<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
+						<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
+						<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
+						<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">
+							Use this dashboard to manage project context, research planning, reflexive journaling and research
+							outcomes.
+						</p>
+						<div class="rops-status-strip" aria-label="Project status">
+							<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
+							<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
+							<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
+						</div>
+					</header>
+
 					<div class="rops-dashboard-sidebar">
 						<nav
 							class="govuk-summary-card rops-project-areas-nav"
@@ -169,20 +183,6 @@
 					</div>
 
 					<div class="rops-dashboard-content">
-						<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
-							<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
-							<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
-							<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">
-								Use this dashboard to manage project context, research planning, reflexive journaling and research
-								outcomes.
-							</p>
-							<div class="rops-status-strip" aria-label="Project status">
-								<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
-								<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
-								<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
-							</div>
-						</header>
-
 						<section class="govuk-summary-card" id="project-details">
 							<div class="govuk-summary-card__title-wrapper">
 								<h2 class="govuk-summary-card__title">Project details</h2>

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -68,6 +68,7 @@
 								<ul class="govuk-list govuk-list--spaced rops-compact-list">
 									<li><a class="govuk-link" href="#reflexive-journal">Reflexive journal</a></li>
 									<li><a class="govuk-link" href="#stakeholders">Stakeholder management</a></li>
+									<li><a class="govuk-link" href="#project-objectives">Project Objectives</a></li>
 									<li><a class="govuk-link" href="#planning">Research planning</a></li>
 									<li>
 										<a
@@ -227,134 +228,131 @@
 									<h2 class="govuk-summary-card__title">Stakeholder management</h2>
 								</div>
 								<div class="govuk-summary-card__content">
-									<div class="rops-two-column">
-										<div>
-											<h3 class="govuk-heading-s">Stakeholders</h3>
-											<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list">
-												<li>No stakeholders yet.</li>
-											</ul>
+									<h3 class="govuk-heading-s">Stakeholders</h3>
+									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list">
+										<li>No stakeholders yet.</li>
+									</ul>
 
-											<button
-												type="button"
-												class="govuk-button govuk-button--secondary"
-												data-module="govuk-button"
-												id="add-stakeholder-toggle"
-												aria-expanded="false"
-												aria-controls="add-stakeholder-panel"
-											>
-												Add stakeholder
-											</button>
+									<button
+										type="button"
+										class="govuk-button govuk-button--secondary"
+										data-module="govuk-button"
+										id="add-stakeholder-toggle"
+										aria-expanded="false"
+										aria-controls="add-stakeholder-panel"
+									>
+										Add stakeholder
+									</button>
 
-											<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
-												<form id="add-stakeholder-form" novalidate>
-													<h4 class="govuk-heading-s">Add stakeholder</h4>
-													<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
-													<div class="govuk-form-group">
-														<label class="govuk-label" for="stakeholder-name">Name</label>
-														<input
-															class="govuk-input govuk-!-width-two-thirds"
-															id="stakeholder-name"
-															name="name"
-															autocomplete="name"
-															required
-														/>
-													</div>
-													<div class="govuk-form-group">
-														<label class="govuk-label" for="stakeholder-role">Role</label>
-														<input
-															class="govuk-input govuk-!-width-two-thirds"
-															id="stakeholder-role"
-															name="role"
-															autocomplete="organization-title"
-															required
-														/>
-													</div>
-													<div class="govuk-form-group">
-														<label class="govuk-label" for="stakeholder-email">Work email</label>
-														<div id="stakeholder-email-hint" class="govuk-hint">
-															Only add staff contact details where needed for project ownership or coordination.
-														</div>
-														<input
-															class="govuk-input govuk-!-width-two-thirds"
-															id="stakeholder-email"
-															name="email"
-															type="email"
-															autocomplete="email"
-															aria-describedby="stakeholder-email-hint"
-														/>
-													</div>
-													<div class="govuk-button-group">
-														<button type="submit" class="govuk-button" data-module="govuk-button">
-															Save stakeholder
-														</button>
-
-														<button
-															type="button"
-															class="govuk-button govuk-button--secondary"
-															data-module="govuk-button"
-															data-close-panel="add-stakeholder-panel"
-															data-toggle="add-stakeholder-toggle"
-														>
-															Cancel
-														</button>
-													</div>
-												</form>
+									<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
+										<form id="add-stakeholder-form" novalidate>
+											<h4 class="govuk-heading-s">Add stakeholder</h4>
+											<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
+											<div class="govuk-form-group">
+												<label class="govuk-label" for="stakeholder-name">Name</label>
+												<input
+													class="govuk-input govuk-!-width-two-thirds"
+													id="stakeholder-name"
+													name="name"
+													autocomplete="name"
+													required
+												/>
 											</div>
-										</div>
-										<div>
-											<h3 class="govuk-heading-s">Objectives</h3>
-											<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list">
-												<li>No objectives yet.</li>
-											</ul>
-
-											<button
-												type="button"
-												class="govuk-button govuk-button--secondary"
-												data-module="govuk-button"
-												id="add-objective-toggle"
-												aria-expanded="false"
-												aria-controls="add-objective-panel"
-											>
-												Add objective
-											</button>
-
-											<div id="add-objective-panel" class="dashboard-action-panel" hidden>
-												<form id="add-objective-form" novalidate>
-													<h4 class="govuk-heading-s">Add objective</h4>
-													<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
-													<div class="govuk-form-group">
-														<label class="govuk-label" for="objective-text">Research objective</label>
-														<div id="objective-text-hint" class="govuk-hint">
-															Keep objectives action-oriented and linked to decisions the team needs to make. Do not
-															include participant personal data.
-														</div>
-														<textarea
-															class="govuk-textarea"
-															id="objective-text"
-															name="objective"
-															rows="4"
-															required
-															aria-describedby="objective-text-hint"
-														></textarea>
-													</div>
-													<div class="govuk-button-group">
-														<button type="submit" class="govuk-button" data-module="govuk-button">
-															Save objective
-														</button>
-
-														<button
-															type="button"
-															class="govuk-button govuk-button--secondary"
-															data-module="govuk-button"
-															data-close-panel="add-objective-panel"
-															data-toggle="add-objective-toggle"
-														>
-															Cancel
-														</button>
-													</div>
-												</form>
+											<div class="govuk-form-group">
+												<label class="govuk-label" for="stakeholder-role">Role</label>
+												<input
+													class="govuk-input govuk-!-width-two-thirds"
+													id="stakeholder-role"
+													name="role"
+													autocomplete="organization-title"
+													required
+												/>
 											</div>
-										</div>
+											<div class="govuk-form-group">
+												<label class="govuk-label" for="stakeholder-email">Work email</label>
+												<div id="stakeholder-email-hint" class="govuk-hint">
+													Only add staff contact details where needed for project ownership or coordination.
+												</div>
+												<input
+													class="govuk-input govuk-!-width-two-thirds"
+													id="stakeholder-email"
+													name="email"
+													type="email"
+													autocomplete="email"
+													aria-describedby="stakeholder-email-hint"
+												/>
+											</div>
+											<div class="govuk-button-group">
+												<button type="submit" class="govuk-button" data-module="govuk-button">Save stakeholder</button>
+
+												<button
+													type="button"
+													class="govuk-button govuk-button--secondary"
+													data-module="govuk-button"
+													data-close-panel="add-stakeholder-panel"
+													data-toggle="add-stakeholder-toggle"
+												>
+													Cancel
+												</button>
+											</div>
+										</form>
+									</div>
+								</div>
+							</section>
+
+							<section id="project-objectives" class="govuk-summary-card">
+								<div class="govuk-summary-card__title-wrapper">
+									<h2 class="govuk-summary-card__title">Project Objectives</h2>
+								</div>
+								<div class="govuk-summary-card__content">
+									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list">
+										<li>No objectives yet.</li>
+									</ul>
+
+									<button
+										type="button"
+										class="govuk-button govuk-button--secondary"
+										data-module="govuk-button"
+										id="add-objective-toggle"
+										aria-expanded="false"
+										aria-controls="add-objective-panel"
+									>
+										Add objective
+									</button>
+
+									<div id="add-objective-panel" class="dashboard-action-panel" hidden>
+										<form id="add-objective-form" novalidate>
+											<h3 class="govuk-heading-s">Add objective</h3>
+											<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
+											<div class="govuk-form-group">
+												<label class="govuk-label" for="objective-text">Research objective</label>
+												<div id="objective-text-hint" class="govuk-hint">
+													Keep objectives action-oriented and linked to decisions the team needs to make. Do not include
+													participant personal data.
+												</div>
+												<textarea
+													class="govuk-textarea"
+													id="objective-text"
+													name="objective"
+													rows="4"
+													required
+													aria-describedby="objective-text-hint"
+												></textarea>
+											</div>
+											<div class="govuk-button-group">
+												<button type="submit" class="govuk-button" data-module="govuk-button">Save objective</button>
+
+												<button
+													type="button"
+													class="govuk-button govuk-button--secondary"
+													data-module="govuk-button"
+													data-close-panel="add-objective-panel"
+													data-toggle="add-objective-toggle"
+												>
+													Cancel
+												</button>
+											</div>
+										</form>
 									</div>
 								</div>
 							</section>

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -55,32 +55,119 @@
 				</div>
 
 				<div class="rops-dashboard-layout">
-					<nav
-						class="govuk-summary-card rops-project-areas-nav"
-						typeof="schema:SiteNavigationElement"
-						aria-labelledby="project-areas-title"
-					>
-						<div class="govuk-summary-card__title-wrapper">
-							<h2 class="govuk-summary-card__title" id="project-areas-title">Project areas</h2>
-						</div>
-						<div class="govuk-summary-card__content">
-							<ul class="govuk-list govuk-list--spaced rops-compact-list">
-								<li><a class="govuk-link" href="#reflexive-journal">Reflexive journal</a></li>
-								<li><a class="govuk-link" href="#stakeholders">Stakeholder management</a></li>
-								<li><a class="govuk-link" href="#planning">Research planning</a></li>
-								<li>
+					<div class="rops-dashboard-sidebar">
+						<nav
+							class="govuk-summary-card rops-project-areas-nav"
+							typeof="schema:SiteNavigationElement"
+							aria-labelledby="project-areas-title"
+						>
+							<div class="govuk-summary-card__title-wrapper">
+								<h2 class="govuk-summary-card__title" id="project-areas-title">Project areas</h2>
+							</div>
+							<div class="govuk-summary-card__content">
+								<ul class="govuk-list govuk-list--spaced rops-compact-list">
+									<li><a class="govuk-link" href="#reflexive-journal">Reflexive journal</a></li>
+									<li><a class="govuk-link" href="#stakeholders">Stakeholder management</a></li>
+									<li><a class="govuk-link" href="#planning">Research planning</a></li>
+									<li>
+										<a
+											class="govuk-link"
+											href="/pages/projects/outcomes/?id="
+											id="outcomes-link"
+											property="schema:relatedLink"
+										>
+											Research outcomes
+										</a>
+									</li>
+								</ul>
+							</div>
+						</nav>
+
+						<section class="govuk-summary-card" id="reflexive-journal">
+							<div class="govuk-summary-card__title-wrapper">
+								<h2 class="govuk-summary-card__title">Reflexive journal</h2>
+								<ul class="govuk-summary-card__actions">
+									<li class="govuk-summary-card__action">
+										<a
+											class="govuk-link"
+											href="/pages/projects/journals/?id="
+											id="journal-link"
+											property="schema:relatedLink"
+										>
+											Open journal
+										</a>
+									</li>
+								</ul>
+							</div>
+							<div class="govuk-summary-card__content">
+								<div class="rops-link-panel">
+									<h3 class="govuk-heading-s">ResearchOps journal</h3>
+									<p class="govuk-body">
+										Record assumptions, decisions, risks and reflections for this project in ResearchOps.
+									</p>
+
 									<a
-										class="govuk-link"
-										href="/pages/projects/outcomes/?id="
-										id="outcomes-link"
-										property="schema:relatedLink"
+										href="/pages/projects/journals/?id="
+										role="button"
+										draggable="false"
+										class="govuk-button"
+										data-module="govuk-button"
+										id="journal-button-link"
 									>
-										Research outcomes
+										Open reflexive journal
 									</a>
-								</li>
-							</ul>
-						</div>
-					</nav>
+								</div>
+
+								<div id="mural-integration">
+									<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
+									<p class="govuk-body">
+										Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system
+										record.
+									</p>
+									<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
+										<span class="pill pill--neutral">Mural is optional for visual journaling</span>
+									</p>
+									<dl class="govuk-summary-list">
+										<div class="govuk-summary-list__row">
+											<dt class="govuk-summary-list__key">Mural account</dt>
+											<dd class="govuk-summary-list__value">
+												<strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong>
+											</dd>
+										</div>
+										<div class="govuk-summary-list__row">
+											<dt class="govuk-summary-list__key">Mural board</dt>
+											<dd class="govuk-summary-list__value">
+												<strong class="govuk-tag govuk-tag--grey" id="mural-board-state">
+													Create or open manually
+												</strong>
+											</dd>
+										</div>
+									</dl>
+									<div class="govuk-button-group rops-mural-actions">
+										<button
+											type="button"
+											class="govuk-button govuk-button--secondary"
+											data-module="govuk-button"
+											id="mural-connect"
+										>
+											Connect Mural
+										</button>
+
+										<button
+											type="button"
+											disabled
+											aria-disabled="true"
+											class="govuk-button govuk-button--secondary"
+											data-module="govuk-button"
+											id="mural-setup"
+										>
+											Create Mural board
+										</button>
+									</div>
+								</div>
+							</div>
+						</section>
+					</div>
 
 					<div class="rops-dashboard-content">
 						<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
@@ -137,91 +224,6 @@
 						</section>
 
 						<div class="rops-dashboard-grid">
-							<section class="govuk-summary-card" id="reflexive-journal">
-								<div class="govuk-summary-card__title-wrapper">
-									<h2 class="govuk-summary-card__title">Reflexive journal</h2>
-									<ul class="govuk-summary-card__actions">
-										<li class="govuk-summary-card__action">
-											<a
-												class="govuk-link"
-												href="/pages/projects/journals/?id="
-												id="journal-link"
-												property="schema:relatedLink"
-											>
-												Open journal
-											</a>
-										</li>
-									</ul>
-								</div>
-								<div class="govuk-summary-card__content">
-									<div class="rops-link-panel">
-										<h3 class="govuk-heading-s">ResearchOps journal</h3>
-										<p class="govuk-body">
-											Record assumptions, decisions, risks and reflections for this project in ResearchOps.
-										</p>
-
-										<a
-											href="/pages/projects/journals/?id="
-											role="button"
-											draggable="false"
-											class="govuk-button"
-											data-module="govuk-button"
-											id="journal-button-link"
-										>
-											Open reflexive journal
-										</a>
-									</div>
-
-									<div id="mural-integration">
-										<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
-										<p class="govuk-body">
-											Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system
-											record.
-										</p>
-										<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
-											<span class="pill pill--neutral">Mural is optional for visual journaling</span>
-										</p>
-										<dl class="govuk-summary-list">
-											<div class="govuk-summary-list__row">
-												<dt class="govuk-summary-list__key">Mural account</dt>
-												<dd class="govuk-summary-list__value">
-													<strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong>
-												</dd>
-											</div>
-											<div class="govuk-summary-list__row">
-												<dt class="govuk-summary-list__key">Mural board</dt>
-												<dd class="govuk-summary-list__value">
-													<strong class="govuk-tag govuk-tag--grey" id="mural-board-state">
-														Create or open manually
-													</strong>
-												</dd>
-											</div>
-										</dl>
-										<div class="govuk-button-group rops-mural-actions">
-											<button
-												type="button"
-												class="govuk-button govuk-button--secondary"
-												data-module="govuk-button"
-												id="mural-connect"
-											>
-												Connect Mural
-											</button>
-
-											<button
-												type="button"
-												disabled
-												aria-disabled="true"
-												class="govuk-button govuk-button--secondary"
-												data-module="govuk-button"
-												id="mural-setup"
-											>
-												Create Mural board
-											</button>
-										</div>
-									</div>
-								</div>
-							</section>
-
 							<section id="stakeholders" class="govuk-summary-card">
 								<div class="govuk-summary-card__title-wrapper">
 									<h2 class="govuk-summary-card__title">Stakeholder management</h2>

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -146,6 +146,7 @@
 											class="govuk-button govuk-button--secondary"
 											data-module="govuk-button"
 											id="mural-connect"
+											hidden="hidden"
 										>
 											Connect Mural
 										</button>

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -100,7 +100,7 @@
 									</li>
 								</ul>
 							</div>
-							<div class="govuk-summary-card__content">
+							<div class="govuk-summary-card__content govuk-body-s">
 								<div class="rops-link-panel">
 									<h3 class="govuk-heading-s">ResearchOps journal</h3>
 									<p class="govuk-body">
@@ -125,7 +125,7 @@
 										Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system
 										record.
 									</p>
-									<dl class="govuk-summary-list">
+									<dl class="govuk-summary-list govuk-body-s">
 										<div class="govuk-summary-list__row">
 											<dt class="govuk-summary-list__key">Mural account</dt>
 											<dd class="govuk-summary-list__value">
@@ -187,8 +187,8 @@
 							<div class="govuk-summary-card__title-wrapper">
 								<h2 class="govuk-summary-card__title">Project details</h2>
 							</div>
-							<div class="govuk-summary-card__content">
-								<dl class="govuk-summary-list">
+							<div class="govuk-summary-card__content govuk-body-s">
+								<dl class="govuk-summary-list govuk-body-s">
 									<div class="govuk-summary-list__row">
 										<dt class="govuk-summary-list__key">Service stage</dt>
 										<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
@@ -227,7 +227,7 @@
 								<div class="govuk-summary-card__title-wrapper">
 									<h2 class="govuk-summary-card__title">Stakeholder management</h2>
 								</div>
-								<div class="govuk-summary-card__content">
+								<div class="govuk-summary-card__content govuk-body-s">
 									<h3 class="govuk-heading-s">Stakeholders</h3>
 									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list">
 										<li>No stakeholders yet.</li>
@@ -304,7 +304,7 @@
 								<div class="govuk-summary-card__title-wrapper">
 									<h2 class="govuk-summary-card__title">Project Objectives</h2>
 								</div>
-								<div class="govuk-summary-card__content">
+								<div class="govuk-summary-card__content govuk-body-s">
 									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list">
 										<li>No objectives yet.</li>
 									</ul>
@@ -361,7 +361,7 @@
 								<div class="govuk-summary-card__title-wrapper">
 									<h2 class="govuk-summary-card__title">Research planning</h2>
 								</div>
-								<div class="govuk-summary-card__content">
+								<div class="govuk-summary-card__content govuk-body-s">
 									<div class="rops-two-column rops-planning-grid">
 										<div>
 											<h3 class="govuk-heading-s">User groups</h3>
@@ -457,7 +457,7 @@
 										</li>
 									</ul>
 								</div>
-								<div class="govuk-summary-card__content">
+								<div class="govuk-summary-card__content govuk-body-s">
 									<div class="rops-two-column">
 										<div>
 											<h3 class="govuk-heading-s">Studies</h3>

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -50,147 +50,16 @@
 					</ol>
 				</nav>
 
-				<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
-					<div class="rops-daas-brand-panel" id="daas-brand-panel" hidden aria-label="DaaS">
-						<img class="rops-daas-brand-panel__logo" src="/images/brands/daas-logo.svg" alt="DaaS" />
-					</div>
+				<div class="rops-daas-brand-panel" id="daas-brand-panel" hidden aria-label="DaaS">
+					<img class="rops-daas-brand-panel__logo" src="/images/brands/daas-logo.svg" alt="DaaS" />
+				</div>
 
-					<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
-					<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
-					<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">
-						Use this dashboard to manage project context, research planning, reflexive journaling and research outcomes.
-					</p>
-					<div class="rops-status-strip" aria-label="Project status">
-						<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
-						<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
-						<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
-					</div>
-				</header>
-
-				<section class="govuk-summary-card" id="project-details">
-					<div class="govuk-summary-card__title-wrapper">
-						<h2 class="govuk-summary-card__title">Project details</h2>
-					</div>
-					<div class="govuk-summary-card__content">
-						<dl class="govuk-summary-list">
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Service stage</dt>
-								<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
-							</div>
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Project stage</dt>
-								<dd class="govuk-summary-list__value" id="kv-project-stage" property="schema:projectStatus">–</dd>
-							</div>
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Client name</dt>
-								<dd class="govuk-summary-list__value" id="kv-client-name" property="schema:client">–</dd>
-							</div>
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Lead researcher</dt>
-								<dd
-									class="govuk-summary-list__value"
-									id="kv-lead-researcher"
-									property="schema:author"
-									typeof="schema:Person"
-								>
-									–
-								</dd>
-							</div>
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Lead researcher email</dt>
-								<dd class="govuk-summary-list__value">
-									<a class="govuk-link" id="kv-lead-email" property="schema:email" href="mailto:">–</a>
-								</dd>
-							</div>
-						</dl>
-					</div>
-				</section>
-
-				<div class="rops-dashboard-grid">
-					<section class="govuk-summary-card" id="reflexive-journal">
-						<div class="govuk-summary-card__title-wrapper">
-							<h2 class="govuk-summary-card__title">Reflexive journal</h2>
-							<ul class="govuk-summary-card__actions">
-								<li class="govuk-summary-card__action">
-									<a
-										class="govuk-link"
-										href="/pages/projects/journals/?id="
-										id="journal-link"
-										property="schema:relatedLink"
-									>
-										Open journal
-									</a>
-								</li>
-							</ul>
-						</div>
-						<div class="govuk-summary-card__content">
-							<div class="rops-link-panel">
-								<h3 class="govuk-heading-s">ResearchOps journal</h3>
-								<p class="govuk-body">
-									Record assumptions, decisions, risks and reflections for this project in ResearchOps.
-								</p>
-
-								<a
-									href="/pages/projects/journals/?id="
-									role="button"
-									draggable="false"
-									class="govuk-button"
-									data-module="govuk-button"
-									id="journal-button-link"
-								>
-									Open reflexive journal
-								</a>
-							</div>
-
-							<div id="mural-integration">
-								<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
-								<p class="govuk-body">
-									Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system
-									record.
-								</p>
-								<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
-									<span class="pill pill--neutral">Mural is optional for visual journaling</span>
-								</p>
-								<dl class="govuk-summary-list">
-									<div class="govuk-summary-list__row">
-										<dt class="govuk-summary-list__key">Mural account</dt>
-										<dd class="govuk-summary-list__value">
-											<strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong>
-										</dd>
-									</div>
-									<div class="govuk-summary-list__row">
-										<dt class="govuk-summary-list__key">Mural board</dt>
-										<dd class="govuk-summary-list__value">
-											<strong class="govuk-tag govuk-tag--grey" id="mural-board-state">Create or open manually</strong>
-										</dd>
-									</div>
-								</dl>
-								<div class="govuk-button-group rops-mural-actions">
-									<button
-										type="button"
-										class="govuk-button govuk-button--secondary"
-										data-module="govuk-button"
-										id="mural-connect"
-									>
-										Connect Mural
-									</button>
-
-									<button
-										type="button"
-										disabled
-										aria-disabled="true"
-										class="govuk-button govuk-button--secondary"
-										data-module="govuk-button"
-										id="mural-setup"
-									>
-										Create Mural board
-									</button>
-								</div>
-							</div>
-						</div>
-					</section>
-
-					<nav class="govuk-summary-card" typeof="schema:SiteNavigationElement" aria-labelledby="project-areas-title">
+				<div class="rops-dashboard-layout">
+					<nav
+						class="govuk-summary-card rops-project-areas-nav"
+						typeof="schema:SiteNavigationElement"
+						aria-labelledby="project-areas-title"
+					>
 						<div class="govuk-summary-card__title-wrapper">
 							<h2 class="govuk-summary-card__title" id="project-areas-title">Project areas</h2>
 						</div>
@@ -213,276 +82,426 @@
 						</div>
 					</nav>
 
-					<section id="stakeholders" class="govuk-summary-card">
-						<div class="govuk-summary-card__title-wrapper">
-							<h2 class="govuk-summary-card__title">Stakeholder management</h2>
-						</div>
-						<div class="govuk-summary-card__content">
-							<div class="rops-two-column">
-								<div>
-									<h3 class="govuk-heading-s">Stakeholders</h3>
-									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list">
-										<li>No stakeholders yet.</li>
-									</ul>
-
-									<button
-										type="button"
-										class="govuk-button govuk-button--secondary"
-										data-module="govuk-button"
-										id="add-stakeholder-toggle"
-										aria-expanded="false"
-										aria-controls="add-stakeholder-panel"
-									>
-										Add stakeholder
-									</button>
-
-									<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
-										<form id="add-stakeholder-form" novalidate>
-											<h4 class="govuk-heading-s">Add stakeholder</h4>
-											<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
-											<div class="govuk-form-group">
-												<label class="govuk-label" for="stakeholder-name">Name</label>
-												<input
-													class="govuk-input govuk-!-width-two-thirds"
-													id="stakeholder-name"
-													name="name"
-													autocomplete="name"
-													required
-												/>
-											</div>
-											<div class="govuk-form-group">
-												<label class="govuk-label" for="stakeholder-role">Role</label>
-												<input
-													class="govuk-input govuk-!-width-two-thirds"
-													id="stakeholder-role"
-													name="role"
-													autocomplete="organization-title"
-													required
-												/>
-											</div>
-											<div class="govuk-form-group">
-												<label class="govuk-label" for="stakeholder-email">Work email</label>
-												<div id="stakeholder-email-hint" class="govuk-hint">
-													Only add staff contact details where needed for project ownership or coordination.
-												</div>
-												<input
-													class="govuk-input govuk-!-width-two-thirds"
-													id="stakeholder-email"
-													name="email"
-													type="email"
-													autocomplete="email"
-													aria-describedby="stakeholder-email-hint"
-												/>
-											</div>
-											<div class="govuk-button-group">
-												<button type="submit" class="govuk-button" data-module="govuk-button">Save stakeholder</button>
-
-												<button
-													type="button"
-													class="govuk-button govuk-button--secondary"
-													data-module="govuk-button"
-													data-close-panel="add-stakeholder-panel"
-													data-toggle="add-stakeholder-toggle"
-												>
-													Cancel
-												</button>
-											</div>
-										</form>
-									</div>
-								</div>
-								<div>
-									<h3 class="govuk-heading-s">Objectives</h3>
-									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list">
-										<li>No objectives yet.</li>
-									</ul>
-
-									<button
-										type="button"
-										class="govuk-button govuk-button--secondary"
-										data-module="govuk-button"
-										id="add-objective-toggle"
-										aria-expanded="false"
-										aria-controls="add-objective-panel"
-									>
-										Add objective
-									</button>
-
-									<div id="add-objective-panel" class="dashboard-action-panel" hidden>
-										<form id="add-objective-form" novalidate>
-											<h4 class="govuk-heading-s">Add objective</h4>
-											<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
-											<div class="govuk-form-group">
-												<label class="govuk-label" for="objective-text">Research objective</label>
-												<div id="objective-text-hint" class="govuk-hint">
-													Keep objectives action-oriented and linked to decisions the team needs to make. Do not include
-													participant personal data.
-												</div>
-												<textarea
-													class="govuk-textarea"
-													id="objective-text"
-													name="objective"
-													rows="4"
-													required
-													aria-describedby="objective-text-hint"
-												></textarea>
-											</div>
-											<div class="govuk-button-group">
-												<button type="submit" class="govuk-button" data-module="govuk-button">Save objective</button>
-
-												<button
-													type="button"
-													class="govuk-button govuk-button--secondary"
-													data-module="govuk-button"
-													data-close-panel="add-objective-panel"
-													data-toggle="add-objective-toggle"
-												>
-													Cancel
-												</button>
-											</div>
-										</form>
-									</div>
-								</div>
+					<div class="rops-dashboard-content">
+						<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
+							<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
+							<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
+							<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">
+								Use this dashboard to manage project context, research planning, reflexive journaling and research
+								outcomes.
+							</p>
+							<div class="rops-status-strip" aria-label="Project status">
+								<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
+								<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
+								<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
 							</div>
-						</div>
-					</section>
+						</header>
 
-					<section id="planning" class="govuk-summary-card">
-						<div class="govuk-summary-card__title-wrapper">
-							<h2 class="govuk-summary-card__title">Research planning</h2>
-						</div>
-						<div class="govuk-summary-card__content">
-							<div class="rops-two-column rops-planning-grid">
-								<div>
-									<h3 class="govuk-heading-s">User groups</h3>
-									<ul class="govuk-list govuk-list--spaced rops-divided-list" id="user-groups-list">
-										<li>No user groups yet.</li>
-									</ul>
-
-									<button
-										type="button"
-										class="govuk-button govuk-button--secondary"
-										data-module="govuk-button"
-										id="add-user-group-toggle"
-										aria-expanded="false"
-										aria-controls="add-user-group-panel"
-									>
-										Add user group
-									</button>
-
-									<div id="add-user-group-panel" class="dashboard-action-panel" hidden>
-										<form id="add-user-group-form" novalidate>
-											<h4 class="govuk-heading-s">Add user group</h4>
-											<div id="add-user-group-status" class="dashboard-action-status" aria-live="polite"></div>
-											<div class="govuk-form-group">
-												<label class="govuk-label" for="user-group-name">User group</label>
-												<input
-													class="govuk-input govuk-!-width-two-thirds"
-													id="user-group-name"
-													name="user-group"
-													required
-												/>
-											</div>
-											<div class="govuk-button-group">
-												<button type="submit" class="govuk-button" data-module="govuk-button">Save user group</button>
-
-												<button
-													type="button"
-													class="govuk-button govuk-button--secondary"
-													data-module="govuk-button"
-													data-close-panel="add-user-group-panel"
-													data-toggle="add-user-group-toggle"
-												>
-													Cancel
-												</button>
-											</div>
-										</form>
+						<section class="govuk-summary-card" id="project-details">
+							<div class="govuk-summary-card__title-wrapper">
+								<h2 class="govuk-summary-card__title">Project details</h2>
+							</div>
+							<div class="govuk-summary-card__content">
+								<dl class="govuk-summary-list">
+									<div class="govuk-summary-list__row">
+										<dt class="govuk-summary-list__key">Service stage</dt>
+										<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
 									</div>
-								</div>
-								<div id="participants-dashboard-panel">
-									<h3 class="govuk-heading-s">Participants</h3>
-									<p class="govuk-body-s" id="participants-summary-status">Loading participants…</p>
-									<p class="govuk-body-s">
-										Participants are managed through study-specific workflows so consent, scheduling and safeguarding
-										states stay traceable.
-									</p>
-									<div class="govuk-button-group">
-										<a
-											href="/pages/project-dashboard/participants/?id="
-											role="button"
-											draggable="false"
-											class="govuk-button govuk-button--secondary"
-											data-module="govuk-button"
-											id="add-participant-link"
+									<div class="govuk-summary-list__row">
+										<dt class="govuk-summary-list__key">Project stage</dt>
+										<dd class="govuk-summary-list__value" id="kv-project-stage" property="schema:projectStatus">–</dd>
+									</div>
+									<div class="govuk-summary-list__row">
+										<dt class="govuk-summary-list__key">Client name</dt>
+										<dd class="govuk-summary-list__value" id="kv-client-name" property="schema:client">–</dd>
+									</div>
+									<div class="govuk-summary-list__row">
+										<dt class="govuk-summary-list__key">Lead researcher</dt>
+										<dd
+											class="govuk-summary-list__value"
+											id="kv-lead-researcher"
+											property="schema:author"
+											typeof="schema:Person"
 										>
-											Add participant
-										</a>
+											–
+										</dd>
+									</div>
+									<div class="govuk-summary-list__row">
+										<dt class="govuk-summary-list__key">Lead researcher email</dt>
+										<dd class="govuk-summary-list__value">
+											<a class="govuk-link" id="kv-lead-email" property="schema:email" href="mailto:">–</a>
+										</dd>
+									</div>
+								</dl>
+							</div>
+						</section>
+
+						<div class="rops-dashboard-grid">
+							<section class="govuk-summary-card" id="reflexive-journal">
+								<div class="govuk-summary-card__title-wrapper">
+									<h2 class="govuk-summary-card__title">Reflexive journal</h2>
+									<ul class="govuk-summary-card__actions">
+										<li class="govuk-summary-card__action">
+											<a
+												class="govuk-link"
+												href="/pages/projects/journals/?id="
+												id="journal-link"
+												property="schema:relatedLink"
+											>
+												Open journal
+											</a>
+										</li>
+									</ul>
+								</div>
+								<div class="govuk-summary-card__content">
+									<div class="rops-link-panel">
+										<h3 class="govuk-heading-s">ResearchOps journal</h3>
+										<p class="govuk-body">
+											Record assumptions, decisions, risks and reflections for this project in ResearchOps.
+										</p>
 
 										<a
-											href="/pages/project-dashboard/participants/import/?id="
+											href="/pages/projects/journals/?id="
 											role="button"
 											draggable="false"
-											class="govuk-button govuk-button--secondary"
+											class="govuk-button"
 											data-module="govuk-button"
-											id="import-participants-link"
+											id="journal-button-link"
 										>
-											Bulk upload participants via CSV
+											Open reflexive journal
 										</a>
 									</div>
-								</div>
-							</div>
-						</div>
-					</section>
 
-					<section id="outcomes" class="govuk-summary-card">
-						<div class="govuk-summary-card__title-wrapper">
-							<h2 class="govuk-summary-card__title">Research outcomes</h2>
-							<ul class="govuk-summary-card__actions">
-								<li class="govuk-summary-card__action">
-									<a class="govuk-link" id="outcomes-card-link" href="/pages/projects/outcomes/?id=">Open outcomes</a>
-								</li>
-							</ul>
-						</div>
-						<div class="govuk-summary-card__content">
-							<div class="rops-two-column">
-								<div>
-									<h3 class="govuk-heading-s">Studies</h3>
-									<ul class="govuk-list govuk-list--spaced rops-study-list" id="studies-list">
-										<li>Loading studies…</li>
+									<div id="mural-integration">
+										<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
+										<p class="govuk-body">
+											Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system
+											record.
+										</p>
+										<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
+											<span class="pill pill--neutral">Mural is optional for visual journaling</span>
+										</p>
+										<dl class="govuk-summary-list">
+											<div class="govuk-summary-list__row">
+												<dt class="govuk-summary-list__key">Mural account</dt>
+												<dd class="govuk-summary-list__value">
+													<strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong>
+												</dd>
+											</div>
+											<div class="govuk-summary-list__row">
+												<dt class="govuk-summary-list__key">Mural board</dt>
+												<dd class="govuk-summary-list__value">
+													<strong class="govuk-tag govuk-tag--grey" id="mural-board-state">
+														Create or open manually
+													</strong>
+												</dd>
+											</div>
+										</dl>
+										<div class="govuk-button-group rops-mural-actions">
+											<button
+												type="button"
+												class="govuk-button govuk-button--secondary"
+												data-module="govuk-button"
+												id="mural-connect"
+											>
+												Connect Mural
+											</button>
+
+											<button
+												type="button"
+												disabled
+												aria-disabled="true"
+												class="govuk-button govuk-button--secondary"
+												data-module="govuk-button"
+												id="mural-setup"
+											>
+												Create Mural board
+											</button>
+										</div>
+									</div>
+								</div>
+							</section>
+
+							<section id="stakeholders" class="govuk-summary-card">
+								<div class="govuk-summary-card__title-wrapper">
+									<h2 class="govuk-summary-card__title">Stakeholder management</h2>
+								</div>
+								<div class="govuk-summary-card__content">
+									<div class="rops-two-column">
+										<div>
+											<h3 class="govuk-heading-s">Stakeholders</h3>
+											<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list">
+												<li>No stakeholders yet.</li>
+											</ul>
+
+											<button
+												type="button"
+												class="govuk-button govuk-button--secondary"
+												data-module="govuk-button"
+												id="add-stakeholder-toggle"
+												aria-expanded="false"
+												aria-controls="add-stakeholder-panel"
+											>
+												Add stakeholder
+											</button>
+
+											<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
+												<form id="add-stakeholder-form" novalidate>
+													<h4 class="govuk-heading-s">Add stakeholder</h4>
+													<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
+													<div class="govuk-form-group">
+														<label class="govuk-label" for="stakeholder-name">Name</label>
+														<input
+															class="govuk-input govuk-!-width-two-thirds"
+															id="stakeholder-name"
+															name="name"
+															autocomplete="name"
+															required
+														/>
+													</div>
+													<div class="govuk-form-group">
+														<label class="govuk-label" for="stakeholder-role">Role</label>
+														<input
+															class="govuk-input govuk-!-width-two-thirds"
+															id="stakeholder-role"
+															name="role"
+															autocomplete="organization-title"
+															required
+														/>
+													</div>
+													<div class="govuk-form-group">
+														<label class="govuk-label" for="stakeholder-email">Work email</label>
+														<div id="stakeholder-email-hint" class="govuk-hint">
+															Only add staff contact details where needed for project ownership or coordination.
+														</div>
+														<input
+															class="govuk-input govuk-!-width-two-thirds"
+															id="stakeholder-email"
+															name="email"
+															type="email"
+															autocomplete="email"
+															aria-describedby="stakeholder-email-hint"
+														/>
+													</div>
+													<div class="govuk-button-group">
+														<button type="submit" class="govuk-button" data-module="govuk-button">
+															Save stakeholder
+														</button>
+
+														<button
+															type="button"
+															class="govuk-button govuk-button--secondary"
+															data-module="govuk-button"
+															data-close-panel="add-stakeholder-panel"
+															data-toggle="add-stakeholder-toggle"
+														>
+															Cancel
+														</button>
+													</div>
+												</form>
+											</div>
+										</div>
+										<div>
+											<h3 class="govuk-heading-s">Objectives</h3>
+											<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list">
+												<li>No objectives yet.</li>
+											</ul>
+
+											<button
+												type="button"
+												class="govuk-button govuk-button--secondary"
+												data-module="govuk-button"
+												id="add-objective-toggle"
+												aria-expanded="false"
+												aria-controls="add-objective-panel"
+											>
+												Add objective
+											</button>
+
+											<div id="add-objective-panel" class="dashboard-action-panel" hidden>
+												<form id="add-objective-form" novalidate>
+													<h4 class="govuk-heading-s">Add objective</h4>
+													<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
+													<div class="govuk-form-group">
+														<label class="govuk-label" for="objective-text">Research objective</label>
+														<div id="objective-text-hint" class="govuk-hint">
+															Keep objectives action-oriented and linked to decisions the team needs to make. Do not
+															include participant personal data.
+														</div>
+														<textarea
+															class="govuk-textarea"
+															id="objective-text"
+															name="objective"
+															rows="4"
+															required
+															aria-describedby="objective-text-hint"
+														></textarea>
+													</div>
+													<div class="govuk-button-group">
+														<button type="submit" class="govuk-button" data-module="govuk-button">
+															Save objective
+														</button>
+
+														<button
+															type="button"
+															class="govuk-button govuk-button--secondary"
+															data-module="govuk-button"
+															data-close-panel="add-objective-panel"
+															data-toggle="add-objective-toggle"
+														>
+															Cancel
+														</button>
+													</div>
+												</form>
+											</div>
+										</div>
+									</div>
+								</div>
+							</section>
+
+							<section id="planning" class="govuk-summary-card">
+								<div class="govuk-summary-card__title-wrapper">
+									<h2 class="govuk-summary-card__title">Research planning</h2>
+								</div>
+								<div class="govuk-summary-card__content">
+									<div class="rops-two-column rops-planning-grid">
+										<div>
+											<h3 class="govuk-heading-s">User groups</h3>
+											<ul class="govuk-list govuk-list--spaced rops-divided-list" id="user-groups-list">
+												<li>No user groups yet.</li>
+											</ul>
+
+											<button
+												type="button"
+												class="govuk-button govuk-button--secondary"
+												data-module="govuk-button"
+												id="add-user-group-toggle"
+												aria-expanded="false"
+												aria-controls="add-user-group-panel"
+											>
+												Add user group
+											</button>
+
+											<div id="add-user-group-panel" class="dashboard-action-panel" hidden>
+												<form id="add-user-group-form" novalidate>
+													<h4 class="govuk-heading-s">Add user group</h4>
+													<div id="add-user-group-status" class="dashboard-action-status" aria-live="polite"></div>
+													<div class="govuk-form-group">
+														<label class="govuk-label" for="user-group-name">User group</label>
+														<input
+															class="govuk-input govuk-!-width-two-thirds"
+															id="user-group-name"
+															name="user-group"
+															required
+														/>
+													</div>
+													<div class="govuk-button-group">
+														<button type="submit" class="govuk-button" data-module="govuk-button">
+															Save user group
+														</button>
+
+														<button
+															type="button"
+															class="govuk-button govuk-button--secondary"
+															data-module="govuk-button"
+															data-close-panel="add-user-group-panel"
+															data-toggle="add-user-group-toggle"
+														>
+															Cancel
+														</button>
+													</div>
+												</form>
+											</div>
+										</div>
+										<div id="participants-dashboard-panel">
+											<h3 class="govuk-heading-s">Participants</h3>
+											<p class="govuk-body-s" id="participants-summary-status">Loading participants…</p>
+											<p class="govuk-body-s">
+												Participants are managed through study-specific workflows so consent, scheduling and
+												safeguarding states stay traceable.
+											</p>
+											<div class="govuk-button-group">
+												<a
+													href="/pages/project-dashboard/participants/?id="
+													role="button"
+													draggable="false"
+													class="govuk-button govuk-button--secondary"
+													data-module="govuk-button"
+													id="add-participant-link"
+												>
+													Add participant
+												</a>
+
+												<a
+													href="/pages/project-dashboard/participants/import/?id="
+													role="button"
+													draggable="false"
+													class="govuk-button govuk-button--secondary"
+													data-module="govuk-button"
+													id="import-participants-link"
+												>
+													Bulk upload participants via CSV
+												</a>
+											</div>
+										</div>
+									</div>
+								</div>
+							</section>
+
+							<section id="outcomes" class="govuk-summary-card">
+								<div class="govuk-summary-card__title-wrapper">
+									<h2 class="govuk-summary-card__title">Research outcomes</h2>
+									<ul class="govuk-summary-card__actions">
+										<li class="govuk-summary-card__action">
+											<a class="govuk-link" id="outcomes-card-link" href="/pages/projects/outcomes/?id=">
+												Open outcomes
+											</a>
+										</li>
 									</ul>
-
-									<a
-										href="/pages/study/new/?id="
-										role="button"
-										draggable="false"
-										class="govuk-button govuk-button--secondary"
-										data-module="govuk-button"
-										id="add-study-link"
-									>
-										Add study
-									</a>
 								</div>
-								<div>
-									<h3 class="govuk-heading-s">Insights</h3>
-									<p class="govuk-body-s">No insights yet.</p>
-									<p class="govuk-body-s">
-										Insights and impact records are managed from the outcomes workflow so they remain linked to evidence
-										and decisions.
-									</p>
+								<div class="govuk-summary-card__content">
+									<div class="rops-two-column">
+										<div>
+											<h3 class="govuk-heading-s">Studies</h3>
+											<ul class="govuk-list govuk-list--spaced rops-study-list" id="studies-list">
+												<li>Loading studies…</li>
+											</ul>
 
-									<a
-										href="/pages/projects/outcomes/?id=#impact-form"
-										role="button"
-										draggable="false"
-										class="govuk-button govuk-button--secondary"
-										data-module="govuk-button"
-										id="add-insight-link"
-									>
-										Add insight
-									</a>
+											<a
+												href="/pages/study/new/?id="
+												role="button"
+												draggable="false"
+												class="govuk-button govuk-button--secondary"
+												data-module="govuk-button"
+												id="add-study-link"
+											>
+												Add study
+											</a>
+										</div>
+										<div>
+											<h3 class="govuk-heading-s">Insights</h3>
+											<p class="govuk-body-s">No insights yet.</p>
+											<p class="govuk-body-s">
+												Insights and impact records are managed from the outcomes workflow so they remain linked to
+												evidence and decisions.
+											</p>
+
+											<a
+												href="/pages/projects/outcomes/?id=#impact-form"
+												role="button"
+												draggable="false"
+												class="govuk-button govuk-button--secondary"
+												data-module="govuk-button"
+												id="add-insight-link"
+											>
+												Add insight
+											</a>
+										</div>
+									</div>
 								</div>
-							</div>
+							</section>
 						</div>
-					</section>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/public/pages/project-dashboard/index.html
+++ b/public/pages/project-dashboard/index.html
@@ -124,9 +124,6 @@
 										Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system
 										record.
 									</p>
-									<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
-										<span class="pill pill--neutral">Mural is optional for visual journaling</span>
-									</p>
 									<dl class="govuk-summary-list">
 										<div class="govuk-summary-list__row">
 											<dt class="govuk-summary-list__key">Mural account</dt>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -220,7 +220,7 @@
 					<h2 class="govuk-summary-card__title">Project Objectives</h2>
 				</div>
 				<div class="govuk-summary-card__content govuk-body-s">
-					<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list"><li>No objectives yet.</li></ul>
+					<div class="rops-objectives-list" id="objectives-list"><p class="govuk-body-s">No objectives yet.</p></div>
 					{{ govukButton({
 						text: "Add objective",
 						type: "button",

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -70,7 +70,7 @@
 						</li>
 					</ul>
 				</div>
-				<div class="govuk-summary-card__content">
+				<div class="govuk-summary-card__content govuk-body-s">
 					<div class="rops-link-panel">
 						<h3 class="govuk-heading-s">ResearchOps journal</h3>
 						<p class="govuk-body">Record assumptions, decisions, risks and reflections for this project in ResearchOps.</p>
@@ -86,7 +86,7 @@
 					<div id="mural-integration">
 						<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
 						<p class="govuk-body">Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system record.</p>
-						<dl class="govuk-summary-list">
+						<dl class="govuk-summary-list govuk-body-s">
 							<div class="govuk-summary-list__row">
 								<dt class="govuk-summary-list__key">Mural account</dt>
 								<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong></dd>
@@ -137,8 +137,8 @@
 				<div class="govuk-summary-card__title-wrapper">
 					<h2 class="govuk-summary-card__title">Project details</h2>
 				</div>
-				<div class="govuk-summary-card__content">
-					<dl class="govuk-summary-list">
+				<div class="govuk-summary-card__content govuk-body-s">
+					<dl class="govuk-summary-list govuk-body-s">
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">Service stage</dt>
 							<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
@@ -168,7 +168,7 @@
 				<div class="govuk-summary-card__title-wrapper">
 					<h2 class="govuk-summary-card__title">Stakeholder management</h2>
 				</div>
-				<div class="govuk-summary-card__content">
+				<div class="govuk-summary-card__content govuk-body-s">
 					<h3 class="govuk-heading-s">Stakeholders</h3>
 					<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list"><li>No stakeholders yet.</li></ul>
 					{{ govukButton({
@@ -219,7 +219,7 @@
 				<div class="govuk-summary-card__title-wrapper">
 					<h2 class="govuk-summary-card__title">Project Objectives</h2>
 				</div>
-				<div class="govuk-summary-card__content">
+				<div class="govuk-summary-card__content govuk-body-s">
 					<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list"><li>No objectives yet.</li></ul>
 					{{ govukButton({
 						text: "Add objective",
@@ -261,7 +261,7 @@
 			<div class="govuk-summary-card__title-wrapper">
 				<h2 class="govuk-summary-card__title">Research planning</h2>
 			</div>
-			<div class="govuk-summary-card__content">
+			<div class="govuk-summary-card__content govuk-body-s">
 				<div class="rops-two-column rops-planning-grid">
 					<div>
 						<h3 class="govuk-heading-s">User groups</h3>
@@ -319,7 +319,7 @@
 					<li class="govuk-summary-card__action"><a class="govuk-link" id="outcomes-card-link" href="/pages/projects/outcomes/?id=">Open outcomes</a></li>
 				</ul>
 			</div>
-			<div class="govuk-summary-card__content">
+			<div class="govuk-summary-card__content govuk-body-s">
 				<div class="rops-two-column">
 					<div>
 						<h3 class="govuk-heading-s">Studies</h3>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -51,12 +51,13 @@
 					<h2 class="govuk-summary-card__title" id="project-areas-title">Project areas</h2>
 				</div>
 				<div class="govuk-summary-card__content">
-					<ul class="govuk-list govuk-list--spaced rops-compact-list">
-						<li><a class="govuk-link" href="#reflexive-journal">Reflexive journal</a></li>
-						<li><a class="govuk-link" href="#stakeholders">Stakeholder management</a></li>
-						<li><a class="govuk-link" href="#planning">Research planning</a></li>
-						<li><a class="govuk-link" href="/pages/projects/outcomes/?id=" id="outcomes-link" property="schema:relatedLink">Research outcomes</a></li>
-					</ul>
+						<ul class="govuk-list govuk-list--spaced rops-compact-list">
+							<li><a class="govuk-link" href="#reflexive-journal">Reflexive journal</a></li>
+							<li><a class="govuk-link" href="#stakeholders">Stakeholder management</a></li>
+							<li><a class="govuk-link" href="#project-objectives">Project Objectives</a></li>
+							<li><a class="govuk-link" href="#planning">Research planning</a></li>
+							<li><a class="govuk-link" href="/pages/projects/outcomes/?id=" id="outcomes-link" property="schema:relatedLink">Research outcomes</a></li>
+						</ul>
 				</div>
 			</nav>
 
@@ -162,100 +163,101 @@
 				</div>
 			</section>
 
-			<div class="rops-dashboard-grid">
-				<section id="stakeholders" class="govuk-summary-card">
-			<div class="govuk-summary-card__title-wrapper">
-				<h2 class="govuk-summary-card__title">Stakeholder management</h2>
-			</div>
-			<div class="govuk-summary-card__content">
-				<div class="rops-two-column">
-					<div>
-						<h3 class="govuk-heading-s">Stakeholders</h3>
-						<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list"><li>No stakeholders yet.</li></ul>
-						{{ govukButton({
-							text: "Add stakeholder",
-							type: "button",
-							classes: "govuk-button--secondary",
-							attributes: {
-								id: "add-stakeholder-toggle",
-								"aria-expanded": "false",
-								"aria-controls": "add-stakeholder-panel"
-							}
-						}) }}
-						<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
-							<form id="add-stakeholder-form" novalidate>
-								<h4 class="govuk-heading-s">Add stakeholder</h4>
-								<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="stakeholder-name">Name</label>
-									<input class="govuk-input govuk-!-width-two-thirds" id="stakeholder-name" name="name" autocomplete="name" required>
-								</div>
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="stakeholder-role">Role</label>
-									<input class="govuk-input govuk-!-width-two-thirds" id="stakeholder-role" name="role" autocomplete="organization-title" required>
-								</div>
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="stakeholder-email">Work email</label>
-									<div id="stakeholder-email-hint" class="govuk-hint">Only add staff contact details where needed for project ownership or coordination.</div>
-									<input class="govuk-input govuk-!-width-two-thirds" id="stakeholder-email" name="email" type="email" autocomplete="email" aria-describedby="stakeholder-email-hint">
-								</div>
-								<div class="govuk-button-group">
-									{{ govukButton({ text: "Save stakeholder", type: "submit" }) }}
-									{{ govukButton({
-										text: "Cancel",
-										type: "button",
-										classes: "govuk-button--secondary",
-										attributes: {
-											"data-close-panel": "add-stakeholder-panel",
-											"data-toggle": "add-stakeholder-toggle"
-										}
-									}) }}
-								</div>
-							</form>
-						</div>
-					</div>
-					<div>
-						<h3 class="govuk-heading-s">Objectives</h3>
-						<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list"><li>No objectives yet.</li></ul>
-						{{ govukButton({
-							text: "Add objective",
-							type: "button",
-							classes: "govuk-button--secondary",
-							attributes: {
-								id: "add-objective-toggle",
-								"aria-expanded": "false",
-								"aria-controls": "add-objective-panel"
-							}
-						}) }}
-						<div id="add-objective-panel" class="dashboard-action-panel" hidden>
-							<form id="add-objective-form" novalidate>
-								<h4 class="govuk-heading-s">Add objective</h4>
-								<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
-								<div class="govuk-form-group">
-									<label class="govuk-label" for="objective-text">Research objective</label>
-									<div id="objective-text-hint" class="govuk-hint">Keep objectives action-oriented and linked to decisions the team needs to make. Do not include participant personal data.</div>
-									<textarea class="govuk-textarea" id="objective-text" name="objective" rows="4" required aria-describedby="objective-text-hint"></textarea>
-								</div>
-								<div class="govuk-button-group">
-									{{ govukButton({ text: "Save objective", type: "submit" }) }}
-									{{ govukButton({
-										text: "Cancel",
-										type: "button",
-										classes: "govuk-button--secondary",
-										attributes: {
-											"data-close-panel": "add-objective-panel",
-											"data-toggle": "add-objective-toggle"
-										}
-									}) }}
-								</div>
-							</form>
-						</div>
+				<div class="rops-dashboard-grid">
+					<section id="stakeholders" class="govuk-summary-card">
+				<div class="govuk-summary-card__title-wrapper">
+					<h2 class="govuk-summary-card__title">Stakeholder management</h2>
+				</div>
+				<div class="govuk-summary-card__content">
+					<h3 class="govuk-heading-s">Stakeholders</h3>
+					<ul class="govuk-list govuk-list--spaced rops-divided-list" id="stakeholders-list"><li>No stakeholders yet.</li></ul>
+					{{ govukButton({
+						text: "Add stakeholder",
+						type: "button",
+						classes: "govuk-button--secondary",
+						attributes: {
+							id: "add-stakeholder-toggle",
+							"aria-expanded": "false",
+							"aria-controls": "add-stakeholder-panel"
+						}
+					}) }}
+					<div id="add-stakeholder-panel" class="dashboard-action-panel" hidden>
+						<form id="add-stakeholder-form" novalidate>
+							<h4 class="govuk-heading-s">Add stakeholder</h4>
+							<div id="add-stakeholder-status" class="dashboard-action-status" aria-live="polite"></div>
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="stakeholder-name">Name</label>
+								<input class="govuk-input govuk-!-width-two-thirds" id="stakeholder-name" name="name" autocomplete="name" required>
+							</div>
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="stakeholder-role">Role</label>
+								<input class="govuk-input govuk-!-width-two-thirds" id="stakeholder-role" name="role" autocomplete="organization-title" required>
+							</div>
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="stakeholder-email">Work email</label>
+								<div id="stakeholder-email-hint" class="govuk-hint">Only add staff contact details where needed for project ownership or coordination.</div>
+								<input class="govuk-input govuk-!-width-two-thirds" id="stakeholder-email" name="email" type="email" autocomplete="email" aria-describedby="stakeholder-email-hint">
+							</div>
+							<div class="govuk-button-group">
+								{{ govukButton({ text: "Save stakeholder", type: "submit" }) }}
+								{{ govukButton({
+									text: "Cancel",
+									type: "button",
+									classes: "govuk-button--secondary",
+									attributes: {
+										"data-close-panel": "add-stakeholder-panel",
+										"data-toggle": "add-stakeholder-toggle"
+									}
+								}) }}
+							</div>
+						</form>
 					</div>
 				</div>
-			</div>
-		</section>
+			</section>
 
-		<section id="planning" class="govuk-summary-card">
+			<section id="project-objectives" class="govuk-summary-card">
+				<div class="govuk-summary-card__title-wrapper">
+					<h2 class="govuk-summary-card__title">Project Objectives</h2>
+				</div>
+				<div class="govuk-summary-card__content">
+					<ul class="govuk-list govuk-list--spaced rops-divided-list" id="objectives-list"><li>No objectives yet.</li></ul>
+					{{ govukButton({
+						text: "Add objective",
+						type: "button",
+						classes: "govuk-button--secondary",
+						attributes: {
+							id: "add-objective-toggle",
+							"aria-expanded": "false",
+							"aria-controls": "add-objective-panel"
+						}
+					}) }}
+					<div id="add-objective-panel" class="dashboard-action-panel" hidden>
+						<form id="add-objective-form" novalidate>
+							<h3 class="govuk-heading-s">Add objective</h3>
+							<div id="add-objective-status" class="dashboard-action-status" aria-live="polite"></div>
+							<div class="govuk-form-group">
+								<label class="govuk-label" for="objective-text">Research objective</label>
+								<div id="objective-text-hint" class="govuk-hint">Keep objectives action-oriented and linked to decisions the team needs to make. Do not include participant personal data.</div>
+								<textarea class="govuk-textarea" id="objective-text" name="objective" rows="4" required aria-describedby="objective-text-hint"></textarea>
+							</div>
+							<div class="govuk-button-group">
+								{{ govukButton({ text: "Save objective", type: "submit" }) }}
+								{{ govukButton({
+									text: "Cancel",
+									type: "button",
+									classes: "govuk-button--secondary",
+									attributes: {
+										"data-close-panel": "add-objective-panel",
+										"data-toggle": "add-objective-toggle"
+									}
+								}) }}
+							</div>
+						</form>
+					</div>
+				</div>
+			</section>
+
+			<section id="planning" class="govuk-summary-card">
 			<div class="govuk-summary-card__title-wrapper">
 				<h2 class="govuk-summary-card__title">Research planning</h2>
 			</div>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -85,9 +85,6 @@
 					<div id="mural-integration">
 						<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
 						<p class="govuk-body">Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system record.</p>
-						<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
-							<span class="pill pill--neutral">Mural is optional for visual journaling</span>
-						</p>
 						<dl class="govuk-summary-list">
 							<div class="govuk-summary-list__row">
 								<dt class="govuk-summary-list__key">Mural account</dt>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -101,7 +101,8 @@
 								type: "button",
 								classes: "govuk-button--secondary",
 								attributes: {
-									id: "mural-connect"
+									id: "mural-connect",
+									hidden: "hidden"
 								}
 							}) }}
 							{{ govukButton({

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -42,111 +42,10 @@
 		]
 	}) }}
 
-	<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
-		{{ daasBrandPanel() }}
-		<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
-		<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
-		<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">Use this dashboard to manage project context, research planning, reflexive journaling and research outcomes.</p>
-		<div class="rops-status-strip" aria-label="Project status">
-			<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
-			<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
-			<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
-		</div>
-	</header>
+	{{ daasBrandPanel() }}
 
-	<section class="govuk-summary-card" id="project-details">
-		<div class="govuk-summary-card__title-wrapper">
-			<h2 class="govuk-summary-card__title">Project details</h2>
-		</div>
-		<div class="govuk-summary-card__content">
-			<dl class="govuk-summary-list">
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Service stage</dt>
-					<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Project stage</dt>
-					<dd class="govuk-summary-list__value" id="kv-project-stage" property="schema:projectStatus">–</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Client name</dt>
-					<dd class="govuk-summary-list__value" id="kv-client-name" property="schema:client">–</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Lead researcher</dt>
-					<dd class="govuk-summary-list__value" id="kv-lead-researcher" property="schema:author" typeof="schema:Person">–</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">Lead researcher email</dt>
-					<dd class="govuk-summary-list__value"><a class="govuk-link" id="kv-lead-email" property="schema:email" href="mailto:">–</a></dd>
-				</div>
-			</dl>
-		</div>
-	</section>
-
-	<div class="rops-dashboard-grid">
-		<section class="govuk-summary-card" id="reflexive-journal">
-			<div class="govuk-summary-card__title-wrapper">
-				<h2 class="govuk-summary-card__title">Reflexive journal</h2>
-				<ul class="govuk-summary-card__actions">
-					<li class="govuk-summary-card__action">
-						<a class="govuk-link" href="/pages/projects/journals/?id=" id="journal-link" property="schema:relatedLink">Open journal</a>
-					</li>
-				</ul>
-			</div>
-			<div class="govuk-summary-card__content">
-				<div class="rops-link-panel">
-					<h3 class="govuk-heading-s">ResearchOps journal</h3>
-					<p class="govuk-body">Record assumptions, decisions, risks and reflections for this project in ResearchOps.</p>
-					{{ govukButton({
-						text: "Open reflexive journal",
-						href: "/pages/projects/journals/?id=",
-						attributes: {
-							id: "journal-button-link"
-						}
-					}) }}
-				</div>
-
-				<div id="mural-integration">
-					<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
-					<p class="govuk-body">Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system record.</p>
-					<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
-						<span class="pill pill--neutral">Mural is optional for visual journaling</span>
-					</p>
-					<dl class="govuk-summary-list">
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">Mural account</dt>
-							<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong></dd>
-						</div>
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">Mural board</dt>
-							<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-board-state">Create or open manually</strong></dd>
-						</div>
-					</dl>
-					<div class="govuk-button-group rops-mural-actions">
-						{{ govukButton({
-							text: "Connect Mural",
-							type: "button",
-							classes: "govuk-button--secondary",
-							attributes: {
-								id: "mural-connect"
-							}
-						}) }}
-						{{ govukButton({
-							text: "Create Mural board",
-							type: "button",
-							classes: "govuk-button--secondary",
-							disabled: true,
-							attributes: {
-								id: "mural-setup"
-							}
-						}) }}
-					</div>
-				</div>
-			</div>
-		</section>
-
-		<nav class="govuk-summary-card" typeof="schema:SiteNavigationElement" aria-labelledby="project-areas-title">
+	<div class="rops-dashboard-layout">
+		<nav class="govuk-summary-card rops-project-areas-nav" typeof="schema:SiteNavigationElement" aria-labelledby="project-areas-title">
 			<div class="govuk-summary-card__title-wrapper">
 				<h2 class="govuk-summary-card__title" id="project-areas-title">Project areas</h2>
 			</div>
@@ -160,7 +59,111 @@
 			</div>
 		</nav>
 
-		<section id="stakeholders" class="govuk-summary-card">
+		<div class="rops-dashboard-content">
+			<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
+				<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
+				<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
+				<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">Use this dashboard to manage project context, research planning, reflexive journaling and research outcomes.</p>
+				<div class="rops-status-strip" aria-label="Project status">
+					<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
+					<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
+					<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
+				</div>
+			</header>
+
+			<section class="govuk-summary-card" id="project-details">
+				<div class="govuk-summary-card__title-wrapper">
+					<h2 class="govuk-summary-card__title">Project details</h2>
+				</div>
+				<div class="govuk-summary-card__content">
+					<dl class="govuk-summary-list">
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Service stage</dt>
+							<dd class="govuk-summary-list__value" id="kv-service-stage" property="schema:phase">–</dd>
+						</div>
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Project stage</dt>
+							<dd class="govuk-summary-list__value" id="kv-project-stage" property="schema:projectStatus">–</dd>
+						</div>
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Client name</dt>
+							<dd class="govuk-summary-list__value" id="kv-client-name" property="schema:client">–</dd>
+						</div>
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Lead researcher</dt>
+							<dd class="govuk-summary-list__value" id="kv-lead-researcher" property="schema:author" typeof="schema:Person">–</dd>
+						</div>
+						<div class="govuk-summary-list__row">
+							<dt class="govuk-summary-list__key">Lead researcher email</dt>
+							<dd class="govuk-summary-list__value"><a class="govuk-link" id="kv-lead-email" property="schema:email" href="mailto:">–</a></dd>
+						</div>
+					</dl>
+				</div>
+			</section>
+
+			<div class="rops-dashboard-grid">
+				<section class="govuk-summary-card" id="reflexive-journal">
+					<div class="govuk-summary-card__title-wrapper">
+						<h2 class="govuk-summary-card__title">Reflexive journal</h2>
+						<ul class="govuk-summary-card__actions">
+							<li class="govuk-summary-card__action">
+								<a class="govuk-link" href="/pages/projects/journals/?id=" id="journal-link" property="schema:relatedLink">Open journal</a>
+							</li>
+						</ul>
+					</div>
+					<div class="govuk-summary-card__content">
+						<div class="rops-link-panel">
+							<h3 class="govuk-heading-s">ResearchOps journal</h3>
+							<p class="govuk-body">Record assumptions, decisions, risks and reflections for this project in ResearchOps.</p>
+							{{ govukButton({
+								text: "Open reflexive journal",
+								href: "/pages/projects/journals/?id=",
+								attributes: {
+									id: "journal-button-link"
+								}
+							}) }}
+						</div>
+
+						<div id="mural-integration">
+							<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
+							<p class="govuk-body">Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system record.</p>
+							<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
+								<span class="pill pill--neutral">Mural is optional for visual journaling</span>
+							</p>
+							<dl class="govuk-summary-list">
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Mural account</dt>
+									<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong></dd>
+								</div>
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Mural board</dt>
+									<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-board-state">Create or open manually</strong></dd>
+								</div>
+							</dl>
+							<div class="govuk-button-group rops-mural-actions">
+								{{ govukButton({
+									text: "Connect Mural",
+									type: "button",
+									classes: "govuk-button--secondary",
+									attributes: {
+										id: "mural-connect"
+									}
+								}) }}
+								{{ govukButton({
+									text: "Create Mural board",
+									type: "button",
+									classes: "govuk-button--secondary",
+									disabled: true,
+									attributes: {
+										id: "mural-setup"
+									}
+								}) }}
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section id="stakeholders" class="govuk-summary-card">
 			<div class="govuk-summary-card__title-wrapper">
 				<h2 class="govuk-summary-card__title">Stakeholder management</h2>
 			</div>
@@ -330,6 +333,8 @@
 				</div>
 			</div>
 		</section>
+		</div>
+		</div>
 	</div>
 </div>
 {% endblock %}

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -45,6 +45,17 @@
 	{{ daasBrandPanel() }}
 
 	<div class="rops-dashboard-layout">
+		<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
+			<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
+			<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
+			<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">Use this dashboard to manage project context, research planning, reflexive journaling and research outcomes.</p>
+			<div class="rops-status-strip" aria-label="Project status">
+				<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
+				<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
+				<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
+			</div>
+		</header>
+
 		<div class="rops-dashboard-sidebar">
 			<nav class="govuk-summary-card rops-project-areas-nav" typeof="schema:SiteNavigationElement" aria-labelledby="project-areas-title">
 				<div class="govuk-summary-card__title-wrapper">
@@ -122,17 +133,6 @@
 		</div>
 
 		<div class="rops-dashboard-content">
-			<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
-				<span id="eyebrow-org" class="govuk-caption-l" property="schema:sourceOrganization"></span>
-				<h1 id="project-title" class="govuk-heading-xl" property="schema:name">Project dashboard</h1>
-				<p id="project-subtitle" class="govuk-body-l rops-dashboard-description" property="schema:description">Use this dashboard to manage project context, research planning, reflexive journaling and research outcomes.</p>
-				<div class="rops-status-strip" aria-label="Project status">
-					<strong class="govuk-tag govuk-tag--blue" id="project-service-stage-tag">Loading service stage</strong>
-					<strong class="govuk-tag govuk-tag--purple" id="project-stage-tag">Loading project stage</strong>
-					<strong class="govuk-tag govuk-tag--grey" id="mural-summary-tag">Mural optional</strong>
-				</div>
-			</header>
-
 			<section class="govuk-summary-card" id="project-details">
 				<div class="govuk-summary-card__title-wrapper">
 					<h2 class="govuk-summary-card__title">Project details</h2>

--- a/src/govuk/templates/pages/project-dashboard.njk
+++ b/src/govuk/templates/pages/project-dashboard.njk
@@ -45,19 +45,82 @@
 	{{ daasBrandPanel() }}
 
 	<div class="rops-dashboard-layout">
-		<nav class="govuk-summary-card rops-project-areas-nav" typeof="schema:SiteNavigationElement" aria-labelledby="project-areas-title">
-			<div class="govuk-summary-card__title-wrapper">
-				<h2 class="govuk-summary-card__title" id="project-areas-title">Project areas</h2>
-			</div>
-			<div class="govuk-summary-card__content">
-				<ul class="govuk-list govuk-list--spaced rops-compact-list">
-					<li><a class="govuk-link" href="#reflexive-journal">Reflexive journal</a></li>
-					<li><a class="govuk-link" href="#stakeholders">Stakeholder management</a></li>
-					<li><a class="govuk-link" href="#planning">Research planning</a></li>
-					<li><a class="govuk-link" href="/pages/projects/outcomes/?id=" id="outcomes-link" property="schema:relatedLink">Research outcomes</a></li>
-				</ul>
-			</div>
-		</nav>
+		<div class="rops-dashboard-sidebar">
+			<nav class="govuk-summary-card rops-project-areas-nav" typeof="schema:SiteNavigationElement" aria-labelledby="project-areas-title">
+				<div class="govuk-summary-card__title-wrapper">
+					<h2 class="govuk-summary-card__title" id="project-areas-title">Project areas</h2>
+				</div>
+				<div class="govuk-summary-card__content">
+					<ul class="govuk-list govuk-list--spaced rops-compact-list">
+						<li><a class="govuk-link" href="#reflexive-journal">Reflexive journal</a></li>
+						<li><a class="govuk-link" href="#stakeholders">Stakeholder management</a></li>
+						<li><a class="govuk-link" href="#planning">Research planning</a></li>
+						<li><a class="govuk-link" href="/pages/projects/outcomes/?id=" id="outcomes-link" property="schema:relatedLink">Research outcomes</a></li>
+					</ul>
+				</div>
+			</nav>
+
+			<section class="govuk-summary-card" id="reflexive-journal">
+				<div class="govuk-summary-card__title-wrapper">
+					<h2 class="govuk-summary-card__title">Reflexive journal</h2>
+					<ul class="govuk-summary-card__actions">
+						<li class="govuk-summary-card__action">
+							<a class="govuk-link" href="/pages/projects/journals/?id=" id="journal-link" property="schema:relatedLink">Open journal</a>
+						</li>
+					</ul>
+				</div>
+				<div class="govuk-summary-card__content">
+					<div class="rops-link-panel">
+						<h3 class="govuk-heading-s">ResearchOps journal</h3>
+						<p class="govuk-body">Record assumptions, decisions, risks and reflections for this project in ResearchOps.</p>
+						{{ govukButton({
+							text: "Open reflexive journal",
+							href: "/pages/projects/journals/?id=",
+							attributes: {
+								id: "journal-button-link"
+							}
+						}) }}
+					</div>
+
+					<div id="mural-integration">
+						<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
+						<p class="govuk-body">Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system record.</p>
+						<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
+							<span class="pill pill--neutral">Mural is optional for visual journaling</span>
+						</p>
+						<dl class="govuk-summary-list">
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Mural account</dt>
+								<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong></dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Mural board</dt>
+								<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-board-state">Create or open manually</strong></dd>
+							</div>
+						</dl>
+						<div class="govuk-button-group rops-mural-actions">
+							{{ govukButton({
+								text: "Connect Mural",
+								type: "button",
+								classes: "govuk-button--secondary",
+								attributes: {
+									id: "mural-connect"
+								}
+							}) }}
+							{{ govukButton({
+								text: "Create Mural board",
+								type: "button",
+								classes: "govuk-button--secondary",
+								disabled: true,
+								attributes: {
+									id: "mural-setup"
+								}
+							}) }}
+						</div>
+					</div>
+				</div>
+			</section>
+		</div>
 
 		<div class="rops-dashboard-content">
 			<header class="rops-dashboard-header" typeof="schema:ResearchProject" resource="#project">
@@ -102,67 +165,6 @@
 			</section>
 
 			<div class="rops-dashboard-grid">
-				<section class="govuk-summary-card" id="reflexive-journal">
-					<div class="govuk-summary-card__title-wrapper">
-						<h2 class="govuk-summary-card__title">Reflexive journal</h2>
-						<ul class="govuk-summary-card__actions">
-							<li class="govuk-summary-card__action">
-								<a class="govuk-link" href="/pages/projects/journals/?id=" id="journal-link" property="schema:relatedLink">Open journal</a>
-							</li>
-						</ul>
-					</div>
-					<div class="govuk-summary-card__content">
-						<div class="rops-link-panel">
-							<h3 class="govuk-heading-s">ResearchOps journal</h3>
-							<p class="govuk-body">Record assumptions, decisions, risks and reflections for this project in ResearchOps.</p>
-							{{ govukButton({
-								text: "Open reflexive journal",
-								href: "/pages/projects/journals/?id=",
-								attributes: {
-									id: "journal-button-link"
-								}
-							}) }}
-						</div>
-
-						<div id="mural-integration">
-							<h3 class="govuk-heading-s">Mural board for visual journaling</h3>
-							<p class="govuk-body">Use Mural only if the team wants a linked visual board. The ResearchOps journal remains the system record.</p>
-							<p id="mural-status" class="rops-mural-status" aria-live="polite" aria-atomic="true">
-								<span class="pill pill--neutral">Mural is optional for visual journaling</span>
-							</p>
-							<dl class="govuk-summary-list">
-								<div class="govuk-summary-list__row">
-									<dt class="govuk-summary-list__key">Mural account</dt>
-									<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-account-state">Connect if needed</strong></dd>
-								</div>
-								<div class="govuk-summary-list__row">
-									<dt class="govuk-summary-list__key">Mural board</dt>
-									<dd class="govuk-summary-list__value"><strong class="govuk-tag govuk-tag--grey" id="mural-board-state">Create or open manually</strong></dd>
-								</div>
-							</dl>
-							<div class="govuk-button-group rops-mural-actions">
-								{{ govukButton({
-									text: "Connect Mural",
-									type: "button",
-									classes: "govuk-button--secondary",
-									attributes: {
-										id: "mural-connect"
-									}
-								}) }}
-								{{ govukButton({
-									text: "Create Mural board",
-									type: "button",
-									classes: "govuk-button--secondary",
-									disabled: true,
-									attributes: {
-										id: "mural-setup"
-									}
-								}) }}
-							</div>
-						</div>
-					</div>
-				</section>
-
 				<section id="stakeholders" class="govuk-summary-card">
 			<div class="govuk-summary-card__title-wrapper">
 				<h2 class="govuk-summary-card__title">Stakeholder management</h2>

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -55,8 +55,12 @@
 
 .rops-dashboard-grid {
 	display: grid;
-	gap: 20px;
+	gap: 30px;
 	grid-template-columns: 1fr;
+}
+
+.rops-dashboard-grid > .govuk-summary-card {
+	margin-bottom: 0;
 }
 
 .rops-dashboard-layout {
@@ -169,6 +173,10 @@
 
 .rops-mural-actions {
 	margin-top: 20px;
+}
+
+#mural-connect[hidden] {
+	display: none;
 }
 
 .rops-disabled-button {

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -163,8 +163,8 @@
 	padding-left: 15px;
 }
 
-.rops-mural-status {
-	margin: 0 0 12px;
+.rops-link-panel .govuk-button {
+	margin-bottom: 8px;
 }
 
 .rops-mural-actions {

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -71,6 +71,7 @@
 
 .rops-dashboard-sidebar {
 	align-content: start;
+	align-self: start;
 	display: grid;
 	gap: 20px;
 }
@@ -94,7 +95,7 @@
 		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
 	}
 
-	.rops-project-areas-nav {
+	.rops-dashboard-sidebar {
 		position: sticky;
 		top: 1rem;
 	}

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -175,6 +175,37 @@
 	padding-bottom: 0;
 }
 
+.rops-objective-list {
+	margin-bottom: 20px;
+}
+
+.rops-objective-list > li {
+	border-bottom: 1px solid #b1b4b6;
+	margin-bottom: 15px;
+	padding-bottom: 15px;
+}
+
+.rops-objective-list > li:last-child {
+	border-bottom: 0;
+	margin-bottom: 0;
+	padding-bottom: 0;
+}
+
+.rops-objective-list__title {
+	display: block;
+}
+
+.rops-objective-list__sublist {
+	margin-bottom: 0;
+	margin-top: 10px;
+}
+
+.rops-objective-list__sublist > li {
+	border-bottom: 0;
+	margin-bottom: 5px;
+	padding-bottom: 0;
+}
+
 .rops-study-list {
 	margin-bottom: 20px;
 }

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -88,6 +88,23 @@
 	align-self: start;
 }
 
+.govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s {
+	.govuk-list,
+	.govuk-label,
+	.govuk-hint {
+		font-size: inherit;
+		line-height: inherit;
+	}
+}
+
+.govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s {
+	.govuk-summary-list__key,
+	.govuk-summary-list__value {
+		font-size: inherit;
+		line-height: inherit;
+	}
+}
+
 .rops-two-column {
 	display: grid;
 	gap: 20px;

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -8,7 +8,7 @@
    ============================================================================ */
 
 .rops-dashboard-header {
-	margin-bottom: 30px;
+	margin-bottom: 0;
 }
 
 .rops-dashboard-description {
@@ -64,9 +64,10 @@
 }
 
 .rops-dashboard-layout {
+	column-gap: 20px;
 	display: grid;
-	gap: 20px;
 	grid-template-columns: 1fr;
+	row-gap: 30px;
 }
 
 .rops-dashboard-layout > * {
@@ -89,12 +90,20 @@
 }
 
 .govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s {
+	.govuk-body,
 	.govuk-list,
 	.govuk-label,
 	.govuk-hint {
 		font-size: inherit;
 		line-height: inherit;
 	}
+}
+
+.govuk-summary-card:not(.rops-project-areas-nav)
+	.govuk-summary-card__content.govuk-body-s
+	dl.govuk-body-s {
+	font-size: inherit;
+	line-height: inherit;
 }
 
 .govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s {
@@ -120,9 +129,21 @@
 		grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
 	}
 
+	.rops-dashboard-header {
+		grid-column: 2;
+		grid-row: 1;
+	}
+
 	.rops-dashboard-sidebar {
+		grid-column: 1;
+		grid-row: 1 / span 2;
 		position: sticky;
 		top: 1rem;
+	}
+
+	.rops-dashboard-content {
+		grid-column: 2;
+		grid-row: 2;
 	}
 
 	.rops-two-column {

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -59,6 +59,20 @@
 	grid-template-columns: 1fr;
 }
 
+.rops-dashboard-layout {
+	display: grid;
+	gap: 20px;
+	grid-template-columns: 1fr;
+}
+
+.rops-dashboard-layout > * {
+	min-width: 0;
+}
+
+.rops-project-areas-nav {
+	align-self: start;
+}
+
 .rops-two-column {
 	display: grid;
 	gap: 20px;
@@ -70,6 +84,10 @@
 }
 
 @media (min-width: 48.0625em) {
+	.rops-dashboard-layout {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
+	}
+
 	.rops-two-column {
 		grid-template-columns: 1fr 1fr;
 	}

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -69,6 +69,12 @@
 	min-width: 0;
 }
 
+.rops-dashboard-sidebar {
+	align-content: start;
+	display: grid;
+	gap: 20px;
+}
+
 .rops-project-areas-nav {
 	align-self: start;
 }

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -96,7 +96,7 @@
 
 @media (min-width: 48.0625em) {
 	.rops-dashboard-layout {
-		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
+		grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
 	}
 
 	.rops-dashboard-sidebar {

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -76,6 +76,10 @@
 	gap: 20px;
 }
 
+.rops-dashboard-sidebar > .govuk-summary-card {
+	margin-bottom: 0;
+}
+
 .rops-project-areas-nav {
 	align-self: start;
 }

--- a/src/styles/project-dashboard.scss
+++ b/src/styles/project-dashboard.scss
@@ -88,6 +88,11 @@
 		grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
 	}
 
+	.rops-project-areas-nav {
+		position: sticky;
+		top: 1rem;
+	}
+
 	.rops-two-column {
 		grid-template-columns: 1fr 1fr;
 	}

--- a/tests/govuk-design-system-baseline-route-state.test.js
+++ b/tests/govuk-design-system-baseline-route-state.test.js
@@ -112,7 +112,7 @@ excludes(projectsPage, "/css/govuk/govuk-frontend-v6.css", "Projects page");
 
 includes(dashboardPage, "/assets/govuk/govuk-frontend.css", "project dashboard page");
 includes(dashboardPage, "class=\"govuk-summary-card\"", "project dashboard page");
-includes(dashboardPage, "class=\"govuk-summary-list\"", "project dashboard page");
+includes(dashboardPage, "class=\"govuk-summary-list govuk-body-s\"", "project dashboard page");
 includes(dashboardPage, "id=\"mural-integration\"", "project dashboard page");
 includes(dashboardPage, "id=\"studies-list\"", "project dashboard page");
 excludes(dashboardPage, "class=\"section\"", "project dashboard page");

--- a/tests/govuk-tables-summary-lists-application-route-state.test.js
+++ b/tests/govuk-tables-summary-lists-application-route-state.test.js
@@ -33,7 +33,7 @@ includes(tableCssSource, ".govuk-summary-list__key", "GOV.UK table stylesheet");
 includes(tableCssSource, ".govuk-summary-list__value", "GOV.UK table stylesheet");
 
 includes(dashboardPageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "project dashboard page");
-includes(dashboardPageSource, "<dl class=\"govuk-summary-list\">", "project dashboard page");
+includes(dashboardPageSource, "<dl class=\"govuk-summary-list govuk-body-s\">", "project dashboard page");
 includes(dashboardPageSource, "class=\"govuk-summary-list__key\"", "project dashboard page");
 includes(dashboardPageSource, "class=\"govuk-summary-list__value\" id=\"kv-service-stage\"", "project dashboard page");
 includes(dashboardPageSource, "id=\"kv-lead-email\"", "project dashboard page");

--- a/tests/mural-ui-route-state.test.js
+++ b/tests/mural-ui-route-state.test.js
@@ -32,6 +32,8 @@ includes("function setSetupAsCreate(projectId, projectName)");
 includes("function setSetupAsOpen(projectId, boardUrl)");
 includes("function observeProjectMeta()");
 includes("function hideConnectButton()");
+includes("function disableAll()");
+includes("function disableAll() {\n\t\thideConnectButton();");
 includes("function setGovukTag(el, text, modifier = \"govuk-tag--grey\")");
 includes("function setOpenLinkState(enabled, boardUrl = \"\")");
 includes("jsonFetch(addDebug(`${API_ORIGIN}/api/health`)).catch(() => {});");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -251,6 +251,8 @@ includes(dashboardSassSource, ".rops-dashboard-sidebar", "project dashboard Sass
 includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
 includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard Sass source");
 includes(dashboardSassSource, "align-self: start;", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard Sass source");
+includes(dashboardSassSource, "margin-bottom: 0;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "position: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "top: 1rem;", "project dashboard Sass source");
@@ -274,6 +276,8 @@ includes(dashboardCssSource, ".rops-dashboard-sidebar", "project dashboard style
 includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
 includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard stylesheet");
 includes(dashboardCssSource, "align-self: start;", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard stylesheet");
+includes(dashboardCssSource, "margin-bottom: 0;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "position: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "top: 1rem;", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -83,6 +83,26 @@ includes(templateSource, "href: \"/pages/project-dashboard/?id=\"", "project das
 includes(templateSource, "rops-planning-grid", "project dashboard template");
 includes(templateSource, "id: \"add-stakeholder-toggle\"", "project dashboard template");
 includes(templateSource, "\"aria-controls\": \"add-stakeholder-panel\"", "project dashboard template");
+includes(templateSource, "href=\"#project-objectives\"", "project dashboard template");
+includes(templateSource, "id=\"project-objectives\"", "project dashboard template");
+includes(templateSource, "Project Objectives", "project dashboard template");
+includes(templateSource, "id=\"objectives-list\"", "project dashboard template");
+includes(templateSource, "id: \"add-objective-toggle\"", "project dashboard template");
+assert.equal(
+	templateSource.indexOf("id=\"stakeholders\"") < templateSource.indexOf("id=\"project-objectives\""),
+	true,
+	"Expected Project Objectives to render after Stakeholder management",
+);
+assert.equal(
+	templateSource.indexOf("id=\"project-objectives\"") < templateSource.indexOf("id=\"planning\""),
+	true,
+	"Expected Project Objectives to render before Research planning",
+);
+assert.equal(
+	templateSource.indexOf("id=\"stakeholders\"") < templateSource.indexOf("id=\"objectives-list\""),
+	true,
+	"Expected objectives list to render outside the Stakeholder management card",
+);
 excludes(templateSource, "rops-summary-card-button", "project dashboard template");
 excludes(templateSource, "id=\"mural-open\"", "project dashboard template");
 excludes(templateSource, "Service stage not recorded", "project dashboard template");
@@ -111,6 +131,11 @@ includes(pageSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "pro
 includes(pageSource, "class=\"rops-dashboard-content\"", "project dashboard page");
 includes(pageSource, "id=\"mural-connect\"", "project dashboard page");
 includes(pageSource, "hidden", "project dashboard page");
+includes(pageSource, "href=\"#project-objectives\"", "project dashboard page");
+includes(pageSource, "id=\"project-objectives\"", "project dashboard page");
+includes(pageSource, "Project Objectives", "project dashboard page");
+includes(pageSource, "id=\"objectives-list\"", "project dashboard page");
+includes(pageSource, "id=\"add-objective-toggle\"", "project dashboard page");
 assert.equal(
 	pageSource.indexOf("id=\"daas-brand-panel\"") < pageSource.indexOf("class=\"rops-dashboard-layout\""),
 	true,
@@ -132,6 +157,21 @@ assert.equal(
 		pageSource.indexOf("class=\"rops-dashboard-content\""),
 	true,
 	"Expected reflexive journal panel to render in the sidebar before dashboard content",
+);
+assert.equal(
+	pageSource.indexOf("id=\"stakeholders\"") < pageSource.indexOf("id=\"project-objectives\""),
+	true,
+	"Expected Project Objectives to render after Stakeholder management",
+);
+assert.equal(
+	pageSource.indexOf("id=\"project-objectives\"") < pageSource.indexOf("id=\"planning\""),
+	true,
+	"Expected Project Objectives to render before Research planning",
+);
+assert.equal(
+	pageSource.indexOf("id=\"stakeholders\"") < pageSource.indexOf("id=\"objectives-list\""),
+	true,
+	"Expected objectives list to render outside the Stakeholder management card",
 );
 includes(pageSource, "/images/brands/daas-logo.svg", "project dashboard page");
 includes(pageSource, "project-dashboard.js?v=project-dashboard-daas-brand-20260616", "project dashboard page");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -32,6 +32,8 @@ excludes(layoutSource, "fallbackFooterHtml", "GOV.UK layout");
 
 includes(templateSource, "{% from \"govuk/components/button/macro.njk\" import govukButton %}", "project dashboard template");
 includes(templateSource, "id=\"mural-integration\"", "project dashboard template");
+excludes(templateSource, "id=\"mural-status\"", "project dashboard template");
+excludes(templateSource, "class=\"rops-mural-status\"", "project dashboard template");
 includes(templateSource, "id=\"journal-link\"", "project dashboard template");
 includes(templateSource, "id=\"outcomes-card-link\"", "project dashboard template");
 includes(templateSource, "{% from \"macros/daas-brand-panel.njk\" import daasBrandPanel %}", "project dashboard template");
@@ -99,6 +101,8 @@ includes(pageSource, "class=\"govuk-summary-list\"", "project dashboard page");
 includes(pageSource, "id=\"project-title\"", "project dashboard page");
 includes(pageSource, "id=\"breadcrumb-project\"", "project dashboard page");
 includes(pageSource, "id=\"daas-brand-panel\"", "project dashboard page");
+excludes(pageSource, "id=\"mural-status\"", "project dashboard page");
+excludes(pageSource, "class=\"rops-mural-status\"", "project dashboard page");
 includes(pageSource, "class=\"rops-daas-brand-panel\"", "project dashboard page");
 includes(pageSource, "class=\"rops-dashboard-layout\"", "project dashboard page");
 includes(pageSource, "class=\"rops-dashboard-sidebar\"", "project dashboard page");
@@ -213,6 +217,8 @@ includes(muralIntegrationSource, "function setSetupAsCreate(projectId, projectNa
 includes(muralIntegrationSource, "function setSetupAsOpen(projectId, boardUrl)", "Mural integration component");
 includes(muralIntegrationSource, "function observeProjectMeta()", "Mural integration component");
 includes(muralIntegrationSource, "function hideConnectButton()", "Mural integration component");
+includes(muralIntegrationSource, "function disableAll()", "Mural integration component");
+includes(muralIntegrationSource, "function disableAll() {\n\t\thideConnectButton();", "Mural integration component");
 includes(muralIntegrationSource, "function setGovukTag(el, text, modifier = \"govuk-tag--grey\")", "Mural integration component");
 includes(muralIntegrationSource, "function setOpenLinkState(enabled, boardUrl = \"\")", "Mural integration component");
 includes(muralIntegrationSource, "jsonFetch(addDebug(`${API_ORIGIN}/api/health`)).catch(() => {});", "Mural integration component");
@@ -253,6 +259,9 @@ includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2
 includes(dashboardSassSource, "align-self: start;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard Sass source");
 includes(dashboardSassSource, "margin-bottom: 0;", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-link-panel .govuk-button", "project dashboard Sass source");
+includes(dashboardSassSource, "margin-bottom: 8px;", "project dashboard Sass source");
+excludes(dashboardSassSource, ".rops-mural-status", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "position: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "top: 1rem;", "project dashboard Sass source");
@@ -278,6 +287,9 @@ includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2f
 includes(dashboardCssSource, "align-self: start;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard stylesheet");
 includes(dashboardCssSource, "margin-bottom: 0;", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-link-panel .govuk-button", "project dashboard stylesheet");
+includes(dashboardCssSource, "margin-bottom: 8px;", "project dashboard stylesheet");
+excludes(dashboardCssSource, ".rops-mural-status", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "position: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "top: 1rem;", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -71,6 +71,18 @@ assert.equal(
 	"Expected DaaS brand panel to render before the dashboard layout",
 );
 assert.equal(
+	templateSource.indexOf("class=\"rops-dashboard-header\"") <
+		templateSource.indexOf("class=\"rops-dashboard-sidebar\""),
+	true,
+	"Expected dashboard header to render before the sidebar in source order",
+);
+assert.equal(
+	templateSource.indexOf("id=\"project-title\"") <
+		templateSource.indexOf("class=\"govuk-summary-card rops-project-areas-nav\""),
+	true,
+	"Expected project title to render before the project areas navigation",
+);
+assert.equal(
 	templateSource.indexOf("class=\"rops-dashboard-sidebar\"") <
 		templateSource.indexOf("class=\"rops-dashboard-content\""),
 	true,
@@ -173,6 +185,17 @@ assert.equal(
 	pageSource.indexOf("id=\"daas-brand-panel\"") < pageSource.indexOf("class=\"rops-dashboard-layout\""),
 	true,
 	"Expected DaaS brand panel to stay before the dashboard layout",
+);
+assert.equal(
+	pageSource.indexOf("class=\"rops-dashboard-header\"") < pageSource.indexOf("class=\"rops-dashboard-sidebar\""),
+	true,
+	"Expected rendered dashboard header to come before the sidebar in source order",
+);
+assert.equal(
+	pageSource.indexOf("id=\"project-title\"") <
+		pageSource.indexOf("class=\"govuk-summary-card rops-project-areas-nav\""),
+	true,
+	"Expected rendered project title to come before the project areas navigation",
 );
 assert.equal(
 	pageSource.indexOf("class=\"rops-dashboard-sidebar\"") < pageSource.indexOf("class=\"rops-dashboard-content\""),
@@ -338,11 +361,18 @@ includes(dashboardSassSource, ".rops-dashboard-sidebar", "project dashboard Sass
 includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-grid > .govuk-summary-card", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-grid {\n\tdisplay: grid;\n\tgap: 30px;", "project dashboard Sass source");
+includes(dashboardSassSource, "column-gap: 20px;", "project dashboard Sass source");
+includes(dashboardSassSource, "row-gap: 30px;", "project dashboard Sass source");
 includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-header {\n\t\tgrid-column: 2;\n\t\tgrid-row: 1;", "project dashboard Sass source");
 includes(dashboardSassSource, "align-self: start;", "project dashboard Sass source");
+includes(dashboardSassSource, "grid-row: 1 / span 2;", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-content {\n\t\tgrid-column: 2;\n\t\tgrid-row: 2;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard Sass source");
 includes(dashboardSassSource, "margin-bottom: 0;", "project dashboard Sass source");
 includes(dashboardSassSource, ".govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s", "project dashboard Sass source");
+includes(dashboardSassSource, ".govuk-body,", "project dashboard Sass source");
+includes(dashboardSassSource, "dl.govuk-body-s {\n\tfont-size: inherit;\n\tline-height: inherit;", "project dashboard Sass source");
 includes(dashboardSassSource, ".govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s", "project dashboard Sass source");
 includes(dashboardSassSource, ".govuk-summary-list__value", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-link-panel .govuk-button", "project dashboard Sass source");
@@ -350,7 +380,7 @@ includes(dashboardSassSource, "margin-bottom: 8px;", "project dashboard Sass sou
 includes(dashboardSassSource, "#mural-connect[hidden]", "project dashboard Sass source");
 includes(dashboardSassSource, "display: none;", "project dashboard Sass source");
 excludes(dashboardSassSource, ".rops-mural-status", "project dashboard Sass source");
-includes(dashboardSassSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-sidebar {\n\t\tgrid-column: 1;", "project dashboard Sass source");
 includes(dashboardSassSource, "position: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "top: 1rem;", "project dashboard Sass source");
 includes(dashboardSassSource, "@media (min-width: 40.0625em)", "project dashboard Sass source");
@@ -373,11 +403,22 @@ includes(dashboardCssSource, ".rops-dashboard-sidebar", "project dashboard style
 includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-grid > .govuk-summary-card", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-grid {\n\tdisplay: grid;\n\tgap: 30px;", "project dashboard stylesheet");
+includes(dashboardCssSource, "column-gap: 20px;", "project dashboard stylesheet");
+includes(dashboardCssSource, "row-gap: 30px;", "project dashboard stylesheet");
 includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-header {\n\t\tgrid-column: 2;\n\t\tgrid-row: 1;", "project dashboard stylesheet");
 includes(dashboardCssSource, "align-self: start;", "project dashboard stylesheet");
+includes(dashboardCssSource, "grid-row: 1/span 2;", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-content {\n\t\tgrid-column: 2;\n\t\tgrid-row: 2;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard stylesheet");
 includes(dashboardCssSource, "margin-bottom: 0;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s", "project dashboard stylesheet");
+includes(dashboardCssSource, ".govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s .govuk-body", "project dashboard stylesheet");
+includes(
+	dashboardCssSource,
+	".govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s dl.govuk-body-s",
+	"project dashboard stylesheet",
+);
 includes(dashboardCssSource, ".govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s", "project dashboard stylesheet");
 includes(dashboardCssSource, ".govuk-summary-list__value", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-link-panel .govuk-button", "project dashboard stylesheet");
@@ -385,7 +426,7 @@ includes(dashboardCssSource, "margin-bottom: 8px;", "project dashboard styleshee
 includes(dashboardCssSource, "#mural-connect[hidden]", "project dashboard stylesheet");
 includes(dashboardCssSource, "display: none;", "project dashboard stylesheet");
 excludes(dashboardCssSource, ".rops-mural-status", "project dashboard stylesheet");
-includes(dashboardCssSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-sidebar {\n\t\tgrid-column: 1;", "project dashboard stylesheet");
 includes(dashboardCssSource, "position: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "top: 1rem;", "project dashboard stylesheet");
 includes(dashboardCssSource, "@media (min-width: 40.0625em)", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -34,6 +34,7 @@ includes(templateSource, "{% from \"govuk/components/button/macro.njk\" import g
 includes(templateSource, "id=\"mural-integration\"", "project dashboard template");
 excludes(templateSource, "id=\"mural-status\"", "project dashboard template");
 excludes(templateSource, "class=\"rops-mural-status\"", "project dashboard template");
+includes(templateSource, "id: \"mural-connect\",\n\t\t\t\t\t\t\t\t\thidden: \"hidden\"", "project dashboard template");
 includes(templateSource, "id=\"journal-link\"", "project dashboard template");
 includes(templateSource, "id=\"outcomes-card-link\"", "project dashboard template");
 includes(templateSource, "{% from \"macros/daas-brand-panel.njk\" import daasBrandPanel %}", "project dashboard template");
@@ -108,6 +109,8 @@ includes(pageSource, "class=\"rops-dashboard-layout\"", "project dashboard page"
 includes(pageSource, "class=\"rops-dashboard-sidebar\"", "project dashboard page");
 includes(pageSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "project dashboard page");
 includes(pageSource, "class=\"rops-dashboard-content\"", "project dashboard page");
+includes(pageSource, "id=\"mural-connect\"", "project dashboard page");
+includes(pageSource, "hidden", "project dashboard page");
 assert.equal(
 	pageSource.indexOf("id=\"daas-brand-panel\"") < pageSource.indexOf("class=\"rops-dashboard-layout\""),
 	true,
@@ -255,12 +258,16 @@ includes(dashboardSassSource, ".rops-daas-brand-panel", "project dashboard Sass 
 includes(dashboardSassSource, ".rops-dashboard-layout", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-grid > .govuk-summary-card", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-grid {\n\tdisplay: grid;\n\tgap: 30px;", "project dashboard Sass source");
 includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);", "project dashboard Sass source");
 includes(dashboardSassSource, "align-self: start;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard Sass source");
 includes(dashboardSassSource, "margin-bottom: 0;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-link-panel .govuk-button", "project dashboard Sass source");
 includes(dashboardSassSource, "margin-bottom: 8px;", "project dashboard Sass source");
+includes(dashboardSassSource, "#mural-connect[hidden]", "project dashboard Sass source");
+includes(dashboardSassSource, "display: none;", "project dashboard Sass source");
 excludes(dashboardSassSource, ".rops-mural-status", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "position: sticky;", "project dashboard Sass source");
@@ -283,12 +290,16 @@ includes(dashboardCssSource, ".rops-daas-brand-panel", "project dashboard styles
 includes(dashboardCssSource, ".rops-dashboard-layout", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-grid > .govuk-summary-card", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-grid {\n\tdisplay: grid;\n\tgap: 30px;", "project dashboard stylesheet");
 includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);", "project dashboard stylesheet");
 includes(dashboardCssSource, "align-self: start;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard stylesheet");
 includes(dashboardCssSource, "margin-bottom: 0;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-link-panel .govuk-button", "project dashboard stylesheet");
 includes(dashboardCssSource, "margin-bottom: 8px;", "project dashboard stylesheet");
+includes(dashboardCssSource, "#mural-connect[hidden]", "project dashboard stylesheet");
+includes(dashboardCssSource, "display: none;", "project dashboard stylesheet");
 excludes(dashboardCssSource, ".rops-mural-status", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "position: sticky;", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -204,6 +204,9 @@ includes(controllerSource, "project.teamNames", "project dashboard controller");
 includes(controllerSource, ".flatMap(brandValues)", "project dashboard controller");
 includes(controllerSource, "rops-daas-brand-panel--visible", "project dashboard controller");
 includes(controllerSource, "function renderStudies", "project dashboard controller");
+includes(controllerSource, "function isStudiesUnavailableError", "project dashboard controller");
+includes(controllerSource, "if (isStudiesUnavailableError(error)) return [];", "project dashboard controller");
+includes(controllerSource, "No studies have been created for this project yet.", "project dashboard controller");
 includes(controllerSource, "function setTagText", "project dashboard controller");
 includes(controllerSource, "project[\"Service stage\"]", "project dashboard controller");
 includes(controllerSource, "project[\"Project stage\"]", "project dashboard controller");
@@ -212,6 +215,8 @@ includes(controllerSource, "setTagText(\"project-stage-tag\", project.status", "
 includes(controllerSource, "method: \"PATCH\"", "project dashboard controller");
 includes(controllerSource, "credentials: \"include\"", "project dashboard controller");
 includes(controllerSource, "class=\"govuk-link govuk-!-font-weight-bold\"", "project dashboard controller");
+excludes(controllerSource, "Could not load studies", "project dashboard controller");
+excludes(controllerSource, "Study records could not be loaded for this project.", "project dashboard controller");
 excludes(controllerSource, "Service stage not recorded", "project dashboard controller");
 excludes(controllerSource, "Project stage not recorded", "project dashboard controller");
 excludes(controllerSource, "rops-api.digikev-kevin-rapley.workers.dev", "project dashboard controller");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -36,6 +36,20 @@ includes(templateSource, "id=\"journal-link\"", "project dashboard template");
 includes(templateSource, "id=\"outcomes-card-link\"", "project dashboard template");
 includes(templateSource, "{% from \"macros/daas-brand-panel.njk\" import daasBrandPanel %}", "project dashboard template");
 includes(templateSource, "{{ daasBrandPanel() }}", "project dashboard template");
+includes(templateSource, "class=\"rops-dashboard-layout\"", "project dashboard template");
+includes(templateSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "project dashboard template");
+includes(templateSource, "class=\"rops-dashboard-content\"", "project dashboard template");
+assert.equal(
+	templateSource.indexOf("{{ daasBrandPanel() }}") < templateSource.indexOf("class=\"rops-dashboard-layout\""),
+	true,
+	"Expected DaaS brand panel to render before the dashboard layout",
+);
+assert.equal(
+	templateSource.indexOf("class=\"govuk-summary-card rops-project-areas-nav\"") <
+		templateSource.indexOf("class=\"rops-dashboard-content\""),
+	true,
+	"Expected project areas navigation to render before dashboard content",
+);
 includes(daasPanelMacroSource, "id=\"daas-brand-panel\"", "DaaS brand panel macro");
 includes(daasPanelMacroSource, "class=\"rops-daas-brand-panel\"", "DaaS brand panel macro");
 includes(daasPanelMacroSource, "/images/brands/daas-logo.svg", "DaaS brand panel macro");
@@ -73,6 +87,20 @@ includes(pageSource, "id=\"project-title\"", "project dashboard page");
 includes(pageSource, "id=\"breadcrumb-project\"", "project dashboard page");
 includes(pageSource, "id=\"daas-brand-panel\"", "project dashboard page");
 includes(pageSource, "class=\"rops-daas-brand-panel\"", "project dashboard page");
+includes(pageSource, "class=\"rops-dashboard-layout\"", "project dashboard page");
+includes(pageSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "project dashboard page");
+includes(pageSource, "class=\"rops-dashboard-content\"", "project dashboard page");
+assert.equal(
+	pageSource.indexOf("id=\"daas-brand-panel\"") < pageSource.indexOf("class=\"rops-dashboard-layout\""),
+	true,
+	"Expected DaaS brand panel to stay before the dashboard layout",
+);
+assert.equal(
+	pageSource.indexOf("class=\"govuk-summary-card rops-project-areas-nav\"") <
+		pageSource.indexOf("class=\"rops-dashboard-content\""),
+	true,
+	"Expected project areas navigation to render before dashboard content",
+);
 includes(pageSource, "/images/brands/daas-logo.svg", "project dashboard page");
 includes(pageSource, "project-dashboard.js?v=project-dashboard-daas-brand-20260616", "project dashboard page");
 includes(pageSource, "project-dashboard.css?v=project-dashboard-daas-brand-20260616", "project dashboard page");
@@ -193,6 +221,9 @@ excludes(muralStateSource, "syncDashboardPresentation", "Project Dashboard Mural
 
 includes(dashboardSassSource, ".rops-dashboard-header", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-daas-brand-panel", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-layout", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
+includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard Sass source");
 includes(dashboardSassSource, "@media (min-width: 40.0625em)", "project dashboard Sass source");
 includes(dashboardSassSource, "#1a1d35", "project dashboard Sass source");
 includes(dashboardSassSource, "home-office-digital-triangles.svg", "project dashboard Sass source");
@@ -208,6 +239,9 @@ includes(dashboardSassSource, "text-overflow: ellipsis;", "project dashboard Sas
 includes(dashboardSassSource, "/* transparency begins in the cascade */", "project dashboard Sass source");
 includes(dashboardCssSource, ".rops-dashboard-header", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-daas-brand-panel", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-layout", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
+includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard stylesheet");
 includes(dashboardCssSource, "@media (min-width: 40.0625em)", "project dashboard stylesheet");
 includes(dashboardCssSource, "#1a1d35", "project dashboard stylesheet");
 includes(dashboardCssSource, "home-office-digital-triangles.svg", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -37,6 +37,7 @@ includes(templateSource, "id=\"outcomes-card-link\"", "project dashboard templat
 includes(templateSource, "{% from \"macros/daas-brand-panel.njk\" import daasBrandPanel %}", "project dashboard template");
 includes(templateSource, "{{ daasBrandPanel() }}", "project dashboard template");
 includes(templateSource, "class=\"rops-dashboard-layout\"", "project dashboard template");
+includes(templateSource, "class=\"rops-dashboard-sidebar\"", "project dashboard template");
 includes(templateSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "project dashboard template");
 includes(templateSource, "class=\"rops-dashboard-content\"", "project dashboard template");
 assert.equal(
@@ -45,10 +46,22 @@ assert.equal(
 	"Expected DaaS brand panel to render before the dashboard layout",
 );
 assert.equal(
-	templateSource.indexOf("class=\"govuk-summary-card rops-project-areas-nav\"") <
+	templateSource.indexOf("class=\"rops-dashboard-sidebar\"") <
 		templateSource.indexOf("class=\"rops-dashboard-content\""),
 	true,
-	"Expected project areas navigation to render before dashboard content",
+	"Expected dashboard sidebar to render before dashboard content",
+);
+assert.equal(
+	templateSource.indexOf("class=\"govuk-summary-card rops-project-areas-nav\"") <
+		templateSource.indexOf("<section class=\"govuk-summary-card\" id=\"reflexive-journal\">"),
+	true,
+	"Expected project areas navigation to render before the reflexive journal panel",
+);
+assert.equal(
+	templateSource.indexOf("<section class=\"govuk-summary-card\" id=\"reflexive-journal\">") <
+		templateSource.indexOf("class=\"rops-dashboard-content\""),
+	true,
+	"Expected reflexive journal panel to render in the sidebar before dashboard content",
 );
 includes(daasPanelMacroSource, "id=\"daas-brand-panel\"", "DaaS brand panel macro");
 includes(daasPanelMacroSource, "class=\"rops-daas-brand-panel\"", "DaaS brand panel macro");
@@ -88,6 +101,7 @@ includes(pageSource, "id=\"breadcrumb-project\"", "project dashboard page");
 includes(pageSource, "id=\"daas-brand-panel\"", "project dashboard page");
 includes(pageSource, "class=\"rops-daas-brand-panel\"", "project dashboard page");
 includes(pageSource, "class=\"rops-dashboard-layout\"", "project dashboard page");
+includes(pageSource, "class=\"rops-dashboard-sidebar\"", "project dashboard page");
 includes(pageSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "project dashboard page");
 includes(pageSource, "class=\"rops-dashboard-content\"", "project dashboard page");
 assert.equal(
@@ -96,10 +110,21 @@ assert.equal(
 	"Expected DaaS brand panel to stay before the dashboard layout",
 );
 assert.equal(
+	pageSource.indexOf("class=\"rops-dashboard-sidebar\"") < pageSource.indexOf("class=\"rops-dashboard-content\""),
+	true,
+	"Expected dashboard sidebar to render before dashboard content",
+);
+assert.equal(
 	pageSource.indexOf("class=\"govuk-summary-card rops-project-areas-nav\"") <
+		pageSource.indexOf("<section class=\"govuk-summary-card\" id=\"reflexive-journal\">"),
+	true,
+	"Expected project areas navigation to render before the reflexive journal panel",
+);
+assert.equal(
+	pageSource.indexOf("<section class=\"govuk-summary-card\" id=\"reflexive-journal\">") <
 		pageSource.indexOf("class=\"rops-dashboard-content\""),
 	true,
-	"Expected project areas navigation to render before dashboard content",
+	"Expected reflexive journal panel to render in the sidebar before dashboard content",
 );
 includes(pageSource, "/images/brands/daas-logo.svg", "project dashboard page");
 includes(pageSource, "project-dashboard.js?v=project-dashboard-daas-brand-20260616", "project dashboard page");
@@ -222,6 +247,7 @@ excludes(muralStateSource, "syncDashboardPresentation", "Project Dashboard Mural
 includes(dashboardSassSource, ".rops-dashboard-header", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-daas-brand-panel", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-layout", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-sidebar", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
 includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard Sass source");
 includes(dashboardSassSource, "position: sticky;", "project dashboard Sass source");
@@ -242,6 +268,7 @@ includes(dashboardSassSource, "/* transparency begins in the cascade */", "proje
 includes(dashboardCssSource, ".rops-dashboard-header", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-daas-brand-panel", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-layout", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-sidebar", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
 includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard stylesheet");
 includes(dashboardCssSource, "position: sticky;", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -249,7 +249,7 @@ includes(dashboardSassSource, ".rops-daas-brand-panel", "project dashboard Sass 
 includes(dashboardSassSource, ".rops-dashboard-layout", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
-includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard Sass source");
+includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);", "project dashboard Sass source");
 includes(dashboardSassSource, "align-self: start;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard Sass source");
 includes(dashboardSassSource, "margin-bottom: 0;", "project dashboard Sass source");
@@ -274,7 +274,7 @@ includes(dashboardCssSource, ".rops-daas-brand-panel", "project dashboard styles
 includes(dashboardCssSource, ".rops-dashboard-layout", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
-includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard stylesheet");
+includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);", "project dashboard stylesheet");
 includes(dashboardCssSource, "align-self: start;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard stylesheet");
 includes(dashboardCssSource, "margin-bottom: 0;", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -121,6 +121,8 @@ includes(templateSource, "href=\"#project-objectives\"", "project dashboard temp
 includes(templateSource, "id=\"project-objectives\"", "project dashboard template");
 includes(templateSource, "Project Objectives", "project dashboard template");
 includes(templateSource, "id=\"objectives-list\"", "project dashboard template");
+includes(templateSource, "class=\"rops-objectives-list\" id=\"objectives-list\"", "project dashboard template");
+excludes(templateSource, "class=\"govuk-list govuk-list--spaced rops-divided-list\" id=\"objectives-list\"", "project dashboard template");
 includes(templateSource, "id: \"add-objective-toggle\"", "project dashboard template");
 assert.equal(
 	templateSource.indexOf("id=\"stakeholders\"") < templateSource.indexOf("id=\"project-objectives\""),
@@ -180,6 +182,8 @@ includes(pageSource, "href=\"#project-objectives\"", "project dashboard page");
 includes(pageSource, "id=\"project-objectives\"", "project dashboard page");
 includes(pageSource, "Project Objectives", "project dashboard page");
 includes(pageSource, "id=\"objectives-list\"", "project dashboard page");
+includes(pageSource, "class=\"rops-objectives-list\" id=\"objectives-list\"", "project dashboard page");
+excludes(pageSource, "class=\"govuk-list govuk-list--spaced rops-divided-list\" id=\"objectives-list\"", "project dashboard page");
 includes(pageSource, "id=\"add-objective-toggle\"", "project dashboard page");
 assert.equal(
 	pageSource.indexOf("id=\"daas-brand-panel\"") < pageSource.indexOf("class=\"rops-dashboard-layout\""),
@@ -252,6 +256,13 @@ includes(controllerSource, "return await loadProjectFromRecord(projectId);", "pr
 includes(controllerSource, "falling back to project list endpoint", "project dashboard controller");
 includes(controllerSource, "function renderProject", "project dashboard controller");
 includes(controllerSource, "function renderProjectBrand", "project dashboard controller");
+includes(controllerSource, "function parseObjectiveMarkdownList", "project dashboard controller");
+includes(controllerSource, "function objectiveLines", "project dashboard controller");
+includes(controllerSource, "function objectiveListHtml", "project dashboard controller");
+includes(controllerSource, "line.match(/^\\d+[.)]\\s+(.+)$/)", "project dashboard controller");
+includes(controllerSource, "line.match(/^[-*+]\\s+(.+)$/)", "project dashboard controller");
+includes(controllerSource, "govuk-list govuk-list--number rops-objective-list", "project dashboard controller");
+includes(controllerSource, "govuk-list govuk-list--bullet rops-objective-list__sublist", "project dashboard controller");
 includes(controllerSource, "function normaliseBrandKey", "project dashboard controller");
 includes(controllerSource, "project.teamName", "project dashboard controller");
 includes(controllerSource, "teamNames: normaliseCommaList(project.teamNames ?? project.team_names ?? project[\"Team Names\"])", "project dashboard controller");
@@ -389,6 +400,9 @@ includes(dashboardSassSource, "home-office-digital-triangles.svg", "project dash
 includes(dashboardSassSource, "background-position: right -3rem bottom -7rem;", "project dashboard Sass source");
 includes(dashboardSassSource, "background-size: 50% 200%;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-study-list", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-objective-list", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-objective-list > li", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-objective-list__sublist > li", "project dashboard Sass source");
 includes(dashboardSassSource, ".dashboard-action-panel", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-planning-grid", "project dashboard Sass source");
 includes(dashboardSassSource, "minmax(170px, 1fr) minmax(0, 1fr);", "project dashboard Sass source");
@@ -435,6 +449,9 @@ includes(dashboardCssSource, "home-office-digital-triangles.svg", "project dashb
 includes(dashboardCssSource, "background-position: right -3rem bottom -7rem", "project dashboard stylesheet");
 includes(dashboardCssSource, "background-size: 50% 200%", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-study-list", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-objective-list", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-objective-list > li", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-objective-list__sublist > li", "project dashboard stylesheet");
 includes(dashboardCssSource, ".dashboard-action-panel", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-planning-grid", "project dashboard stylesheet");
 includes(dashboardCssSource, "minmax(170px, 1fr) minmax(0, 1fr);", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -22,6 +22,17 @@ function excludes(source, text, label) {
 	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
+function countOccurrences(source, text) {
+	return source.split(text).length - 1;
+}
+
+function projectAreasNavSource(source) {
+	const start = source.indexOf("class=\"govuk-summary-card rops-project-areas-nav\"");
+	if (start === -1) return "";
+	const end = source.indexOf("</nav>", start);
+	return source.slice(start, end);
+}
+
 includes(renderGovukPagesSource, "template: 'pages/project-dashboard.njk'", "GOV.UK page renderer");
 includes(renderGovukPagesSource, "output: 'public/pages/project-dashboard/index.html'", "GOV.UK page renderer");
 
@@ -43,6 +54,17 @@ includes(templateSource, "class=\"rops-dashboard-layout\"", "project dashboard t
 includes(templateSource, "class=\"rops-dashboard-sidebar\"", "project dashboard template");
 includes(templateSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "project dashboard template");
 includes(templateSource, "class=\"rops-dashboard-content\"", "project dashboard template");
+assert.equal(
+	countOccurrences(templateSource, "class=\"govuk-summary-card__content govuk-body-s\""),
+	6,
+	"Expected non-navigation dashboard panels to use govuk-body-s content wrappers",
+);
+assert.equal(
+	countOccurrences(templateSource, "class=\"govuk-summary-list govuk-body-s\""),
+	2,
+	"Expected dashboard summary lists to use dl.govuk-body-s",
+);
+excludes(projectAreasNavSource(templateSource), "govuk-summary-card__content govuk-body-s", "project areas navigation template");
 assert.equal(
 	templateSource.indexOf("{{ daasBrandPanel() }}") < templateSource.indexOf("class=\"rops-dashboard-layout\""),
 	true,
@@ -118,7 +140,7 @@ includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "project dashb
 includes(pageSource, "<x-include src=\"/partials/header.html\"", "project dashboard page");
 includes(pageSource, "<x-include src=\"/partials/footer.html\"", "project dashboard page");
 includes(pageSource, "class=\"govuk-summary-card\"", "project dashboard page");
-includes(pageSource, "class=\"govuk-summary-list\"", "project dashboard page");
+includes(pageSource, "class=\"govuk-summary-list govuk-body-s\"", "project dashboard page");
 includes(pageSource, "id=\"project-title\"", "project dashboard page");
 includes(pageSource, "id=\"breadcrumb-project\"", "project dashboard page");
 includes(pageSource, "id=\"daas-brand-panel\"", "project dashboard page");
@@ -129,6 +151,17 @@ includes(pageSource, "class=\"rops-dashboard-layout\"", "project dashboard page"
 includes(pageSource, "class=\"rops-dashboard-sidebar\"", "project dashboard page");
 includes(pageSource, "class=\"govuk-summary-card rops-project-areas-nav\"", "project dashboard page");
 includes(pageSource, "class=\"rops-dashboard-content\"", "project dashboard page");
+assert.equal(
+	countOccurrences(pageSource, "class=\"govuk-summary-card__content govuk-body-s\""),
+	6,
+	"Expected rendered non-navigation dashboard panels to use govuk-body-s content wrappers",
+);
+assert.equal(
+	countOccurrences(pageSource, "class=\"govuk-summary-list govuk-body-s\""),
+	2,
+	"Expected rendered dashboard summary lists to use dl.govuk-body-s",
+);
+excludes(projectAreasNavSource(pageSource), "govuk-summary-card__content govuk-body-s", "rendered project areas navigation");
 includes(pageSource, "id=\"mural-connect\"", "project dashboard page");
 includes(pageSource, "hidden", "project dashboard page");
 includes(pageSource, "href=\"#project-objectives\"", "project dashboard page");
@@ -309,6 +342,9 @@ includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2
 includes(dashboardSassSource, "align-self: start;", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard Sass source");
 includes(dashboardSassSource, "margin-bottom: 0;", "project dashboard Sass source");
+includes(dashboardSassSource, ".govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s", "project dashboard Sass source");
+includes(dashboardSassSource, ".govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s", "project dashboard Sass source");
+includes(dashboardSassSource, ".govuk-summary-list__value", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-link-panel .govuk-button", "project dashboard Sass source");
 includes(dashboardSassSource, "margin-bottom: 8px;", "project dashboard Sass source");
 includes(dashboardSassSource, "#mural-connect[hidden]", "project dashboard Sass source");
@@ -341,6 +377,9 @@ includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 2f
 includes(dashboardCssSource, "align-self: start;", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-dashboard-sidebar > .govuk-summary-card", "project dashboard stylesheet");
 includes(dashboardCssSource, "margin-bottom: 0;", "project dashboard stylesheet");
+includes(dashboardCssSource, ".govuk-summary-card:not(.rops-project-areas-nav) .govuk-summary-card__content.govuk-body-s", "project dashboard stylesheet");
+includes(dashboardCssSource, ".govuk-summary-card:not(.rops-project-areas-nav) dl.govuk-body-s", "project dashboard stylesheet");
+includes(dashboardCssSource, ".govuk-summary-list__value", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-link-panel .govuk-button", "project dashboard stylesheet");
 includes(dashboardCssSource, "margin-bottom: 8px;", "project dashboard stylesheet");
 includes(dashboardCssSource, "#mural-connect[hidden]", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -250,6 +250,8 @@ includes(dashboardSassSource, ".rops-dashboard-layout", "project dashboard Sass 
 includes(dashboardSassSource, ".rops-dashboard-sidebar", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
 includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard Sass source");
+includes(dashboardSassSource, "align-self: start;", "project dashboard Sass source");
+includes(dashboardSassSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "position: sticky;", "project dashboard Sass source");
 includes(dashboardSassSource, "top: 1rem;", "project dashboard Sass source");
 includes(dashboardSassSource, "@media (min-width: 40.0625em)", "project dashboard Sass source");
@@ -271,6 +273,8 @@ includes(dashboardCssSource, ".rops-dashboard-layout", "project dashboard styles
 includes(dashboardCssSource, ".rops-dashboard-sidebar", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
 includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard stylesheet");
+includes(dashboardCssSource, "align-self: start;", "project dashboard stylesheet");
+includes(dashboardCssSource, ".rops-dashboard-sidebar {\n\t\tposition: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "position: sticky;", "project dashboard stylesheet");
 includes(dashboardCssSource, "top: 1rem;", "project dashboard stylesheet");
 includes(dashboardCssSource, "@media (min-width: 40.0625em)", "project dashboard stylesheet");

--- a/tests/project-dashboard-route-state.test.js
+++ b/tests/project-dashboard-route-state.test.js
@@ -224,6 +224,8 @@ includes(dashboardSassSource, ".rops-daas-brand-panel", "project dashboard Sass 
 includes(dashboardSassSource, ".rops-dashboard-layout", "project dashboard Sass source");
 includes(dashboardSassSource, ".rops-project-areas-nav", "project dashboard Sass source");
 includes(dashboardSassSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard Sass source");
+includes(dashboardSassSource, "position: sticky;", "project dashboard Sass source");
+includes(dashboardSassSource, "top: 1rem;", "project dashboard Sass source");
 includes(dashboardSassSource, "@media (min-width: 40.0625em)", "project dashboard Sass source");
 includes(dashboardSassSource, "#1a1d35", "project dashboard Sass source");
 includes(dashboardSassSource, "home-office-digital-triangles.svg", "project dashboard Sass source");
@@ -242,6 +244,8 @@ includes(dashboardCssSource, ".rops-daas-brand-panel", "project dashboard styles
 includes(dashboardCssSource, ".rops-dashboard-layout", "project dashboard stylesheet");
 includes(dashboardCssSource, ".rops-project-areas-nav", "project dashboard stylesheet");
 includes(dashboardCssSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);", "project dashboard stylesheet");
+includes(dashboardCssSource, "position: sticky;", "project dashboard stylesheet");
+includes(dashboardCssSource, "top: 1rem;", "project dashboard stylesheet");
 includes(dashboardCssSource, "@media (min-width: 40.0625em)", "project dashboard stylesheet");
 includes(dashboardCssSource, "#1a1d35", "project dashboard stylesheet");
 includes(dashboardCssSource, "home-office-digital-triangles.svg", "project dashboard stylesheet");


### PR DESCRIPTION
## Summary
- Keep the DaaS brand panel full width before the dashboard layout.
- Move Project areas and Reflexive journal into a sticky left sidebar, with the main dashboard content in the right column.
- Use a one-third / two-thirds desktop layout and preserve the single-column mobile layout.
- Move Objectives into a separate Project Objectives panel beneath Stakeholder management.
- Hide the disabled Connect Mural button while keeping it in the HTML.
- Treat the no-studies Research outcomes state as normal empty content instead of surfacing studies_unavailable or technical detail to users.
- Apply govuk-body-s to non-navigation dashboard panel content, with dl.govuk-body-s summary lists so dt and dd inherit the smaller size.

## Audit trace
- docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.md
- docs/agent-audit/reasoning/2026/06/23/project-dashboard-areas-nav-layout.json

## Validation
- node --test tests/project-dashboard-route-state.test.js tests/govuk-design-system-baseline-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js
- npm run format:check
- npm run lint (passes with existing warnings)
- npm test (245 tests passed)
- npm run validate
- Browser checks for desktop/mobile layout, sticky sidebar, sidebar ratio, panel spacing, and Mural button connected/disconnected states

Note: npm test -- --ci cannot run in this repo state because the script passes --ci through to Node, which exits with node: bad option: --ci.