### PR TITLE
Fix signed-out header sign-in link

### DIFF
--- a/docs/agent-audit/reasoning/2026/06/23/signed-out-header-sign-in-link.json
+++ b/docs/agent-audit/reasoning/2026/06/23/signed-out-header-sign-in-link.json
@@ -1,0 +1,98 @@
+{
+  "traceId": "atrace-20260623-signed-out-header-sign-in-link",
+  "date": "2026-06-23",
+  "branch": "fix/signed-out-header-sign-in-link",
+  "traceRequired": true,
+  "traceReason": "repository-affecting work on a fix/ branch",
+  "taskSummary": "Show a Sign in link in the shared header when the user is not logged in, replacing the username and Sign out links.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch, trace and validation discipline.",
+    "ResearchOps Developer Control governed service-specific auth header behaviour.",
+    "Multi-Functional Team governed user-facing clarity for signed-out account state.",
+    "GOV.UK Design System governed header/navigation accessibility and link clarity."
+  ],
+  "filesRead": [
+    "README.md",
+    ".github/CODEOWNERS",
+    ".github/pull_request_template.md",
+    ".github/workflows/ci.yml",
+    ".github/workflows/validate.yml",
+    ".github/workflows/render-govuk-pages.yml",
+    "package.json",
+    "package-lock.json",
+    "RECENT_LEARNINGS.md",
+    "public/partials/header.html",
+    "public/js/auth-header-links.js",
+    "public/js/govuk-frontend-init.js",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "tests/auth-header-links-route-state.test.js",
+    "tests/auth-story-1-acceptance-route-state.test.js"
+  ],
+  "filesModifiedOrCreated": [
+    "docs/agent-audit/reasoning/2026/06/23/signed-out-header-sign-in-link.md",
+    "docs/agent-audit/reasoning/2026/06/23/signed-out-header-sign-in-link.json",
+    "public/js/auth-header-links.js",
+    "public/js/govuk-frontend-init.js",
+    "public/pages/account/index.html",
+    "public/partials/header.html",
+    "scripts/govuk/render-govuk-pages.mjs",
+    "tests/auth-header-links-route-state.test.js"
+  ],
+  "validation": [
+    "npm run agent:model -- task text: passed",
+    "npm test -- tests/auth-header-links-route-state.test.js: passed",
+    "npm test -- tests/auth-header-links-route-state.test.js tests/auth-story-1-acceptance-route-state.test.js: passed, 2 tests",
+    "npx prettier -c touched files: passed",
+    "npm run build:govuk-pages: passed",
+    "browser check with /api/me returning 401: passed",
+    "npm run lint: passed with existing repository warnings and no errors",
+    "npm test: passed, 245 tests",
+    "npm run trace:coverage -- --date 2026-06-23: passed",
+    "git diff --check: passed"
+  ],
+  "validationNotRun": [
+    "Live Cloudflare deployment verification was not run because this change only updates static header markup and client-side header state handling."
+  ],
+  "residualRisks": [
+    "The signed-out browser check used a local static server and mocked unauthenticated /api/me response.",
+    "Existing repository-wide lint warnings remain outside this change."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/23/signed-out-header-sign-in-link.md
+++ b/docs/agent-audit/reasoning/2026/06/23/signed-out-header-sign-in-link.md
@@ -1,0 +1,88 @@
+# Trace - signed-out header sign-in link
+
+- Date: 2026-06-23
+- Branch: `fix/signed-out-header-sign-in-link`
+- Trace decision: required because this is repository-affecting work on a `fix/` branch.
+- Task: when a user is not logged in to the ResearchOps service, replace the username and Sign out header links with a Sign in link that takes the user to the sign-in page.
+
+## Operating Model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped conditional bundles:
+
+- `cloudflare`: no Worker, binding, route or deployment behaviour was changed.
+- `openai-platform`: no OpenAI API or model behaviour was changed.
+- `mcp-agent-tooling`: no MCP or agent-tool contract behaviour was changed.
+- `airtable-public-api`: no Airtable integration behaviour was changed.
+- `mural-public-api`: no Mural integration behaviour was changed.
+
+Precedence applied:
+
+- GitHub Diamond governed branch, trace and validation discipline.
+- ResearchOps Developer Control governed service-specific auth header behaviour.
+- Multi-Functional Team governed user-facing clarity for signed-out account state.
+- GOV.UK Design System governed header/navigation accessibility and link clarity.
+
+## Files Read
+
+- `README.md`
+- `.github/CODEOWNERS`
+- `.github/pull_request_template.md`
+- `.github/workflows/ci.yml`
+- `.github/workflows/validate.yml`
+- `.github/workflows/render-govuk-pages.yml`
+- `package.json`
+- `package-lock.json`
+- `RECENT_LEARNINGS.md`
+- `public/partials/header.html`
+- `public/js/auth-header-links.js`
+- `public/js/govuk-frontend-init.js`
+- `scripts/govuk/render-govuk-pages.mjs`
+- `tests/auth-header-links-route-state.test.js`
+- `tests/auth-story-1-acceptance-route-state.test.js`
+
+## Changes
+
+- Updated the shared header default account state to show a visible `Sign in` link to `/pages/account/sign-in/`.
+- Kept the `Sign out` link hidden by default and made `auth-header-links.js` reveal it only after `/api/me` confirms a signed-in account.
+- Added signed-out rendering behaviour for failed, unauthenticated or empty account responses.
+- Bumped the auth header cache key from `header-account-links-20260615-2` to `header-account-links-20260623-1`.
+- Updated the generated account page and the route-state test expectations for the new default signed-out header state.
+
+## Validation
+
+- `npm run agent:model -- "<task>"`: passed; selected GitHub Diamond, ResearchOps Developer Control, Multi-Functional Team and GOV.UK Design System bundles.
+- `npm test -- tests/auth-header-links-route-state.test.js`: passed.
+- `npm test -- tests/auth-header-links-route-state.test.js tests/auth-story-1-acceptance-route-state.test.js`: passed, 2 tests.
+- `npx prettier -c public/partials/header.html public/js/auth-header-links.js public/js/govuk-frontend-init.js scripts/govuk/render-govuk-pages.mjs public/pages/account/index.html tests/auth-header-links-route-state.test.js`: passed.
+- `npm run build:govuk-pages`: passed.
+- Browser check with `/api/me` returning 401: passed; `Sign in` was visible, linked to `/pages/account/sign-in/`, and `Sign out` was hidden.
+- `npm run lint`: passed with existing repository warnings and no errors.
+- `npm test`: passed, 245 tests.
+- `npm run trace:coverage -- --date 2026-06-23`: passed.
+- `git diff --check`: passed.
+
+## Residual Risk
+
+- The check covered the signed-out path locally with a static server and mocked unauthenticated `/api/me`; live Cloudflare deployment was not changed or verified.
+- Existing repository-wide lint warnings remain outside this change.

--- a/public/js/auth-header-links.js
+++ b/public/js/auth-header-links.js
@@ -77,12 +77,20 @@ function hydrateAccountLinks(root = document) {
 function renderSignedInUser(elements, context) {
 	const name = displayName(context).trim();
 	if (!name) {
-		setVisible(elements.accountNav, false);
+		renderSignedOutUser(elements);
 		return;
 	}
 
 	elements.userLink.textContent = name;
 	elements.userLink.setAttribute('href', CONFIG.ACCOUNT_URL);
+	setVisible(elements.signOutLink, true);
+	setVisible(elements.accountNav, true);
+}
+
+function renderSignedOutUser(elements) {
+	elements.userLink.textContent = 'Sign in';
+	elements.userLink.setAttribute('href', CONFIG.SIGN_IN_URL);
+	setVisible(elements.signOutLink, false);
 	setVisible(elements.accountNav, true);
 }
 
@@ -107,10 +115,13 @@ async function init(root = document) {
 
 	try {
 		const response = await fetchJson('/api/me');
-		if (!response.ok || !response.data?.ok) return;
+		if (!response.ok || !response.data?.ok) {
+			renderSignedOutUser(elements);
+			return;
+		}
 		renderSignedInUser(elements, response.data);
 	} catch {
-		setVisible(elements.accountNav, false);
+		renderSignedOutUser(elements);
 	}
 }
 
@@ -140,6 +151,7 @@ window.__ropsAuthHeaderLinks = Object.freeze({
 	hydrateAccountLinks,
 	initAuthHeaderLinks,
 	renderSignedInUser,
+	renderSignedOutUser,
 });
 
 export { initAuthHeaderLinks };

--- a/public/js/govuk-frontend-init.js
+++ b/public/js/govuk-frontend-init.js
@@ -22,7 +22,7 @@ document.addEventListener('x-include:loaded', (event) => {
 	initialiseGovukFrontend(event.target);
 	const src = event?.detail?.src || event?.target?.getAttribute?.('src') || '';
 	if (String(src).startsWith('/partials/header.html')) {
-		import('/js/auth-header-links.js?v=header-account-links-20260615-2').then((module) => {
+		import('/js/auth-header-links.js?v=header-account-links-20260623-1').then((module) => {
 			module.initAuthHeaderLinks(event.target);
 		});
 	}

--- a/public/pages/account/index.html
+++ b/public/pages/account/index.html
@@ -6,8 +6,8 @@
 		<title>Your ResearchOps account - ResearchOps Demo Suite</title>
 		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
-		<script type="module" src="/components/layout.js?v=header-account-links-20260615-2" defer></script>
-		<script type="module" src="/js/govuk-frontend-init.js?v=header-account-links-20260615-2" defer></script>
+		<script type="module" src="/components/layout.js?v=header-account-links-20260623-1" defer></script>
+		<script type="module" src="/js/govuk-frontend-init.js?v=header-account-links-20260623-1" defer></script>
 	</head>
 	<body class="govuk-template__body">
 		<script>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -98,9 +98,9 @@
 				<span class="govuk-header__product-name">ResearchOps Demo Suite</span>
 			</a>
 		</div>
-		<nav class="researchops-header__account" aria-label="Account" data-auth-header-account hidden>
-			<a class="govuk-header__link researchops-header__account-link" href="/pages/account/" data-auth-header-user>User name</a>
-			<a class="govuk-header__link researchops-header__account-link" href="/pages/account/sign-in/" data-auth-header-sign-out>Sign out</a>
+		<nav class="researchops-header__account" aria-label="Account" data-auth-header-account>
+			<a class="govuk-header__link researchops-header__account-link" href="/pages/account/sign-in/" data-auth-header-user>Sign in</a>
+			<a class="govuk-header__link researchops-header__account-link" href="/pages/account/sign-in/" data-auth-header-sign-out hidden aria-hidden="true">Sign out</a>
 		</nav>
 	</div>
 
@@ -180,4 +180,4 @@
 	ensureMainContentTarget();
 	initServiceNavigation();
 </script>
-<script type="module" src="/js/auth-header-links.js?v=header-account-links-20260615-2"></script>
+<script type="module" src="/js/auth-header-links.js?v=header-account-links-20260623-1"></script>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -226,7 +226,7 @@ export const govukPages = [
 			pageTitle: 'Your ResearchOps account - ResearchOps Demo Suite',
 			serviceName: 'ResearchOps Demo Suite',
 			activeNavigation: '',
-			layoutCacheKey: 'header-account-links-20260615-2',
+			layoutCacheKey: 'header-account-links-20260623-1',
 			navigation: accountNavigation,
 		},
 	},

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -20,15 +20,15 @@ function excludes(source, text, label) {
 	assert.equal(source.includes(text), false, `Expected ${label} not to include: ${text}`);
 }
 
-function assertSharedHeaderContainsSignedInAccountNavigation() {
+function assertSharedHeaderContainsAccountNavigation() {
 	includes(headerPartial, 'class="researchops-header__account"', 'shared header partial');
 	includes(headerPartial, 'aria-label="Account"', 'shared header partial');
-	includes(headerPartial, 'data-auth-header-account hidden', 'shared header partial');
-	includes(headerPartial, 'href="/pages/account/" data-auth-header-user>User name</a>', 'shared header partial');
-	includes(headerPartial, 'data-auth-header-sign-out>Sign out</a>', 'shared header partial');
+	includes(headerPartial, 'data-auth-header-account>', 'shared header partial');
+	includes(headerPartial, 'href="/pages/account/sign-in/" data-auth-header-user>Sign in</a>', 'shared header partial');
+	includes(headerPartial, 'data-auth-header-sign-out hidden aria-hidden="true">Sign out</a>', 'shared header partial');
 	includes(
 		headerPartial,
-		'<script type="module" src="/js/auth-header-links.js?v=header-account-links-20260615-2"></script>',
+		'<script type="module" src="/js/auth-header-links.js?v=header-account-links-20260623-1"></script>',
 		'shared header partial',
 	);
 }
@@ -42,8 +42,12 @@ function assertHeaderScriptUsesAccountContextSessionCheck() {
 	excludes(headerScript, "fetchJson('/api/me/identity')", 'header auth script');
 	includes(headerScript, 'const hydratedAccountNavs = new WeakSet()', 'header auth script');
 	includes(headerScript, 'hydratedAccountNavs.has(elements.accountNav)', 'header auth script');
+	includes(headerScript, "elements.userLink.textContent = 'Sign in'", 'header auth script');
+	includes(headerScript, "elements.userLink.setAttribute('href', CONFIG.SIGN_IN_URL)", 'header auth script');
 	includes(headerScript, 'elements.userLink.textContent = name', 'header auth script');
 	includes(headerScript, "elements.userLink.setAttribute('href', CONFIG.ACCOUNT_URL)", 'header auth script');
+	includes(headerScript, 'setVisible(elements.signOutLink, true)', 'header auth script');
+	includes(headerScript, 'setVisible(elements.signOutLink, false)', 'header auth script');
 	includes(headerScript, "await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });", 'header auth script');
 	includes(headerScript, 'location.assign(CONFIG.SIGN_IN_URL)', 'header auth script');
 	includes(headerScript, "document.addEventListener('x-include:loaded'", 'header auth script');
@@ -73,18 +77,18 @@ function assertHeaderPartialBypassesStaleIncludeCache() {
 	includes(layoutScript, 'return "no-store";', 'shared include loader');
 	includes(layoutScript, 'new CustomEvent("x-include:loaded", { bubbles: true', 'shared include loader');
 	includes(layoutScript, 'new CustomEvent("x-include:error", { bubbles: true', 'shared include loader');
-	includes(accountPage, '/components/layout.js?v=header-account-links-20260615-2', 'account page');
-	includes(accountPage, '/js/govuk-frontend-init.js?v=header-account-links-20260615-2', 'account page');
+	includes(accountPage, '/components/layout.js?v=header-account-links-20260623-1', 'account page');
+	includes(accountPage, '/js/govuk-frontend-init.js?v=header-account-links-20260623-1', 'account page');
 	includes(accountPage, '<x-include src="/partials/header.html"', 'account page');
 	includes(researchopsLayoutTemplate, '{% if layoutCacheKey %}?v={{ layoutCacheKey }}{% endif %}', 'ResearchOps layout template');
-	includes(govukPageRenderer, "layoutCacheKey: 'header-account-links-20260615-2'", 'GOV.UK page renderer');
+	includes(govukPageRenderer, "layoutCacheKey: 'header-account-links-20260623-1'", 'GOV.UK page renderer');
 	includes(servicePageNormaliser, 'function hasIncludeForPartial', 'service page normaliser');
 	includes(servicePageNormaliser, '(?:\\\\?[^"\']*)?', 'service page normaliser');
 }
 
 function assertSharedInitLoadsHeaderAuthAfterInclude() {
 	includes(govukInitScript, "String(src).startsWith('/partials/header.html')", 'GOV.UK frontend init');
-	includes(govukInitScript, "import('/js/auth-header-links.js?v=header-account-links-20260615-2')", 'GOV.UK frontend init');
+	includes(govukInitScript, "import('/js/auth-header-links.js?v=header-account-links-20260623-1')", 'GOV.UK frontend init');
 	includes(govukInitScript, 'module.initAuthHeaderLinks(event.target)', 'GOV.UK frontend init');
 }
 
@@ -92,7 +96,7 @@ function assertAuthAcceptanceReferencesHeaderSignOut() {
 	includes(authStoryTest, 'assertAC8SignOutIsAvailableAndUnderstandable', 'auth story route-state test');
 }
 
-assertSharedHeaderContainsSignedInAccountNavigation();
+assertSharedHeaderContainsAccountNavigation();
 assertHeaderScriptUsesAccountContextSessionCheck();
 assertHeaderAccountLinksAreRightAligned();
 assertHeaderPartialBypassesStaleIncludeCache();


### PR DESCRIPTION
## What’s changing?
When a user is signed out, the shared ResearchOps header now shows a visible `Sign in` link to `/pages/account/sign-in/` instead of hiding the account area or showing username/sign-out placeholders. The signed-in state still replaces that link with the user name and reveals `Sign out` after `/api/me` confirms the session.

This also updates the auth header cache key, generated account page, route-state assertions, and required audit trace.

Trace: `docs/agent-audit/reasoning/2026/06/23/signed-out-header-sign-in-link.md`

## Why?
Signed-out users need an obvious way to reach the sign-in page from the top-right account area shown in the service header.

## How tested?
- [x] Unit tests: `npm test` passed, 245 tests
- [x] Manual checks: local browser check with `/api/me` returning 401 confirmed `Sign in` is visible, links to `/pages/account/sign-in/`, and `Sign out` is hidden
- [x] Accessibility checks: header link remains a normal navigation link in the `Account` navigation landmark
- [x] Additional validation: `npm run lint`, `npm run build:govuk-pages`, `npm run trace:coverage -- --date 2026-06-23`, `git diff --check`

## Risk / rollout
- [x] Low - scoped to shared header signed-out/signed-in account link behaviour
- [ ] Medium
- [ ] High - behind a feature flag

Rollback: revert commit `0528fd01`.