### PR TITLE
Fix signed-out masthead sign-out visibility

### DIFF
--- a/RECENT_LEARNINGS.md
+++ b/RECENT_LEARNINGS.md
@@ -2,6 +2,14 @@
 
 This file records repeatable repository-specific lessons for ResearchOps agents and maintainers. It is not a changelog.
 
+## 2026-06-24 — Header hidden states need visual CSS assertions and cache-busted shared CSS
+
+Context: PR #425 changed the shared masthead so signed-out users saw a `Sign in` account link and the `Sign out` link used the HTML `hidden` attribute. After merge, the live masthead visually showed both `Sign in` and `Sign out` even though the sign-out link was intended to be hidden. The route-state test only checked the markup and broad account-nav hidden CSS, and the local browser check used accessibility-role visibility rather than also checking computed display and layout dimensions for the hidden anchor. The shared header stylesheet was also loaded without a cache-busting query string.
+
+Learning: A hidden control can be absent from the accessibility tree while still requiring explicit CSS protection and deployed asset cache handling. Shared masthead states need tests that cover individual hidden account links, not only the parent nav. Browser checks for visual regressions should inspect computed `display` and element dimensions for hidden controls, and shared CSS changes that affect deployed header chrome need a versioned stylesheet URL.
+
+Action: When changing signed-in or signed-out header account states, add or update CSS assertions for each hidden account link selector, not just the container. Use a browser check that verifies `display: none` and zero rendered dimensions for hidden controls. Cache-bust shared header CSS when the fix relies on updated CSS reaching already-deployed browsers.
+
 ## 2026-06-04 — Migration work requires a proactive test-contract impact sweep
 
 Context: PR #345 migrated the study page to a new rendering and component model. The implementation work moved faster than the test-contract review. Several CI failures were discovered sequentially because route-state, shared assertion and generated-output tests still referred to legacy markup and contract terms. These included old CSS classes, route IDs, generated stylesheet paths, script URLs, DOM hooks and exact HTML strings that were no longer the correct contract after migration.

--- a/docs/agent-audit/reasoning/2026/06/24/hide-signed-out-sign-out-link.json
+++ b/docs/agent-audit/reasoning/2026/06/24/hide-signed-out-sign-out-link.json
@@ -1,0 +1,92 @@
+{
+  "traceId": "atrace-20260624-hide-signed-out-sign-out-link",
+  "date": "2026-06-24",
+  "branch": "fix/hide-signed-out-sign-out-link",
+  "traceRequired": true,
+  "traceReason": "repository-affecting work on a fix/ branch",
+  "taskSummary": "Fix signed-out masthead state so only Sign in is visually shown and Sign out is hidden.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "precedenceDecisions": [
+    "GitHub Diamond governed branch hygiene, trace creation, validation, commit, push and PR creation.",
+    "ResearchOps Developer Control governed service-specific shared header behaviour.",
+    "Multi-Functional Team governed clear signed-out user-facing account state.",
+    "GOV.UK Design System governed header/navigation accessibility and visual state."
+  ],
+  "filesRead": [
+    "README.md",
+    ".github/CODEOWNERS",
+    ".github/pull_request_template.md",
+    "package.json",
+    "package-lock.json",
+    "RECENT_LEARNINGS.md",
+    "public/partials/header.html",
+    "public/css/govuk/govuk-header-service-brand.css",
+    "public/js/auth-header-links.js",
+    "tests/auth-header-links-route-state.test.js",
+    "tests/govuk-page-chrome-navigation-route-state.test.js"
+  ],
+  "filesModifiedOrCreated": [
+    "RECENT_LEARNINGS.md",
+    "docs/agent-audit/reasoning/2026/06/24/hide-signed-out-sign-out-link.md",
+    "docs/agent-audit/reasoning/2026/06/24/hide-signed-out-sign-out-link.json",
+    "public/css/govuk/govuk-header-service-brand.css",
+    "public/partials/header.html",
+    "tests/auth-header-links-route-state.test.js",
+    "tests/govuk-page-chrome-navigation-route-state.test.js"
+  ],
+  "validation": [
+    "npm run agent:model -- task text: passed",
+    "live asset inspection with curl: confirmed missing individual hidden account-link CSS before fix",
+    "npm test -- tests/auth-header-links-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js: passed, 2 tests",
+    "browser check with /api/me returning 401: passed",
+    "npm run lint: passed with existing repository warnings and no errors",
+    "npm test: passed, 245 tests",
+    "trace JSON parse plus Prettier check for changed files: passed",
+    "npm run trace:coverage -- --date 2026-06-24: passed",
+    "git diff --check: passed"
+  ],
+  "validationNotRun": [
+    "Live Cloudflare Pages deployment verification was not run because this branch has not yet been merged or deployed."
+  ],
+  "residualRisks": [
+    "The browser check used a local static server and mocked unauthenticated /api/me response.",
+    "Live deployment will update through the normal PR merge and Pages deployment path."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/06/24/hide-signed-out-sign-out-link.md
+++ b/docs/agent-audit/reasoning/2026/06/24/hide-signed-out-sign-out-link.md
@@ -1,0 +1,89 @@
+# Trace - hide signed-out Sign out masthead link
+
+- Date: 2026-06-24
+- Branch: `fix/hide-signed-out-sign-out-link`
+- Trace decision: required because this is repository-affecting work on a `fix/` branch.
+- Task: fix the merged PR #425 regression where signed-out users visually saw both `Sign in` and `Sign out` in the masthead.
+
+## Operating Model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped conditional bundles:
+
+- `cloudflare`: no Worker, binding, route or deployment behaviour was changed.
+- `openai-platform`: no OpenAI API or model behaviour was changed.
+- `mcp-agent-tooling`: no MCP or agent-tool contract behaviour was changed.
+- `airtable-public-api`: no Airtable integration behaviour was changed.
+- `mural-public-api`: no Mural integration behaviour was changed.
+
+Precedence applied:
+
+- GitHub Diamond governed branch hygiene, trace creation, validation, commit, push and PR creation.
+- ResearchOps Developer Control governed service-specific shared header behaviour.
+- Multi-Functional Team governed clear signed-out user-facing account state.
+- GOV.UK Design System governed header/navigation accessibility and visual state.
+
+## Files Read
+
+- `README.md`
+- `.github/CODEOWNERS`
+- `.github/pull_request_template.md`
+- `package.json`
+- `package-lock.json`
+- `RECENT_LEARNINGS.md`
+- `public/partials/header.html`
+- `public/css/govuk/govuk-header-service-brand.css`
+- `public/js/auth-header-links.js`
+- `tests/auth-header-links-route-state.test.js`
+- `tests/govuk-page-chrome-navigation-route-state.test.js`
+
+## Diagnosis
+
+- Live `https://research-operations.com/partials/header.html` and `https://researchops.pages.dev/partials/header.html` contained `hidden aria-hidden="true"` on the `Sign out` anchor.
+- Live `govuk-header-service-brand.css` only had a selector for `.researchops-header__account[hidden]`, not `.researchops-header__account-link[hidden]`.
+- The previous test asserted the hidden attribute existed in markup but did not assert the individual hidden account-link CSS selector.
+- The shared header stylesheet URL was unversioned, so browsers could retain the old account-link CSS.
+
+## Changes
+
+- Added `.researchops-header__account-link[hidden] { display: none !important; }` to the shared header stylesheet.
+- Cache-busted the shared header stylesheet URL with `hide-signed-out-sign-out-20260624-1` in both the link tag and `ensurePageChromeStylesheet`.
+- Updated route-state tests to assert the versioned stylesheet URL and individual hidden account-link CSS rule.
+- Added a `RECENT_LEARNINGS.md` entry for the visual hidden-state and shared CSS cache-busting trap.
+
+## Validation
+
+- `npm run agent:model -- "<task>"`: passed; always-load bundles selected. GOV.UK Design System was manually selected from the conditional UI rule because the task is masthead CSS/header UI.
+- Live asset inspection with `curl`: confirmed header markup had `hidden` on `Sign out` and CSS lacked an individual hidden link selector before this fix.
+- `npm test -- tests/auth-header-links-route-state.test.js tests/govuk-page-chrome-navigation-route-state.test.js`: passed, 2 tests.
+- Browser check with `/api/me` returning 401: passed; `Sign in` was visible and `Sign out` had `display: none` with zero rendered dimensions.
+- `npm run lint`: passed with existing repository warnings and no errors.
+- `npm test`: passed, 245 tests.
+- Trace JSON parse plus Prettier check for changed files: passed.
+- `npm run trace:coverage -- --date 2026-06-24`: passed.
+- `git diff --check`: passed.
+
+## Residual Risk
+
+- Live Cloudflare Pages deployment was not changed locally; this branch needs normal PR merge and deployment to update the served stylesheet.
+- The browser check used a local static server with mocked unauthenticated `/api/me`.

--- a/public/css/govuk/govuk-header-service-brand.css
+++ b/public/css/govuk/govuk-header-service-brand.css
@@ -126,6 +126,10 @@
 	white-space: nowrap;
 	}
 
+.researchops-header__account-link[hidden] {
+	display: none !important;
+	}
+
 @media (forced-colors: active) {
 	.govuk-header .researchops-header__logotype,
 	.govuk-header .researchops-header__wordmark,

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,5 +1,5 @@
 <!-- public/partials/header.html -->
-<link rel="stylesheet" href="/css/govuk/govuk-header-service-brand.css" media="screen" />
+<link rel="stylesheet" href="/css/govuk/govuk-header-service-brand.css?v=hide-signed-out-sign-out-20260624-1" media="screen" />
 <link rel="stylesheet" href="/css/govuk/govuk-main-content-focus.css" media="screen" />
 <link id="researchops-home-office-brand" rel="stylesheet" href="/css/brands/home-office.css" media="screen" disabled />
 <script type="module" src="/js/brand-variant.js"></script>
@@ -141,7 +141,7 @@
 <script>
 	function ensurePageChromeStylesheet() {
 		const stylesheets = [
-			"/css/govuk/govuk-header-service-brand.css",
+			"/css/govuk/govuk-header-service-brand.css?v=hide-signed-out-sign-out-20260624-1",
 			"/css/govuk/govuk-main-content-focus.css",
 		];
 

--- a/tests/auth-header-links-route-state.test.js
+++ b/tests/auth-header-links-route-state.test.js
@@ -70,6 +70,13 @@ function assertHeaderAccountLinksAreRightAligned() {
 	includes(headerCss, 'display: none;', 'header stylesheet');
 	includes(headerCss, '.researchops-header__account-link', 'header stylesheet');
 	includes(headerCss, 'white-space: nowrap;', 'header stylesheet');
+	includes(headerCss, '.researchops-header__account-link[hidden]', 'header stylesheet');
+	includes(headerCss, 'display: none !important;', 'header stylesheet');
+	includes(
+		headerPartial,
+		'/css/govuk/govuk-header-service-brand.css?v=hide-signed-out-sign-out-20260624-1',
+		'shared header partial',
+	);
 }
 
 function assertHeaderPartialBypassesStaleIncludeCache() {

--- a/tests/govuk-page-chrome-navigation-route-state.test.js
+++ b/tests/govuk-page-chrome-navigation-route-state.test.js
@@ -63,7 +63,11 @@ excludes(headerServiceBrandCss, "word-spacing: -6px;", "header product-name styl
 excludes(headerServiceBrandCss, "box-shadow: 0 3px 0 #ffffff;", "header product-name stylesheet");
 
 includes(headerPartial, "class=\"govuk-skip-link\" href=\"#main-content\"", "shared header partial");
-includes(headerPartial, "href=\"/css/govuk/govuk-header-service-brand.css\"", "shared header partial");
+includes(
+	headerPartial,
+	"href=\"/css/govuk/govuk-header-service-brand.css?v=hide-signed-out-sign-out-20260624-1\"",
+	"shared header partial"
+);
 includes(
 	headerPartial,
 	"class=\"govuk-template__header govuk-header\" role=\"banner\" data-module=\"govuk-header\"",


### PR DESCRIPTION
## Summary
- Hide the individual `Sign out` account link with explicit hidden-state CSS so signed-out users only see `Sign in`.
- Cache-bust the shared header stylesheet URL to avoid stale masthead CSS after deploy.
- Add route-state assertions for the hidden-link CSS rule and versioned header stylesheet, plus the required audit trace and learning note.

## Validation
- `npm run lint` passed with existing repository warnings and no errors.
- `npm test` passed, 245 tests.
- Focused route-state tests passed.
- Local browser check with `/api/me` returning 401 confirmed `Sign in` visible and `Sign out` rendered with `display: none` and zero dimensions.
- `npm run trace:coverage -- --date 2026-06-24` passed.
- `git diff --check` passed.
- GitHub PR checks passed: CodeQL, Node 20, Node 22, Cloudflare Pages, a11y, bdd-smoke, lychee, prettier, release gate, repository contract, Cloudflare Workers, and CodeQL analysis jobs.

## Trace
- `docs/agent-audit/reasoning/2026/06/24/hide-signed-out-sign-out-link.md`
