### PR TITLE
Fix reporting site deployment source

### DIFF
--- a/.github/workflows/deploy-reporting-site.yml
+++ b/.github/workflows/deploy-reporting-site.yml
@@ -1,0 +1,122 @@
+name: Deploy reporting site
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-reporting-site-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  WRANGLER_VERSION: "4.34.0"
+  REPORTING_PAGES_PROJECT: reopsreporting
+  REPORTING_PAGES_URL: https://reopsreporting.pages.dev/
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Validate committed reporting site
+        run: node scripts/validate-reports-site.mjs
+
+      - name: Confirm reporting site artefact
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          grep -F "ResearchOps application visual walkthrough" reports-site/index.html >/dev/null
+
+          if grep -F "govuk-template" reports-site/index.html >/dev/null; then
+            echo "reports-site/index.html must not be the GOV.UK service app shell."
+            exit 1
+          fi
+
+          if grep -F "<title>ResearchOps Demo Suite</title>" reports-site/index.html >/dev/null; then
+            echo "reports-site/index.html must not be the public ResearchOps service home page."
+            exit 1
+          fi
+
+      - name: Record Wrangler toolchain version
+        run: npx --yes wrangler@${WRANGLER_VERSION} --version
+
+      - name: Deploy committed reporting site to Cloudflare Pages
+        id: deploy_reporting_site
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} pages deploy reports-site \
+            --project-name=${REPORTING_PAGES_PROJECT} \
+            --branch=main \
+            --commit-hash=${GITHUB_SHA} \
+            --commit-message="Reporting site ${GITHUB_RUN_ID}"
+
+      - name: Show Wrangler failure log
+        if: >-
+          ${{
+            always() &&
+            steps.deploy_reporting_site.outcome == 'failure'
+          }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest="$(ls -t "$HOME/.config/.wrangler/logs"/wrangler-*.log 2>/dev/null | head -n 1 || true)"
+
+          if [ -z "$latest" ]; then
+            echo "No Wrangler log file was found."
+            exit 0
+          fi
+
+          echo "Wrangler log: $latest"
+          echo "::group::Wrangler failure log tail"
+          tail -n 240 "$latest"
+          echo "::endgroup::"
+
+      - name: Upload Wrangler logs
+        if: >-
+          ${{
+            always() &&
+            steps.deploy_reporting_site.outcome == 'failure'
+          }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: reporting-site-wrangler-pages-deploy-logs
+          path: ~/.config/.wrangler/logs/*.log
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Verify reporting site was updated
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expected_started_at="$(node -e "const fs = require('node:fs'); const manifest = JSON.parse(fs.readFileSync('reports-site/manifest.json', 'utf8')); console.log(manifest.startedAt);")"
+          echo "Expected reporting timestamp: ${expected_started_at}"
+
+          for attempt in {1..18}; do
+            body="$(curl --fail --silent --show-error --location --max-time 10 "${REPORTING_PAGES_URL}?run=${GITHUB_RUN_ID}-${attempt}" || true)"
+            if printf '%s' "$body" | grep -F "Run started: ${expected_started_at}" >/dev/null; then
+              echo "Reporting site updated: ${REPORTING_PAGES_URL}"
+              exit 0
+            fi
+            echo "Reporting site has not updated yet. Attempt ${attempt}/18."
+            sleep 10
+          done
+
+          echo "Reporting site did not show the committed report timestamp after deployment."
+          exit 1

--- a/docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.json
+++ b/docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.json
@@ -1,0 +1,101 @@
+{
+  "traceId": "reopsreporting-static-site",
+  "date": "2026-07-01",
+  "branch": "fix/reopsreporting-static-site",
+  "task": "Fix reopsreporting.pages.dev serving the GOV.UK-branded ResearchOps service instead of the committed static reports-site walkthrough.",
+  "traceRequired": true,
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/"
+    }
+  ],
+  "skippedBundles": [
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "evidence": [
+    "Live reopsreporting.pages.dev returned x-researchops-brand: govuk and ResearchOps Demo Suite.",
+    "reports-site/index.html contains ResearchOps application visual walkthrough.",
+    "root wrangler.toml keeps public as the main ResearchOps Pages output.",
+    "qa-bdd deploys reports-site only on manual workflow_dispatch when publish_reporting_site is true."
+  ],
+  "filesModified": [
+    ".github/workflows/deploy-reporting-site.yml",
+    "tests/reporting-site-deploy-route-state.test.js",
+    "docs/qa/visual-walkthrough.md",
+    "docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.md",
+    "docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.json"
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/reporting-site-deploy-route-state.test.js tests/reporting-review-generation-model.test.js tests/cloudflare-pages-output-dir.test.js",
+      "status": "passed",
+      "details": "Final focused route-state and reporting tests passed."
+    },
+    {
+      "command": "node --test tests/reporting-site-deploy-route-state.test.js tests/reporting-review-generation-model.test.js tests/cloudflare-pages-output-dir.test.js",
+      "status": "failed",
+      "details": "The new ES module test used the test runner global without importing node:test."
+    },
+    {
+      "command": "node scripts/validate-reports-site.mjs",
+      "status": "passed"
+    },
+    {
+      "command": "npx prettier -c .github/workflows/deploy-reporting-site.yml tests/reporting-site-deploy-route-state.test.js docs/qa/visual-walkthrough.md docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.md docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.json",
+      "status": "passed"
+    },
+    {
+      "command": "npm run trace:coverage",
+      "status": "passed"
+    },
+    {
+      "command": "npx --yes wrangler@4.34.0 pages deploy reports-site --project-name=reopsreporting --branch=main --commit-hash=$(git rev-parse HEAD) --commit-message=\"Restore reporting site static reports-site\"",
+      "status": "failed",
+      "details": "Wrangler reported that CLOUDFLARE_API_TOKEN is required in this non-interactive environment."
+    },
+    {
+      "command": "npm run validate",
+      "status": "passed"
+    }
+  ],
+  "residualRisks": [
+    "Cloudflare dashboard Git integration may still need correction if it is independently publishing public to the reopsreporting Pages project.",
+    "Production deployment cannot be proven locally without GitHub Actions secrets and Cloudflare deploy execution."
+  ],
+  "pivots": [
+    "Narrowed the public-app guard from any ResearchOps Demo Suite text to the exact public app title because the static report includes captured acceptance criteria that mention that service name."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.md
+++ b/docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.md
@@ -1,0 +1,77 @@
+# ReOps Reporting Static Site Trace
+
+Date: 2026-07-01
+Branch: `fix/reopsreporting-static-site`
+Task: Fix `https://reopsreporting.pages.dev/` serving the GOV.UK-branded ResearchOps service instead of the committed static `reports-site/` walkthrough.
+
+## Operating Model
+
+Loaded files:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+Skipped bundles:
+
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+Precedence decision: GitHub Diamond governed branch, trace, PR and validation discipline. ResearchOps Developer Control governed repository patterns. Multi-Functional Team governed public-service assurance framing. GOV.UK Design System was relevant only to distinguishing the wrong GOV.UK-branded app shell from the static reporting site. Cloudflare governed Pages deployment behaviour.
+
+## Evidence
+
+- Current branch began on `main`; work moved to approved branch `fix/reopsreporting-static-site`.
+- Live `https://reopsreporting.pages.dev/` returned HTTP 200 with `x-researchops-brand: govuk`, `<html class="govuk-template">`, and `<title>ResearchOps Demo Suite</title>`.
+- `reports-site/index.html` contains `<title>ResearchOps application visual walkthrough</title>` and static walkthrough content.
+- Root `wrangler.toml` intentionally keeps `pages_build_output_dir = "public"` for the main ResearchOps Pages app.
+- Existing `qa-bdd` deployment of `reports-site/` only runs on manual dispatch when `publish_reporting_site` is true.
+
+## Changes
+
+- Added `.github/workflows/deploy-reporting-site.yml` to validate and deploy the committed `reports-site/` directory to the `reopsreporting` Pages project after every `main` push and on manual dispatch.
+- Added a pre-deploy guard that rejects the GOV.UK service app shell markers before publishing.
+- Added `tests/reporting-site-deploy-route-state.test.js` to pin the reporting deployment source, project name, verification check and distinction between `public/` and `reports-site/`.
+- Updated `docs/qa/visual-walkthrough.md` to document the dedicated reporting-site deployment.
+
+## Validation
+
+Initial result:
+
+- `node --test tests/reporting-site-deploy-route-state.test.js tests/reporting-review-generation-model.test.js tests/cloudflare-pages-output-dir.test.js` failed because the new ES module test used the test runner global without importing `node:test`.
+- A follow-up run failed because the static report legitimately contains `ResearchOps Demo Suite` inside captured acceptance criteria. The pre-deploy guard was narrowed to reject the public app `<title>` instead.
+
+Passed checks:
+
+- `node --test tests/reporting-site-deploy-route-state.test.js tests/reporting-review-generation-model.test.js tests/cloudflare-pages-output-dir.test.js`
+- `node scripts/validate-reports-site.mjs`
+- `npx prettier -c .github/workflows/deploy-reporting-site.yml tests/reporting-site-deploy-route-state.test.js docs/qa/visual-walkthrough.md docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.md docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.json`
+- `npm run trace:coverage`
+- `npm run validate`
+
+Deployment check:
+
+- `npx --yes wrangler@4.34.0 pages deploy reports-site --project-name=reopsreporting --branch=main --commit-hash=$(git rev-parse HEAD) --commit-message="Restore reporting site static reports-site"` failed locally because Wrangler requires `CLOUDFLARE_API_TOKEN` in this non-interactive environment.
+
+## Risks And Limits
+
+- This repository change ensures GitHub Actions deploys the static reporting artefact. If the Cloudflare Pages project still has a dashboard Git integration that publishes `public/`, Cloudflare-side settings should also be corrected or disabled to avoid competing deployments.
+- Local work cannot prove the production deploy until the PR is merged and the workflow has access to `CF_API_TOKEN` and `CF_ACCOUNT_ID`.

--- a/docs/qa/visual-walkthrough.md
+++ b/docs/qa/visual-walkthrough.md
@@ -235,6 +235,8 @@ When the manual walkthrough job runs, it first completes the smoke suite and the
 4. prints a staged diff summary
 5. commits `Update application visual walkthrough report` when files changed
 6. pushes the generated report back to `main`
-7. deploys to `reopsreporting` only on manual runs where `publish_reporting_site` is true
+7. deploys the generated `reports-site/` artefact to `reopsreporting` on manual runs where `publish_reporting_site` is true
 
 `reports-site/**` is ignored by the push trigger, so report-only commits do not create a workflow loop.
+
+The separate `Deploy reporting site` workflow deploys the committed `reports-site/` directory to the `reopsreporting` Cloudflare Pages project after every `main` push and on manual dispatch. It validates `reports-site/` first and rejects the GOV.UK service app shell, so the reporting project is reset to the static walkthrough artefact even when the main ResearchOps Pages app changes.

--- a/tests/reporting-site-deploy-route-state.test.js
+++ b/tests/reporting-site-deploy-route-state.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const reportingDeployWorkflow = fs.readFileSync(
+	'.github/workflows/deploy-reporting-site.yml',
+	'utf8'
+);
+const qaBddWorkflow = fs.readFileSync('.github/workflows/qa-bdd.yml', 'utf8');
+const rootPagesConfig = fs.readFileSync('wrangler.toml', 'utf8');
+const reportsSiteIndex = fs.readFileSync('reports-site/index.html', 'utf8');
+const publicIndex = fs.readFileSync('public/index.html', 'utf8');
+
+test('reporting Pages project deploys the committed reports-site artefact', () => {
+	assert.match(reportingDeployWorkflow, /REPORTING_PAGES_PROJECT:\s+reopsreporting/);
+	assert.match(reportingDeployWorkflow, /REPORTING_PAGES_URL:\s+https:\/\/reopsreporting\.pages\.dev\//);
+	assert.match(reportingDeployWorkflow, /branches:\s+\[main\]/);
+	assert.match(reportingDeployWorkflow, /node scripts\/validate-reports-site\.mjs/);
+	assert.match(reportingDeployWorkflow, /pages deploy reports-site\s+\\/);
+	assert.match(reportingDeployWorkflow, /--project-name=\$\{REPORTING_PAGES_PROJECT\}/);
+	assert.match(reportingDeployWorkflow, /Run started: \$\{expected_started_at\}/);
+	assert.doesNotMatch(reportingDeployWorkflow, /pages deploy public/);
+	assert.doesNotMatch(reportingDeployWorkflow, /paths:/);
+});
+
+test('reporting workflow guards against deploying the GOV.UK service app', () => {
+	assert.match(
+		reportingDeployWorkflow,
+		/ResearchOps application visual walkthrough/,
+		'The workflow should assert the reporting-site title before deployment.'
+	);
+	assert.match(
+		reportingDeployWorkflow,
+		/govuk-template/,
+		'The workflow should reject the GOV.UK app shell before deployment.'
+	);
+	assert.match(
+		reportingDeployWorkflow,
+		/<title>ResearchOps Demo Suite<\/title>/,
+		'The workflow should reject the public service home page before deployment.'
+	);
+});
+
+test('main service and reporting site have distinct deployment roots', () => {
+	assert.match(rootPagesConfig, /^pages_build_output_dir\s*=\s*["']public["']$/m);
+
+	assert.match(publicIndex, /<html class="govuk-template"/);
+	assert.match(publicIndex, /<title>ResearchOps Demo Suite<\/title>/);
+
+	assert.match(reportsSiteIndex, /<html lang="en-GB">/);
+	assert.match(reportsSiteIndex, /<title>ResearchOps application visual walkthrough<\/title>/);
+	assert.doesNotMatch(reportsSiteIndex, /govuk-template/);
+	assert.doesNotMatch(reportsSiteIndex, /<title>ResearchOps Demo Suite<\/title>/);
+});
+
+test('manual walkthrough still deploys the generated report when requested', () => {
+	assert.match(qaBddWorkflow, /publish_reporting_site:/);
+	assert.match(qaBddWorkflow, /pages deploy reports-site\s+\\/);
+	assert.match(qaBddWorkflow, /--project-name=\$\{REPORTING_PAGES_PROJECT\}/);
+	assert.match(qaBddWorkflow, /Run started: \$\{expected_started_at\}/);
+});


### PR DESCRIPTION
## Summary
- Add a dedicated `Deploy reporting site` workflow that validates and deploys the committed `reports-site/` directory to the `reopsreporting` Cloudflare Pages project after every `main` push and on manual dispatch.
- Add guards so the reporting deploy fails if the artefact looks like the GOV.UK service app shell instead of the static walkthrough site.
- Add route-state coverage for the reporting deployment source and document the dedicated deployment path.
- Add the required branch trace under `docs/agent-audit/reasoning/2026/07/01/`.

## Evidence
- Live `https://reopsreporting.pages.dev/` was observed serving the GOV.UK-branded ResearchOps home page with `x-researchops-brand: govuk`.
- `reports-site/index.html` was observed as the static walkthrough report (`ResearchOps application visual walkthrough`).

## Validation
- `node --test tests/reporting-site-deploy-route-state.test.js tests/reporting-review-generation-model.test.js tests/cloudflare-pages-output-dir.test.js`
- `node scripts/validate-reports-site.mjs`
- `npx prettier -c .github/workflows/deploy-reporting-site.yml tests/reporting-site-deploy-route-state.test.js docs/qa/visual-walkthrough.md docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.md docs/agent-audit/reasoning/2026/07/01/reopsreporting-static-site.json`
- `npm run trace:coverage`
- `npm run validate`

## Deployment limitation
A direct local `wrangler pages deploy reports-site --project-name=reopsreporting` was attempted, but Wrangler reported that `CLOUDFLARE_API_TOKEN` is required in this non-interactive environment. The new workflow will need `CF_API_TOKEN` and `CF_ACCOUNT_ID` secrets available in GitHub Actions.

## Risk and rollback
If Cloudflare dashboard Git integration is also publishing `public/` to `reopsreporting`, that Cloudflare-side setting should still be corrected or disabled to avoid competing deployments. Rollback is to revert this PR; the existing manual `qa-bdd` reporting deploy path is unchanged.
