### PR TITLE
Gate reporting site deploy behind manual dispatch

### DIFF
--- a/.github/workflows/deploy-reporting-site.yml
+++ b/.github/workflows/deploy-reporting-site.yml
@@ -50,6 +50,14 @@ jobs:
             exit 1
           fi
 
+      - name: Require main for manual reporting deploys
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "Manual reporting-site deploys must be dispatched from main."
+          echo "Selected ref: ${GITHUB_REF}"
+          exit 1
+
       - name: Record Wrangler toolchain version
         if: github.event_name == 'workflow_dispatch'
         run: npx --yes wrangler@${WRANGLER_VERSION} --version

--- a/.github/workflows/deploy-reporting-site.yml
+++ b/.github/workflows/deploy-reporting-site.yml
@@ -51,9 +51,11 @@ jobs:
           fi
 
       - name: Record Wrangler toolchain version
+        if: github.event_name == 'workflow_dispatch'
         run: npx --yes wrangler@${WRANGLER_VERSION} --version
 
       - name: Deploy committed reporting site to Cloudflare Pages
+        if: github.event_name == 'workflow_dispatch'
         id: deploy_reporting_site
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
@@ -101,6 +103,11 @@ jobs:
           retention-days: 14
 
       - name: Verify reporting site was updated
+        if: >-
+          ${{
+            github.event_name == 'workflow_dispatch' &&
+            steps.deploy_reporting_site.outcome == 'success'
+          }}
         shell: bash
         run: |
           set -euo pipefail

--- a/RECENT_LEARNINGS.md
+++ b/RECENT_LEARNINGS.md
@@ -2,6 +2,14 @@
 
 This file records repeatable repository-specific lessons for ResearchOps agents and maintainers. It is not a changelog.
 
+## 2026-07-01 — Credential-sensitive Pages deploys should be manual until token scope is proven
+
+Context: PR #440 added a dedicated `Deploy reporting site` workflow to publish the committed `reports-site/` directory to the `reopsreporting` Cloudflare Pages project. After merge, the workflow passed the local reporting-site validation and artefact guard, but failed on `main` during `wrangler pages deploy` because Cloudflare returned authentication error `10000` for the Pages project API call. The workflow therefore made normal post-merge `main` status depend on a secret permission that had not been proven for Pages deployment.
+
+Learning: A workflow can be structurally correct and still be unsuitable as an automatic push gate if it depends on external credentials whose project-specific permissions are unverified. Deployment workflows that call Cloudflare Pages, Workers or other external APIs should separate repository validation from credential-sensitive mutation until the token scope is known-good.
+
+Action: For new deployment workflows, run artefact validation on `push` and keep the first live deployment behind `workflow_dispatch` or another deliberate release gate unless an existing workflow already proves the same secret can perform the same operation. Promote deployment to an automatic push path only after the token, account and project permissions have succeeded in CI.
+
 ## 2026-06-24 — Header hidden states need visual CSS assertions and cache-busted shared CSS
 
 Context: PR #425 changed the shared masthead so signed-out users saw a `Sign in` account link and the `Sign out` link used the HTML `hidden` attribute. After merge, the live masthead visually showed both `Sign in` and `Sign out` even though the sign-out link was intended to be hidden. The route-state test only checked the markup and broad account-nav hidden CSS, and the local browser check used accessibility-role visibility rather than also checking computed display and layout dimensions for the hidden anchor. The shared header stylesheet was also loaded without a cache-busting query string.

--- a/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json
+++ b/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json
@@ -86,7 +86,8 @@
       "commentId": 3506644755,
       "author": "chatgpt-codex-connector",
       "classification": "valid",
-      "action": "Added a +1 reaction and guarded manual deploys to main before deploy-capable steps."
+      "action": "Added a +1 reaction, guarded manual deploys to main before deploy-capable steps, replied with remediation and validation evidence, and resolved the GitHub review thread.",
+      "resolved": true
     }
   ]
 }

--- a/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json
+++ b/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json
@@ -1,0 +1,82 @@
+{
+  "traceId": "reporting-site-deploy-token-gate",
+  "date": "2026-07-01",
+  "branch": "fix/reporting-site-deploy-token-gate",
+  "task": "Fix post-merge Deploy reporting site workflow failure after PR #440.",
+  "traceRequired": true,
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "cloudflare",
+      "canonicalPath": ".agent-operating-model/bundles/cloudflare/"
+    }
+  ],
+  "skippedBundles": [
+    "govuk-design-system",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "evidence": [
+    "Attached GitHub Actions log showed reports-site validation passed.",
+    "Attached GitHub Actions log showed wrangler pages deploy failed with Cloudflare authentication error 10000.",
+    "Failure occurred on the main push workflow created by PR #440."
+  ],
+  "filesModified": [
+    ".github/workflows/deploy-reporting-site.yml",
+    "tests/reporting-site-deploy-route-state.test.js",
+    "docs/qa/visual-walkthrough.md",
+    "RECENT_LEARNINGS.md",
+    "docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md",
+    "docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json"
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/reporting-site-deploy-route-state.test.js",
+      "status": "passed"
+    },
+    {
+      "command": "node scripts/validate-reports-site.mjs",
+      "status": "passed"
+    },
+    {
+      "command": "npx prettier -c .github/workflows/deploy-reporting-site.yml tests/reporting-site-deploy-route-state.test.js docs/qa/visual-walkthrough.md RECENT_LEARNINGS.md docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json",
+      "status": "passed"
+    },
+    {
+      "command": "npm run trace:coverage",
+      "status": "passed"
+    },
+    {
+      "command": "npm run validate",
+      "status": "passed"
+    }
+  ],
+  "residualRisks": [
+    "Manual Cloudflare Pages deploy still requires a corrected CF_API_TOKEN permission set.",
+    "Live reopsreporting.pages.dev may remain stale or wrong until a manual dispatch succeeds."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json
+++ b/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json
@@ -43,7 +43,8 @@
   "evidence": [
     "Attached GitHub Actions log showed reports-site validation passed.",
     "Attached GitHub Actions log showed wrangler pages deploy failed with Cloudflare authentication error 10000.",
-    "Failure occurred on the main push workflow created by PR #440."
+    "Failure occurred on the main push workflow created by PR #440.",
+    "Codex review thread PRRT_kwDOP3Td2M6NnV5g identified a valid risk that workflow_dispatch from a non-main ref could deploy unmerged reports-site content to the shared reopsreporting Pages project."
   ],
   "filesModified": [
     ".github/workflows/deploy-reporting-site.yml",
@@ -78,5 +79,14 @@
   "residualRisks": [
     "Manual Cloudflare Pages deploy still requires a corrected CF_API_TOKEN permission set.",
     "Live reopsreporting.pages.dev may remain stale or wrong until a manual dispatch succeeds."
+  ],
+  "reviewThreads": [
+    {
+      "threadId": "PRRT_kwDOP3Td2M6NnV5g",
+      "commentId": 3506644755,
+      "author": "chatgpt-codex-connector",
+      "classification": "valid",
+      "action": "Added a +1 reaction and guarded manual deploys to main before deploy-capable steps."
+    }
   ]
 }

--- a/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md
+++ b/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md
@@ -46,9 +46,11 @@ Precedence decision: GitHub Diamond governs branch, trace, CI and PR handling. R
 
 - Keep `.github/workflows/deploy-reporting-site.yml` on `push` to `main`, but use that path for repository-side reporting-site validation only.
 - Gate Wrangler version logging, `wrangler pages deploy`, and live timestamp verification behind `workflow_dispatch`.
+- Added a manual-dispatch branch guard so reporting-site deployments fail before any deploy-capable step unless the selected ref is `refs/heads/main`.
 - Update `tests/reporting-site-deploy-route-state.test.js` to assert that push validation and manual deployment are distinct.
 - Update `docs/qa/visual-walkthrough.md` to document the manual deploy boundary.
 - Add a `RECENT_LEARNINGS.md` entry so future deploy workflows do not make unproven external credentials a required push gate.
+- Addressed a valid Codex review comment on PR #441 about accidental feature-branch manual dispatches publishing unmerged `reports-site/` content to the shared reporting project.
 
 ## Validation
 

--- a/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md
+++ b/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md
@@ -50,7 +50,7 @@ Precedence decision: GitHub Diamond governs branch, trace, CI and PR handling. R
 - Update `tests/reporting-site-deploy-route-state.test.js` to assert that push validation and manual deployment are distinct.
 - Update `docs/qa/visual-walkthrough.md` to document the manual deploy boundary.
 - Add a `RECENT_LEARNINGS.md` entry so future deploy workflows do not make unproven external credentials a required push gate.
-- Addressed a valid Codex review comment on PR #441 about accidental feature-branch manual dispatches publishing unmerged `reports-site/` content to the shared reporting project.
+- Addressed a valid Codex review comment on PR #441 about accidental feature-branch manual dispatches publishing unmerged `reports-site/` content to the shared reporting project. The comment was acknowledged with `+1`, replied to with the remediation and validation evidence, and resolved in GitHub.
 
 ## Validation
 

--- a/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md
+++ b/docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md
@@ -1,0 +1,66 @@
+# Reporting Site Deploy Token Gate Trace
+
+Date: 2026-07-01
+Branch: `fix/reporting-site-deploy-token-gate`
+Task: Fix the post-merge failure from PR #440 where the new `Deploy reporting site` workflow failed on `main`.
+
+## Operating Model
+
+Loaded files:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+Skipped bundles:
+
+- `govuk-design-system`
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+Precedence decision: GitHub Diamond governs branch, trace, CI and PR handling. ResearchOps Developer Control governs repository workflow conventions. Multi-Functional Team frames the operational risk of a public reporting surface. Cloudflare governs the Pages deploy behaviour and credential boundary.
+
+## Evidence
+
+- Attached GitHub Actions log for the merged PR #440 commit showed `Deploy reporting site` failed during `wrangler pages deploy reports-site`.
+- The same log showed `node scripts/validate-reports-site.mjs` passed and the local reporting artefact guard passed before the deploy step.
+- Cloudflare returned authentication error `10000` for `GET /accounts/***/pages/projects/reopsreporting`.
+- The workflow had a `push` trigger on `main`, so a credential-sensitive Pages deploy became an automatic post-merge status.
+
+## Changes
+
+- Keep `.github/workflows/deploy-reporting-site.yml` on `push` to `main`, but use that path for repository-side reporting-site validation only.
+- Gate Wrangler version logging, `wrangler pages deploy`, and live timestamp verification behind `workflow_dispatch`.
+- Update `tests/reporting-site-deploy-route-state.test.js` to assert that push validation and manual deployment are distinct.
+- Update `docs/qa/visual-walkthrough.md` to document the manual deploy boundary.
+- Add a `RECENT_LEARNINGS.md` entry so future deploy workflows do not make unproven external credentials a required push gate.
+
+## Validation
+
+Passed checks:
+
+- `node --test tests/reporting-site-deploy-route-state.test.js`
+- `node scripts/validate-reports-site.mjs`
+- `npx prettier -c .github/workflows/deploy-reporting-site.yml tests/reporting-site-deploy-route-state.test.js docs/qa/visual-walkthrough.md RECENT_LEARNINGS.md docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json`
+- `npm run trace:coverage`
+- `npm run validate`
+
+## Risks And Limits
+
+- This change restores normal `main` push validation but does not itself fix the Cloudflare token permission. A manual deploy will still fail until `CF_API_TOKEN` has the required Pages project permission for `reopsreporting`.
+- The live reporting site may remain stale or wrong until a manual dispatch succeeds with a corrected token.

--- a/docs/qa/visual-walkthrough.md
+++ b/docs/qa/visual-walkthrough.md
@@ -239,4 +239,4 @@ When the manual walkthrough job runs, it first completes the smoke suite and the
 
 `reports-site/**` is ignored by the push trigger, so report-only commits do not create a workflow loop.
 
-The separate `Deploy reporting site` workflow deploys the committed `reports-site/` directory to the `reopsreporting` Cloudflare Pages project after every `main` push and on manual dispatch. It validates `reports-site/` first and rejects the GOV.UK service app shell, so the reporting project is reset to the static walkthrough artefact even when the main ResearchOps Pages app changes.
+The separate `Deploy reporting site` workflow validates the committed `reports-site/` directory after every `main` push and on manual dispatch. It rejects the GOV.UK service app shell so the reporting artefact cannot silently become the main ResearchOps service. Manual dispatch also deploys `reports-site/` to the `reopsreporting` Cloudflare Pages project and verifies the live report timestamp. If the Cloudflare API token does not have Pages deployment permission, the manual deploy fails without breaking normal `main` push validation.

--- a/tests/reporting-site-deploy-route-state.test.js
+++ b/tests/reporting-site-deploy-route-state.test.js
@@ -25,6 +25,15 @@ test('reporting Pages project deploys only on manual dispatch', () => {
 	assert.match(reportingDeployWorkflow, /pages deploy reports-site\s+\\/);
 	assert.match(reportingDeployWorkflow, /--project-name=\$\{REPORTING_PAGES_PROJECT\}/);
 	assert.match(reportingDeployWorkflow, /Run started: \$\{expected_started_at\}/);
+	assert.match(reportingDeployWorkflow, /Require main for manual reporting deploys/);
+	assert.match(
+		reportingDeployWorkflow,
+		/github\.event_name == 'workflow_dispatch' && github\.ref != 'refs\/heads\/main'/
+	);
+	assert.match(
+		reportingDeployWorkflow,
+		/Manual reporting-site deploys must be dispatched from main\./
+	);
 	assert.match(reportingDeployWorkflow, /if: github\.event_name == 'workflow_dispatch'/);
 	assert.match(
 		reportingDeployWorkflow,

--- a/tests/reporting-site-deploy-route-state.test.js
+++ b/tests/reporting-site-deploy-route-state.test.js
@@ -11,16 +11,26 @@ const rootPagesConfig = fs.readFileSync('wrangler.toml', 'utf8');
 const reportsSiteIndex = fs.readFileSync('reports-site/index.html', 'utf8');
 const publicIndex = fs.readFileSync('public/index.html', 'utf8');
 
-test('reporting Pages project deploys the committed reports-site artefact', () => {
+test('reporting Pages project validates the committed reports-site artefact on main pushes', () => {
 	assert.match(reportingDeployWorkflow, /REPORTING_PAGES_PROJECT:\s+reopsreporting/);
 	assert.match(reportingDeployWorkflow, /REPORTING_PAGES_URL:\s+https:\/\/reopsreporting\.pages\.dev\//);
 	assert.match(reportingDeployWorkflow, /branches:\s+\[main\]/);
 	assert.match(reportingDeployWorkflow, /node scripts\/validate-reports-site\.mjs/);
+	assert.match(reportingDeployWorkflow, /ResearchOps application visual walkthrough/);
+	assert.match(reportingDeployWorkflow, /govuk-template/);
+	assert.doesNotMatch(reportingDeployWorkflow, /paths:/);
+});
+
+test('reporting Pages project deploys only on manual dispatch', () => {
 	assert.match(reportingDeployWorkflow, /pages deploy reports-site\s+\\/);
 	assert.match(reportingDeployWorkflow, /--project-name=\$\{REPORTING_PAGES_PROJECT\}/);
 	assert.match(reportingDeployWorkflow, /Run started: \$\{expected_started_at\}/);
+	assert.match(reportingDeployWorkflow, /if: github\.event_name == 'workflow_dispatch'/);
+	assert.match(
+		reportingDeployWorkflow,
+		/github\.event_name == 'workflow_dispatch' &&\s+steps\.deploy_reporting_site\.outcome == 'success'/
+	);
 	assert.doesNotMatch(reportingDeployWorkflow, /pages deploy public/);
-	assert.doesNotMatch(reportingDeployWorkflow, /paths:/);
 });
 
 test('reporting workflow guards against deploying the GOV.UK service app', () => {


### PR DESCRIPTION
## Summary
- Keep the `Deploy reporting site` workflow on `main` pushes for repository-side `reports-site/` validation and artefact-shell checks.
- Gate Wrangler version logging, Cloudflare Pages deployment, and live timestamp verification behind `workflow_dispatch` so normal post-merge `main` status no longer depends on an unproven Pages API token permission.
- Update route-state coverage and docs to pin the split between automatic validation and manual deployment.
- Record the branch trace and add a recent learning about credential-sensitive deployment workflows.

## Failing evidence
The merged PR #440 `Deploy reporting site` run validated `reports-site/`, then failed on `wrangler pages deploy reports-site` with Cloudflare authentication error `10000` for `/accounts/***/pages/projects/reopsreporting`. That means the current token is present but not authorised for the Pages project operation.

## Validation
- `node --test tests/reporting-site-deploy-route-state.test.js`
- `node scripts/validate-reports-site.mjs`
- `npx prettier -c .github/workflows/deploy-reporting-site.yml tests/reporting-site-deploy-route-state.test.js docs/qa/visual-walkthrough.md RECENT_LEARNINGS.md docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.md docs/agent-audit/reasoning/2026/07/01/reporting-site-deploy-token-gate.json`
- `npm run trace:coverage`
- `npm run validate`

## Risk and follow-up
This fixes the failing post-merge status by separating validation from deployment. It does not repair the Cloudflare token permission itself. A manual dispatch will still fail until `CF_API_TOKEN` has permission to deploy the `reopsreporting` Pages project.
