### PR TITLE
Fix BDD walkthrough protected page capture

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.json
+++ b/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.json
@@ -44,7 +44,8 @@
     "Attached logs_77064295337.zip showed visual walkthrough failed for 4 captures.",
     "The AI rewrite state waited for stale copy: Concise rewrite (optional):.",
     "The project-dashboard state was redirected to sign-in before mocked project API routes could render Assisted Digital Support Discovery.",
-    "public/_worker.js protects /pages/projects, /pages/project-dashboard and /pages/repository."
+    "public/_worker.js protects /pages/projects, /pages/project-dashboard and /pages/repository.",
+    "Codex review threads PRRT_kwDOP3Td2M6NqBfg and PRRT_kwDOP3Td2M6NqBgU correctly identified that /pages/projects/index.html bypassed the Worker-protected /pages/projects/ route."
   ],
   "filesModified": [
     "scripts/visual-walkthrough.mjs",
@@ -56,6 +57,10 @@
   "validation": [
     {
       "command": "targeted Playwright check for step-2-ai-rewrite-shown",
+      "status": "passed"
+    },
+    {
+      "command": "targeted Playwright check for /pages/projects/",
       "status": "passed"
     },
     {
@@ -85,10 +90,28 @@
   ],
   "validationNotes": [
     "npm run qa:cucumber:ci failed when first run without a local server or BASE_URL because http://localhost:8788/ refused connections; it passed when rerun with the deployed base URL used by the workflow.",
-    "Remote authenticated project-dashboard verification needs the GitHub RESEARCHOPS_QA_BDD_AUTH_CODE secret, which was not available locally."
+    "Remote authenticated project-dashboard and projects verification needs the GitHub RESEARCHOPS_QA_BDD_AUTH_CODE secret, which was not available locally."
   ],
   "residualRisks": [
     "The workflow secret-backed remote auth path was not fully reproduced locally.",
     "Future Worker protection changes must keep SERVER_PROTECTED_PAGE_IDS aligned with public/_worker.js."
+  ],
+  "reviewThreads": [
+    {
+      "threadId": "PRRT_kwDOP3Td2M6NqBfg",
+      "commentId": 3507616452,
+      "author": "chatgpt-codex-connector",
+      "classification": "valid",
+      "action": "Added a +1 reaction, updated the Projects walkthrough state to capture /pages/projects/, validated the fix, replied with evidence and resolved the thread.",
+      "resolved": true
+    },
+    {
+      "threadId": "PRRT_kwDOP3Td2M6NqBgU",
+      "commentId": 3507616541,
+      "author": "chatgpt-codex-connector",
+      "classification": "valid-duplicate",
+      "action": "Added a +1 reaction, covered by the same Projects walkthrough state and test update, replied with evidence and resolved the thread.",
+      "resolved": true
+    }
   ]
 }

--- a/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.json
+++ b/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.json
@@ -1,0 +1,94 @@
+{
+  "traceId": "bdd-walkthrough-protected-pages",
+  "date": "2026-07-01",
+  "branch": "fix/bdd-walkthrough-protected-pages",
+  "task": "Investigate attached full BDD walkthrough logs and fix the failing walkthrough captures.",
+  "traceRequired": true,
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    }
+  ],
+  "skippedBundles": [
+    "govuk-design-system",
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "evidence": [
+    "Attached logs_77064295337.zip showed bdd-smoke passed with 3 scenarios and 11 steps.",
+    "Attached logs_77064295337.zip showed visual walkthrough failed for 4 captures.",
+    "The AI rewrite state waited for stale copy: Concise rewrite (optional):.",
+    "The project-dashboard state was redirected to sign-in before mocked project API routes could render Assisted Digital Support Discovery.",
+    "public/_worker.js protects /pages/projects, /pages/project-dashboard and /pages/repository."
+  ],
+  "filesModified": [
+    "scripts/visual-walkthrough.mjs",
+    "visual-walkthrough.config.mjs",
+    "tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.md",
+    "docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.json"
+  ],
+  "validation": [
+    {
+      "command": "targeted Playwright check for step-2-ai-rewrite-shown",
+      "status": "passed"
+    },
+    {
+      "command": "static protected-page contract check",
+      "status": "passed"
+    },
+    {
+      "command": "BASE_URL=https://researchops.pages.dev/ npm run qa:cucumber:ci",
+      "status": "passed"
+    },
+    {
+      "command": "npm run qa:cucumber:walkthrough",
+      "status": "passed"
+    },
+    {
+      "command": "node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "status": "passed"
+    },
+    {
+      "command": "npx prettier -c scripts/visual-walkthrough.mjs visual-walkthrough.config.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "status": "passed"
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed"
+    }
+  ],
+  "validationNotes": [
+    "npm run qa:cucumber:ci failed when first run without a local server or BASE_URL because http://localhost:8788/ refused connections; it passed when rerun with the deployed base URL used by the workflow.",
+    "Remote authenticated project-dashboard verification needs the GitHub RESEARCHOPS_QA_BDD_AUTH_CODE secret, which was not available locally."
+  ],
+  "residualRisks": [
+    "The workflow secret-backed remote auth path was not fully reproduced locally.",
+    "Future Worker protection changes must keep SERVER_PROTECTED_PAGE_IDS aligned with public/_worker.js."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.md
+++ b/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.md
@@ -45,11 +45,13 @@ Precedence decision: GitHub Diamond governs branch, trace and validation handlin
 - Two failures waited for `Assisted Digital Support Discovery` on `/pages/project-dashboard/?id=recVisualProject001`.
 - A targeted Playwright reproduction against `https://researchops.pages.dev/` showed that project-dashboard redirected to `/pages/account/sign-in/?returnTo=...` before mocked project API routes could render the fixture.
 - `public/_worker.js` protects `/pages/projects`, `/pages/project-dashboard` and `/pages/repository`; the visual walkthrough only used QA server auth for `repository`.
+- Codex review threads `PRRT_kwDOP3Td2M6NqBfg` and `PRRT_kwDOP3Td2M6NqBgU` correctly identified that the `projects` registry entry still captured `/pages/projects/index.html`, which bypasses the Worker-protected `/pages/projects/` URL.
 
 ## Changes
 
 - Updated `scripts/visual-walkthrough.mjs` so the remote visual walkthrough uses the QA BDD auth bypass for `projects`, `project-dashboard` and `repository`.
 - Updated `visual-walkthrough.config.mjs` so the AI rewrite state waits for `#apply-ai-obj-rewrite` instead of stale copy.
+- Updated the Projects default walkthrough state so it keeps `/pages/projects/index.html` as the generated-file registry path but captures `/pages/projects/`, the Worker-protected URL, and waits for `Assisted Digital Support Discovery`.
 - Updated `tests/qa-bdd-authenticated-walkthrough-route-state.test.js` to lock both behaviours into the route-state contract.
 
 ## Validation
@@ -57,6 +59,7 @@ Precedence decision: GitHub Diamond governs branch, trace and validation handlin
 Passed checks:
 
 - Targeted Playwright check for the local static `step-2-ai-rewrite-shown` state: `ai-rewrite-state=ok`
+- Targeted Playwright check for the local static `/pages/projects/` state: `projects-protected-state=ok`
 - Static protected-page contract check: `protected-page-set=ok`
 - `BASE_URL=https://researchops.pages.dev/ npm run qa:cucumber:ci`
 - `npm run qa:cucumber:walkthrough`
@@ -70,5 +73,10 @@ Validation note:
 
 ## Risks And Limits
 
-- The remote authenticated project-dashboard path could not be fully verified locally because `RESEARCHOPS_QA_BDD_AUTH_CODE` was not available in the local secure env. The workflow already supplies that secret, and the code path now includes project-dashboard in the set that requests authenticated storage state.
+- The remote authenticated project-dashboard and projects paths could not be fully verified locally because `RESEARCHOPS_QA_BDD_AUTH_CODE` was not available in the local secure env. The workflow already supplies that secret, and the code path now includes both pages in the set that requests authenticated storage state.
 - The fix assumes the Worker protection contract remains the three routes currently encoded in `public/_worker.js`: `/pages/projects`, `/pages/project-dashboard` and `/pages/repository`.
+
+## Codex Review Threads
+
+- `PRRT_kwDOP3Td2M6NqBfg` / comment `3507616452`: valid. Added `+1`, updated the Projects walkthrough state to capture `/pages/projects/`, validated, replied, and resolved.
+- `PRRT_kwDOP3Td2M6NqBgU` / comment `3507616541`: valid duplicate. Added `+1`, covered by the same code and test change, validated, replied, and resolved.

--- a/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.md
+++ b/docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.md
@@ -1,0 +1,74 @@
+# BDD Walkthrough Protected Pages Trace
+
+Date: 2026-07-01
+Branch: `fix/bdd-walkthrough-protected-pages`
+Task: Investigate the attached full BDD walkthrough failure logs and fix the walkthrough failure.
+
+## Operating Model
+
+Loaded files:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+
+Skipped bundles:
+
+- `govuk-design-system`
+- `cloudflare`
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+Precedence decision: GitHub Diamond governs branch, trace and validation handling. ResearchOps Developer Control governs the walkthrough implementation and test-contract update. Multi-Functional Team frames the reporting walkthrough as assurance evidence for a public-sector service.
+
+## Evidence
+
+- The attached `logs_77064295337.zip` showed the `bdd-smoke` job passed: `3 scenarios (3 passed)` and `11 steps (11 passed)`.
+- The same archive showed the `walkthrough` job failed in `npm run qa:visual-walkthrough` with `Error: Visual walkthrough failed for 4 capture(s).`
+- Two failures waited for stale text: `Concise rewrite (optional):`, while the current objectives assist component renders the `#apply-ai-obj-rewrite` control under the `Concise rewrite` heading.
+- Two failures waited for `Assisted Digital Support Discovery` on `/pages/project-dashboard/?id=recVisualProject001`.
+- A targeted Playwright reproduction against `https://researchops.pages.dev/` showed that project-dashboard redirected to `/pages/account/sign-in/?returnTo=...` before mocked project API routes could render the fixture.
+- `public/_worker.js` protects `/pages/projects`, `/pages/project-dashboard` and `/pages/repository`; the visual walkthrough only used QA server auth for `repository`.
+
+## Changes
+
+- Updated `scripts/visual-walkthrough.mjs` so the remote visual walkthrough uses the QA BDD auth bypass for `projects`, `project-dashboard` and `repository`.
+- Updated `visual-walkthrough.config.mjs` so the AI rewrite state waits for `#apply-ai-obj-rewrite` instead of stale copy.
+- Updated `tests/qa-bdd-authenticated-walkthrough-route-state.test.js` to lock both behaviours into the route-state contract.
+
+## Validation
+
+Passed checks:
+
+- Targeted Playwright check for the local static `step-2-ai-rewrite-shown` state: `ai-rewrite-state=ok`
+- Static protected-page contract check: `protected-page-set=ok`
+- `BASE_URL=https://researchops.pages.dev/ npm run qa:cucumber:ci`
+- `npm run qa:cucumber:walkthrough`
+- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js`
+- `npx prettier -c scripts/visual-walkthrough.mjs visual-walkthrough.config.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js`
+- `git diff --check`
+
+Validation note:
+
+- `npm run qa:cucumber:ci` was first run without a local server or `BASE_URL` and failed with `net::ERR_CONNECTION_REFUSED` for `http://localhost:8788/`. The same suite passed when rerun against the deployed workflow base URL.
+
+## Risks And Limits
+
+- The remote authenticated project-dashboard path could not be fully verified locally because `RESEARCHOPS_QA_BDD_AUTH_CODE` was not available in the local secure env. The workflow already supplies that secret, and the code path now includes project-dashboard in the set that requests authenticated storage state.
+- The fix assumes the Worker protection contract remains the three routes currently encoded in `public/_worker.js`: `/pages/projects`, `/pages/project-dashboard` and `/pages/repository`.

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -93,7 +93,7 @@ const baseURL = normalizeBaseURL(
 const useLocalAssets = process.env.WALKTHROUGH_LOCAL_ASSETS === 'true';
 const qaBddAuthEmail = process.env.RESEARCHOPS_QA_BDD_AUTH_EMAIL || SIGN_IN_EMAIL;
 const qaBddAuthCode = String(process.env.RESEARCHOPS_QA_BDD_AUTH_CODE || '').replace(/\s+/g, '');
-const SERVER_PROTECTED_PAGE_IDS = new Set(['repository']);
+const SERVER_PROTECTED_PAGE_IDS = new Set(['projects', 'project-dashboard', 'repository']);
 let qaBddStorageStatePromise = null;
 const captureProfiles = (visualWalkthroughConfig.profiles || DEFAULT_PROFILES).map((profile) => ({
 	...profile,

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -11,6 +11,7 @@ const packageSource = fs.readFileSync('package.json', 'utf8');
 const stepSource = fs.readFileSync('features/steps/common.steps.js', 'utf8');
 const worldSource = fs.readFileSync('features/support/world.js', 'utf8');
 const visualWalkthroughSource = fs.readFileSync('scripts/visual-walkthrough.mjs', 'utf8');
+const visualWalkthroughConfigSource = fs.readFileSync('visual-walkthrough.config.mjs', 'utf8');
 const helperSource = fs.readFileSync('scripts/walkthrough-playwright.mjs', 'utf8');
 const passwordlessSource = fs.readFileSync('infra/cloudflare/src/core/auth/passwordless.js', 'utf8');
 const participantConsentSource = fs.readFileSync('public/js/participant-consent-page.js', 'utf8');
@@ -49,7 +50,12 @@ test('visual walkthrough uses local assets and deterministic authenticated mocks
 	assert.match(visualWalkthroughSource, /process\.env\.WALKTHROUGH_LOCAL_ASSETS === 'true'/);
 	assert.match(visualWalkthroughSource, /playwrightRequest\.newContext/);
 	assert.match(visualWalkthroughSource, /RESEARCHOPS_QA_BDD_AUTH_CODE/);
-	assert.match(visualWalkthroughSource, /SERVER_PROTECTED_PAGE_IDS = new Set\(\['repository'\]\)/);
+	assert.match(
+		visualWalkthroughSource,
+		/SERVER_PROTECTED_PAGE_IDS = new Set\(\['projects', 'project-dashboard', 'repository'\]\)/,
+	);
+	assert.match(visualWalkthroughConfigSource, /selector: '#apply-ai-obj-rewrite'/);
+	assert.doesNotMatch(visualWalkthroughConfigSource, /Concise rewrite \(optional\):/);
 	assert.match(helperSource, /operationalMockRoutes/);
 	assert.match(helperSource, /typeof body === 'function'/);
 	assert.match(helperSource, /SIGN_IN_EMAIL = 'qa-bdd\.walkthrough@example\.gov\.uk'/);

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -54,6 +54,12 @@ test('visual walkthrough uses local assets and deterministic authenticated mocks
 		visualWalkthroughSource,
 		/SERVER_PROTECTED_PAGE_IDS = new Set\(\['projects', 'project-dashboard', 'repository'\]\)/,
 	);
+	const projectsPage = visualWalkthroughConfig.pages.find((page) => page.id === 'projects');
+	assert.equal(projectsPage.path, '/pages/projects/index.html');
+	assert.equal(projectsPage.defaultState.path, '/pages/projects/');
+	assert.deepEqual(projectsPage.defaultState.actions, [
+		{ type: 'waitForText', text: 'Assisted Digital Support Discovery' },
+	]);
 	assert.match(visualWalkthroughConfigSource, /selector: '#apply-ai-obj-rewrite'/);
 	assert.doesNotMatch(visualWalkthroughConfigSource, /Concise rewrite \(optional\):/);
 	assert.match(helperSource, /operationalMockRoutes/);

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -287,7 +287,16 @@ export const visualWalkthroughConfig = {
 		},
 		registeredPage('start-overview', 'Start a research project', 'Core', '/pages/start/overview/index.html', 'Overview page for creating a research project.'),
 		startPage,
-		registeredPage('projects', 'Projects', 'Projects', '/pages/projects/index.html', 'Project list page.'),
+		{
+			...registeredPage('projects', 'Projects', 'Projects', '/pages/projects/index.html', 'Project list page.'),
+			defaultState: {
+				id: 'default',
+				title: 'Projects list with authenticated project context',
+				description: 'Projects page captured through the Worker-protected route.',
+				path: '/pages/projects/',
+				actions: [{ type: 'waitForText', text: 'Assisted Digital Support Discovery' }],
+			},
+		},
 		statefulPage('project-dashboard', 'Project dashboard', 'Projects', '/pages/project-dashboard/index.html', 'Project dashboard page.', 'Project dashboard with operational project context', 'Dashboard captured with a deterministic project ID.', operationalPaths.projectDashboard, 'Assisted Digital Support Discovery'),
 		statefulPage('project-dashboard-add-study', 'Add study', 'Projects', '/pages/study/new/index.html', 'Create a study from the project dashboard action workflow.', 'Add study with parent project context', 'Add-study workflow captured with the parent project ID present.', operationalPaths.addStudy, 'Add study'),
 		statefulPage('project-dashboard-add-participant', 'Add participant', 'Projects', '/pages/project-dashboard/participants/index.html', 'Add a study-linked participant from the project dashboard action workflow.', 'Add participant with parent context', 'Participant workflow captured with the project ID present.', operationalPaths.addParticipant, 'Add participant'),

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -118,7 +118,7 @@ const startPage = {
 				...stepTwoFilledActions,
 				{ type: 'waitForSelector', selector: '#ai-objectives-tools:not(.hidden)' },
 				{ type: 'click', selector: '#btn-obj-ai-rewrite' },
-				{ type: 'waitForText', text: 'Concise rewrite (optional):' },
+				{ type: 'waitForSelector', selector: '#apply-ai-obj-rewrite' },
 			],
 		},
 		{ id: 'step-3-default', title: 'Step 3 default state', description: 'Final data-entry step.', actions: stepThreeActions },


### PR DESCRIPTION
## Summary
- authenticate all server-protected visual walkthrough pages that the Pages Worker preflight protects
- update the AI rewrite walkthrough wait to target the current rendered apply control
- update the route-state test contract and add the required audit trace

## Validation
- targeted Playwright check for `step-2-ai-rewrite-shown`: passed
- static protected-page contract check: passed
- `BASE_URL=https://researchops.pages.dev/ npm run qa:cucumber:ci`: passed
- `npm run qa:cucumber:walkthrough`: passed
- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js`: passed
- `npx prettier -c scripts/visual-walkthrough.mjs visual-walkthrough.config.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.md docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.json`: passed
- `npm run trace:coverage -- --date 2026-07-01`: passed
- `git diff --check`: passed

## Trace
- `docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.md`
- `docs/agent-audit/reasoning/2026/07/01/bdd-walkthrough-protected-pages.json`

## Notes
- First local `npm run qa:cucumber:ci` attempt failed because no local server or `BASE_URL` was set; rerunning against the workflow base URL passed.
- Local env does not include `RESEARCHOPS_QA_BDD_AUTH_CODE`, so the GitHub workflow remains the authoritative verification for the secret-backed remote auth path.