### PR TITLE
Fix product proof walkthrough media capture

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.json
+++ b/docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.json
@@ -1,0 +1,87 @@
+{
+  "traceId": "product-proof-walkthrough-lazy-media",
+  "date": "2026-07-01",
+  "branch": "fix/bdd-reporting-pages-github-publish",
+  "task": "Fix the BDD visual walkthrough so Product Proof real UI examples appear in captured screenshots.",
+  "traceRequired": true,
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "evidence": [
+    "The Product Proof page renders eight real UI example images from public/assets/researchops/product-proof/.",
+    "The Product Proof template marks those images with loading=\"lazy\".",
+    "The visual walkthrough captured full-page screenshots after DOM, network and font settling but did not scroll the page before screenshot capture.",
+    "Full-page screenshots can include below-the-fold lazy image frames before the browser has requested those images."
+  ],
+  "filesModified": [
+    "scripts/visual-walkthrough.mjs",
+    "tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.md",
+    "docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.json"
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/product-proof-route-state.test.js",
+      "status": "passed"
+    },
+    {
+      "command": "Product Proof capture smoke check with local assets",
+      "status": "passed",
+      "details": "All eight data-product-proof-media images completed at 1365 by 900 before screenshot capture; the temporary screenshot /tmp/researchops-product-proof-loaded.png showed the real UI examples."
+    },
+    {
+      "command": "npx prettier -c scripts/visual-walkthrough.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.md docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.json",
+      "status": "passed"
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed"
+    },
+    {
+      "command": "npm run trace:coverage -- --date 2026-07-01",
+      "status": "passed"
+    },
+    {
+      "command": "npm run validate",
+      "status": "passed"
+    }
+  ],
+  "residualRisks": [
+    "The change keeps public-page lazy loading intact for users and changes only the evidence-capture flow.",
+    "The helper waits on image completion with a timeout so a broken image cannot hang the walkthrough indefinitely."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.md
+++ b/docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.md
@@ -1,0 +1,67 @@
+# Product Proof Walkthrough Lazy Media Trace
+
+Date: 2026-07-01
+Branch: `fix/bdd-reporting-pages-github-publish`
+Task: Fix the BDD visual walkthrough so the ResearchOps Product Proof real UI examples appear in captured screenshots.
+
+## Operating Model
+
+Loaded files:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped bundles:
+
+- `cloudflare`
+- `openai-platform`
+- `mcp-agent-tooling`
+- `airtable-public-api`
+- `mural-public-api`
+
+Precedence decision: GitHub Diamond governs branch, trace and validation behaviour. ResearchOps Developer Control governs visual walkthrough implementation. Multi-Functional Team and GOV.UK Design System govern public-service evidence quality and accessibility expectations.
+
+## Evidence
+
+- The Product Proof page renders eight real UI example images from `public/assets/researchops/product-proof/`.
+- The Product Proof template marks those images with `loading="lazy"`.
+- The visual walkthrough captured full-page screenshots after DOM, network and font settling but did not scroll the page before screenshot capture.
+- Full-page screenshots can include below-the-fold lazy image frames before the browser has requested those images.
+
+## Changes
+
+- Added `loadFullPageImages(page)` to the visual walkthrough capture script.
+- The helper temporarily treats lazy images as eager, scrolls through the full page to trigger viewport-dependent loading, waits for image load or error completion, returns to the top, then captures the screenshot.
+- Called the helper immediately before every full-page screenshot.
+- Added route-state test coverage for the lazy-media loading step.
+
+## Validation
+
+Validation to run before reporting completion:
+
+- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/product-proof-route-state.test.js`: passed.
+- Product Proof capture smoke check with local assets: passed. All eight `data-product-proof-media` images completed at 1365 by 900 before screenshot capture, and `/tmp/researchops-product-proof-loaded.png` showed the real UI examples.
+- `npx prettier -c scripts/visual-walkthrough.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.md docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.json`: passed.
+- `git diff --check`: passed.
+- `npm run trace:coverage -- --date 2026-07-01`: passed.
+- `npm run validate`: passed.
+
+## Risks And Limits
+
+- The change keeps public-page lazy loading intact for users and changes only the evidence-capture flow.
+- The helper waits on image completion with a timeout so a broken image cannot hang the walkthrough indefinitely.

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -262,6 +262,67 @@ async function settlePage(page) {
 	await page.waitForTimeout(200);
 }
 
+async function loadFullPageImages(page) {
+	await page.evaluate(async () => {
+		const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+		const images = Array.from(document.images);
+
+		for (const image of images) {
+			if (image.loading === 'lazy') image.loading = 'eager';
+		}
+
+		const documentHeight = () =>
+			Math.max(
+				document.body.scrollHeight,
+				document.body.offsetHeight,
+				document.body.clientHeight,
+				document.documentElement.scrollHeight,
+				document.documentElement.offsetHeight,
+				document.documentElement.clientHeight
+			);
+		const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 800;
+		const scrollStep = Math.max(200, Math.floor(viewportHeight * 0.75));
+
+		for (let y = 0; y < documentHeight(); y += scrollStep) {
+			window.scrollTo(0, y);
+			await sleep(75);
+		}
+
+		window.scrollTo(0, documentHeight());
+		await sleep(100);
+
+		await Promise.all(
+			images.map(
+				(image) =>
+					new Promise((resolve) => {
+						if (image.complete) {
+							resolve();
+							return;
+						}
+
+						const timeout = window.setTimeout(resolve, 2000);
+						const done = () => {
+							window.clearTimeout(timeout);
+							resolve();
+						};
+
+						image.addEventListener('load', done, { once: true });
+						image.addEventListener('error', done, { once: true });
+					})
+			)
+		);
+
+		window.scrollTo(0, 0);
+	});
+
+	try {
+		await page.waitForLoadState('networkidle', { timeout: 3000 });
+	} catch {
+		// Pages can keep network work open. The screenshot should still include loaded media.
+	}
+	await page.waitForTimeout(100);
+}
+
 async function runAction(page, action) {
 	const timeout = action.timeout ?? 5000;
 
@@ -375,6 +436,7 @@ async function captureState(browser, pageConfig, stateConfig, profile) {
 			await settlePage(page);
 		}
 
+		await loadFullPageImages(page);
 		await page.screenshot({ path: screenshotPath, fullPage: true, animations: 'disabled' });
 
 		return {
@@ -824,6 +886,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 export {
 	captureReport,
 	captureState,
+	loadFullPageImages,
 	pageCaptureConfig,
 	registerMockRoutes,
 	runAction,

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -67,6 +67,15 @@ test('visual walkthrough uses local assets and deterministic authenticated mocks
 	assert.match(helperSource, /SIGN_IN_EMAIL = 'qa-bdd\.walkthrough@example\.gov\.uk'/);
 });
 
+test('visual walkthrough loads below-the-fold lazy media before full-page screenshots', () => {
+	assert.match(visualWalkthroughSource, /async function loadFullPageImages\(page\)/);
+	assert.match(visualWalkthroughSource, /document\.images/);
+	assert.match(visualWalkthroughSource, /image\.loading = 'eager'/);
+	assert.match(visualWalkthroughSource, /window\.scrollTo\(0, y\)/);
+	assert.match(visualWalkthroughSource, /await loadFullPageImages\(page\);\n\t\tawait page\.screenshot/);
+	assert.match(visualWalkthroughSource, /loadFullPageImages,/);
+});
+
 test('visual walkthrough is a manual job with QA auth secret wiring', () => {
 	const walkthroughJobIndex = qaBddWorkflowSource.indexOf('  walkthrough:');
 	const walkthroughJob = qaBddWorkflowSource.slice(walkthroughJobIndex);


### PR DESCRIPTION
## Summary
- Load below-the-fold lazy images before full-page visual walkthrough screenshots
- Keep Product Proof public-page lazy loading intact for users
- Add route-state coverage for the screenshot media loading helper
- Add audit trace: `docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.md`

## Validation
- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/product-proof-route-state.test.js`
- Product Proof local capture smoke check: all 8 real UI example images completed at 1365x900 before screenshot capture
- `npx prettier -c scripts/visual-walkthrough.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.md docs/agent-audit/reasoning/2026/07/01/product-proof-walkthrough-lazy-media.json`
- `git diff --check`
- `npm run trace:coverage -- --date 2026-07-01`
- `npm run validate`