### PR TITLE
Fix walkthrough data-backed states

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.json
+++ b/docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.json
@@ -1,0 +1,89 @@
+{
+  "date": "2026-07-01",
+  "branch": "fix/walkthrough-data-backed-states",
+  "traceRequired": true,
+  "taskSummary": "Keep walkthrough error states while adding deterministic data-backed captures for six data-dependent pages.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "filesModified": [
+    "visual-walkthrough.config.mjs",
+    "visual-walkthrough.operational-fixtures.mjs",
+    "tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+    "tests/auth-team-access-review-route-state.test.js",
+    "docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.md",
+    "docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.json"
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js tests/visual-walkthrough-registry-coverage.test.js tests/study-guides-route-state.test.js tests/study-session-route-state.test.js tests/journal-entry-page-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "node --check visual-walkthrough.config.mjs && node --check visual-walkthrough.operational-fixtures.mjs",
+      "result": "passed"
+    },
+    {
+      "command": "npx prettier -c visual-walkthrough.config.mjs visual-walkthrough.operational-fixtures.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "Local Playwright state verification",
+      "result": "passed",
+      "evidence": "Verified six data-backed defaults and six explicit error states rendered expected content."
+    },
+    {
+      "command": "npx eslint visual-walkthrough.config.mjs visual-walkthrough.operational-fixtures.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js",
+      "result": "passed",
+      "evidence": "Existing flat-config eslint-env warnings only."
+    },
+    {
+      "command": "npm run generated-css:check",
+      "result": "passed"
+    },
+    {
+      "command": "npm run lint",
+      "result": "blocked",
+      "evidence": "Repository-wide Prettier check failed on existing .claude/settings.local.json before ESLint ran."
+    }
+  ],
+  "residualRisks": [
+    "The full BDD walkthrough was not regenerated in this branch.",
+    "Repository-wide lint remains blocked by an unrelated local settings formatting issue."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.md
+++ b/docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.md
@@ -1,0 +1,93 @@
+# Walkthrough data-backed states
+
+Date: 2026-07-01
+Branch: `fix/walkthrough-data-backed-states`
+
+## Task
+
+After PR #444 was merged to `main`, the BDD walkthrough still captured several data-dependent pages as missing-context or validation states. Keep those error states, but add normal captures backed by deterministic data for add study, journal entry, edit journal entry, discussion guides, study session and team access requests.
+
+## Trace decision
+
+The active branch prefix `fix/` requires an auditable trace for repository-affecting work.
+
+## Operating model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped bundles:
+
+- `cloudflare`: no Worker, binding, Pages deployment or Cloudflare API change.
+- `openai-platform`: no OpenAI API integration changed.
+- `mcp-agent-tooling`: no MCP tooling changed.
+- `airtable-public-api`: no Airtable API implementation changed.
+- `mural-public-api`: no Mural API implementation changed.
+
+## Files read
+
+- `visual-walkthrough.config.mjs`
+- `visual-walkthrough.operational-fixtures.mjs`
+- `scripts/walkthrough-playwright.mjs`
+- `scripts/visual-walkthrough.mjs`
+- `public/pages/study/new/study-new.js`
+- `public/js/journal-entry.js`
+- `public/js/journal-entry-edit.js`
+- `public/components/guides/guides-page.js`
+- `public/components/guides/guide-editor.js`
+- `public/components/session-controller.js`
+- `public/components/session-consent-controller.js`
+- `public/js/auth-team-access-review-page.js`
+- `tests/qa-bdd-authenticated-walkthrough-route-state.test.js`
+- `tests/auth-team-access-review-route-state.test.js`
+- `tests/visual-walkthrough-registry-coverage.test.js`
+
+## Files modified
+
+- `visual-walkthrough.config.mjs`
+- `visual-walkthrough.operational-fixtures.mjs`
+- `tests/qa-bdd-authenticated-walkthrough-route-state.test.js`
+- `tests/auth-team-access-review-route-state.test.js`
+- `docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.md`
+- `docs/agent-audit/reasoning/2026/07/01/walkthrough-data-backed-states.json`
+
+## Work done
+
+- Changed the add-study operational path to use the project ID parameter the page reads.
+- Added deterministic journal-entry, discussion-guide, participant-consent and team-access review fixtures.
+- Added mock routes for journal entry detail/list, guide detail and team access review requests.
+- Made the six data-dependent walkthrough defaults use the operational data-backed state.
+- Kept the previous missing-ID, consent-gate, empty guide source and team-access decision failures as explicit named states.
+- Added route-state tests that assert the operational defaults and named error states remain registered.
+
+## Validation
+
+- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js tests/visual-walkthrough-registry-coverage.test.js tests/study-guides-route-state.test.js tests/study-session-route-state.test.js tests/journal-entry-page-route-state.test.js`: passed.
+- `node --check visual-walkthrough.config.mjs && node --check visual-walkthrough.operational-fixtures.mjs`: passed.
+- `npx prettier -c visual-walkthrough.config.mjs visual-walkthrough.operational-fixtures.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js`: passed.
+- Local Playwright state verification for the six normal states and six explicit error states: passed.
+- `npx eslint visual-walkthrough.config.mjs visual-walkthrough.operational-fixtures.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js`: passed with existing flat-config warnings about `eslint-env` comments.
+- `npm run generated-css:check`: passed.
+
+## Issues and residual risk
+
+- `npm run lint` did not complete because the repository-wide Prettier check flagged existing `.claude/settings.local.json` formatting before ESLint ran. Targeted Prettier, targeted ESLint and generated CSS checks passed for this change.
+- The local Playwright verification checks rendered content and state actions, but the full BDD walkthrough was not regenerated in this branch.

--- a/tests/auth-team-access-review-route-state.test.js
+++ b/tests/auth-team-access-review-route-state.test.js
@@ -85,9 +85,10 @@ includes(renderWorkflow, 'No GOV.UK renderer page registration found for:', 'GOV
 includes(renderWorkflow, 'output_paths < "$changed_outputs_path"', 'GOV.UK render workflow');
 excludes(renderWorkflow, 'git add -A public/index.html public/pages', 'GOV.UK render workflow');
 
-includes(walkthroughConfig, "registeredPage('team-access-requests'", 'visual walkthrough registry');
+includes(walkthroughConfig, "id: 'team-access-requests'", 'visual walkthrough registry');
 includes(walkthroughConfig, "'Review team access requests'", 'visual walkthrough registry');
 includes(walkthroughConfig, "'/pages/team/access-requests/index.html'", 'visual walkthrough registry');
+includes(walkthroughConfig, 'operationalPaths.teamAccessRequests', 'visual walkthrough registry');
 
 for (const source of [template, page]) {
 	includesText(source, 'Review team access requests', 'team access review page');

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import test from 'node:test';
 
 import { visualWalkthroughConfig } from '../visual-walkthrough.config.mjs';
+import { operationalPaths } from '../visual-walkthrough.operational-fixtures.mjs';
 import { repositoryStaticPages } from '../src/govuk/data/repository-page.mjs';
 
 const featureSource = fs.readFileSync('features/authenticated-walkthrough.feature', 'utf8');
@@ -176,4 +177,30 @@ test('participant consent same-origin API URLs are valid during walkthrough capt
 	assert.match(participantConsentSource, /hasStudyContextParams/);
 	assert.match(participantConsentSource, /renderLoadError\(error\)/);
 	assert.doesNotMatch(participantConsentSource, /new URL\(apiUrl\(path\)\)/);
+});
+
+test('data-dependent walkthrough pages keep operational defaults and explicit error states', () => {
+	const pages = new Map(visualWalkthroughConfig.pages.map((page) => [page.id, page]));
+	const stateIds = (pageId) => new Set((pages.get(pageId)?.states || []).map((state) => state.id));
+
+	assert.match(operationalPaths.addStudy, /\/pages\/study\/new\/\?id=recVisualProject001$/);
+	assert.equal(pages.get('project-dashboard-add-study').defaultState.path, operationalPaths.addStudy);
+	assert.equal(stateIds('project-dashboard-add-study').has('missing-project-id-error'), true);
+
+	assert.equal(pages.get('journal-entry').defaultState.path, operationalPaths.journalEntry);
+	assert.equal(stateIds('journal-entry').has('missing-journal-entry-id-error'), true);
+	assert.equal(pages.get('journal-entry-edit').defaultState.path, operationalPaths.journalEntryEdit);
+	assert.equal(stateIds('journal-entry-edit').has('missing-journal-entry-id-error'), true);
+
+	assert.equal(pages.get('study-guides').defaultState.path, operationalPaths.studyGuides);
+	assert.equal(stateIds('study-guides').has('empty-guide-source-error'), true);
+
+	assert.deepEqual(pages.get('study-session').defaultState.actions.slice(0, 2), [
+		{ type: 'waitForSelector', selector: '#participant-select option[value="ptp_001"]', state: 'attached' },
+		{ type: 'select', selector: '#participant-select', value: 'ptp_001' },
+	]);
+	assert.equal(stateIds('study-session').has('participant-consent-gate'), true);
+
+	assert.equal(pages.get('team-access-requests').defaultState.path, operationalPaths.teamAccessRequests);
+	assert.equal(stateIds('team-access-requests').has('decision-error'), true);
 });

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -142,6 +142,185 @@ const teamRoleAssignmentsPage = {
 	},
 };
 
+const addStudyPage = {
+	...statefulPage(
+		'project-dashboard-add-study',
+		'Add study',
+		'Projects',
+		'/pages/study/new/index.html',
+		'Create a study from the project dashboard action workflow.',
+		'Add study with parent project context',
+		'Add-study workflow captured with the parent project ID present.',
+		operationalPaths.addStudy,
+		'Assisted Digital Support Discovery'
+	),
+	states: [
+		{
+			id: 'missing-project-id-error',
+			title: 'Missing project ID error',
+			description: 'Validation state shown when the add-study route is opened without parent project context.',
+			path: '/pages/study/new/index.html',
+			actions: [{ type: 'waitForText', text: 'Missing project ID' }],
+		},
+	],
+};
+
+const journalEntryPage = {
+	id: 'journal-entry',
+	title: 'Journal entry',
+	group: 'Projects',
+	path: '/pages/journal/entry/index.html',
+	description: 'Journal entry detail page.',
+	defaultState: {
+		id: 'default',
+		title: 'Journal entry with saved content',
+		description: 'Journal entry detail captured with deterministic project and entry context.',
+		path: operationalPaths.journalEntry,
+		actions: [{ type: 'waitForText', text: 'Reflection on support handoffs' }],
+	},
+	states: [
+		{
+			id: 'missing-journal-entry-id-error',
+			title: 'Missing journal entry ID error',
+			description: 'Error state shown when the journal detail route is opened without an entry ID.',
+			path: '/pages/journal/entry/index.html',
+			actions: [{ type: 'waitForText', text: 'Missing journal entry ID.' }],
+		},
+	],
+};
+
+const journalEntryEditPage = {
+	id: 'journal-entry-edit',
+	title: 'Edit journal entry',
+	group: 'Projects',
+	path: '/pages/journal/edit/index.html',
+	description: 'Journal entry edit page.',
+	defaultState: {
+		id: 'default',
+		title: 'Edit journal entry with saved content',
+		description: 'Journal entry edit form captured with deterministic project and entry context.',
+		path: operationalPaths.journalEntryEdit,
+		actions: [{ type: 'waitForSelector', selector: '#journal-entry-edit-form', state: 'visible' }],
+	},
+	states: [
+		{
+			id: 'missing-journal-entry-id-error',
+			title: 'Missing journal entry ID error',
+			description: 'Error state shown when the journal edit route is opened without an entry ID.',
+			path: '/pages/journal/edit/index.html',
+			actions: [{ type: 'waitForText', text: 'Missing journal entry ID.' }],
+		},
+	],
+};
+
+const studyGuidesPage = {
+	...statefulPage(
+		'study-guides',
+		'Discussion guides',
+		'Study',
+		'/pages/study/guides/index.html',
+		'Discussion guide list and editor page.',
+		'Discussion guides with saved source',
+		'Discussion guides page captured with the canonical Study record ID and opened guide source.',
+		operationalPaths.studyGuides,
+		'Opening and consent'
+	),
+	defaultState: {
+		id: 'default',
+		title: 'Discussion guides with saved source',
+		description: 'Discussion guides page captured with the canonical Study record ID and opened guide source.',
+		path: operationalPaths.studyGuides,
+		actions: [{ type: 'waitForSelector', selector: '#guide-preview h2:first-of-type' }],
+	},
+	states: [
+		{
+			id: 'empty-guide-source-error',
+			title: 'Empty guide source validation',
+			description: 'Guide editor validation state shown when a publish action is attempted without guide source.',
+			path: operationalPaths.studyGuides,
+			actions: [
+				{ type: 'waitForSelector', selector: '#guide-source', state: 'visible' },
+				{ type: 'fill', selector: '#guide-source', value: '' },
+				{ type: 'click', selector: '#btn-publish' },
+				{ type: 'waitForText', text: 'Enter guide source' },
+			],
+		},
+	],
+};
+
+const studySessionPage = {
+	...statefulPage(
+		'study-session',
+		'Study session',
+		'Study',
+		'/pages/study/session/index.html',
+		'Session running and note capture page.',
+		'Study session with participant ready',
+		'Session workspace captured with a selected participant and ready consent status.',
+		operationalPaths.studySession,
+		'Begin a session'
+	),
+	defaultState: {
+		id: 'default',
+		title: 'Study session with participant ready',
+		description: 'Session workspace captured with a selected participant and ready consent status.',
+		path: operationalPaths.studySession,
+		actions: [
+			{ type: 'waitForSelector', selector: '#participant-select option[value="ptp_001"]', state: 'attached' },
+			{ type: 'select', selector: '#participant-select', value: 'ptp_001' },
+			{ type: 'waitForText', text: 'Ready for session' },
+		],
+	},
+	states: [
+		{
+			id: 'participant-consent-gate',
+			title: 'Participant consent gate',
+			description: 'Session warning state shown before a participant has been selected.',
+			path: operationalPaths.studySession,
+			actions: [{ type: 'waitForText', text: 'Choose a participant to review consent status before starting a session.' }],
+		},
+	],
+};
+
+const teamAccessRequestsPage = {
+	id: 'team-access-requests',
+	title: 'Review team access requests',
+	group: 'Team administration',
+	path: '/pages/team/access-requests/index.html',
+	description: 'Team Admin review page for pending team access requests.',
+	defaultState: {
+		id: 'default',
+		title: 'Pending team access requests',
+		description: 'Team access review page captured with a deterministic pending request.',
+		path: operationalPaths.teamAccessRequests,
+		actions: [{ type: 'waitForText', text: 'Request from Morgan Lee' }],
+	},
+	states: [
+		{
+			id: 'decision-error',
+			title: 'Team access decision error',
+			description: 'Error state shown when a pending team access decision cannot be completed.',
+			path: operationalPaths.teamAccessRequests,
+			mockRoutes: [
+				{
+					url: /\/api\/team-access\/requests\/approve(?:\?.*)?$/,
+					method: 'POST',
+					status: 500,
+					body: {
+						ok: false,
+						message: 'Team access request could not be completed.',
+					},
+				},
+			],
+			actions: [
+				{ type: 'waitForSelector', selector: '[data-approve-request="tar_visual_001"]' },
+				{ type: 'click', selector: '[data-approve-request="tar_visual_001"]' },
+				{ type: 'waitForText', text: 'Team access request could not be completed.' },
+			],
+		},
+	],
+};
+
 const accountSignInPage = {
 	id: 'account-sign-in',
 	title: 'Sign in to ResearchOps',
@@ -298,23 +477,23 @@ export const visualWalkthroughConfig = {
 			},
 		},
 		statefulPage('project-dashboard', 'Project dashboard', 'Projects', '/pages/project-dashboard/index.html', 'Project dashboard page.', 'Project dashboard with operational project context', 'Dashboard captured with a deterministic project ID.', operationalPaths.projectDashboard, 'Assisted Digital Support Discovery'),
-		statefulPage('project-dashboard-add-study', 'Add study', 'Projects', '/pages/study/new/index.html', 'Create a study from the project dashboard action workflow.', 'Add study with parent project context', 'Add-study workflow captured with the parent project ID present.', operationalPaths.addStudy, 'Add study'),
+		addStudyPage,
 		statefulPage('project-dashboard-add-participant', 'Add participant', 'Projects', '/pages/project-dashboard/participants/index.html', 'Add a study-linked participant from the project dashboard action workflow.', 'Add participant with parent context', 'Participant workflow captured with the project ID present.', operationalPaths.addParticipant, 'Add participant'),
 		statefulPage('project-dashboard-import-participants', 'Import participants', 'Projects', '/pages/project-dashboard/participants/import/index.html', 'Import study-linked participants from CSV.', 'Import participants with parent context', 'CSV import workflow captured with the project ID present.', operationalPaths.importParticipants, 'Import participants'),
 		statefulPage('outcomes', 'Project outcomes', 'Projects', '/pages/projects/outcomes/index.html', 'Outcomes page for project-level findings and outputs.', 'Project outcomes with project context', 'Outcomes page captured with a deterministic project ID.', operationalPaths.outcomes, 'Impact & ROI'),
 		statefulPage('journals', 'Project journals', 'Projects', '/pages/projects/journals/index.html', 'Reflexive journal page.', 'Project journals with project context', 'Reflexive journal page captured with project context.', operationalPaths.journals, 'Reflexive Journal & Analysis'),
-		statefulPage('journal-entry', 'Journal entry', 'Projects', '/pages/journal/entry/index.html', 'Journal entry detail page.', 'Journal entry route', 'Journal entry detail route captured before API hydration.', '/pages/journal/entry/index.html', 'Journal entry'),
-		statefulPage('journal-entry-edit', 'Edit journal entry', 'Projects', '/pages/journal/edit/index.html', 'Journal entry edit page.', 'Journal entry edit route', 'Journal entry edit route captured before API hydration.', '/pages/journal/edit/index.html', 'Edit journal entry'),
+		journalEntryPage,
+		journalEntryEditPage,
 		statefulPage('study', 'Study overview', 'Study', '/pages/study/index.html', 'Study overview and readiness controls.', 'Study overview with readiness context', 'Study overview captured with the canonical Study record ID.', operationalPaths.study, 'Assisted digital support interview round 1'),
-		statefulPage('study-guides', 'Discussion guides', 'Study', '/pages/study/guides/index.html', 'Discussion guide list and editor page.', 'Discussion guides with study context', 'Discussion guides page captured with the canonical Study record ID.', operationalPaths.studyGuides, 'Guides for this study'),
+		studyGuidesPage,
 		statefulPage('study-note-takers-observers', 'Note takers and observers', 'Study', '/pages/study/note-takers-observers/index.html', 'Study support roles setup page.', 'Note takers and observers with study context', 'Support roles setup captured with the canonical Study record ID.', operationalPaths.studyNoteTakersObservers, 'Note takers and observers'),
 		statefulPage('study-participants', 'Participants', 'Study', '/pages/study/participants/index.html', 'Participants page for a study.', 'Study participants with records', 'Participants page captured with the canonical Study record ID.', operationalPaths.studyParticipants, 'Participants'),
-		statefulPage('study-session', 'Study session', 'Study', '/pages/study/session/index.html', 'Session running and note capture page.', 'Study session with study context', 'Session workspace captured with the canonical Study record ID.', operationalPaths.studySession, 'Begin a session'),
+		studySessionPage,
 		statefulPage('study-consent-forms', 'Study consent forms', 'Study', '/pages/study/consent-forms/index.html', 'Study-specific consent form configuration page.', 'Study consent forms with study context', 'Consent form configuration captured with the canonical Study record ID.', operationalPaths.studyConsentForms, 'Consent forms'),
 		registeredPage('study-participant-consent', 'Participant consent', 'Study', '/pages/study/participant-consent/index.html', 'Study-scoped participant consent recording and review page.'),
 		registeredPage('synthesize', 'Study synthesis', 'Study', '/pages/study/synthesis/index.html', 'Study-scoped evidence grouping and theme creation page.'),
 		statefulPage('team-registration-requests', 'Review account requests', 'Team administration', '/pages/team/registration-requests/index.html', 'Team Admin review page for pending account registration requests.', 'Pending account requests', 'Registration request review page captured with a deterministic pending request.', operationalPaths.teamRegistrationRequests, 'Pending account requests'),
-		registeredPage('team-access-requests', 'Review team access requests', 'Team administration', '/pages/team/access-requests/index.html', 'Team Admin review page for pending team access requests.'),
+		teamAccessRequestsPage,
 		teamRoleAssignmentsPage,
 		registeredPage('search', 'Search', 'Utilities', '/pages/search/index.html', 'Search page.'),
 		registeredPage('notes', 'Notes', 'Utilities', '/pages/notes/index.html', 'Notes page.'),

--- a/visual-walkthrough.operational-fixtures.mjs
+++ b/visual-walkthrough.operational-fixtures.mjs
@@ -8,6 +8,7 @@
 export const operationalProjectId = 'recVisualProject001';
 export const operationalStudyId = 'recVisualStudy001';
 export const operationalParticipantId = 'recVisualParticipant001';
+export const operationalJournalEntryId = 'recVisualJournal001';
 export const operationalAuthUserId = 'usr_visual_team_admin';
 export const operationalAuthTeamId = 'team_researchops_core';
 export const operationalAuthTeamName = 'ResearchOps Core';
@@ -16,11 +17,13 @@ export const operationalPaths = {
 	accountSignIn: '/pages/account/sign-in/index.html',
 	accountRegistration: '/pages/account/register/index.html',
 	projectDashboard: `/pages/project-dashboard/?id=${operationalProjectId}`,
-	addStudy: `/pages/study/new/?pid=${operationalProjectId}`,
+	addStudy: `/pages/study/new/?id=${operationalProjectId}`,
 	addParticipant: `/pages/project-dashboard/participants/?id=${operationalProjectId}`,
 	importParticipants: `/pages/project-dashboard/participants/import/?id=${operationalProjectId}`,
 	outcomes: `/pages/projects/outcomes/?id=${operationalProjectId}`,
 	journals: `/pages/projects/journals/?id=${operationalProjectId}`,
+	journalEntry: `/pages/journal/entry/?id=${operationalJournalEntryId}&project=${operationalProjectId}`,
+	journalEntryEdit: `/pages/journal/edit/?id=${operationalJournalEntryId}&project=${operationalProjectId}`,
 	study: `/pages/study/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
 	studyGuides: `/pages/study/guides/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
 	studyNoteTakersObservers: `/pages/study/note-takers-observers/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
@@ -28,6 +31,7 @@ export const operationalPaths = {
 	studySession: `/pages/study/session/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
 	studyConsentForms: `/pages/study/consent-forms/?pid=${operationalProjectId}&sid=${operationalStudyId}`,
 	teamRegistrationRequests: '/pages/team/registration-requests/',
+	teamAccessRequests: '/pages/team/access-requests/',
 	teamRoleAssignments: '/pages/team/role-assignments/',
 };
 
@@ -131,7 +135,44 @@ export const operationalGuides = [
 		studyId: operationalStudyId,
 		title: 'Assisted digital support discussion guide',
 		status: 'Published',
+		version: 0,
 		updatedAt: '2026-04-26T11:00:00.000Z',
+		createdBy: {
+			name: 'Alex Morgan',
+		},
+		sourceMarkdown: `# Assisted digital support discussion guide
+
+## Opening and consent
+Confirm the participant understands the research purpose, recording choices and how their contribution will be used.
+
+## Current journey
+Ask the participant to describe the last time they needed help with a digital service.
+
+## Support handoff
+Explore where they expected support, where they found it and what would have reduced uncertainty.
+
+## Wrap-up
+Check whether there is anything else they expected from the service before, during or after the handoff.`,
+		variables: {
+			study: {
+				title: 'Assisted digital support interview round 1',
+			},
+		},
+	},
+];
+
+export const operationalJournalEntries = [
+	{
+		id: operationalJournalEntryId,
+		project: operationalProjectId,
+		projectId: operationalProjectId,
+		localProjectId: operationalProjectId,
+		local_project_id: operationalProjectId,
+		category: 'perceptions',
+		content:
+			'Reflection on support handoffs: participants may see assisted digital support as part of the main service rather than a separate channel.',
+		tags: ['assisted-digital', 'handoff', 'researcher-reflection'],
+		createdAt: '2026-05-07T13:20:00.000Z',
 	},
 ];
 
@@ -157,6 +198,21 @@ export const operationalParticipantConsentRecords = [
 		status: 'Ready for session',
 		withdrawn: false,
 		updatedAt: '2026-05-01T09:45:00.000Z',
+	},
+	{
+		id: 'recVisualParticipantConsentSession001',
+		studyId: operationalStudyId,
+		participantId: 'recPARTICIPANT001',
+		status: 'Ready for session',
+		withdrawn: false,
+		captureMethod: 'Recorded in ResearchOps',
+		consentFormVersion: 1,
+		responses: {
+			recording: 'agreed',
+			observers: 'agreed',
+			transcription: 'agreed',
+		},
+		updatedAt: '2026-05-01T10:15:00.000Z',
 	},
 ];
 
@@ -258,6 +314,21 @@ export const operationalRegistrationRequests = [
 		requestedReason: 'Planning and analysing the assisted digital support study.',
 		status: 'pending_review',
 		submittedAt: '2026-05-13T09:00:00.000Z',
+	},
+];
+
+export const operationalTeamAccessReviewRequests = [
+	{
+		id: 'tar_visual_001',
+		requesterUserId: 'usr_visual_researcher',
+		requesterName: 'Morgan Lee',
+		requesterEmail: 'morgan.lee@example.gov.uk',
+		teamId: operationalAuthTeamId,
+		teamName: operationalAuthTeamName,
+		message:
+			'I need to contribute to the assisted digital support discovery and review repository evidence.',
+		status: 'pending',
+		requestedAt: '2026-05-14T08:45:00.000Z',
 	},
 ];
 
@@ -506,6 +577,14 @@ export function operationalMockRoutes() {
 			},
 		},
 		{
+			url: /\/api\/team-access\/requests\/review(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				requests: operationalTeamAccessReviewRequests,
+			},
+		},
+		{
 			url: /\/api\/projects(?:\?.*)?$/,
 			method: 'GET',
 			body: {
@@ -560,6 +639,41 @@ export function operationalMockRoutes() {
 			body: {
 				ok: true,
 				guides: operationalGuides,
+			},
+		},
+		{
+			url: /\/api\/guides\/[^/?]+(?:\?.*)?$/,
+			method: 'GET',
+			body: ({ url }) => {
+				const guideId = decodeURIComponent(new URL(url).pathname.split('/').pop() || '');
+				const guide =
+					operationalGuides.find((entry) => entry.id === guideId) || operationalGuides[0];
+				return {
+					ok: true,
+					guide,
+				};
+			},
+		},
+		{
+			url: /\/api\/journal-entries\/[^/?]+(?:\?.*)?$/,
+			method: 'GET',
+			body: ({ url }) => {
+				const entryId = decodeURIComponent(new URL(url).pathname.split('/').pop() || '');
+				const entry =
+					operationalJournalEntries.find((item) => item.id === entryId) ||
+					operationalJournalEntries[0];
+				return {
+					ok: true,
+					entry,
+				};
+			},
+		},
+		{
+			url: /\/api\/journal-entries(?:\?.*)?$/,
+			method: 'GET',
+			body: {
+				ok: true,
+				entries: operationalJournalEntries,
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- add deterministic walkthrough fixtures for journal entries, guide source, session consent and team access review requests
- make the affected walkthrough defaults capture data-backed states instead of missing-context screens
- keep the missing-ID, guide-source, consent-gate and team-access failure cases as explicit named states

## Validation
- node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js tests/visual-walkthrough-registry-coverage.test.js tests/study-guides-route-state.test.js tests/study-session-route-state.test.js tests/journal-entry-page-route-state.test.js
- node --check visual-walkthrough.config.mjs && node --check visual-walkthrough.operational-fixtures.mjs
- npx prettier -c visual-walkthrough.config.mjs visual-walkthrough.operational-fixtures.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js
- local Playwright state verification for the six data-backed defaults and six explicit error states
- npx eslint visual-walkthrough.config.mjs visual-walkthrough.operational-fixtures.mjs tests/qa-bdd-authenticated-walkthrough-route-state.test.js tests/auth-team-access-review-route-state.test.js
- npm run generated-css:check
- npm run trace:coverage

## Note
- npm run lint is blocked by an existing repository-wide Prettier warning in .claude/settings.local.json before ESLint runs; targeted formatting and ESLint checks for this change pass.