### PR TITLE
Arrange report site single pages in two columns

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.json
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-07-01",
+  "branch": "fix/report-site-two-column-pages",
+  "traceRequired": true,
+  "taskSummary": "Arrange ordinary single-state report-site pages in a two-column grid while keeping multi-state walkthrough sections outside that grid.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "filesModified": [
+    "scripts/render-reporting-review-site.mjs",
+    "scripts/visual-walkthrough.mjs",
+    "tests/reporting-review-generation-model.test.js",
+    "reports-site/index.html",
+    "docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.md",
+    "docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.json"
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "node scripts/validate-reports-site.mjs",
+      "result": "passed"
+    },
+    {
+      "command": "npx playwright screenshot --viewport-size=1440,1600 file://$PWD/reports-site/index.html /tmp/report-site-two-column.png",
+      "result": "passed"
+    },
+    {
+      "command": "DOM structure check for synthesize outside .group__pages and repository inside .group__pages",
+      "result": "passed"
+    },
+    {
+      "command": "npm run lint -- --quiet",
+      "result": "passed",
+      "evidence": "Existing ESLint flat-config eslint-env warnings only."
+    },
+    {
+      "command": "npm run validate",
+      "result": "passed"
+    },
+    {
+      "command": "npm run format -- tests/reporting-review-generation-model.test.js",
+      "result": "failed",
+      "evidence": "The repository format wrapper treated the file argument as a generated-CSS target; direct Prettier formatting and the normal lint/format gate passed."
+    }
+  ],
+  "residualRisks": [
+    "The change updates report layout only; screenshots were not recaptured."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.md
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.md
@@ -1,0 +1,85 @@
+# Report site two-column pages
+
+Date: 2026-07-01
+Branch: `fix/report-site-two-column-pages`
+
+## Task
+
+The reporting site needed ordinary single-state pages arranged in a two-column grid. Multi-state walkthrough sections, such as the Study synthesis example, needed to remain outside that two-column page grid.
+
+## Trace decision
+
+The active branch prefix `fix/` requires an auditable trace for repository-affecting work.
+
+## Operating model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped bundles:
+
+- `cloudflare`: no Worker, binding, Pages deployment or Cloudflare API change.
+- `openai-platform`: no OpenAI API integration changed.
+- `mcp-agent-tooling`: no MCP tooling changed.
+- `airtable-public-api`: no Airtable API implementation changed.
+- `mural-public-api`: no Mural API implementation changed.
+
+## Files read
+
+- `scripts/render-reporting-review-site.mjs`
+- `scripts/visual-walkthrough.mjs`
+- `scripts/reporting-review-evidence.mjs`
+- `tests/reporting-review-generation-model.test.js`
+- `tests/reports-site-validation.test.js`
+- `tests/reporting-site-deploy-route-state.test.js`
+- `reports-site/index.html`
+- `reports-site/manifest.json`
+
+## Files modified
+
+- `scripts/render-reporting-review-site.mjs`
+- `scripts/visual-walkthrough.mjs`
+- `tests/reporting-review-generation-model.test.js`
+- `reports-site/index.html`
+- `docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.md`
+- `docs/agent-audit/reasoning/2026/07/01/report-site-two-column-pages.json`
+
+## Work done
+
+- Added a two-column `.group__pages` layout for ordinary single-state report pages.
+- Kept multi-state walkthrough pages outside the two-column page grid.
+- Updated the raw visual walkthrough renderer and the final reporting-review renderer so future report rebuilds keep the same structure.
+- Regenerated the committed `reports-site/index.html` from the current manifest.
+- Added a regression test for the two-column grid and multi-state page exclusion.
+
+## Validation
+
+- `node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js`: passed.
+- `node scripts/validate-reports-site.mjs`: passed.
+- Browser screenshot check of `reports-site/index.html` at 1440px: passed.
+- DOM structure check confirming `synthesize` sits outside `.group__pages` while ordinary pages sit inside it: passed.
+- `npm run lint -- --quiet`: passed with existing ESLint flat-config warnings about `eslint-env` comments.
+- `npm run validate`: passed.
+
+## Issues and residual risk
+
+- `npm run format -- tests/reporting-review-generation-model.test.js` failed because the repository format wrapper passes trailing file arguments to the generated-CSS formatter. Prettier was run directly for the touched files and the normal lint/format check passed through `npm run lint -- --quiet`.
+- The change updates report layout only; screenshots were not recaptured.

--- a/reports-site/index.html
+++ b/reports-site/index.html
@@ -18,7 +18,9 @@ h3, h4, h5 { margin: 0 0 6px; }
 .profile-switcher__button[aria-pressed="true"] { background: #1d70b8; color: #fff; }
 .profile-switcher__button:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 .group { margin-bottom: 40px; }
-.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 18px 0; overflow: hidden; }
+.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 0; overflow: hidden; }
+.page-card--multi-step { grid-column: 1 / -1; }
 .page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
 .states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
 .state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }
@@ -38,7 +40,10 @@ h3, h4, h5 { margin: 0 0 6px; }
 .review-risk-list dd { margin: 0; }
 .capture { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
 .capture__figure { margin: 10px 0 0; }
-.capture__figure img { border: 1px solid #d8d8d8; height: auto; max-width: 100%; }</style>
+.capture__figure img { border: 1px solid #d8d8d8; height: auto; max-width: 100%; }
+@media (max-width: 900px) {
+	.group__pages { grid-template-columns: 1fr; }
+}</style>
 </head>
 <body>
 	<header>
@@ -70,6 +75,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 		<section class="group" aria-labelledby="group-Core">
 			<h2 id="group-Core">Core</h2>
 			
+			<div class="group__pages">
+				
 	<article class="page-card" id="home" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Home</h3>
@@ -406,7 +413,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="start" data-review-group-id="start" data-review-evidence-level="group">
+			</div>
+	<article class="page-card page-card--multi-step" id="start" data-review-group-id="start" data-review-evidence-level="group">
 		<div class="page-card__header">
 			<h3>Start research project</h3>
 			<p class="meta">/pages/start/index.html</p>
@@ -865,7 +873,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 		<section class="group" aria-labelledby="group-Account">
 			<h2 id="group-Account">Account</h2>
 			
-	<article class="page-card" id="account-sign-in" data-review-group-id="" data-review-evidence-level="generated">
+	<article class="page-card page-card--multi-step" id="account-sign-in" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Sign in to ResearchOps</h3>
 			<p class="meta">/pages/account/sign-in/index.html</p>
@@ -1031,6 +1039,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			<div class="group__pages">
+				
 	<article class="page-card" id="account-registration" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Request a ResearchOps account</h3>
@@ -1291,10 +1301,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			</div>
 		</section>
 		<section class="group" aria-labelledby="group-Projects">
 			<h2 id="group-Projects">Projects</h2>
 			
+			<div class="group__pages">
+				
 	<article class="page-card" id="projects" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Projects</h3>
@@ -1534,7 +1547,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="project-dashboard-add-study" data-review-group-id="" data-review-evidence-level="generated">
+			</div>
+	<article class="page-card page-card--multi-step" id="project-dashboard-add-study" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Add study</h3>
 			<p class="meta">/pages/study/new/index.html</p>
@@ -1697,6 +1711,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			<div class="group__pages">
+				
 	<article class="page-card" id="project-dashboard-add-participant" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Add participant</h3>
@@ -1958,7 +1974,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="journals" data-review-group-id="" data-review-evidence-level="generated">
+			</div>
+	<article class="page-card page-card--multi-step" id="journals" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Project journals</h3>
 			<p class="meta">/pages/projects/journals/index.html</p>
@@ -2913,7 +2930,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="journal-entry" data-review-group-id="" data-review-evidence-level="generated">
+	<article class="page-card page-card--multi-step" id="journal-entry" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Journal entry</h3>
 			<p class="meta">/pages/journal/entry/index.html</p>
@@ -3076,7 +3093,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="journal-entry-edit" data-review-group-id="" data-review-evidence-level="generated">
+	<article class="page-card page-card--multi-step" id="journal-entry-edit" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Edit journal entry</h3>
 			<p class="meta">/pages/journal/edit/index.html</p>
@@ -3243,6 +3260,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 		<section class="group" aria-labelledby="group-Study">
 			<h2 id="group-Study">Study</h2>
 			
+			<div class="group__pages">
+				
 	<article class="page-card" id="study" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Study overview</h3>
@@ -3330,7 +3349,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="study-guides" data-review-group-id="" data-review-evidence-level="generated">
+			</div>
+	<article class="page-card page-card--multi-step" id="study-guides" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Discussion guides</h3>
 			<p class="meta">/pages/study/guides/index.html</p>
@@ -3496,6 +3516,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			<div class="group__pages">
+				
 	<article class="page-card" id="study-note-takers-observers" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Note takers and observers</h3>
@@ -3670,7 +3692,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="study-session" data-review-group-id="" data-review-evidence-level="generated">
+			</div>
+	<article class="page-card page-card--multi-step" id="study-session" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Study session</h3>
 			<p class="meta">/pages/study/session/index.html</p>
@@ -3835,6 +3858,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			<div class="group__pages">
+				
 	<article class="page-card" id="study-consent-forms" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Study consent forms</h3>
@@ -3922,7 +3947,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="study-participant-consent" data-review-group-id="participant-consent" data-review-evidence-level="group">
+			</div>
+	<article class="page-card page-card--multi-step" id="study-participant-consent" data-review-group-id="participant-consent" data-review-evidence-level="group">
 		<div class="page-card__header">
 			<h3>Participant consent</h3>
 			<p class="meta">/pages/study/participant-consent/index.html</p>
@@ -4214,7 +4240,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="synthesize" data-review-group-id="analysis" data-review-evidence-level="group">
+	<article class="page-card page-card--multi-step" id="synthesize" data-review-group-id="analysis" data-review-evidence-level="group">
 		<div class="page-card__header">
 			<h3>Study synthesis</h3>
 			<p class="meta">/pages/study/synthesis/index.html</p>
@@ -4615,6 +4641,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 		<section class="group" aria-labelledby="group-Team administration">
 			<h2 id="group-Team administration">Team administration</h2>
 			
+			<div class="group__pages">
+				
 	<article class="page-card" id="team-registration-requests" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Review account requests</h3>
@@ -4702,7 +4730,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
-	<article class="page-card" id="team-access-requests" data-review-group-id="" data-review-evidence-level="generated">
+			</div>
+	<article class="page-card page-card--multi-step" id="team-access-requests" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Review team access requests</h3>
 			<p class="meta">/pages/team/access-requests/index.html</p>
@@ -4867,6 +4896,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			<div class="group__pages">
+				
 	<article class="page-card" id="team-role-assignments" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Assign a role to a team member</h3>
@@ -4954,10 +4985,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			</div>
 		</section>
 		<section class="group" aria-labelledby="group-Utilities">
 			<h2 id="group-Utilities">Utilities</h2>
 			
+			<div class="group__pages">
+				
 	<article class="page-card" id="search" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Search</h3>
@@ -5302,10 +5336,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			</div>
 		</section>
 		<section class="group" aria-labelledby="group-Research repository">
 			<h2 id="group-Research repository">Research repository</h2>
 			
+			<div class="group__pages">
+				
 	<article class="page-card" id="repository" data-review-group-id="" data-review-evidence-level="generated">
 		<div class="page-card__header">
 			<h3>Research repository</h3>
@@ -6524,6 +6561,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 	</article>
 		</div>
 	</article>
+			</div>
 		</section>
 	</main>
 	

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -143,9 +143,15 @@ function renderState(page = {}, state = {}) {
 	</article>`;
 }
 
+function isMultiStepPage(page = {}) {
+	return (page.states || []).length > 1;
+}
+
 function renderPage(page = {}) {
+	const pageClass = isMultiStepPage(page) ? 'page-card page-card--multi-step' : 'page-card';
+
 	return `
-	<article class="page-card" id="${escapeHtml(page.id)}" data-review-group-id="${escapeHtml(page.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(page.reviewEvidenceLevel || 'generated')}">
+	<article class="${pageClass}" id="${escapeHtml(page.id)}" data-review-group-id="${escapeHtml(page.reviewGroupId || '')}" data-review-evidence-level="${escapeHtml(page.reviewEvidenceLevel || 'generated')}">
 		<div class="page-card__header">
 			<h3>${escapeHtml(page.title)}</h3>
 			<p class="meta">${escapeHtml(page.path)}</p>
@@ -156,6 +162,33 @@ function renderPage(page = {}) {
 			${(page.states || []).map((state) => renderState(page, state)).join('')}
 		</div>
 	</article>`;
+}
+
+function renderPageGrid(pages = []) {
+	const blocks = [];
+	let singlePages = [];
+
+	function flushSinglePages() {
+		if (singlePages.length === 0) return;
+		blocks.push(`
+			<div class="group__pages">
+				${singlePages.map(renderPage).join('')}
+			</div>`);
+		singlePages = [];
+	}
+
+	for (const page of pages) {
+		if (isMultiStepPage(page)) {
+			flushSinglePages();
+			blocks.push(renderPage(page));
+		} else {
+			singlePages.push(page);
+		}
+	}
+
+	flushSinglePages();
+
+	return blocks.join('');
 }
 
 function renderProfileSwitcher(profiles = []) {
@@ -235,7 +268,9 @@ h3, h4, h5 { margin: 0 0 6px; }
 .profile-switcher__button[aria-pressed="true"] { background: #1d70b8; color: #fff; }
 .profile-switcher__button:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 .group { margin-bottom: 40px; }
-.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 18px 0; overflow: hidden; }
+.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 0; overflow: hidden; }
+.page-card--multi-step { grid-column: 1 / -1; }
 .page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
 .states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
 .state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }
@@ -255,7 +290,10 @@ h3, h4, h5 { margin: 0 0 6px; }
 .review-risk-list dd { margin: 0; }
 .capture { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
 .capture__figure { margin: 10px 0 0; }
-.capture__figure img { border: 1px solid #d8d8d8; height: auto; max-width: 100%; }`;
+.capture__figure img { border: 1px solid #d8d8d8; height: auto; max-width: 100%; }
+@media (max-width: 900px) {
+	.group__pages { grid-template-columns: 1fr; }
+}`;
 }
 
 export function renderReportingReviewHtml(manifest = {}) {
@@ -284,7 +322,7 @@ export function renderReportingReviewHtml(manifest = {}) {
 		${groups.map(([group, pages]) => `
 		<section class="group" aria-labelledby="group-${escapeHtml(group)}">
 			<h2 id="group-${escapeHtml(group)}">${escapeHtml(group)}</h2>
-			${pages.map(renderPage).join('')}
+			${renderPageGrid(pages)}
 		</section>`).join('')}
 	</main>
 	${renderProfileSwitcherScript(reviewedManifest.profiles)}

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -715,6 +715,103 @@ function renderCapture(page, state, capture) {
 					</section>`;
 }
 
+function isMultiStepPage(page = {}) {
+	return (page.states || []).length > 1;
+}
+
+function renderPageGrid(pages = []) {
+	const blocks = [];
+	let singlePages = [];
+
+	function flushSinglePages() {
+		if (singlePages.length === 0) return;
+		blocks.push(`
+		<div class="group__pages">
+			${singlePages
+				.map(
+					(page) => `
+		<article class="page-card" id="${escapeHtml(page.id)}">
+			<div class="page-card__header">
+				<h3>${escapeHtml(page.title)}</h3>
+				<p class="meta">${escapeHtml(page.path)}</p>
+				<p class="meta">${escapeHtml(page.description)}</p>
+			</div>
+			<div class="states">
+				${page.states
+					.map(
+						(state) => `
+				<section class="state ${state.status === 'failed' ? 'failed' : ''}" id="${escapeHtml(
+							slugify(`${page.id}-${state.id}`)
+						)}" data-state-id="${escapeHtml(state.id)}">
+					<div class="state__header">
+						<h4>${escapeHtml(state.title)}</h4>
+						<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
+						${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
+						${renderEvidenceTypes(state)}
+					</div>
+					${renderStateAcceptanceCriteria(state)}
+					${renderDesignRisk(state)}
+					<div class="state__captures">
+						${state.captures.map((capture) => renderCapture(page, state, capture)).join('')}
+					</div>
+				</section>`
+					)
+					.join('')}
+			</div>
+		</article>`
+				)
+				.join('')}
+		</div>`);
+		singlePages = [];
+	}
+
+	function renderMultiStepPage(page) {
+		return `
+		<article class="page-card page-card--multi-step" id="${escapeHtml(page.id)}">
+			<div class="page-card__header">
+				<h3>${escapeHtml(page.title)}</h3>
+				<p class="meta">${escapeHtml(page.path)}</p>
+				<p class="meta">${escapeHtml(page.description)}</p>
+			</div>
+			<div class="states">
+				${page.states
+					.map(
+						(state) => `
+				<section class="state ${state.status === 'failed' ? 'failed' : ''}" id="${escapeHtml(
+							slugify(`${page.id}-${state.id}`)
+						)}" data-state-id="${escapeHtml(state.id)}">
+					<div class="state__header">
+						<h4>${escapeHtml(state.title)}</h4>
+						<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
+						${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
+						${renderEvidenceTypes(state)}
+					</div>
+					${renderStateAcceptanceCriteria(state)}
+					${renderDesignRisk(state)}
+					<div class="state__captures">
+						${state.captures.map((capture) => renderCapture(page, state, capture)).join('')}
+					</div>
+				</section>`
+					)
+					.join('')}
+			</div>
+		</article>`;
+	}
+
+	for (const page of pages) {
+		if (isMultiStepPage(page)) {
+			flushSinglePages();
+			blocks.push(renderMultiStepPage(page));
+		} else {
+			singlePages.push(page);
+		}
+	}
+
+	flushSinglePages();
+
+	return blocks.join('');
+}
+
 function renderHtml(manifest) {
 	const groups = groupPages(manifest.pages);
 
@@ -749,7 +846,9 @@ function renderHtml(manifest) {
 		.profile-switcher__button { background: #f3f2f1; border: 2px solid #0b0c0c; border-radius: 0; cursor: pointer; font: inherit; padding: 8px 12px; }
 		.profile-switcher__button[aria-pressed="true"] { background: #1d70b8; color: #fff; }
 		.profile-switcher__button:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
-		.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 18px 0; overflow: hidden; }
+		.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+		.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 0; overflow: hidden; }
+		.page-card--multi-step { grid-column: 1 / -1; }
 		.page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
 		.states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
 		.state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }
@@ -787,6 +886,9 @@ function renderHtml(manifest) {
 		.failed .state__header, .failed .capture__header { background: #fff4f2; }
 		.summary { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
 		[hidden] { display: none !important; }
+		@media (max-width: 900px) {
+			.group__pages { grid-template-columns: 1fr; }
+		}
 	</style>
 </head>
 <body>
@@ -811,40 +913,7 @@ function renderHtml(manifest) {
 			([group, pages]) => `
 	<section class="group" id="${escapeHtml(slugify(group))}">
 		<h2>${escapeHtml(group)}</h2>
-		${pages
-			.map(
-				(page) => `
-		<article class="page-card" id="${escapeHtml(page.id)}">
-			<div class="page-card__header">
-				<h3>${escapeHtml(page.title)}</h3>
-				<p class="meta">${escapeHtml(page.path)}</p>
-				<p class="meta">${escapeHtml(page.description)}</p>
-			</div>
-			<div class="states">
-				${page.states
-					.map(
-						(state) => `
-				<section class="state ${state.status === 'failed' ? 'failed' : ''}" id="${escapeHtml(
-						slugify(`${page.id}-${state.id}`)
-					)}" data-state-id="${escapeHtml(state.id)}">
-					<div class="state__header">
-						<h4>${escapeHtml(state.title)}</h4>
-						<p class="meta">${escapeHtml(state.status)} · ${escapeHtml(state.url)}</p>
-						${state.description ? `<p>${escapeHtml(state.description)}</p>` : ''}
-						${renderEvidenceTypes(state)}
-					</div>
-					${renderStateAcceptanceCriteria(state)}
-					${renderDesignRisk(state)}
-					<div class="state__captures">
-						${state.captures.map((capture) => renderCapture(page, state, capture)).join('')}
-					</div>
-				</section>`
-					)
-					.join('')}
-			</div>
-		</article>`
-			)
-			.join('')}
+		${renderPageGrid(pages)}
 	</section>`
 		)
 		.join('')}

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -166,6 +166,32 @@ test('rendered report emits group evidence above states without runtime grouping
 	assert.doesNotMatch(html, /insertAdjacentElement/);
 });
 
+test('rendered report lays out non-multi-step pages in a two-column group grid', () => {
+	const html = renderReportingReviewHtml(manifestFixture());
+	const homePageIndex = html.indexOf('<article class="page-card" id="home"');
+	const startPageIndex = html.indexOf(
+		'<article class="page-card page-card--multi-step" id="start"'
+	);
+
+	assert.match(
+		html,
+		/\.group__pages \{ display: grid; gap: 18px; grid-template-columns: repeat\(2, minmax\(0, 1fr\)\); \}/
+	);
+	assert.match(html, /@media \(max-width: 900px\)/);
+	assert.ok(homePageIndex > -1, 'Single-state pages should keep the ordinary page-card class.');
+	assert.ok(startPageIndex > -1, 'Pages with multiple states should be marked as multi-step.');
+	assert.match(
+		html,
+		/<\/div>\s*<article class="page-card page-card--multi-step" id="start"/,
+		'Multi-step pages should sit outside the two-column page grid.'
+	);
+	assert.doesNotMatch(
+		html.slice(homePageIndex, startPageIndex),
+		/page-card--multi-step/,
+		'Non-multi-step pages should not be forced full-width.'
+	);
+});
+
 test('non-curated pages keep generated screen-state criteria', () => {
 	const html = renderReportingReviewHtml(manifestFixture());
 	const homeIndex = html.indexOf('Home page');


### PR DESCRIPTION
## Summary
- arrange ordinary single-state reporting pages in a two-column grid
- keep multi-state walkthrough sections, such as Study synthesis, outside that two-column grid
- update both report renderers and regenerate the committed reports-site HTML

## Validation
- node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js
- node scripts/validate-reports-site.mjs
- npx playwright screenshot --viewport-size=1440,1600 file://$PWD/reports-site/index.html /tmp/report-site-two-column.png
- DOM structure check for synthesize outside .group__pages and repository inside .group__pages
- npm run lint -- --quiet
- npm run validate

## Notes
- Screenshots were not recaptured; this is a static report layout/rendering change.