### PR TITLE
Refine report site grid spacing

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.json
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.json
@@ -1,0 +1,82 @@
+{
+  "date": "2026-07-01",
+  "branch": "fix/report-site-row-gap-details-closed",
+  "traceRequired": true,
+  "taskSummary": "Keep visible row gaps in the reporting site two-column layout and close group-level evidence details by default.",
+  "operatingModelFilesLoaded": [
+    "AGENTS.md",
+    ".agent-operating-model/orchestration.xml",
+    ".agent-operating-model/bundle-registry.json",
+    ".agent-operating-model/task-signal-catalog.json",
+    ".agent-operating-model/selection-rules.json",
+    ".agent-operating-model/bootstrap-checklist.md",
+    ".agent-operating-model/precedence-policy.md",
+    ".agent-operating-model/trace-policy.md",
+    ".agent-operating-model/trace-layers.md",
+    ".agent-operating-model/behavioural-evals.json",
+    ".agent-operating-model/github-mutation-policy.md"
+  ],
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "canonicalPath": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "govuk-design-system",
+      "canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+    }
+  ],
+  "skippedBundles": [
+    "cloudflare",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "filesModified": [
+    "scripts/render-reporting-review-site.mjs",
+    "scripts/visual-walkthrough.mjs",
+    "tests/reporting-review-generation-model.test.js",
+    "reports-site/index.html",
+    "docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.md",
+    "docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.json"
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "node scripts/validate-reports-site.mjs",
+      "result": "passed"
+    },
+    {
+      "command": "DOM structure check for grid margins, multi-step margins and closed grouping details",
+      "result": "passed"
+    },
+    {
+      "command": "npx playwright screenshot --viewport-size=1440,1600 file://$PWD/reports-site/index.html /tmp/report-site-row-gap-details-closed.png",
+      "result": "passed"
+    },
+    {
+      "command": "npm run lint -- --quiet",
+      "result": "passed",
+      "evidence": "Existing ESLint flat-config eslint-env warnings only."
+    },
+    {
+      "command": "npm run validate",
+      "result": "passed"
+    }
+  ],
+  "residualRisks": [
+    "The change updates static report layout only; screenshots were not recaptured."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.md
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.md
@@ -1,0 +1,72 @@
+# Report site row gap and closed grouping evidence
+
+Date: 2026-07-01
+Branch: `fix/report-site-row-gap-details-closed`
+
+## Task
+
+Follow up the reporting site two-column layout so row gaps remain visible between report rows and group-level evidence details labelled "What this grouping should support" are closed by default.
+
+## Trace decision
+
+The active branch prefix `fix/` requires an auditable trace for repository-affecting work.
+
+## Operating model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped bundles:
+
+- `cloudflare`: no Worker, binding, Pages deployment or Cloudflare API change.
+- `openai-platform`: no OpenAI API integration changed.
+- `mcp-agent-tooling`: no MCP tooling changed.
+- `airtable-public-api`: no Airtable API implementation changed.
+- `mural-public-api`: no Mural API implementation changed.
+
+## Files modified
+
+- `scripts/render-reporting-review-site.mjs`
+- `scripts/visual-walkthrough.mjs`
+- `tests/reporting-review-generation-model.test.js`
+- `reports-site/index.html`
+- `docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.md`
+- `docs/agent-audit/reasoning/2026/07/01/report-site-row-gap-details-closed.json`
+
+## Work done
+
+- Added vertical margins to two-column page-grid blocks and standalone multi-state page cards so rows retain a visible gap.
+- Removed the `open` attribute from group-level review evidence details so "What this grouping should support" is closed by default.
+- Regenerated `reports-site/index.html`.
+- Added regression assertions for grid spacing, multi-step spacing and closed grouping details.
+
+## Validation
+
+- `node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js`: passed.
+- `node scripts/validate-reports-site.mjs`: passed.
+- DOM structure check for grid margins, multi-step margins and closed grouping details: passed.
+- Browser screenshot capture of `reports-site/index.html` at 1440px: passed.
+- `npm run lint -- --quiet`: passed with existing ESLint flat-config warnings about `eslint-env` comments.
+- `npm run validate`: passed.
+
+## Residual risk
+
+- The change updates static report layout only; screenshots were not recaptured.

--- a/reports-site/index.html
+++ b/reports-site/index.html
@@ -18,9 +18,9 @@ h3, h4, h5 { margin: 0 0 6px; }
 .profile-switcher__button[aria-pressed="true"] { background: #1d70b8; color: #fff; }
 .profile-switcher__button:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 .group { margin-bottom: 40px; }
-.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 18px 0; }
 .page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 0; overflow: hidden; }
-.page-card--multi-step { grid-column: 1 / -1; }
+.page-card--multi-step { grid-column: 1 / -1; margin: 18px 0; }
 .page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
 .states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
 .state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }
@@ -422,7 +422,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 			
 		<section class="review-evidence review-evidence--group" data-review-group-id="start" data-review-evidence-level="group">
 			<h4>Start research project — group-level review evidence</h4>
-			<details open>
+			<details>
 				<summary>What this grouping should support</summary>
 				<p>Applies once to the full grouping. State cards below contain only scenario-specific review evidence.</p>
 				<h5>Gherkin acceptance criteria <strong class="review-status review-status--needs-review">needs review</strong></h5>
@@ -3956,7 +3956,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 			
 		<section class="review-evidence review-evidence--group" data-review-group-id="participant-consent" data-review-evidence-level="group">
 			<h4>Participant consent — group-level review evidence</h4>
-			<details open>
+			<details>
 				<summary>What this grouping should support</summary>
 				<p>Applies once to the full grouping. State cards below contain only scenario-specific review evidence.</p>
 				<h5>Gherkin acceptance criteria <strong class="review-status review-status--needs-review">needs review</strong></h5>
@@ -4248,7 +4248,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 			
 		<section class="review-evidence review-evidence--group" data-review-group-id="analysis" data-review-evidence-level="group">
 			<h4>Study synthesis — group-level review evidence</h4>
-			<details open>
+			<details>
 				<summary>What this grouping should support</summary>
 				<p>Applies once to the full grouping. State cards below contain only scenario-specific review evidence.</p>
 				<h5>Gherkin acceptance criteria <strong class="review-status review-status--needs-review">needs review</strong></h5>

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -59,7 +59,7 @@ function renderGroupEvidence(page = {}) {
 	return `
 		<section class="review-evidence review-evidence--group" data-review-group-id="${escapeHtml(page.reviewGroupId)}" data-review-evidence-level="group">
 			<h4>${escapeHtml(evidence.title)} — group-level review evidence</h4>
-			<details open>
+			<details>
 				<summary>What this grouping should support</summary>
 				<p>Applies once to the full grouping. State cards below contain only scenario-specific review evidence.</p>
 				<h5>Gherkin acceptance criteria ${renderStatus(evidence.acceptanceStatus)}</h5>
@@ -268,9 +268,9 @@ h3, h4, h5 { margin: 0 0 6px; }
 .profile-switcher__button[aria-pressed="true"] { background: #1d70b8; color: #fff; }
 .profile-switcher__button:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 .group { margin-bottom: 40px; }
-.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 18px 0; }
 .page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 0; overflow: hidden; }
-.page-card--multi-step { grid-column: 1 / -1; }
+.page-card--multi-step { grid-column: 1 / -1; margin: 18px 0; }
 .page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
 .states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
 .state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -846,9 +846,9 @@ function renderHtml(manifest) {
 		.profile-switcher__button { background: #f3f2f1; border: 2px solid #0b0c0c; border-radius: 0; cursor: pointer; font: inherit; padding: 8px 12px; }
 		.profile-switcher__button[aria-pressed="true"] { background: #1d70b8; color: #fff; }
 		.profile-switcher__button:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
-		.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+		.group__pages { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 18px 0; }
 		.page-card { border: 1px solid #d8d8d8; border-radius: 8px; margin: 0; overflow: hidden; }
-		.page-card--multi-step { grid-column: 1 / -1; }
+		.page-card--multi-step { grid-column: 1 / -1; margin: 18px 0; }
 		.page-card__header { background: #f7f7f7; border-bottom: 1px solid #d8d8d8; padding: 14px 16px; }
 		.states { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 16px; }
 		.state { border: 1px solid #e5e5e5; border-radius: 6px; overflow: hidden; background: #fff; }

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -161,6 +161,7 @@ test('rendered report emits group evidence above states without runtime grouping
 	assert.match(html, /data-review-evidence-level="group"/);
 	assert.match(html, /data-suppress-generated-state-criteria="true"/);
 	assert.match(html, /What this grouping should support/);
+	assert.doesNotMatch(html, /<details open>\s*<summary>What this grouping should support/);
 	assert.match(html, /What this state should support/);
 	assert.doesNotMatch(html, /reporting-review-grouping-script/);
 	assert.doesNotMatch(html, /insertAdjacentElement/);
@@ -175,8 +176,9 @@ test('rendered report lays out non-multi-step pages in a two-column group grid',
 
 	assert.match(
 		html,
-		/\.group__pages \{ display: grid; gap: 18px; grid-template-columns: repeat\(2, minmax\(0, 1fr\)\); \}/
+		/\.group__pages \{ display: grid; gap: 18px; grid-template-columns: repeat\(2, minmax\(0, 1fr\)\); margin: 18px 0; \}/
 	);
+	assert.match(html, /\.page-card--multi-step \{ grid-column: 1 \/ -1; margin: 18px 0; \}/);
 	assert.match(html, /@media \(max-width: 900px\)/);
 	assert.ok(homePageIndex > -1, 'Single-state pages should keep the ordinary page-card class.');
 	assert.ok(startPageIndex > -1, 'Pages with multiple states should be marked as multi-step.');


### PR DESCRIPTION
## Summary
- keep visible vertical gaps between reporting site grid rows and standalone multi-state sections
- make group-level "What this grouping should support" details closed by default
- regenerate the committed reporting site HTML and protect the behavior with tests

## Validation
- node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js
- node scripts/validate-reports-site.mjs
- DOM structure check for grid margins, multi-step margins and closed grouping details
- npx playwright screenshot --viewport-size=1440,1600 file://$PWD/reports-site/index.html /tmp/report-site-row-gap-details-closed.png
- npm run lint -- --quiet
- npm run validate

## Notes
- Screenshots were not recaptured; this is a static report layout/rendering change.