### PR TITLE
Add report screenshot lightbox

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.json
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.json
@@ -1,0 +1,80 @@
+{
+	"date": "2026-07-01",
+	"branch": "fix/report-site-screenshot-lightbox",
+	"traceRequired": true,
+	"taskSummary": "Crop reporting site screenshot previews to a visible 665px height and open full screenshots in a scrollable modal lightbox.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/bootstrap-checklist.md",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/trace-layers.md",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/github-mutation-policy.md"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/"
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+		}
+	],
+	"skippedBundles": [
+		"cloudflare",
+		"openai-platform",
+		"mcp-agent-tooling",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"filesModified": [
+		"scripts/render-reporting-review-site.mjs",
+		"scripts/visual-walkthrough.mjs",
+		"reports-site/index.html",
+		"tests/reporting-review-generation-model.test.js",
+		"docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.md",
+		"docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.json"
+	],
+	"validation": [
+		{
+			"command": "node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js",
+			"result": "passed"
+		},
+		{
+			"command": "node scripts/validate-reports-site.mjs",
+			"result": "passed",
+			"evidence": "Validated 46 pages, 81 states and 162 captures."
+		},
+		{
+			"command": "Playwright browser check against reports-site/index.html",
+			"result": "passed",
+			"evidence": "First thumbnail rendered at exactly 665px, the modal opened, the full image was taller than the modal body and the modal body used overflow:auto."
+		},
+		{
+			"command": "npm run lint -- --quiet",
+			"result": "passed",
+			"notes": "Existing ESLint-env deprecation warnings were reported."
+		},
+		{
+			"command": "npm run validate",
+			"result": "passed"
+		}
+	],
+	"residualRisks": [
+		"The static report lightbox supports close, Escape and focus return but does not implement a full focus trap."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.json
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.json
@@ -2,7 +2,7 @@
 	"date": "2026-07-01",
 	"branch": "fix/report-site-screenshot-lightbox",
 	"traceRequired": true,
-	"taskSummary": "Crop reporting site screenshot previews to a visible 665px height and open full screenshots in a scrollable modal lightbox.",
+	"taskSummary": "Crop reporting site screenshot previews to a visible 665px height and open full screenshots in a scrollable modal lightbox with keyboard focus trapped inside the modal.",
 	"operatingModelFilesLoaded": [
 		"AGENTS.md",
 		".agent-operating-model/orchestration.xml",
@@ -65,6 +65,11 @@
 			"evidence": "First thumbnail rendered at exactly 665px, the modal opened, the full image was taller than the modal body and the modal body used overflow:auto."
 		},
 		{
+			"command": "Playwright keyboard check against reports-site/index.html",
+			"result": "passed",
+			"evidence": "Tab and Shift+Tab remained inside the lightbox, Escape closed it and focus returned to the triggering thumbnail."
+		},
+		{
 			"command": "npm run lint -- --quiet",
 			"result": "passed",
 			"notes": "Existing ESLint-env deprecation warnings were reported."
@@ -75,6 +80,6 @@
 		}
 	],
 	"residualRisks": [
-		"The static report lightbox supports close, Escape and focus return but does not implement a full focus trap."
+		"No known residual accessibility issue remains from the Codex comment. The static report lightbox now keeps keyboard focus inside the modal while it is open."
 	]
 }

--- a/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.md
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.md
@@ -55,19 +55,21 @@ Skipped bundles:
 
 - Set screenshot preview images to a consistent visible 665px height using top-aligned object-fit cropping.
 - Wrapped screenshots in lightbox links while keeping the existing image paths for direct fallback.
-- Added a modal dialog with a scrollable image body, close button, Escape handling and focus restoration.
+- Added a modal dialog with a scrollable image body, close button, Escape handling, focus restoration and Tab/Shift+Tab focus trapping.
 - Applied the same behavior to both the reporting review renderer and the raw visual walkthrough renderer.
 - Regenerated the committed `reports-site/index.html` artefact.
-- Added a renderer test covering the crop CSS, lightbox markup and click/Escape behavior.
+- Added a renderer test covering the crop CSS, lightbox markup, click/Escape behavior and focus trap logic.
+- Addressed Codex PR feedback that `aria-modal` dialogs must keep keyboard focus inside the modal while open.
 
 ## Validation
 
 - `node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js`: passed.
 - `node scripts/validate-reports-site.mjs`: passed, validating 46 pages, 81 states and 162 captures.
 - Playwright browser check: passed. First screenshot preview rendered at exactly 665px, the lightbox opened, full image was taller than the modal body and the body used `overflow: auto`.
+- Playwright keyboard check: passed. Tab and Shift+Tab remained inside the lightbox, Escape closed it and focus returned to the triggering thumbnail.
 - `npm run lint -- --quiet`: passed with existing ESLint-env deprecation warnings only.
 - `npm run validate`: passed.
 
 ## Residual risk
 
-The modal is intentionally small and static. It provides keyboard close and focus return, but it does not implement a full focus trap because this report is a static review artefact rather than the primary service application.
+No known residual accessibility issue remains from the Codex comment. The static report lightbox now keeps keyboard focus inside the modal while it is open.

--- a/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.md
+++ b/docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.md
@@ -1,0 +1,73 @@
+# Report site screenshot lightbox
+
+Date: 2026-07-01
+Branch: `fix/report-site-screenshot-lightbox`
+
+## Task
+
+Crop every screenshot preview in the reporting site to the same visible height of 665px and open the full screenshot in a scrollable modal lightbox when selected.
+
+## Trace decision
+
+The active branch prefix `fix/` requires an auditable trace for repository-affecting work.
+
+## Operating model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped bundles:
+
+- `cloudflare`: no Worker, Pages deployment, binding or runtime configuration changed.
+- `openai-platform`: no OpenAI API integration changed.
+- `mcp-agent-tooling`: no MCP tooling changed.
+- `airtable-public-api`: no Airtable API implementation changed.
+- `mural-public-api`: no Mural API implementation changed.
+
+## Files modified
+
+- `scripts/render-reporting-review-site.mjs`
+- `scripts/visual-walkthrough.mjs`
+- `reports-site/index.html`
+- `tests/reporting-review-generation-model.test.js`
+- `docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.md`
+- `docs/agent-audit/reasoning/2026/07/01/report-site-screenshot-lightbox.json`
+
+## Work done
+
+- Set screenshot preview images to a consistent visible 665px height using top-aligned object-fit cropping.
+- Wrapped screenshots in lightbox links while keeping the existing image paths for direct fallback.
+- Added a modal dialog with a scrollable image body, close button, Escape handling and focus restoration.
+- Applied the same behavior to both the reporting review renderer and the raw visual walkthrough renderer.
+- Regenerated the committed `reports-site/index.html` artefact.
+- Added a renderer test covering the crop CSS, lightbox markup and click/Escape behavior.
+
+## Validation
+
+- `node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js`: passed.
+- `node scripts/validate-reports-site.mjs`: passed, validating 46 pages, 81 states and 162 captures.
+- Playwright browser check: passed. First screenshot preview rendered at exactly 665px, the lightbox opened, full image was taller than the modal body and the body used `overflow: auto`.
+- `npm run lint -- --quiet`: passed with existing ESLint-env deprecation warnings only.
+- `npm run validate`: passed.
+
+## Residual risk
+
+The modal is intentionally small and static. It provides keyboard close and focus return, but it does not implement a full focus trap because this report is a static review artefact rather than the primary service application.

--- a/reports-site/index.html
+++ b/reports-site/index.html
@@ -6627,6 +6627,14 @@ h3, h4, h5 { margin: 0 0 6px; }
 		const closeButton = lightbox.querySelector('[data-lightbox-close]');
 		let lastFocusedElement = null;
 
+		function focusableElements() {
+			return Array.from(
+				lightbox.querySelectorAll(
+					'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+			).filter((element) => element.offsetParent !== null);
+		}
+
 		function closeLightbox() {
 			lightbox.hidden = true;
 			document.documentElement.classList.remove('has-lightbox');
@@ -6645,6 +6653,33 @@ h3, h4, h5 { margin: 0 0 6px; }
 			closeButton.focus();
 		}
 
+		function trapLightboxFocus(event) {
+			if (event.key !== 'Tab' || lightbox.hidden) return;
+
+			const focusable = focusableElements();
+			if (focusable.length === 0) return;
+
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+
+			if (!lightbox.contains(document.activeElement)) {
+				event.preventDefault();
+				first.focus();
+				return;
+			}
+
+			if (event.shiftKey && document.activeElement === first) {
+				event.preventDefault();
+				last.focus();
+				return;
+			}
+
+			if (!event.shiftKey && document.activeElement === last) {
+				event.preventDefault();
+				first.focus();
+			}
+		}
+
 		for (const link of document.querySelectorAll('[data-lightbox-image]')) {
 			link.addEventListener('click', (event) => {
 				event.preventDefault();
@@ -6658,6 +6693,7 @@ h3, h4, h5 { margin: 0 0 6px; }
 		});
 		document.addEventListener('keydown', (event) => {
 			if (!lightbox.hidden && event.key === 'Escape') closeLightbox();
+			trapLightboxFocus(event);
 		});
 	})();
 	</script>

--- a/reports-site/index.html
+++ b/reports-site/index.html
@@ -40,9 +40,21 @@ h3, h4, h5 { margin: 0 0 6px; }
 .review-risk-list dd { margin: 0; }
 .capture { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
 .capture__figure { margin: 10px 0 0; }
-.capture__figure img { border: 1px solid #d8d8d8; height: auto; max-width: 100%; }
+.capture__lightbox-link { display: block; }
+.capture__lightbox-link:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+.capture__figure img { border: 1px solid #d8d8d8; box-sizing: border-box; display: block; height: 665px; max-width: 100%; object-fit: cover; object-position: top center; width: 100%; }
+.has-lightbox { overflow: hidden; }
+.lightbox { background: rgba(11, 12, 12, 0.75); bottom: 0; left: 0; padding: 24px; position: fixed; right: 0; top: 0; z-index: 1000; }
+.lightbox__panel { background: #fff; display: flex; flex-direction: column; height: 100%; margin: 0 auto; max-width: 1200px; }
+.lightbox__header { align-items: center; border-bottom: 1px solid #d8d8d8; display: flex; gap: 16px; justify-content: space-between; padding: 12px 16px; }
+.lightbox__header h2 { border-bottom: 0; margin: 0; padding: 0; }
+.lightbox__close { background: #f3f2f1; border: 2px solid #0b0c0c; cursor: pointer; font: inherit; padding: 8px 12px; }
+.lightbox__close:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+.lightbox__body { flex: 1; overflow: auto; padding: 16px; }
+.lightbox__image { display: block; height: auto; max-width: 100%; }
 @media (max-width: 900px) {
 	.group__pages { grid-template-columns: 1fr; }
+	.lightbox { padding: 12px; }
 }</style>
 </head>
 <body>
@@ -228,13 +240,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__home__default.png"><img loading="lazy" src="screenshots/desktop/core__home__default.png" alt="Screenshot of Home in the Default state state for Desktop." /></a><figcaption>Home — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__home__default.png" aria-label="Open full screenshot for Home — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/core__home__default.png" alt="Screenshot of Home in the Default state state for Desktop." /></a><figcaption>Home — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__home__default.png"><img loading="lazy" src="screenshots/mobile/core__home__default.png" alt="Screenshot of Home in the Default state state for Mobile." /></a><figcaption>Home — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__home__default.png" aria-label="Open full screenshot for Home — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/core__home__default.png" alt="Screenshot of Home in the Default state state for Mobile." /></a><figcaption>Home — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -315,13 +327,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/product-proof/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__product-proof__default.png"><img loading="lazy" src="screenshots/desktop/core__product-proof__default.png" alt="Screenshot of ResearchOps Product Proof in the Lifecycle proof before sign-in state for Desktop." /></a><figcaption>ResearchOps Product Proof — Lifecycle proof before sign-in — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__product-proof__default.png" aria-label="Open full screenshot for ResearchOps Product Proof — Lifecycle proof before sign-in — Desktop"><img loading="lazy" src="screenshots/desktop/core__product-proof__default.png" alt="Screenshot of ResearchOps Product Proof in the Lifecycle proof before sign-in state for Desktop." /></a><figcaption>ResearchOps Product Proof — Lifecycle proof before sign-in — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/product-proof/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__product-proof__default.png"><img loading="lazy" src="screenshots/mobile/core__product-proof__default.png" alt="Screenshot of ResearchOps Product Proof in the Lifecycle proof before sign-in state for Mobile." /></a><figcaption>ResearchOps Product Proof — Lifecycle proof before sign-in — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__product-proof__default.png" aria-label="Open full screenshot for ResearchOps Product Proof — Lifecycle proof before sign-in — Mobile"><img loading="lazy" src="screenshots/mobile/core__product-proof__default.png" alt="Screenshot of ResearchOps Product Proof in the Lifecycle proof before sign-in state for Mobile." /></a><figcaption>ResearchOps Product Proof — Lifecycle proof before sign-in — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -401,13 +413,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/overview/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start-overview__default.png"><img loading="lazy" src="screenshots/desktop/core__start-overview__default.png" alt="Screenshot of Start a research project in the Default state state for Desktop." /></a><figcaption>Start a research project — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start-overview__default.png" aria-label="Open full screenshot for Start a research project — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/core__start-overview__default.png" alt="Screenshot of Start a research project in the Default state state for Desktop." /></a><figcaption>Start a research project — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/overview/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start-overview__default.png"><img loading="lazy" src="screenshots/mobile/core__start-overview__default.png" alt="Screenshot of Start a research project in the Default state state for Mobile." /></a><figcaption>Start a research project — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start-overview__default.png" aria-label="Open full screenshot for Start a research project — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/core__start-overview__default.png" alt="Screenshot of Start a research project in the Default state state for Mobile." /></a><figcaption>Start a research project — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -498,13 +510,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__default.png"><img loading="lazy" src="screenshots/desktop/core__start__default.png" alt="Screenshot of Start research project in the Default state state for Desktop." /></a><figcaption>Start research project — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__default.png" aria-label="Open full screenshot for Start research project — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__default.png" alt="Screenshot of Start research project in the Default state state for Desktop." /></a><figcaption>Start research project — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__default.png"><img loading="lazy" src="screenshots/mobile/core__start__default.png" alt="Screenshot of Start research project in the Default state state for Mobile." /></a><figcaption>Start research project — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__default.png" aria-label="Open full screenshot for Start research project — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__default.png" alt="Screenshot of Start research project in the Default state state for Mobile." /></a><figcaption>Start research project — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -550,13 +562,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__step-1-filled.png"><img loading="lazy" src="screenshots/desktop/core__start__step-1-filled.png" alt="Screenshot of Start research project in the Step 1 completed state for Desktop." /></a><figcaption>Start research project — Step 1 completed — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__step-1-filled.png" aria-label="Open full screenshot for Start research project — Step 1 completed — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__step-1-filled.png" alt="Screenshot of Start research project in the Step 1 completed state for Desktop." /></a><figcaption>Start research project — Step 1 completed — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__step-1-filled.png"><img loading="lazy" src="screenshots/mobile/core__start__step-1-filled.png" alt="Screenshot of Start research project in the Step 1 completed state for Mobile." /></a><figcaption>Start research project — Step 1 completed — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__step-1-filled.png" aria-label="Open full screenshot for Start research project — Step 1 completed — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__step-1-filled.png" alt="Screenshot of Start research project in the Step 1 completed state for Mobile." /></a><figcaption>Start research project — Step 1 completed — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -601,13 +613,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__step-2-default.png"><img loading="lazy" src="screenshots/desktop/core__start__step-2-default.png" alt="Screenshot of Start research project in the Step 2 default state state for Desktop." /></a><figcaption>Start research project — Step 2 default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__step-2-default.png" aria-label="Open full screenshot for Start research project — Step 2 default state — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__step-2-default.png" alt="Screenshot of Start research project in the Step 2 default state state for Desktop." /></a><figcaption>Start research project — Step 2 default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__step-2-default.png"><img loading="lazy" src="screenshots/mobile/core__start__step-2-default.png" alt="Screenshot of Start research project in the Step 2 default state state for Mobile." /></a><figcaption>Start research project — Step 2 default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__step-2-default.png" aria-label="Open full screenshot for Start research project — Step 2 default state — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__step-2-default.png" alt="Screenshot of Start research project in the Step 2 default state state for Mobile." /></a><figcaption>Start research project — Step 2 default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -652,13 +664,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__step-2-filled-no-ai.png"><img loading="lazy" src="screenshots/desktop/core__start__step-2-filled-no-ai.png" alt="Screenshot of Start research project in the Step 2 completed state for Desktop." /></a><figcaption>Start research project — Step 2 completed — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__step-2-filled-no-ai.png" aria-label="Open full screenshot for Start research project — Step 2 completed — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__step-2-filled-no-ai.png" alt="Screenshot of Start research project in the Step 2 completed state for Desktop." /></a><figcaption>Start research project — Step 2 completed — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__step-2-filled-no-ai.png"><img loading="lazy" src="screenshots/mobile/core__start__step-2-filled-no-ai.png" alt="Screenshot of Start research project in the Step 2 completed state for Mobile." /></a><figcaption>Start research project — Step 2 completed — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__step-2-filled-no-ai.png" aria-label="Open full screenshot for Start research project — Step 2 completed — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__step-2-filled-no-ai.png" alt="Screenshot of Start research project in the Step 2 completed state for Mobile." /></a><figcaption>Start research project — Step 2 completed — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -703,13 +715,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__step-2-ai-rewrite-shown.png"><img loading="lazy" src="screenshots/desktop/core__start__step-2-ai-rewrite-shown.png" alt="Screenshot of Start research project in the Step 2 AI rewrite shown state for Desktop." /></a><figcaption>Start research project — Step 2 AI rewrite shown — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__step-2-ai-rewrite-shown.png" aria-label="Open full screenshot for Start research project — Step 2 AI rewrite shown — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__step-2-ai-rewrite-shown.png" alt="Screenshot of Start research project in the Step 2 AI rewrite shown state for Desktop." /></a><figcaption>Start research project — Step 2 AI rewrite shown — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__step-2-ai-rewrite-shown.png"><img loading="lazy" src="screenshots/mobile/core__start__step-2-ai-rewrite-shown.png" alt="Screenshot of Start research project in the Step 2 AI rewrite shown state for Mobile." /></a><figcaption>Start research project — Step 2 AI rewrite shown — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__step-2-ai-rewrite-shown.png" aria-label="Open full screenshot for Start research project — Step 2 AI rewrite shown — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__step-2-ai-rewrite-shown.png" alt="Screenshot of Start research project in the Step 2 AI rewrite shown state for Mobile." /></a><figcaption>Start research project — Step 2 AI rewrite shown — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -754,13 +766,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__step-3-default.png"><img loading="lazy" src="screenshots/desktop/core__start__step-3-default.png" alt="Screenshot of Start research project in the Step 3 default state state for Desktop." /></a><figcaption>Start research project — Step 3 default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__step-3-default.png" aria-label="Open full screenshot for Start research project — Step 3 default state — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__step-3-default.png" alt="Screenshot of Start research project in the Step 3 default state state for Desktop." /></a><figcaption>Start research project — Step 3 default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__step-3-default.png"><img loading="lazy" src="screenshots/mobile/core__start__step-3-default.png" alt="Screenshot of Start research project in the Step 3 default state state for Mobile." /></a><figcaption>Start research project — Step 3 default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__step-3-default.png" aria-label="Open full screenshot for Start research project — Step 3 default state — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__step-3-default.png" alt="Screenshot of Start research project in the Step 3 default state state for Mobile." /></a><figcaption>Start research project — Step 3 default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -805,13 +817,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__step-3-filled.png"><img loading="lazy" src="screenshots/desktop/core__start__step-3-filled.png" alt="Screenshot of Start research project in the Step 3 completed state for Desktop." /></a><figcaption>Start research project — Step 3 completed — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__step-3-filled.png" aria-label="Open full screenshot for Start research project — Step 3 completed — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__step-3-filled.png" alt="Screenshot of Start research project in the Step 3 completed state for Desktop." /></a><figcaption>Start research project — Step 3 completed — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__step-3-filled.png"><img loading="lazy" src="screenshots/mobile/core__start__step-3-filled.png" alt="Screenshot of Start research project in the Step 3 completed state for Mobile." /></a><figcaption>Start research project — Step 3 completed — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__step-3-filled.png" aria-label="Open full screenshot for Start research project — Step 3 completed — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__step-3-filled.png" alt="Screenshot of Start research project in the Step 3 completed state for Mobile." /></a><figcaption>Start research project — Step 3 completed — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -857,13 +869,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/core__start__step-4-check-answers.png"><img loading="lazy" src="screenshots/desktop/core__start__step-4-check-answers.png" alt="Screenshot of Start research project in the Step 4 check your answers state for Desktop." /></a><figcaption>Start research project — Step 4 check your answers — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/core__start__step-4-check-answers.png" aria-label="Open full screenshot for Start research project — Step 4 check your answers — Desktop"><img loading="lazy" src="screenshots/desktop/core__start__step-4-check-answers.png" alt="Screenshot of Start research project in the Step 4 check your answers state for Desktop." /></a><figcaption>Start research project — Step 4 check your answers — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/start/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/core__start__step-4-check-answers.png"><img loading="lazy" src="screenshots/mobile/core__start__step-4-check-answers.png" alt="Screenshot of Start research project in the Step 4 check your answers state for Mobile." /></a><figcaption>Start research project — Step 4 check your answers — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/core__start__step-4-check-answers.png" aria-label="Open full screenshot for Start research project — Step 4 check your answers — Mobile"><img loading="lazy" src="screenshots/mobile/core__start__step-4-check-answers.png" alt="Screenshot of Start research project in the Step 4 check your answers state for Mobile." /></a><figcaption>Start research project — Step 4 check your answers — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -948,13 +960,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/account/sign-in/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/account__account-sign-in__default.png"><img loading="lazy" src="screenshots/desktop/account__account-sign-in__default.png" alt="Screenshot of Sign in to ResearchOps in the Email address requested state for Desktop." /></a><figcaption>Sign in to ResearchOps — Email address requested — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/account__account-sign-in__default.png" aria-label="Open full screenshot for Sign in to ResearchOps — Email address requested — Desktop"><img loading="lazy" src="screenshots/desktop/account__account-sign-in__default.png" alt="Screenshot of Sign in to ResearchOps in the Email address requested state for Desktop." /></a><figcaption>Sign in to ResearchOps — Email address requested — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/account/sign-in/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/account__account-sign-in__default.png"><img loading="lazy" src="screenshots/mobile/account__account-sign-in__default.png" alt="Screenshot of Sign in to ResearchOps in the Email address requested state for Mobile." /></a><figcaption>Sign in to ResearchOps — Email address requested — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/account__account-sign-in__default.png" aria-label="Open full screenshot for Sign in to ResearchOps — Email address requested — Mobile"><img loading="lazy" src="screenshots/mobile/account__account-sign-in__default.png" alt="Screenshot of Sign in to ResearchOps in the Email address requested state for Mobile." /></a><figcaption>Sign in to ResearchOps — Email address requested — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1027,13 +1039,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/account/sign-in/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/account__account-sign-in__code-requested.png"><img loading="lazy" src="screenshots/desktop/account__account-sign-in__code-requested.png" alt="Screenshot of Sign in to ResearchOps in the 6 digit code requested state for Desktop." /></a><figcaption>Sign in to ResearchOps — 6 digit code requested — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/account__account-sign-in__code-requested.png" aria-label="Open full screenshot for Sign in to ResearchOps — 6 digit code requested — Desktop"><img loading="lazy" src="screenshots/desktop/account__account-sign-in__code-requested.png" alt="Screenshot of Sign in to ResearchOps in the 6 digit code requested state for Desktop." /></a><figcaption>Sign in to ResearchOps — 6 digit code requested — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/account/sign-in/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/account__account-sign-in__code-requested.png"><img loading="lazy" src="screenshots/mobile/account__account-sign-in__code-requested.png" alt="Screenshot of Sign in to ResearchOps in the 6 digit code requested state for Mobile." /></a><figcaption>Sign in to ResearchOps — 6 digit code requested — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/account__account-sign-in__code-requested.png" aria-label="Open full screenshot for Sign in to ResearchOps — 6 digit code requested — Mobile"><img loading="lazy" src="screenshots/mobile/account__account-sign-in__code-requested.png" alt="Screenshot of Sign in to ResearchOps in the 6 digit code requested state for Mobile." /></a><figcaption>Sign in to ResearchOps — 6 digit code requested — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1116,13 +1128,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/account/register/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/account__account-registration__default.png"><img loading="lazy" src="screenshots/desktop/account__account-registration__default.png" alt="Screenshot of Request a ResearchOps account in the Account request form state for Desktop." /></a><figcaption>Request a ResearchOps account — Account request form — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/account__account-registration__default.png" aria-label="Open full screenshot for Request a ResearchOps account — Account request form — Desktop"><img loading="lazy" src="screenshots/desktop/account__account-registration__default.png" alt="Screenshot of Request a ResearchOps account in the Account request form state for Desktop." /></a><figcaption>Request a ResearchOps account — Account request form — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/account/register/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/account__account-registration__default.png"><img loading="lazy" src="screenshots/mobile/account__account-registration__default.png" alt="Screenshot of Request a ResearchOps account in the Account request form state for Mobile." /></a><figcaption>Request a ResearchOps account — Account request form — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/account__account-registration__default.png" aria-label="Open full screenshot for Request a ResearchOps account — Account request form — Mobile"><img loading="lazy" src="screenshots/mobile/account__account-registration__default.png" alt="Screenshot of Request a ResearchOps account in the Account request form state for Mobile." /></a><figcaption>Request a ResearchOps account — Account request form — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1202,13 +1214,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/account/team-access/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/account__account-team-access__default.png"><img loading="lazy" src="screenshots/desktop/account__account-team-access__default.png" alt="Screenshot of Request access to a team in the Default state state for Desktop." /></a><figcaption>Request access to a team — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/account__account-team-access__default.png" aria-label="Open full screenshot for Request access to a team — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/account__account-team-access__default.png" alt="Screenshot of Request access to a team in the Default state state for Desktop." /></a><figcaption>Request access to a team — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/account/team-access/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/account__account-team-access__default.png"><img loading="lazy" src="screenshots/mobile/account__account-team-access__default.png" alt="Screenshot of Request access to a team in the Default state state for Mobile." /></a><figcaption>Request access to a team — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/account__account-team-access__default.png" aria-label="Open full screenshot for Request access to a team — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/account__account-team-access__default.png" alt="Screenshot of Request access to a team in the Default state state for Mobile." /></a><figcaption>Request access to a team — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1289,13 +1301,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/account/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/account__account-dashboard__default.png"><img loading="lazy" src="screenshots/desktop/account__account-dashboard__default.png" alt="Screenshot of Your ResearchOps account in the Signed-in account dashboard state for Desktop." /></a><figcaption>Your ResearchOps account — Signed-in account dashboard — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/account__account-dashboard__default.png" aria-label="Open full screenshot for Your ResearchOps account — Signed-in account dashboard — Desktop"><img loading="lazy" src="screenshots/desktop/account__account-dashboard__default.png" alt="Screenshot of Your ResearchOps account in the Signed-in account dashboard state for Desktop." /></a><figcaption>Your ResearchOps account — Signed-in account dashboard — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/account/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/account__account-dashboard__default.png"><img loading="lazy" src="screenshots/mobile/account__account-dashboard__default.png" alt="Screenshot of Your ResearchOps account in the Signed-in account dashboard state for Mobile." /></a><figcaption>Your ResearchOps account — Signed-in account dashboard — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/account__account-dashboard__default.png" aria-label="Open full screenshot for Your ResearchOps account — Signed-in account dashboard — Mobile"><img loading="lazy" src="screenshots/mobile/account__account-dashboard__default.png" alt="Screenshot of Your ResearchOps account in the Signed-in account dashboard state for Mobile." /></a><figcaption>Your ResearchOps account — Signed-in account dashboard — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1448,13 +1460,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__projects__default.png"><img loading="lazy" src="screenshots/desktop/projects__projects__default.png" alt="Screenshot of Projects in the Projects list with authenticated project context state for Desktop." /></a><figcaption>Projects — Projects list with authenticated project context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__projects__default.png" aria-label="Open full screenshot for Projects — Projects list with authenticated project context — Desktop"><img loading="lazy" src="screenshots/desktop/projects__projects__default.png" alt="Screenshot of Projects in the Projects list with authenticated project context state for Desktop." /></a><figcaption>Projects — Projects list with authenticated project context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__projects__default.png"><img loading="lazy" src="screenshots/mobile/projects__projects__default.png" alt="Screenshot of Projects in the Projects list with authenticated project context state for Mobile." /></a><figcaption>Projects — Projects list with authenticated project context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__projects__default.png" aria-label="Open full screenshot for Projects — Projects list with authenticated project context — Mobile"><img loading="lazy" src="screenshots/mobile/projects__projects__default.png" alt="Screenshot of Projects in the Projects list with authenticated project context state for Mobile." /></a><figcaption>Projects — Projects list with authenticated project context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1535,13 +1547,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/project-dashboard/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__project-dashboard__default.png"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard__default.png" alt="Screenshot of Project dashboard in the Project dashboard with operational project context state for Desktop." /></a><figcaption>Project dashboard — Project dashboard with operational project context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__project-dashboard__default.png" aria-label="Open full screenshot for Project dashboard — Project dashboard with operational project context — Desktop"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard__default.png" alt="Screenshot of Project dashboard in the Project dashboard with operational project context state for Desktop." /></a><figcaption>Project dashboard — Project dashboard with operational project context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/project-dashboard/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__project-dashboard__default.png"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard__default.png" alt="Screenshot of Project dashboard in the Project dashboard with operational project context state for Mobile." /></a><figcaption>Project dashboard — Project dashboard with operational project context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__project-dashboard__default.png" aria-label="Open full screenshot for Project dashboard — Project dashboard with operational project context — Mobile"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard__default.png" alt="Screenshot of Project dashboard in the Project dashboard with operational project context state for Mobile." /></a><figcaption>Project dashboard — Project dashboard with operational project context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1623,13 +1635,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/new/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__project-dashboard-add-study__default.png"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-add-study__default.png" alt="Screenshot of Add study in the Add study with parent project context state for Desktop." /></a><figcaption>Add study — Add study with parent project context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__project-dashboard-add-study__default.png" aria-label="Open full screenshot for Add study — Add study with parent project context — Desktop"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-add-study__default.png" alt="Screenshot of Add study in the Add study with parent project context state for Desktop." /></a><figcaption>Add study — Add study with parent project context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/new/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__project-dashboard-add-study__default.png"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-add-study__default.png" alt="Screenshot of Add study in the Add study with parent project context state for Mobile." /></a><figcaption>Add study — Add study with parent project context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__project-dashboard-add-study__default.png" aria-label="Open full screenshot for Add study — Add study with parent project context — Mobile"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-add-study__default.png" alt="Screenshot of Add study in the Add study with parent project context state for Mobile." /></a><figcaption>Add study — Add study with parent project context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1699,13 +1711,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/new/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__project-dashboard-add-study__missing-project-id-error.png"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-add-study__missing-project-id-error.png" alt="Screenshot of Add study in the Missing project ID error state for Desktop." /></a><figcaption>Add study — Missing project ID error — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__project-dashboard-add-study__missing-project-id-error.png" aria-label="Open full screenshot for Add study — Missing project ID error — Desktop"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-add-study__missing-project-id-error.png" alt="Screenshot of Add study in the Missing project ID error state for Desktop." /></a><figcaption>Add study — Missing project ID error — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/new/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__project-dashboard-add-study__missing-project-id-error.png"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-add-study__missing-project-id-error.png" alt="Screenshot of Add study in the Missing project ID error state for Mobile." /></a><figcaption>Add study — Missing project ID error — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__project-dashboard-add-study__missing-project-id-error.png" aria-label="Open full screenshot for Add study — Missing project ID error — Mobile"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-add-study__missing-project-id-error.png" alt="Screenshot of Add study in the Missing project ID error state for Mobile." /></a><figcaption>Add study — Missing project ID error — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1788,13 +1800,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/project-dashboard/participants/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__project-dashboard-add-participant__default.png"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-add-participant__default.png" alt="Screenshot of Add participant in the Add participant with parent context state for Desktop." /></a><figcaption>Add participant — Add participant with parent context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__project-dashboard-add-participant__default.png" aria-label="Open full screenshot for Add participant — Add participant with parent context — Desktop"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-add-participant__default.png" alt="Screenshot of Add participant in the Add participant with parent context state for Desktop." /></a><figcaption>Add participant — Add participant with parent context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/project-dashboard/participants/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__project-dashboard-add-participant__default.png"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-add-participant__default.png" alt="Screenshot of Add participant in the Add participant with parent context state for Mobile." /></a><figcaption>Add participant — Add participant with parent context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__project-dashboard-add-participant__default.png" aria-label="Open full screenshot for Add participant — Add participant with parent context — Mobile"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-add-participant__default.png" alt="Screenshot of Add participant in the Add participant with parent context state for Mobile." /></a><figcaption>Add participant — Add participant with parent context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1875,13 +1887,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/project-dashboard/participants/import/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__project-dashboard-import-participants__default.png"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-import-participants__default.png" alt="Screenshot of Import participants in the Import participants with parent context state for Desktop." /></a><figcaption>Import participants — Import participants with parent context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__project-dashboard-import-participants__default.png" aria-label="Open full screenshot for Import participants — Import participants with parent context — Desktop"><img loading="lazy" src="screenshots/desktop/projects__project-dashboard-import-participants__default.png" alt="Screenshot of Import participants in the Import participants with parent context state for Desktop." /></a><figcaption>Import participants — Import participants with parent context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/project-dashboard/participants/import/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__project-dashboard-import-participants__default.png"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-import-participants__default.png" alt="Screenshot of Import participants in the Import participants with parent context state for Mobile." /></a><figcaption>Import participants — Import participants with parent context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__project-dashboard-import-participants__default.png" aria-label="Open full screenshot for Import participants — Import participants with parent context — Mobile"><img loading="lazy" src="screenshots/mobile/projects__project-dashboard-import-participants__default.png" alt="Screenshot of Import participants in the Import participants with parent context state for Mobile." /></a><figcaption>Import participants — Import participants with parent context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -1962,13 +1974,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/outcomes/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__outcomes__default.png"><img loading="lazy" src="screenshots/desktop/projects__outcomes__default.png" alt="Screenshot of Project outcomes in the Project outcomes with project context state for Desktop." /></a><figcaption>Project outcomes — Project outcomes with project context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__outcomes__default.png" aria-label="Open full screenshot for Project outcomes — Project outcomes with project context — Desktop"><img loading="lazy" src="screenshots/desktop/projects__outcomes__default.png" alt="Screenshot of Project outcomes in the Project outcomes with project context state for Desktop." /></a><figcaption>Project outcomes — Project outcomes with project context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/outcomes/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__outcomes__default.png"><img loading="lazy" src="screenshots/mobile/projects__outcomes__default.png" alt="Screenshot of Project outcomes in the Project outcomes with project context state for Mobile." /></a><figcaption>Project outcomes — Project outcomes with project context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__outcomes__default.png" aria-label="Open full screenshot for Project outcomes — Project outcomes with project context — Mobile"><img loading="lazy" src="screenshots/mobile/projects__outcomes__default.png" alt="Screenshot of Project outcomes in the Project outcomes with project context state for Mobile." /></a><figcaption>Project outcomes — Project outcomes with project context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2050,13 +2062,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__default.png"><img loading="lazy" src="screenshots/desktop/projects__journals__default.png" alt="Screenshot of Project journals in the Journal entries with realistic reflexive data state for Desktop." /></a><figcaption>Project journals — Journal entries with realistic reflexive data — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__default.png" aria-label="Open full screenshot for Project journals — Journal entries with realistic reflexive data — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__default.png" alt="Screenshot of Project journals in the Journal entries with realistic reflexive data state for Desktop." /></a><figcaption>Project journals — Journal entries with realistic reflexive data — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__default.png"><img loading="lazy" src="screenshots/mobile/projects__journals__default.png" alt="Screenshot of Project journals in the Journal entries with realistic reflexive data state for Mobile." /></a><figcaption>Project journals — Journal entries with realistic reflexive data — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__default.png" aria-label="Open full screenshot for Project journals — Journal entries with realistic reflexive data — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__default.png" alt="Screenshot of Project journals in the Journal entries with realistic reflexive data state for Mobile." /></a><figcaption>Project journals — Journal entries with realistic reflexive data — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2126,13 +2138,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#codes</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__codes-with-realistic-data.png"><img loading="lazy" src="screenshots/desktop/projects__journals__codes-with-realistic-data.png" alt="Screenshot of Project journals in the Codes with realistic data state for Desktop." /></a><figcaption>Project journals — Codes with realistic data — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__codes-with-realistic-data.png" aria-label="Open full screenshot for Project journals — Codes with realistic data — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__codes-with-realistic-data.png" alt="Screenshot of Project journals in the Codes with realistic data state for Desktop." /></a><figcaption>Project journals — Codes with realistic data — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#codes</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__codes-with-realistic-data.png"><img loading="lazy" src="screenshots/mobile/projects__journals__codes-with-realistic-data.png" alt="Screenshot of Project journals in the Codes with realistic data state for Mobile." /></a><figcaption>Project journals — Codes with realistic data — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__codes-with-realistic-data.png" aria-label="Open full screenshot for Project journals — Codes with realistic data — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__codes-with-realistic-data.png" alt="Screenshot of Project journals in the Codes with realistic data state for Mobile." /></a><figcaption>Project journals — Codes with realistic data — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2202,13 +2214,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#memos</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__memos-with-realistic-data.png"><img loading="lazy" src="screenshots/desktop/projects__journals__memos-with-realistic-data.png" alt="Screenshot of Project journals in the Memos with realistic data state for Desktop." /></a><figcaption>Project journals — Memos with realistic data — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__memos-with-realistic-data.png" aria-label="Open full screenshot for Project journals — Memos with realistic data — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__memos-with-realistic-data.png" alt="Screenshot of Project journals in the Memos with realistic data state for Desktop." /></a><figcaption>Project journals — Memos with realistic data — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#memos</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__memos-with-realistic-data.png"><img loading="lazy" src="screenshots/mobile/projects__journals__memos-with-realistic-data.png" alt="Screenshot of Project journals in the Memos with realistic data state for Mobile." /></a><figcaption>Project journals — Memos with realistic data — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__memos-with-realistic-data.png" aria-label="Open full screenshot for Project journals — Memos with realistic data — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__memos-with-realistic-data.png" alt="Screenshot of Project journals in the Memos with realistic data state for Mobile." /></a><figcaption>Project journals — Memos with realistic data — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2281,13 +2293,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-timeline.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-timeline.png" alt="Screenshot of Project journals in the Analysis timeline with realistic journal entries state for Desktop." /></a><figcaption>Project journals — Analysis timeline with realistic journal entries — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-timeline.png" aria-label="Open full screenshot for Project journals — Analysis timeline with realistic journal entries — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-timeline.png" alt="Screenshot of Project journals in the Analysis timeline with realistic journal entries state for Desktop." /></a><figcaption>Project journals — Analysis timeline with realistic journal entries — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-timeline.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-timeline.png" alt="Screenshot of Project journals in the Analysis timeline with realistic journal entries state for Mobile." /></a><figcaption>Project journals — Analysis timeline with realistic journal entries — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-timeline.png" aria-label="Open full screenshot for Project journals — Analysis timeline with realistic journal entries — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-timeline.png" alt="Screenshot of Project journals in the Analysis timeline with realistic journal entries state for Mobile." /></a><figcaption>Project journals — Analysis timeline with realistic journal entries — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2360,13 +2372,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-cooccurrence-table.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-table.png" alt="Screenshot of Project journals in the Analysis code co-occurrence table state for Desktop." /></a><figcaption>Project journals — Analysis code co-occurrence table — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-cooccurrence-table.png" aria-label="Open full screenshot for Project journals — Analysis code co-occurrence table — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-table.png" alt="Screenshot of Project journals in the Analysis code co-occurrence table state for Desktop." /></a><figcaption>Project journals — Analysis code co-occurrence table — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-cooccurrence-table.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-table.png" alt="Screenshot of Project journals in the Analysis code co-occurrence table state for Mobile." /></a><figcaption>Project journals — Analysis code co-occurrence table — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-cooccurrence-table.png" aria-label="Open full screenshot for Project journals — Analysis code co-occurrence table — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-table.png" alt="Screenshot of Project journals in the Analysis code co-occurrence table state for Mobile." /></a><figcaption>Project journals — Analysis code co-occurrence table — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2440,13 +2452,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-cooccurrence-ranked-bar-chart.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-ranked-bar-chart.png" alt="Screenshot of Project journals in the Analysis ranked co-occurrence bar chart state for Desktop." /></a><figcaption>Project journals — Analysis ranked co-occurrence bar chart — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-cooccurrence-ranked-bar-chart.png" aria-label="Open full screenshot for Project journals — Analysis ranked co-occurrence bar chart — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-ranked-bar-chart.png" alt="Screenshot of Project journals in the Analysis ranked co-occurrence bar chart state for Desktop." /></a><figcaption>Project journals — Analysis ranked co-occurrence bar chart — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-cooccurrence-ranked-bar-chart.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-ranked-bar-chart.png" alt="Screenshot of Project journals in the Analysis ranked co-occurrence bar chart state for Mobile." /></a><figcaption>Project journals — Analysis ranked co-occurrence bar chart — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-cooccurrence-ranked-bar-chart.png" aria-label="Open full screenshot for Project journals — Analysis ranked co-occurrence bar chart — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-ranked-bar-chart.png" alt="Screenshot of Project journals in the Analysis ranked co-occurrence bar chart state for Mobile." /></a><figcaption>Project journals — Analysis ranked co-occurrence bar chart — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2520,13 +2532,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-cooccurrence-matrix-heatmap.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-matrix-heatmap.png" alt="Screenshot of Project journals in the Analysis co-occurrence matrix heatmap state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence matrix heatmap — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-cooccurrence-matrix-heatmap.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence matrix heatmap — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-matrix-heatmap.png" alt="Screenshot of Project journals in the Analysis co-occurrence matrix heatmap state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence matrix heatmap — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-cooccurrence-matrix-heatmap.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-matrix-heatmap.png" alt="Screenshot of Project journals in the Analysis co-occurrence matrix heatmap state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence matrix heatmap — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-cooccurrence-matrix-heatmap.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence matrix heatmap — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-matrix-heatmap.png" alt="Screenshot of Project journals in the Analysis co-occurrence matrix heatmap state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence matrix heatmap — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2600,13 +2612,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-cooccurrence-small-multiples.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-small-multiples.png" alt="Screenshot of Project journals in the Analysis co-occurrence small multiples state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence small multiples — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-cooccurrence-small-multiples.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence small multiples — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-small-multiples.png" alt="Screenshot of Project journals in the Analysis co-occurrence small multiples state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence small multiples — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-cooccurrence-small-multiples.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-small-multiples.png" alt="Screenshot of Project journals in the Analysis co-occurrence small multiples state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence small multiples — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-cooccurrence-small-multiples.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence small multiples — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-small-multiples.png" alt="Screenshot of Project journals in the Analysis co-occurrence small multiples state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence small multiples — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2680,13 +2692,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-cooccurrence-stacked-summary.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-stacked-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence stacked summary state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence stacked summary — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-cooccurrence-stacked-summary.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence stacked summary — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-stacked-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence stacked summary state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence stacked summary — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-cooccurrence-stacked-summary.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-stacked-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence stacked summary state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence stacked summary — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-cooccurrence-stacked-summary.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence stacked summary — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-stacked-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence stacked summary state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence stacked summary — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2760,13 +2772,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-cooccurrence-clustered-summary.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-clustered-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence clustered summary state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence clustered summary — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-cooccurrence-clustered-summary.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence clustered summary — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-cooccurrence-clustered-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence clustered summary state for Desktop." /></a><figcaption>Project journals — Analysis co-occurrence clustered summary — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-cooccurrence-clustered-summary.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-clustered-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence clustered summary state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence clustered summary — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-cooccurrence-clustered-summary.png" aria-label="Open full screenshot for Project journals — Analysis co-occurrence clustered summary — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-cooccurrence-clustered-summary.png" alt="Screenshot of Project journals in the Analysis co-occurrence clustered summary state for Mobile." /></a><figcaption>Project journals — Analysis co-occurrence clustered summary — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2840,13 +2852,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-code-retrieval.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-code-retrieval.png" alt="Screenshot of Project journals in the Analysis code retrieval state for Desktop." /></a><figcaption>Project journals — Analysis code retrieval — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-code-retrieval.png" aria-label="Open full screenshot for Project journals — Analysis code retrieval — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-code-retrieval.png" alt="Screenshot of Project journals in the Analysis code retrieval state for Desktop." /></a><figcaption>Project journals — Analysis code retrieval — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-code-retrieval.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-code-retrieval.png" alt="Screenshot of Project journals in the Analysis code retrieval state for Mobile." /></a><figcaption>Project journals — Analysis code retrieval — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-code-retrieval.png" aria-label="Open full screenshot for Project journals — Analysis code retrieval — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-code-retrieval.png" alt="Screenshot of Project journals in the Analysis code retrieval state for Mobile." /></a><figcaption>Project journals — Analysis code retrieval — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -2918,13 +2930,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journals__analysis-export.png"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-export.png" alt="Screenshot of Project journals in the Analysis export state for Desktop." /></a><figcaption>Project journals — Analysis export — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journals__analysis-export.png" aria-label="Open full screenshot for Project journals — Analysis export — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journals__analysis-export.png" alt="Screenshot of Project journals in the Analysis export state for Desktop." /></a><figcaption>Project journals — Analysis export — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/projects/journals/?id=recVisualProject001#analysis</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journals__analysis-export.png"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-export.png" alt="Screenshot of Project journals in the Analysis export state for Mobile." /></a><figcaption>Project journals — Analysis export — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journals__analysis-export.png" aria-label="Open full screenshot for Project journals — Analysis export — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journals__analysis-export.png" alt="Screenshot of Project journals in the Analysis export state for Mobile." /></a><figcaption>Project journals — Analysis export — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3005,13 +3017,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/journal/entry/?id=recVisualJournal001&amp;project=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journal-entry__default.png"><img loading="lazy" src="screenshots/desktop/projects__journal-entry__default.png" alt="Screenshot of Journal entry in the Journal entry with saved content state for Desktop." /></a><figcaption>Journal entry — Journal entry with saved content — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journal-entry__default.png" aria-label="Open full screenshot for Journal entry — Journal entry with saved content — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journal-entry__default.png" alt="Screenshot of Journal entry in the Journal entry with saved content state for Desktop." /></a><figcaption>Journal entry — Journal entry with saved content — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/journal/entry/?id=recVisualJournal001&amp;project=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journal-entry__default.png"><img loading="lazy" src="screenshots/mobile/projects__journal-entry__default.png" alt="Screenshot of Journal entry in the Journal entry with saved content state for Mobile." /></a><figcaption>Journal entry — Journal entry with saved content — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journal-entry__default.png" aria-label="Open full screenshot for Journal entry — Journal entry with saved content — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journal-entry__default.png" alt="Screenshot of Journal entry in the Journal entry with saved content state for Mobile." /></a><figcaption>Journal entry — Journal entry with saved content — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3081,13 +3093,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/journal/entry/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journal-entry__missing-journal-entry-id-error.png"><img loading="lazy" src="screenshots/desktop/projects__journal-entry__missing-journal-entry-id-error.png" alt="Screenshot of Journal entry in the Missing journal entry ID error state for Desktop." /></a><figcaption>Journal entry — Missing journal entry ID error — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journal-entry__missing-journal-entry-id-error.png" aria-label="Open full screenshot for Journal entry — Missing journal entry ID error — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journal-entry__missing-journal-entry-id-error.png" alt="Screenshot of Journal entry in the Missing journal entry ID error state for Desktop." /></a><figcaption>Journal entry — Missing journal entry ID error — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/journal/entry/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journal-entry__missing-journal-entry-id-error.png"><img loading="lazy" src="screenshots/mobile/projects__journal-entry__missing-journal-entry-id-error.png" alt="Screenshot of Journal entry in the Missing journal entry ID error state for Mobile." /></a><figcaption>Journal entry — Missing journal entry ID error — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journal-entry__missing-journal-entry-id-error.png" aria-label="Open full screenshot for Journal entry — Missing journal entry ID error — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journal-entry__missing-journal-entry-id-error.png" alt="Screenshot of Journal entry in the Missing journal entry ID error state for Mobile." /></a><figcaption>Journal entry — Missing journal entry ID error — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3168,13 +3180,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/journal/edit/?id=recVisualJournal001&amp;project=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journal-entry-edit__default.png"><img loading="lazy" src="screenshots/desktop/projects__journal-entry-edit__default.png" alt="Screenshot of Edit journal entry in the Edit journal entry with saved content state for Desktop." /></a><figcaption>Edit journal entry — Edit journal entry with saved content — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journal-entry-edit__default.png" aria-label="Open full screenshot for Edit journal entry — Edit journal entry with saved content — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journal-entry-edit__default.png" alt="Screenshot of Edit journal entry in the Edit journal entry with saved content state for Desktop." /></a><figcaption>Edit journal entry — Edit journal entry with saved content — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/journal/edit/?id=recVisualJournal001&amp;project=recVisualProject001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journal-entry-edit__default.png"><img loading="lazy" src="screenshots/mobile/projects__journal-entry-edit__default.png" alt="Screenshot of Edit journal entry in the Edit journal entry with saved content state for Mobile." /></a><figcaption>Edit journal entry — Edit journal entry with saved content — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journal-entry-edit__default.png" aria-label="Open full screenshot for Edit journal entry — Edit journal entry with saved content — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journal-entry-edit__default.png" alt="Screenshot of Edit journal entry in the Edit journal entry with saved content state for Mobile." /></a><figcaption>Edit journal entry — Edit journal entry with saved content — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3244,13 +3256,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/journal/edit/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/projects__journal-entry-edit__missing-journal-entry-id-error.png"><img loading="lazy" src="screenshots/desktop/projects__journal-entry-edit__missing-journal-entry-id-error.png" alt="Screenshot of Edit journal entry in the Missing journal entry ID error state for Desktop." /></a><figcaption>Edit journal entry — Missing journal entry ID error — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/projects__journal-entry-edit__missing-journal-entry-id-error.png" aria-label="Open full screenshot for Edit journal entry — Missing journal entry ID error — Desktop"><img loading="lazy" src="screenshots/desktop/projects__journal-entry-edit__missing-journal-entry-id-error.png" alt="Screenshot of Edit journal entry in the Missing journal entry ID error state for Desktop." /></a><figcaption>Edit journal entry — Missing journal entry ID error — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/journal/edit/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/projects__journal-entry-edit__missing-journal-entry-id-error.png"><img loading="lazy" src="screenshots/mobile/projects__journal-entry-edit__missing-journal-entry-id-error.png" alt="Screenshot of Edit journal entry in the Missing journal entry ID error state for Mobile." /></a><figcaption>Edit journal entry — Missing journal entry ID error — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/projects__journal-entry-edit__missing-journal-entry-id-error.png" aria-label="Open full screenshot for Edit journal entry — Missing journal entry ID error — Mobile"><img loading="lazy" src="screenshots/mobile/projects__journal-entry-edit__missing-journal-entry-id-error.png" alt="Screenshot of Edit journal entry in the Missing journal entry ID error state for Mobile." /></a><figcaption>Edit journal entry — Missing journal entry ID error — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3337,13 +3349,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study__default.png"><img loading="lazy" src="screenshots/desktop/study__study__default.png" alt="Screenshot of Study overview in the Study overview with readiness context state for Desktop." /></a><figcaption>Study overview — Study overview with readiness context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study__default.png" aria-label="Open full screenshot for Study overview — Study overview with readiness context — Desktop"><img loading="lazy" src="screenshots/desktop/study__study__default.png" alt="Screenshot of Study overview in the Study overview with readiness context state for Desktop." /></a><figcaption>Study overview — Study overview with readiness context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study__default.png"><img loading="lazy" src="screenshots/mobile/study__study__default.png" alt="Screenshot of Study overview in the Study overview with readiness context state for Mobile." /></a><figcaption>Study overview — Study overview with readiness context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study__default.png" aria-label="Open full screenshot for Study overview — Study overview with readiness context — Mobile"><img loading="lazy" src="screenshots/mobile/study__study__default.png" alt="Screenshot of Study overview in the Study overview with readiness context state for Mobile." /></a><figcaption>Study overview — Study overview with readiness context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3425,13 +3437,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/guides/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-guides__default.png"><img loading="lazy" src="screenshots/desktop/study__study-guides__default.png" alt="Screenshot of Discussion guides in the Discussion guides with saved source state for Desktop." /></a><figcaption>Discussion guides — Discussion guides with saved source — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-guides__default.png" aria-label="Open full screenshot for Discussion guides — Discussion guides with saved source — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-guides__default.png" alt="Screenshot of Discussion guides in the Discussion guides with saved source state for Desktop." /></a><figcaption>Discussion guides — Discussion guides with saved source — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/guides/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-guides__default.png"><img loading="lazy" src="screenshots/mobile/study__study-guides__default.png" alt="Screenshot of Discussion guides in the Discussion guides with saved source state for Mobile." /></a><figcaption>Discussion guides — Discussion guides with saved source — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-guides__default.png" aria-label="Open full screenshot for Discussion guides — Discussion guides with saved source — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-guides__default.png" alt="Screenshot of Discussion guides in the Discussion guides with saved source state for Mobile." /></a><figcaption>Discussion guides — Discussion guides with saved source — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3504,13 +3516,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/guides/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-guides__empty-guide-source-error.png"><img loading="lazy" src="screenshots/desktop/study__study-guides__empty-guide-source-error.png" alt="Screenshot of Discussion guides in the Empty guide source validation state for Desktop." /></a><figcaption>Discussion guides — Empty guide source validation — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-guides__empty-guide-source-error.png" aria-label="Open full screenshot for Discussion guides — Empty guide source validation — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-guides__empty-guide-source-error.png" alt="Screenshot of Discussion guides in the Empty guide source validation state for Desktop." /></a><figcaption>Discussion guides — Empty guide source validation — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/guides/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-guides__empty-guide-source-error.png"><img loading="lazy" src="screenshots/mobile/study__study-guides__empty-guide-source-error.png" alt="Screenshot of Discussion guides in the Empty guide source validation state for Mobile." /></a><figcaption>Discussion guides — Empty guide source validation — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-guides__empty-guide-source-error.png" aria-label="Open full screenshot for Discussion guides — Empty guide source validation — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-guides__empty-guide-source-error.png" alt="Screenshot of Discussion guides in the Empty guide source validation state for Mobile." /></a><figcaption>Discussion guides — Empty guide source validation — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3593,13 +3605,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/note-takers-observers/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-note-takers-observers__default.png"><img loading="lazy" src="screenshots/desktop/study__study-note-takers-observers__default.png" alt="Screenshot of Note takers and observers in the Note takers and observers with study context state for Desktop." /></a><figcaption>Note takers and observers — Note takers and observers with study context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-note-takers-observers__default.png" aria-label="Open full screenshot for Note takers and observers — Note takers and observers with study context — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-note-takers-observers__default.png" alt="Screenshot of Note takers and observers in the Note takers and observers with study context state for Desktop." /></a><figcaption>Note takers and observers — Note takers and observers with study context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/note-takers-observers/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-note-takers-observers__default.png"><img loading="lazy" src="screenshots/mobile/study__study-note-takers-observers__default.png" alt="Screenshot of Note takers and observers in the Note takers and observers with study context state for Mobile." /></a><figcaption>Note takers and observers — Note takers and observers with study context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-note-takers-observers__default.png" aria-label="Open full screenshot for Note takers and observers — Note takers and observers with study context — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-note-takers-observers__default.png" alt="Screenshot of Note takers and observers in the Note takers and observers with study context state for Mobile." /></a><figcaption>Note takers and observers — Note takers and observers with study context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3680,13 +3692,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/participants/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-participants__default.png"><img loading="lazy" src="screenshots/desktop/study__study-participants__default.png" alt="Screenshot of Participants in the Study participants with records state for Desktop." /></a><figcaption>Participants — Study participants with records — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-participants__default.png" aria-label="Open full screenshot for Participants — Study participants with records — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-participants__default.png" alt="Screenshot of Participants in the Study participants with records state for Desktop." /></a><figcaption>Participants — Study participants with records — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/participants/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-participants__default.png"><img loading="lazy" src="screenshots/mobile/study__study-participants__default.png" alt="Screenshot of Participants in the Study participants with records state for Mobile." /></a><figcaption>Participants — Study participants with records — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-participants__default.png" aria-label="Open full screenshot for Participants — Study participants with records — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-participants__default.png" alt="Screenshot of Participants in the Study participants with records state for Mobile." /></a><figcaption>Participants — Study participants with records — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3770,13 +3782,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/session/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-session__default.png"><img loading="lazy" src="screenshots/desktop/study__study-session__default.png" alt="Screenshot of Study session in the Study session with participant ready state for Desktop." /></a><figcaption>Study session — Study session with participant ready — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-session__default.png" aria-label="Open full screenshot for Study session — Study session with participant ready — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-session__default.png" alt="Screenshot of Study session in the Study session with participant ready state for Desktop." /></a><figcaption>Study session — Study session with participant ready — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/session/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-session__default.png"><img loading="lazy" src="screenshots/mobile/study__study-session__default.png" alt="Screenshot of Study session in the Study session with participant ready state for Mobile." /></a><figcaption>Study session — Study session with participant ready — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-session__default.png" aria-label="Open full screenshot for Study session — Study session with participant ready — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-session__default.png" alt="Screenshot of Study session in the Study session with participant ready state for Mobile." /></a><figcaption>Study session — Study session with participant ready — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3846,13 +3858,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/session/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-session__participant-consent-gate.png"><img loading="lazy" src="screenshots/desktop/study__study-session__participant-consent-gate.png" alt="Screenshot of Study session in the Participant consent gate state for Desktop." /></a><figcaption>Study session — Participant consent gate — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-session__participant-consent-gate.png" aria-label="Open full screenshot for Study session — Participant consent gate — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-session__participant-consent-gate.png" alt="Screenshot of Study session in the Participant consent gate state for Desktop." /></a><figcaption>Study session — Participant consent gate — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/session/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-session__participant-consent-gate.png"><img loading="lazy" src="screenshots/mobile/study__study-session__participant-consent-gate.png" alt="Screenshot of Study session in the Participant consent gate state for Mobile." /></a><figcaption>Study session — Participant consent gate — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-session__participant-consent-gate.png" aria-label="Open full screenshot for Study session — Participant consent gate — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-session__participant-consent-gate.png" alt="Screenshot of Study session in the Participant consent gate state for Mobile." /></a><figcaption>Study session — Participant consent gate — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -3935,13 +3947,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/consent-forms/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-consent-forms__default.png"><img loading="lazy" src="screenshots/desktop/study__study-consent-forms__default.png" alt="Screenshot of Study consent forms in the Study consent forms with study context state for Desktop." /></a><figcaption>Study consent forms — Study consent forms with study context — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-consent-forms__default.png" aria-label="Open full screenshot for Study consent forms — Study consent forms with study context — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-consent-forms__default.png" alt="Screenshot of Study consent forms in the Study consent forms with study context state for Desktop." /></a><figcaption>Study consent forms — Study consent forms with study context — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/consent-forms/?pid=recVisualProject001&amp;sid=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-consent-forms__default.png"><img loading="lazy" src="screenshots/mobile/study__study-consent-forms__default.png" alt="Screenshot of Study consent forms in the Study consent forms with study context state for Mobile." /></a><figcaption>Study consent forms — Study consent forms with study context — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-consent-forms__default.png" aria-label="Open full screenshot for Study consent forms — Study consent forms with study context — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-consent-forms__default.png" alt="Screenshot of Study consent forms in the Study consent forms with study context state for Mobile." /></a><figcaption>Study consent forms — Study consent forms with study context — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4024,13 +4036,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-participant-consent__default.png"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__default.png" alt="Screenshot of Participant consent in the Consent workspace loaded state for Desktop." /></a><figcaption>Participant consent — Consent workspace loaded — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-participant-consent__default.png" aria-label="Open full screenshot for Participant consent — Consent workspace loaded — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__default.png" alt="Screenshot of Participant consent in the Consent workspace loaded state for Desktop." /></a><figcaption>Participant consent — Consent workspace loaded — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-participant-consent__default.png"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__default.png" alt="Screenshot of Participant consent in the Consent workspace loaded state for Mobile." /></a><figcaption>Participant consent — Consent workspace loaded — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-participant-consent__default.png" aria-label="Open full screenshot for Participant consent — Consent workspace loaded — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__default.png" alt="Screenshot of Participant consent in the Consent workspace loaded state for Mobile." /></a><figcaption>Participant consent — Consent workspace loaded — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4075,13 +4087,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/participant-consent/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-participant-consent__missing-context-error.png"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__missing-context-error.png" alt="Screenshot of Participant consent in the Missing study context error state state for Desktop." /></a><figcaption>Participant consent — Missing study context error state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-participant-consent__missing-context-error.png" aria-label="Open full screenshot for Participant consent — Missing study context error state — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__missing-context-error.png" alt="Screenshot of Participant consent in the Missing study context error state state for Desktop." /></a><figcaption>Participant consent — Missing study context error state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/participant-consent/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-participant-consent__missing-context-error.png"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__missing-context-error.png" alt="Screenshot of Participant consent in the Missing study context error state state for Mobile." /></a><figcaption>Participant consent — Missing study context error state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-participant-consent__missing-context-error.png" aria-label="Open full screenshot for Participant consent — Missing study context error state — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__missing-context-error.png" alt="Screenshot of Participant consent in the Missing study context error state state for Mobile." /></a><figcaption>Participant consent — Missing study context error state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4126,13 +4138,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-participant-consent__no-published-consent-form.png"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__no-published-consent-form.png" alt="Screenshot of Participant consent in the No published consent form state state for Desktop." /></a><figcaption>Participant consent — No published consent form state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-participant-consent__no-published-consent-form.png" aria-label="Open full screenshot for Participant consent — No published consent form state — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__no-published-consent-form.png" alt="Screenshot of Participant consent in the No published consent form state state for Desktop." /></a><figcaption>Participant consent — No published consent form state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-participant-consent__no-published-consent-form.png"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__no-published-consent-form.png" alt="Screenshot of Participant consent in the No published consent form state state for Mobile." /></a><figcaption>Participant consent — No published consent form state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-participant-consent__no-published-consent-form.png" aria-label="Open full screenshot for Participant consent — No published consent form state — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__no-published-consent-form.png" alt="Screenshot of Participant consent in the No published consent form state state for Mobile." /></a><figcaption>Participant consent — No published consent form state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4177,13 +4189,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-participant-consent__no-participants.png"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__no-participants.png" alt="Screenshot of Participant consent in the No participants state state for Desktop." /></a><figcaption>Participant consent — No participants state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-participant-consent__no-participants.png" aria-label="Open full screenshot for Participant consent — No participants state — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__no-participants.png" alt="Screenshot of Participant consent in the No participants state state for Desktop." /></a><figcaption>Participant consent — No participants state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-participant-consent__no-participants.png"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__no-participants.png" alt="Screenshot of Participant consent in the No participants state state for Mobile." /></a><figcaption>Participant consent — No participants state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-participant-consent__no-participants.png" aria-label="Open full screenshot for Participant consent — No participants state — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__no-participants.png" alt="Screenshot of Participant consent in the No participants state state for Mobile." /></a><figcaption>Participant consent — No participants state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4228,13 +4240,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__study-participant-consent__participant-selected.png"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__participant-selected.png" alt="Screenshot of Participant consent in the Participant selected for consent review state for Desktop." /></a><figcaption>Participant consent — Participant selected for consent review — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__study-participant-consent__participant-selected.png" aria-label="Open full screenshot for Participant consent — Participant selected for consent review — Desktop"><img loading="lazy" src="screenshots/desktop/study__study-participant-consent__participant-selected.png" alt="Screenshot of Participant consent in the Participant selected for consent review state for Desktop." /></a><figcaption>Participant consent — Participant selected for consent review — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/participant-consent/?pid=recVisualConsentProject001&amp;sid=recVisualConsentStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__study-participant-consent__participant-selected.png"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__participant-selected.png" alt="Screenshot of Participant consent in the Participant selected for consent review state for Mobile." /></a><figcaption>Participant consent — Participant selected for consent review — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__study-participant-consent__participant-selected.png" aria-label="Open full screenshot for Participant consent — Participant selected for consent review — Mobile"><img loading="lazy" src="screenshots/mobile/study__study-participant-consent__participant-selected.png" alt="Screenshot of Participant consent in the Participant selected for consent review state for Mobile." /></a><figcaption>Participant consent — Participant selected for consent review — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4319,13 +4331,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/synthesis/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__synthesize__missing-sid-error.png"><img loading="lazy" src="screenshots/desktop/study__synthesize__missing-sid-error.png" alt="Screenshot of Study synthesis in the Missing study ID error state state for Desktop." /></a><figcaption>Study synthesis — Missing study ID error state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__synthesize__missing-sid-error.png" aria-label="Open full screenshot for Study synthesis — Missing study ID error state — Desktop"><img loading="lazy" src="screenshots/desktop/study__synthesize__missing-sid-error.png" alt="Screenshot of Study synthesis in the Missing study ID error state state for Desktop." /></a><figcaption>Study synthesis — Missing study ID error state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/synthesis/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__synthesize__missing-sid-error.png"><img loading="lazy" src="screenshots/mobile/study__synthesize__missing-sid-error.png" alt="Screenshot of Study synthesis in the Missing study ID error state state for Mobile." /></a><figcaption>Study synthesis — Missing study ID error state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__synthesize__missing-sid-error.png" aria-label="Open full screenshot for Study synthesis — Missing study ID error state — Mobile"><img loading="lazy" src="screenshots/mobile/study__synthesize__missing-sid-error.png" alt="Screenshot of Study synthesis in the Missing study ID error state state for Mobile." /></a><figcaption>Study synthesis — Missing study ID error state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4370,13 +4382,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__synthesize__empty-evidence.png"><img loading="lazy" src="screenshots/desktop/study__synthesize__empty-evidence.png" alt="Screenshot of Study synthesis in the Empty evidence state state for Desktop." /></a><figcaption>Study synthesis — Empty evidence state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__synthesize__empty-evidence.png" aria-label="Open full screenshot for Study synthesis — Empty evidence state — Desktop"><img loading="lazy" src="screenshots/desktop/study__synthesize__empty-evidence.png" alt="Screenshot of Study synthesis in the Empty evidence state state for Desktop." /></a><figcaption>Study synthesis — Empty evidence state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__synthesize__empty-evidence.png"><img loading="lazy" src="screenshots/mobile/study__synthesize__empty-evidence.png" alt="Screenshot of Study synthesis in the Empty evidence state state for Mobile." /></a><figcaption>Study synthesis — Empty evidence state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__synthesize__empty-evidence.png" aria-label="Open full screenshot for Study synthesis — Empty evidence state — Mobile"><img loading="lazy" src="screenshots/mobile/study__synthesize__empty-evidence.png" alt="Screenshot of Study synthesis in the Empty evidence state state for Mobile." /></a><figcaption>Study synthesis — Empty evidence state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4421,13 +4433,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__synthesize__evidence-loaded.png"><img loading="lazy" src="screenshots/desktop/study__synthesize__evidence-loaded.png" alt="Screenshot of Study synthesis in the Evidence available before working clusters state for Desktop." /></a><figcaption>Study synthesis — Evidence available before working clusters — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__synthesize__evidence-loaded.png" aria-label="Open full screenshot for Study synthesis — Evidence available before working clusters — Desktop"><img loading="lazy" src="screenshots/desktop/study__synthesize__evidence-loaded.png" alt="Screenshot of Study synthesis in the Evidence available before working clusters state for Desktop." /></a><figcaption>Study synthesis — Evidence available before working clusters — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__synthesize__evidence-loaded.png"><img loading="lazy" src="screenshots/mobile/study__synthesize__evidence-loaded.png" alt="Screenshot of Study synthesis in the Evidence available before working clusters state for Mobile." /></a><figcaption>Study synthesis — Evidence available before working clusters — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__synthesize__evidence-loaded.png" aria-label="Open full screenshot for Study synthesis — Evidence available before working clusters — Mobile"><img loading="lazy" src="screenshots/mobile/study__synthesize__evidence-loaded.png" alt="Screenshot of Study synthesis in the Evidence available before working clusters state for Mobile." /></a><figcaption>Study synthesis — Evidence available before working clusters — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4472,13 +4484,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__synthesize__working-cluster-created.png"><img loading="lazy" src="screenshots/desktop/study__synthesize__working-cluster-created.png" alt="Screenshot of Study synthesis in the Working cluster grouping created state for Desktop." /></a><figcaption>Study synthesis — Working cluster grouping created — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__synthesize__working-cluster-created.png" aria-label="Open full screenshot for Study synthesis — Working cluster grouping created — Desktop"><img loading="lazy" src="screenshots/desktop/study__synthesize__working-cluster-created.png" alt="Screenshot of Study synthesis in the Working cluster grouping created state for Desktop." /></a><figcaption>Study synthesis — Working cluster grouping created — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__synthesize__working-cluster-created.png"><img loading="lazy" src="screenshots/mobile/study__synthesize__working-cluster-created.png" alt="Screenshot of Study synthesis in the Working cluster grouping created state for Mobile." /></a><figcaption>Study synthesis — Working cluster grouping created — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__synthesize__working-cluster-created.png" aria-label="Open full screenshot for Study synthesis — Working cluster grouping created — Mobile"><img loading="lazy" src="screenshots/mobile/study__synthesize__working-cluster-created.png" alt="Screenshot of Study synthesis in the Working cluster grouping created state for Mobile." /></a><figcaption>Study synthesis — Working cluster grouping created — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4523,13 +4535,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__synthesize__evidence-added-to-cluster.png"><img loading="lazy" src="screenshots/desktop/study__synthesize__evidence-added-to-cluster.png" alt="Screenshot of Study synthesis in the Evidence added to working cluster grouping state for Desktop." /></a><figcaption>Study synthesis — Evidence added to working cluster grouping — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__synthesize__evidence-added-to-cluster.png" aria-label="Open full screenshot for Study synthesis — Evidence added to working cluster grouping — Desktop"><img loading="lazy" src="screenshots/desktop/study__synthesize__evidence-added-to-cluster.png" alt="Screenshot of Study synthesis in the Evidence added to working cluster grouping state for Desktop." /></a><figcaption>Study synthesis — Evidence added to working cluster grouping — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__synthesize__evidence-added-to-cluster.png"><img loading="lazy" src="screenshots/mobile/study__synthesize__evidence-added-to-cluster.png" alt="Screenshot of Study synthesis in the Evidence added to working cluster grouping state for Mobile." /></a><figcaption>Study synthesis — Evidence added to working cluster grouping — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__synthesize__evidence-added-to-cluster.png" aria-label="Open full screenshot for Study synthesis — Evidence added to working cluster grouping — Mobile"><img loading="lazy" src="screenshots/mobile/study__synthesize__evidence-added-to-cluster.png" alt="Screenshot of Study synthesis in the Evidence added to working cluster grouping state for Mobile." /></a><figcaption>Study synthesis — Evidence added to working cluster grouping — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4574,13 +4586,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__synthesize__theme-blocked-without-evidence.png"><img loading="lazy" src="screenshots/desktop/study__synthesize__theme-blocked-without-evidence.png" alt="Screenshot of Study synthesis in the Theme creation hidden before evidence is grouped state for Desktop." /></a><figcaption>Study synthesis — Theme creation hidden before evidence is grouped — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__synthesize__theme-blocked-without-evidence.png" aria-label="Open full screenshot for Study synthesis — Theme creation hidden before evidence is grouped — Desktop"><img loading="lazy" src="screenshots/desktop/study__synthesize__theme-blocked-without-evidence.png" alt="Screenshot of Study synthesis in the Theme creation hidden before evidence is grouped state for Desktop." /></a><figcaption>Study synthesis — Theme creation hidden before evidence is grouped — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__synthesize__theme-blocked-without-evidence.png"><img loading="lazy" src="screenshots/mobile/study__synthesize__theme-blocked-without-evidence.png" alt="Screenshot of Study synthesis in the Theme creation hidden before evidence is grouped state for Mobile." /></a><figcaption>Study synthesis — Theme creation hidden before evidence is grouped — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__synthesize__theme-blocked-without-evidence.png" aria-label="Open full screenshot for Study synthesis — Theme creation hidden before evidence is grouped — Mobile"><img loading="lazy" src="screenshots/mobile/study__synthesize__theme-blocked-without-evidence.png" alt="Screenshot of Study synthesis in the Theme creation hidden before evidence is grouped state for Mobile." /></a><figcaption>Study synthesis — Theme creation hidden before evidence is grouped — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4625,13 +4637,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/study__synthesize__theme-created.png"><img loading="lazy" src="screenshots/desktop/study__synthesize__theme-created.png" alt="Screenshot of Study synthesis in the Theme created with evidence traceability state for Desktop." /></a><figcaption>Study synthesis — Theme created with evidence traceability — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/study__synthesize__theme-created.png" aria-label="Open full screenshot for Study synthesis — Theme created with evidence traceability — Desktop"><img loading="lazy" src="screenshots/desktop/study__synthesize__theme-created.png" alt="Screenshot of Study synthesis in the Theme created with evidence traceability state for Desktop." /></a><figcaption>Study synthesis — Theme created with evidence traceability — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/study/synthesis/?id=recVisualStudy001</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/study__synthesize__theme-created.png"><img loading="lazy" src="screenshots/mobile/study__synthesize__theme-created.png" alt="Screenshot of Study synthesis in the Theme created with evidence traceability state for Mobile." /></a><figcaption>Study synthesis — Theme created with evidence traceability — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/study__synthesize__theme-created.png" aria-label="Open full screenshot for Study synthesis — Theme created with evidence traceability — Mobile"><img loading="lazy" src="screenshots/mobile/study__synthesize__theme-created.png" alt="Screenshot of Study synthesis in the Theme created with evidence traceability state for Mobile." /></a><figcaption>Study synthesis — Theme created with evidence traceability — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4718,13 +4730,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/team/registration-requests/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/team-administration__team-registration-requests__default.png"><img loading="lazy" src="screenshots/desktop/team-administration__team-registration-requests__default.png" alt="Screenshot of Review account requests in the Pending account requests state for Desktop." /></a><figcaption>Review account requests — Pending account requests — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/team-administration__team-registration-requests__default.png" aria-label="Open full screenshot for Review account requests — Pending account requests — Desktop"><img loading="lazy" src="screenshots/desktop/team-administration__team-registration-requests__default.png" alt="Screenshot of Review account requests in the Pending account requests state for Desktop." /></a><figcaption>Review account requests — Pending account requests — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/team/registration-requests/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/team-administration__team-registration-requests__default.png"><img loading="lazy" src="screenshots/mobile/team-administration__team-registration-requests__default.png" alt="Screenshot of Review account requests in the Pending account requests state for Mobile." /></a><figcaption>Review account requests — Pending account requests — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/team-administration__team-registration-requests__default.png" aria-label="Open full screenshot for Review account requests — Pending account requests — Mobile"><img loading="lazy" src="screenshots/mobile/team-administration__team-registration-requests__default.png" alt="Screenshot of Review account requests in the Pending account requests state for Mobile." /></a><figcaption>Review account requests — Pending account requests — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4806,13 +4818,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/team/access-requests/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/team-administration__team-access-requests__default.png"><img loading="lazy" src="screenshots/desktop/team-administration__team-access-requests__default.png" alt="Screenshot of Review team access requests in the Pending team access requests state for Desktop." /></a><figcaption>Review team access requests — Pending team access requests — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/team-administration__team-access-requests__default.png" aria-label="Open full screenshot for Review team access requests — Pending team access requests — Desktop"><img loading="lazy" src="screenshots/desktop/team-administration__team-access-requests__default.png" alt="Screenshot of Review team access requests in the Pending team access requests state for Desktop." /></a><figcaption>Review team access requests — Pending team access requests — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/team/access-requests/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/team-administration__team-access-requests__default.png"><img loading="lazy" src="screenshots/mobile/team-administration__team-access-requests__default.png" alt="Screenshot of Review team access requests in the Pending team access requests state for Mobile." /></a><figcaption>Review team access requests — Pending team access requests — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/team-administration__team-access-requests__default.png" aria-label="Open full screenshot for Review team access requests — Pending team access requests — Mobile"><img loading="lazy" src="screenshots/mobile/team-administration__team-access-requests__default.png" alt="Screenshot of Review team access requests in the Pending team access requests state for Mobile." /></a><figcaption>Review team access requests — Pending team access requests — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4884,13 +4896,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/team/access-requests/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/team-administration__team-access-requests__decision-error.png"><img loading="lazy" src="screenshots/desktop/team-administration__team-access-requests__decision-error.png" alt="Screenshot of Review team access requests in the Team access decision error state for Desktop." /></a><figcaption>Review team access requests — Team access decision error — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/team-administration__team-access-requests__decision-error.png" aria-label="Open full screenshot for Review team access requests — Team access decision error — Desktop"><img loading="lazy" src="screenshots/desktop/team-administration__team-access-requests__decision-error.png" alt="Screenshot of Review team access requests in the Team access decision error state for Desktop." /></a><figcaption>Review team access requests — Team access decision error — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/team/access-requests/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/team-administration__team-access-requests__decision-error.png"><img loading="lazy" src="screenshots/mobile/team-administration__team-access-requests__decision-error.png" alt="Screenshot of Review team access requests in the Team access decision error state for Mobile." /></a><figcaption>Review team access requests — Team access decision error — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/team-administration__team-access-requests__decision-error.png" aria-label="Open full screenshot for Review team access requests — Team access decision error — Mobile"><img loading="lazy" src="screenshots/mobile/team-administration__team-access-requests__decision-error.png" alt="Screenshot of Review team access requests in the Team access decision error state for Mobile." /></a><figcaption>Review team access requests — Team access decision error — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -4973,13 +4985,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/team/role-assignments/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/team-administration__team-role-assignments__default.png"><img loading="lazy" src="screenshots/desktop/team-administration__team-role-assignments__default.png" alt="Screenshot of Assign a role to a team member in the Role assignment form with Team Admin scope state for Desktop." /></a><figcaption>Assign a role to a team member — Role assignment form with Team Admin scope — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/team-administration__team-role-assignments__default.png" aria-label="Open full screenshot for Assign a role to a team member — Role assignment form with Team Admin scope — Desktop"><img loading="lazy" src="screenshots/desktop/team-administration__team-role-assignments__default.png" alt="Screenshot of Assign a role to a team member in the Role assignment form with Team Admin scope state for Desktop." /></a><figcaption>Assign a role to a team member — Role assignment form with Team Admin scope — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/team/role-assignments/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/team-administration__team-role-assignments__default.png"><img loading="lazy" src="screenshots/mobile/team-administration__team-role-assignments__default.png" alt="Screenshot of Assign a role to a team member in the Role assignment form with Team Admin scope state for Mobile." /></a><figcaption>Assign a role to a team member — Role assignment form with Team Admin scope — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/team-administration__team-role-assignments__default.png" aria-label="Open full screenshot for Assign a role to a team member — Role assignment form with Team Admin scope — Mobile"><img loading="lazy" src="screenshots/mobile/team-administration__team-role-assignments__default.png" alt="Screenshot of Assign a role to a team member in the Role assignment form with Team Admin scope state for Mobile." /></a><figcaption>Assign a role to a team member — Role assignment form with Team Admin scope — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5066,13 +5078,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/search/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/utilities__search__default.png"><img loading="lazy" src="screenshots/desktop/utilities__search__default.png" alt="Screenshot of Search in the Default state state for Desktop." /></a><figcaption>Search — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/utilities__search__default.png" aria-label="Open full screenshot for Search — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/utilities__search__default.png" alt="Screenshot of Search in the Default state state for Desktop." /></a><figcaption>Search — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/search/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/utilities__search__default.png"><img loading="lazy" src="screenshots/mobile/utilities__search__default.png" alt="Screenshot of Search in the Default state state for Mobile." /></a><figcaption>Search — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/utilities__search__default.png" aria-label="Open full screenshot for Search — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/utilities__search__default.png" alt="Screenshot of Search in the Default state state for Mobile." /></a><figcaption>Search — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5152,13 +5164,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/notes/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/utilities__notes__default.png"><img loading="lazy" src="screenshots/desktop/utilities__notes__default.png" alt="Screenshot of Notes in the Default state state for Desktop." /></a><figcaption>Notes — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/utilities__notes__default.png" aria-label="Open full screenshot for Notes — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/utilities__notes__default.png" alt="Screenshot of Notes in the Default state state for Desktop." /></a><figcaption>Notes — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/notes/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/utilities__notes__default.png"><img loading="lazy" src="screenshots/mobile/utilities__notes__default.png" alt="Screenshot of Notes in the Default state state for Mobile." /></a><figcaption>Notes — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/utilities__notes__default.png" aria-label="Open full screenshot for Notes — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/utilities__notes__default.png" alt="Screenshot of Notes in the Default state state for Mobile." /></a><figcaption>Notes — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5238,13 +5250,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/consent/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/utilities__consent__default.png"><img loading="lazy" src="screenshots/desktop/utilities__consent__default.png" alt="Screenshot of Consent in the Default state state for Desktop." /></a><figcaption>Consent — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/utilities__consent__default.png" aria-label="Open full screenshot for Consent — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/utilities__consent__default.png" alt="Screenshot of Consent in the Default state state for Desktop." /></a><figcaption>Consent — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/consent/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/utilities__consent__default.png"><img loading="lazy" src="screenshots/mobile/utilities__consent__default.png" alt="Screenshot of Consent in the Default state state for Mobile." /></a><figcaption>Consent — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/utilities__consent__default.png" aria-label="Open full screenshot for Consent — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/utilities__consent__default.png" alt="Screenshot of Consent in the Default state state for Mobile." /></a><figcaption>Consent — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5324,13 +5336,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/sessions/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/utilities__sessions__default.png"><img loading="lazy" src="screenshots/desktop/utilities__sessions__default.png" alt="Screenshot of Sessions in the Default state state for Desktop." /></a><figcaption>Sessions — Default state — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/utilities__sessions__default.png" aria-label="Open full screenshot for Sessions — Default state — Desktop"><img loading="lazy" src="screenshots/desktop/utilities__sessions__default.png" alt="Screenshot of Sessions in the Default state state for Desktop." /></a><figcaption>Sessions — Default state — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/sessions/index.html</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/utilities__sessions__default.png"><img loading="lazy" src="screenshots/mobile/utilities__sessions__default.png" alt="Screenshot of Sessions in the Default state state for Mobile." /></a><figcaption>Sessions — Default state — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/utilities__sessions__default.png" aria-label="Open full screenshot for Sessions — Default state — Mobile"><img loading="lazy" src="screenshots/mobile/utilities__sessions__default.png" alt="Screenshot of Sessions in the Default state state for Mobile." /></a><figcaption>Sessions — Default state — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5418,13 +5430,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository__default.png" alt="Screenshot of Research repository in the Repository front page with published artefacts state for Desktop." /></a><figcaption>Research repository — Repository front page with published artefacts — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository__default.png" aria-label="Open full screenshot for Research repository — Repository front page with published artefacts — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository__default.png" alt="Screenshot of Research repository in the Repository front page with published artefacts state for Desktop." /></a><figcaption>Research repository — Repository front page with published artefacts — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository__default.png" alt="Screenshot of Research repository in the Repository front page with published artefacts state for Mobile." /></a><figcaption>Research repository — Repository front page with published artefacts — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository__default.png" aria-label="Open full screenshot for Research repository — Repository front page with published artefacts — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository__default.png" alt="Screenshot of Research repository in the Repository front page with published artefacts state for Mobile." /></a><figcaption>Research repository — Repository front page with published artefacts — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5505,13 +5517,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/service-areas/?service_area=assisted-digital-support</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-service-areas__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-service-areas__default.png" alt="Screenshot of Browse evidence by service area in the Browse evidence by service area state for Desktop." /></a><figcaption>Browse evidence by service area — Browse evidence by service area — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-service-areas__default.png" aria-label="Open full screenshot for Browse evidence by service area — Browse evidence by service area — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-service-areas__default.png" alt="Screenshot of Browse evidence by service area in the Browse evidence by service area state for Desktop." /></a><figcaption>Browse evidence by service area — Browse evidence by service area — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/service-areas/?service_area=assisted-digital-support</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-service-areas__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-service-areas__default.png" alt="Screenshot of Browse evidence by service area in the Browse evidence by service area state for Mobile." /></a><figcaption>Browse evidence by service area — Browse evidence by service area — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-service-areas__default.png" aria-label="Open full screenshot for Browse evidence by service area — Browse evidence by service area — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-service-areas__default.png" alt="Screenshot of Browse evidence by service area in the Browse evidence by service area state for Mobile." /></a><figcaption>Browse evidence by service area — Browse evidence by service area — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5592,13 +5604,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/user-groups/?user_group=frontline-staff</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-user-groups__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-user-groups__default.png" alt="Screenshot of Browse by user group in the Browse by user group state for Desktop." /></a><figcaption>Browse by user group — Browse by user group — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-user-groups__default.png" aria-label="Open full screenshot for Browse by user group — Browse by user group — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-user-groups__default.png" alt="Screenshot of Browse by user group in the Browse by user group state for Desktop." /></a><figcaption>Browse by user group — Browse by user group — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/user-groups/?user_group=frontline-staff</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-user-groups__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-user-groups__default.png" alt="Screenshot of Browse by user group in the Browse by user group state for Mobile." /></a><figcaption>Browse by user group — Browse by user group — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-user-groups__default.png" aria-label="Open full screenshot for Browse by user group — Browse by user group — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-user-groups__default.png" alt="Screenshot of Browse by user group in the Browse by user group state for Mobile." /></a><figcaption>Browse by user group — Browse by user group — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5679,13 +5691,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/methods/?method=interviews</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-methods__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-methods__default.png" alt="Screenshot of Browse evidence by research method in the Browse evidence by research method state for Desktop." /></a><figcaption>Browse evidence by research method — Browse evidence by research method — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-methods__default.png" aria-label="Open full screenshot for Browse evidence by research method — Browse evidence by research method — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-methods__default.png" alt="Screenshot of Browse evidence by research method in the Browse evidence by research method state for Desktop." /></a><figcaption>Browse evidence by research method — Browse evidence by research method — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/methods/?method=interviews</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-methods__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-methods__default.png" alt="Screenshot of Browse evidence by research method in the Browse evidence by research method state for Mobile." /></a><figcaption>Browse evidence by research method — Browse evidence by research method — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-methods__default.png" aria-label="Open full screenshot for Browse evidence by research method — Browse evidence by research method — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-methods__default.png" alt="Screenshot of Browse evidence by research method in the Browse evidence by research method state for Mobile." /></a><figcaption>Browse evidence by research method — Browse evidence by research method — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5766,13 +5778,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/risks/?risk_area=evidence-boundaries</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-risks__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-risks__default.png" alt="Screenshot of Browse evidence by risk or constraint in the Browse evidence by risk or constraint state for Desktop." /></a><figcaption>Browse evidence by risk or constraint — Browse evidence by risk or constraint — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-risks__default.png" aria-label="Open full screenshot for Browse evidence by risk or constraint — Browse evidence by risk or constraint — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-risks__default.png" alt="Screenshot of Browse evidence by risk or constraint in the Browse evidence by risk or constraint state for Desktop." /></a><figcaption>Browse evidence by risk or constraint — Browse evidence by risk or constraint — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/risks/?risk_area=evidence-boundaries</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-risks__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-risks__default.png" alt="Screenshot of Browse evidence by risk or constraint in the Browse evidence by risk or constraint state for Mobile." /></a><figcaption>Browse evidence by risk or constraint — Browse evidence by risk or constraint — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-risks__default.png" aria-label="Open full screenshot for Browse evidence by risk or constraint — Browse evidence by risk or constraint — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-risks__default.png" alt="Screenshot of Browse evidence by risk or constraint in the Browse evidence by risk or constraint state for Mobile." /></a><figcaption>Browse evidence by risk or constraint — Browse evidence by risk or constraint — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5853,13 +5865,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/artefacts/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-artefacts__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts__default.png" alt="Screenshot of Repository artefact in the Repository artefact state for Desktop." /></a><figcaption>Repository artefact — Repository artefact — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-artefacts__default.png" aria-label="Open full screenshot for Repository artefact — Repository artefact — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts__default.png" alt="Screenshot of Repository artefact in the Repository artefact state for Desktop." /></a><figcaption>Repository artefact — Repository artefact — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/artefacts/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-artefacts__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts__default.png" alt="Screenshot of Repository artefact in the Repository artefact state for Mobile." /></a><figcaption>Repository artefact — Repository artefact — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-artefacts__default.png" aria-label="Open full screenshot for Repository artefact — Repository artefact — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts__default.png" alt="Screenshot of Repository artefact in the Repository artefact state for Mobile." /></a><figcaption>Repository artefact — Repository artefact — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -5940,13 +5952,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/artefacts/staff-evidence-boundaries/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-artefacts-staff-evidence-boundaries__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-staff-evidence-boundaries__default.png" alt="Screenshot of Staff need clearer evidence boundaries before accepting recommendations in the Staff need clearer evidence boundaries before accepting recommendations state for Desktop." /></a><figcaption>Staff need clearer evidence boundaries before accepting recommendations — Staff need clearer evidence boundaries before accepting recommendations — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-artefacts-staff-evidence-boundaries__default.png" aria-label="Open full screenshot for Staff need clearer evidence boundaries before accepting recommendations — Staff need clearer evidence boundaries before accepting recommendations — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-staff-evidence-boundaries__default.png" alt="Screenshot of Staff need clearer evidence boundaries before accepting recommendations in the Staff need clearer evidence boundaries before accepting recommendations state for Desktop." /></a><figcaption>Staff need clearer evidence boundaries before accepting recommendations — Staff need clearer evidence boundaries before accepting recommendations — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/artefacts/staff-evidence-boundaries/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-artefacts-staff-evidence-boundaries__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-staff-evidence-boundaries__default.png" alt="Screenshot of Staff need clearer evidence boundaries before accepting recommendations in the Staff need clearer evidence boundaries before accepting recommendations state for Mobile." /></a><figcaption>Staff need clearer evidence boundaries before accepting recommendations — Staff need clearer evidence boundaries before accepting recommendations — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-artefacts-staff-evidence-boundaries__default.png" aria-label="Open full screenshot for Staff need clearer evidence boundaries before accepting recommendations — Staff need clearer evidence boundaries before accepting recommendations — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-staff-evidence-boundaries__default.png" alt="Screenshot of Staff need clearer evidence boundaries before accepting recommendations in the Staff need clearer evidence boundaries before accepting recommendations state for Mobile." /></a><figcaption>Staff need clearer evidence boundaries before accepting recommendations — Staff need clearer evidence boundaries before accepting recommendations — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6027,13 +6039,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/artefacts/check-answers-review-anxiety/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-artefacts-check-answers-review-anxiety__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-check-answers-review-anxiety__default.png" alt="Screenshot of Check answers pages reduce review anxiety when change links are explicit in the Check answers pages reduce review anxiety when change links are explicit state for Desktop." /></a><figcaption>Check answers pages reduce review anxiety when change links are explicit — Check answers pages reduce review anxiety when change links are explicit — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-artefacts-check-answers-review-anxiety__default.png" aria-label="Open full screenshot for Check answers pages reduce review anxiety when change links are explicit — Check answers pages reduce review anxiety when change links are explicit — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-check-answers-review-anxiety__default.png" alt="Screenshot of Check answers pages reduce review anxiety when change links are explicit in the Check answers pages reduce review anxiety when change links are explicit state for Desktop." /></a><figcaption>Check answers pages reduce review anxiety when change links are explicit — Check answers pages reduce review anxiety when change links are explicit — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/artefacts/check-answers-review-anxiety/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-artefacts-check-answers-review-anxiety__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-check-answers-review-anxiety__default.png" alt="Screenshot of Check answers pages reduce review anxiety when change links are explicit in the Check answers pages reduce review anxiety when change links are explicit state for Mobile." /></a><figcaption>Check answers pages reduce review anxiety when change links are explicit — Check answers pages reduce review anxiety when change links are explicit — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-artefacts-check-answers-review-anxiety__default.png" aria-label="Open full screenshot for Check answers pages reduce review anxiety when change links are explicit — Check answers pages reduce review anxiety when change links are explicit — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-check-answers-review-anxiety__default.png" alt="Screenshot of Check answers pages reduce review anxiety when change links are explicit in the Check answers pages reduce review anxiety when change links are explicit state for Mobile." /></a><figcaption>Check answers pages reduce review anxiety when change links are explicit — Check answers pages reduce review anxiety when change links are explicit — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6114,13 +6126,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/artefacts/consent-state-workarounds/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-artefacts-consent-state-workarounds__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-consent-state-workarounds__default.png" alt="Screenshot of Operational teams rely on local workarounds when consent states are unclear in the Operational teams rely on local workarounds when consent states are unclear state for Desktop." /></a><figcaption>Operational teams rely on local workarounds when consent states are unclear — Operational teams rely on local workarounds when consent states are unclear — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-artefacts-consent-state-workarounds__default.png" aria-label="Open full screenshot for Operational teams rely on local workarounds when consent states are unclear — Operational teams rely on local workarounds when consent states are unclear — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-consent-state-workarounds__default.png" alt="Screenshot of Operational teams rely on local workarounds when consent states are unclear in the Operational teams rely on local workarounds when consent states are unclear state for Desktop." /></a><figcaption>Operational teams rely on local workarounds when consent states are unclear — Operational teams rely on local workarounds when consent states are unclear — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/artefacts/consent-state-workarounds/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-artefacts-consent-state-workarounds__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-consent-state-workarounds__default.png" alt="Screenshot of Operational teams rely on local workarounds when consent states are unclear in the Operational teams rely on local workarounds when consent states are unclear state for Mobile." /></a><figcaption>Operational teams rely on local workarounds when consent states are unclear — Operational teams rely on local workarounds when consent states are unclear — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-artefacts-consent-state-workarounds__default.png" aria-label="Open full screenshot for Operational teams rely on local workarounds when consent states are unclear — Operational teams rely on local workarounds when consent states are unclear — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-consent-state-workarounds__default.png" alt="Screenshot of Operational teams rely on local workarounds when consent states are unclear in the Operational teams rely on local workarounds when consent states are unclear state for Mobile." /></a><figcaption>Operational teams rely on local workarounds when consent states are unclear — Operational teams rely on local workarounds when consent states are unclear — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6201,13 +6213,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/artefacts/lightweight-capture-before-tagging/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png" alt="Screenshot of Researchers need lightweight capture before structured tagging in the Researchers need lightweight capture before structured tagging state for Desktop." /></a><figcaption>Researchers need lightweight capture before structured tagging — Researchers need lightweight capture before structured tagging — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png" aria-label="Open full screenshot for Researchers need lightweight capture before structured tagging — Researchers need lightweight capture before structured tagging — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png" alt="Screenshot of Researchers need lightweight capture before structured tagging in the Researchers need lightweight capture before structured tagging state for Desktop." /></a><figcaption>Researchers need lightweight capture before structured tagging — Researchers need lightweight capture before structured tagging — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/artefacts/lightweight-capture-before-tagging/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png" alt="Screenshot of Researchers need lightweight capture before structured tagging in the Researchers need lightweight capture before structured tagging state for Mobile." /></a><figcaption>Researchers need lightweight capture before structured tagging — Researchers need lightweight capture before structured tagging — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png" aria-label="Open full screenshot for Researchers need lightweight capture before structured tagging — Researchers need lightweight capture before structured tagging — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-artefacts-lightweight-capture-before-tagging__default.png" alt="Screenshot of Researchers need lightweight capture before structured tagging in the Researchers need lightweight capture before structured tagging state for Mobile." /></a><figcaption>Researchers need lightweight capture before structured tagging — Researchers need lightweight capture before structured tagging — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6288,13 +6300,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/review/candidates/new/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-review-candidates-new__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-candidates-new__default.png" alt="Screenshot of Create candidate artefact in the Create candidate artefact state for Desktop." /></a><figcaption>Create candidate artefact — Create candidate artefact — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-review-candidates-new__default.png" aria-label="Open full screenshot for Create candidate artefact — Create candidate artefact — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-candidates-new__default.png" alt="Screenshot of Create candidate artefact in the Create candidate artefact state for Desktop." /></a><figcaption>Create candidate artefact — Create candidate artefact — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/review/candidates/new/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-review-candidates-new__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-candidates-new__default.png" alt="Screenshot of Create candidate artefact in the Create candidate artefact state for Mobile." /></a><figcaption>Create candidate artefact — Create candidate artefact — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-review-candidates-new__default.png" aria-label="Open full screenshot for Create candidate artefact — Create candidate artefact — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-candidates-new__default.png" alt="Screenshot of Create candidate artefact in the Create candidate artefact state for Mobile." /></a><figcaption>Create candidate artefact — Create candidate artefact — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6375,13 +6387,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/review/candidates/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-review-candidates__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-candidates__default.png" alt="Screenshot of Candidate artefacts in the Candidate artefacts state for Desktop." /></a><figcaption>Candidate artefacts — Candidate artefacts — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-review-candidates__default.png" aria-label="Open full screenshot for Candidate artefacts — Candidate artefacts — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-candidates__default.png" alt="Screenshot of Candidate artefacts in the Candidate artefacts state for Desktop." /></a><figcaption>Candidate artefacts — Candidate artefacts — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/review/candidates/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-review-candidates__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-candidates__default.png" alt="Screenshot of Candidate artefacts in the Candidate artefacts state for Mobile." /></a><figcaption>Candidate artefacts — Candidate artefacts — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-review-candidates__default.png" aria-label="Open full screenshot for Candidate artefacts — Candidate artefacts — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-candidates__default.png" alt="Screenshot of Candidate artefacts in the Candidate artefacts state for Mobile." /></a><figcaption>Candidate artefacts — Candidate artefacts — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6462,13 +6474,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/review/stale/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-review-stale__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-stale__default.png" alt="Screenshot of Due review in the Due review state for Desktop." /></a><figcaption>Due review — Due review — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-review-stale__default.png" aria-label="Open full screenshot for Due review — Due review — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-stale__default.png" alt="Screenshot of Due review in the Due review state for Desktop." /></a><figcaption>Due review — Due review — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/review/stale/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-review-stale__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-stale__default.png" alt="Screenshot of Due review in the Due review state for Mobile." /></a><figcaption>Due review — Due review — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-review-stale__default.png" aria-label="Open full screenshot for Due review — Due review — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-stale__default.png" alt="Screenshot of Due review in the Due review state for Mobile." /></a><figcaption>Due review — Due review — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6549,13 +6561,13 @@ h3, h4, h5 { margin: 0 0 6px; }
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Desktop · captured · https://research-operations.com/pages/repository/review/withdrawn/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/desktop/research-repository__repository-review-withdrawn__default.png"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-withdrawn__default.png" alt="Screenshot of Withdrawn artefacts in the Withdrawn artefacts state for Desktop." /></a><figcaption>Withdrawn artefacts — Withdrawn artefacts — Desktop</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/desktop/research-repository__repository-review-withdrawn__default.png" aria-label="Open full screenshot for Withdrawn artefacts — Withdrawn artefacts — Desktop"><img loading="lazy" src="screenshots/desktop/research-repository__repository-review-withdrawn__default.png" alt="Screenshot of Withdrawn artefacts in the Withdrawn artefacts state for Desktop." /></a><figcaption>Withdrawn artefacts — Withdrawn artefacts — Desktop</figcaption></figure>
 		</section>
 		<section class="capture" data-profile="mobile">
 			<h5>Screenshot evidence</h5>
 			<p class="meta">Mobile · captured · https://research-operations.com/pages/repository/review/withdrawn/</p>
 			
-			<figure class="capture__figure"><a href="screenshots/mobile/research-repository__repository-review-withdrawn__default.png"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-withdrawn__default.png" alt="Screenshot of Withdrawn artefacts in the Withdrawn artefacts state for Mobile." /></a><figcaption>Withdrawn artefacts — Withdrawn artefacts — Mobile</figcaption></figure>
+			<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="screenshots/mobile/research-repository__repository-review-withdrawn__default.png" aria-label="Open full screenshot for Withdrawn artefacts — Withdrawn artefacts — Mobile"><img loading="lazy" src="screenshots/mobile/research-repository__repository-review-withdrawn__default.png" alt="Screenshot of Withdrawn artefacts in the Withdrawn artefacts state for Mobile." /></a><figcaption>Withdrawn artefacts — Withdrawn artefacts — Mobile</figcaption></figure>
 		</section>
 		</div>
 	</article>
@@ -6564,6 +6576,18 @@ h3, h4, h5 { margin: 0 0 6px; }
 			</div>
 		</section>
 	</main>
+	
+	<div class="lightbox" role="dialog" aria-modal="true" aria-labelledby="lightbox-title" hidden>
+		<div class="lightbox__panel">
+			<div class="lightbox__header">
+				<h2 id="lightbox-title">Screenshot evidence</h2>
+				<button type="button" class="lightbox__close" data-lightbox-close>Close</button>
+			</div>
+			<div class="lightbox__body">
+				<img class="lightbox__image" alt="" />
+			</div>
+		</div>
+	</div>
 	
 	<script>
 	(function () {
@@ -6591,6 +6615,50 @@ h3, h4, h5 { margin: 0 0 6px; }
 		}
 
 		applyProfileFilter(defaultProfile);
+	})();
+	</script>
+	
+	<script>
+	(function () {
+		const lightbox = document.querySelector('.lightbox');
+		if (!lightbox) return;
+
+		const image = lightbox.querySelector('.lightbox__image');
+		const closeButton = lightbox.querySelector('[data-lightbox-close]');
+		let lastFocusedElement = null;
+
+		function closeLightbox() {
+			lightbox.hidden = true;
+			document.documentElement.classList.remove('has-lightbox');
+			image.removeAttribute('src');
+			image.alt = '';
+			if (lastFocusedElement) lastFocusedElement.focus();
+		}
+
+		function openLightbox(link) {
+			const thumbnail = link.querySelector('img');
+			lastFocusedElement = document.activeElement;
+			image.src = link.href;
+			image.alt = thumbnail ? thumbnail.alt : 'Full screenshot evidence';
+			lightbox.hidden = false;
+			document.documentElement.classList.add('has-lightbox');
+			closeButton.focus();
+		}
+
+		for (const link of document.querySelectorAll('[data-lightbox-image]')) {
+			link.addEventListener('click', (event) => {
+				event.preventDefault();
+				openLightbox(link);
+			});
+		}
+
+		closeButton.addEventListener('click', closeLightbox);
+		lightbox.addEventListener('click', (event) => {
+			if (event.target === lightbox) closeLightbox();
+		});
+		document.addEventListener('keydown', (event) => {
+			if (!lightbox.hidden && event.key === 'Escape') closeLightbox();
+		});
 	})();
 	</script>
 </body>

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -279,6 +279,14 @@ function renderLightboxScript() {
 		const closeButton = lightbox.querySelector('[data-lightbox-close]');
 		let lastFocusedElement = null;
 
+		function focusableElements() {
+			return Array.from(
+				lightbox.querySelectorAll(
+					'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+			).filter((element) => element.offsetParent !== null);
+		}
+
 		function closeLightbox() {
 			lightbox.hidden = true;
 			document.documentElement.classList.remove('has-lightbox');
@@ -297,6 +305,33 @@ function renderLightboxScript() {
 			closeButton.focus();
 		}
 
+		function trapLightboxFocus(event) {
+			if (event.key !== 'Tab' || lightbox.hidden) return;
+
+			const focusable = focusableElements();
+			if (focusable.length === 0) return;
+
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+
+			if (!lightbox.contains(document.activeElement)) {
+				event.preventDefault();
+				first.focus();
+				return;
+			}
+
+			if (event.shiftKey && document.activeElement === first) {
+				event.preventDefault();
+				last.focus();
+				return;
+			}
+
+			if (!event.shiftKey && document.activeElement === last) {
+				event.preventDefault();
+				first.focus();
+			}
+		}
+
 		for (const link of document.querySelectorAll('[data-lightbox-image]')) {
 			link.addEventListener('click', (event) => {
 				event.preventDefault();
@@ -310,6 +345,7 @@ function renderLightboxScript() {
 		});
 		document.addEventListener('keydown', (event) => {
 			if (!lightbox.hidden && event.key === 'Escape') closeLightbox();
+			trapLightboxFocus(event);
 		});
 	})();
 	</script>`;

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -114,7 +114,7 @@ function renderEvidenceTypes(state = {}) {
 function renderCapture(page = {}, state = {}, capture = {}) {
 	const alt = `Screenshot of ${page.title} in the ${state.title} state for ${capture.profileTitle || capture.profile}.`;
 	const image = capture.screenshot
-		? `<figure class="capture__figure"><a href="${escapeHtml(capture.screenshot)}"><img loading="lazy" src="${escapeHtml(capture.screenshot)}" alt="${escapeHtml(alt)}" /></a><figcaption>${escapeHtml(page.title)} — ${escapeHtml(state.title)} — ${escapeHtml(capture.profileTitle || capture.profile)}</figcaption></figure>`
+		? `<figure class="capture__figure"><a class="capture__lightbox-link" data-lightbox-image href="${escapeHtml(capture.screenshot)}" aria-label="Open full screenshot for ${escapeHtml(page.title)} — ${escapeHtml(state.title)} — ${escapeHtml(capture.profileTitle || capture.profile)}"><img loading="lazy" src="${escapeHtml(capture.screenshot)}" alt="${escapeHtml(alt)}" /></a><figcaption>${escapeHtml(page.title)} — ${escapeHtml(state.title)} — ${escapeHtml(capture.profileTitle || capture.profile)}</figcaption></figure>`
 		: '';
 
 	return `
@@ -217,6 +217,21 @@ function renderProfileSwitcher(profiles = []) {
 	</nav>`;
 }
 
+function renderLightbox() {
+	return `
+	<div class="lightbox" role="dialog" aria-modal="true" aria-labelledby="lightbox-title" hidden>
+		<div class="lightbox__panel">
+			<div class="lightbox__header">
+				<h2 id="lightbox-title">Screenshot evidence</h2>
+				<button type="button" class="lightbox__close" data-lightbox-close>Close</button>
+			</div>
+			<div class="lightbox__body">
+				<img class="lightbox__image" alt="" />
+			</div>
+		</div>
+	</div>`;
+}
+
 function renderProfileSwitcherScript(profiles = []) {
 	if (!Array.isArray(profiles) || profiles.length === 0) return '';
 
@@ -249,6 +264,53 @@ function renderProfileSwitcherScript(profiles = []) {
 		}
 
 		applyProfileFilter(defaultProfile);
+	})();
+	</script>`;
+}
+
+function renderLightboxScript() {
+	return `
+	<script>
+	(function () {
+		const lightbox = document.querySelector('.lightbox');
+		if (!lightbox) return;
+
+		const image = lightbox.querySelector('.lightbox__image');
+		const closeButton = lightbox.querySelector('[data-lightbox-close]');
+		let lastFocusedElement = null;
+
+		function closeLightbox() {
+			lightbox.hidden = true;
+			document.documentElement.classList.remove('has-lightbox');
+			image.removeAttribute('src');
+			image.alt = '';
+			if (lastFocusedElement) lastFocusedElement.focus();
+		}
+
+		function openLightbox(link) {
+			const thumbnail = link.querySelector('img');
+			lastFocusedElement = document.activeElement;
+			image.src = link.href;
+			image.alt = thumbnail ? thumbnail.alt : 'Full screenshot evidence';
+			lightbox.hidden = false;
+			document.documentElement.classList.add('has-lightbox');
+			closeButton.focus();
+		}
+
+		for (const link of document.querySelectorAll('[data-lightbox-image]')) {
+			link.addEventListener('click', (event) => {
+				event.preventDefault();
+				openLightbox(link);
+			});
+		}
+
+		closeButton.addEventListener('click', closeLightbox);
+		lightbox.addEventListener('click', (event) => {
+			if (event.target === lightbox) closeLightbox();
+		});
+		document.addEventListener('keydown', (event) => {
+			if (!lightbox.hidden && event.key === 'Escape') closeLightbox();
+		});
 	})();
 	</script>`;
 }
@@ -290,9 +352,21 @@ h3, h4, h5 { margin: 0 0 6px; }
 .review-risk-list dd { margin: 0; }
 .capture { border-top: 1px solid #e5e5e5; padding: 10px 12px; }
 .capture__figure { margin: 10px 0 0; }
-.capture__figure img { border: 1px solid #d8d8d8; height: auto; max-width: 100%; }
+.capture__lightbox-link { display: block; }
+.capture__lightbox-link:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+.capture__figure img { border: 1px solid #d8d8d8; box-sizing: border-box; display: block; height: 665px; max-width: 100%; object-fit: cover; object-position: top center; width: 100%; }
+.has-lightbox { overflow: hidden; }
+.lightbox { background: rgba(11, 12, 12, 0.75); bottom: 0; left: 0; padding: 24px; position: fixed; right: 0; top: 0; z-index: 1000; }
+.lightbox__panel { background: #fff; display: flex; flex-direction: column; height: 100%; margin: 0 auto; max-width: 1200px; }
+.lightbox__header { align-items: center; border-bottom: 1px solid #d8d8d8; display: flex; gap: 16px; justify-content: space-between; padding: 12px 16px; }
+.lightbox__header h2 { border-bottom: 0; margin: 0; padding: 0; }
+.lightbox__close { background: #f3f2f1; border: 2px solid #0b0c0c; cursor: pointer; font: inherit; padding: 8px 12px; }
+.lightbox__close:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+.lightbox__body { flex: 1; overflow: auto; padding: 16px; }
+.lightbox__image { display: block; height: auto; max-width: 100%; }
 @media (max-width: 900px) {
 	.group__pages { grid-template-columns: 1fr; }
+	.lightbox { padding: 12px; }
 }`;
 }
 
@@ -325,7 +399,9 @@ export function renderReportingReviewHtml(manifest = {}) {
 			${renderPageGrid(pages)}
 		</section>`).join('')}
 	</main>
+	${renderLightbox()}
 	${renderProfileSwitcherScript(reviewedManifest.profiles)}
+	${renderLightboxScript()}
 </body>
 </html>`;
 }

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -978,6 +978,34 @@ function renderHtml(manifest) {
 				document.documentElement.classList.add('has-lightbox');
 				lightboxCloseButton.focus();
 			}
+			function lightboxFocusableElements() {
+				return Array.from(
+					lightbox.querySelectorAll(
+						'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+					)
+				).filter((element) => element.offsetParent !== null);
+			}
+			function trapLightboxFocus(event) {
+				if (event.key !== 'Tab' || lightbox.hidden) return;
+				const focusable = lightboxFocusableElements();
+				if (focusable.length === 0) return;
+				const first = focusable[0];
+				const last = focusable[focusable.length - 1];
+				if (!lightbox.contains(document.activeElement)) {
+					event.preventDefault();
+					first.focus();
+					return;
+				}
+				if (event.shiftKey && document.activeElement === first) {
+					event.preventDefault();
+					last.focus();
+					return;
+				}
+				if (!event.shiftKey && document.activeElement === last) {
+					event.preventDefault();
+					first.focus();
+				}
+			}
 			if (lightbox && lightboxImage && lightboxCloseButton) {
 				for (const link of document.querySelectorAll('[data-lightbox-image]')) {
 					link.addEventListener('click', (event) => {
@@ -991,6 +1019,7 @@ function renderHtml(manifest) {
 				});
 				document.addEventListener('keydown', (event) => {
 					if (!lightbox.hidden && event.key === 'Escape') closeLightbox();
+					trapLightboxFocus(event);
 				});
 			}
 			activate(buttons[0]?.dataset.profileFilter || 'desktop');

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -705,7 +705,7 @@ function renderCapture(page, state, capture) {
 						${
 							capture.screenshot
 								? `<figure class="capture__figure">
-									<a href="${escapeHtml(capture.screenshot)}"><img loading="lazy" src="${escapeHtml(capture.screenshot)}" alt="${escapeHtml(
+									<a class="capture__lightbox-link" data-lightbox-image href="${escapeHtml(capture.screenshot)}" aria-label="Open full screenshot for ${escapeHtml(screenshotCaption(page, state, capture))}"><img loading="lazy" src="${escapeHtml(capture.screenshot)}" alt="${escapeHtml(
 										screenshotAltText(page, state, capture)
 									)}" /></a>
 									<figcaption>${escapeHtml(screenshotCaption(page, state, capture))}</figcaption>
@@ -880,14 +880,26 @@ function renderHtml(manifest) {
 		.capture:first-of-type { border-top: 0; }
 		.capture__header { padding: 10px 12px; border-bottom: 1px solid #e5e5e5; }
 		.capture__figure { margin: 0; }
-		.capture img { display: block; width: 100%; height: auto; }
+		.capture__lightbox-link { display: block; }
+		.capture__lightbox-link:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+		.capture img { box-sizing: border-box; display: block; width: 100%; height: 665px; object-fit: cover; object-position: top center; }
 		.capture figcaption { border-top: 1px solid #e5e5e5; color: #444; font-weight: 700; padding: 8px 12px; }
 		.failed { border-color: #d4351c; }
 		.failed .state__header, .failed .capture__header { background: #fff4f2; }
 		.summary { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+		.has-lightbox { overflow: hidden; }
+		.lightbox { background: rgba(11, 12, 12, 0.75); bottom: 0; left: 0; padding: 24px; position: fixed; right: 0; top: 0; z-index: 1000; }
+		.lightbox__panel { background: #fff; display: flex; flex-direction: column; height: 100%; margin: 0 auto; max-width: 1200px; }
+		.lightbox__header { align-items: center; border-bottom: 1px solid #d8d8d8; display: flex; gap: 16px; justify-content: space-between; padding: 12px 16px; }
+		.lightbox__header h2 { border-bottom: 0; margin: 0; padding: 0; }
+		.lightbox__close { background: #f3f2f1; border: 2px solid #0b0c0c; cursor: pointer; font: inherit; padding: 8px 12px; }
+		.lightbox__close:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
+		.lightbox__body { flex: 1; overflow: auto; padding: 16px; }
+		.lightbox__image { display: block; height: auto; max-width: 100%; }
 		[hidden] { display: none !important; }
 		@media (max-width: 900px) {
 			.group__pages { grid-template-columns: 1fr; }
+			.lightbox { padding: 12px; }
 		}
 	</style>
 </head>
@@ -917,10 +929,25 @@ function renderHtml(manifest) {
 	</section>`
 		)
 		.join('')}
+	<div class="lightbox" role="dialog" aria-modal="true" aria-labelledby="lightbox-title" hidden>
+		<div class="lightbox__panel">
+			<div class="lightbox__header">
+				<h2 id="lightbox-title">Screenshot evidence</h2>
+				<button type="button" class="lightbox__close" data-lightbox-close>Close</button>
+			</div>
+			<div class="lightbox__body">
+				<img class="lightbox__image" alt="" />
+			</div>
+		</div>
+	</div>
 	<script>
 		(() => {
 			const buttons = Array.from(document.querySelectorAll('[data-profile-filter]'));
 			const captures = Array.from(document.querySelectorAll('[data-profile]'));
+			const lightbox = document.querySelector('.lightbox');
+			const lightboxImage = lightbox?.querySelector('.lightbox__image');
+			const lightboxCloseButton = lightbox?.querySelector('[data-lightbox-close]');
+			let lastFocusedElement = null;
 			function activate(profile) {
 				const scrollY = window.scrollY;
 				document.body.dataset.activeProfile = profile;
@@ -934,6 +961,37 @@ function renderHtml(manifest) {
 			}
 			for (const button of buttons) {
 				button.addEventListener('click', () => activate(button.dataset.profileFilter));
+			}
+			function closeLightbox() {
+				lightbox.hidden = true;
+				document.documentElement.classList.remove('has-lightbox');
+				lightboxImage.removeAttribute('src');
+				lightboxImage.alt = '';
+				if (lastFocusedElement) lastFocusedElement.focus();
+			}
+			function openLightbox(link) {
+				const thumbnail = link.querySelector('img');
+				lastFocusedElement = document.activeElement;
+				lightboxImage.src = link.href;
+				lightboxImage.alt = thumbnail ? thumbnail.alt : 'Full screenshot evidence';
+				lightbox.hidden = false;
+				document.documentElement.classList.add('has-lightbox');
+				lightboxCloseButton.focus();
+			}
+			if (lightbox && lightboxImage && lightboxCloseButton) {
+				for (const link of document.querySelectorAll('[data-lightbox-image]')) {
+					link.addEventListener('click', (event) => {
+						event.preventDefault();
+						openLightbox(link);
+					});
+				}
+				lightboxCloseButton.addEventListener('click', closeLightbox);
+				lightbox.addEventListener('click', (event) => {
+					if (event.target === lightbox) closeLightbox();
+				});
+				document.addEventListener('keydown', (event) => {
+					if (!lightbox.hidden && event.key === 'Escape') closeLightbox();
+				});
 			}
 			activate(buttons[0]?.dataset.profileFilter || 'desktop');
 		})();

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -207,6 +207,11 @@ test('rendered report crops screenshot thumbnails and opens full images in a lig
 	assert.match(html, /event\.preventDefault\(\);\s*openLightbox\(link\);/);
 	assert.match(html, /image\.src = link\.href/);
 	assert.match(html, /event\.key === 'Escape'/);
+	assert.match(html, /function trapLightboxFocus\(event\)/);
+	assert.match(html, /event\.key !== 'Tab'/);
+	assert.match(html, /!lightbox\.contains\(document\.activeElement\)/);
+	assert.match(html, /event\.shiftKey && document\.activeElement === first/);
+	assert.match(html, /!event\.shiftKey && document\.activeElement === last/);
 });
 
 test('non-curated pages keep generated screen-state criteria', () => {

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -194,6 +194,21 @@ test('rendered report lays out non-multi-step pages in a two-column group grid',
 	);
 });
 
+test('rendered report crops screenshot thumbnails and opens full images in a lightbox', () => {
+	const html = renderReportingReviewHtml(manifestFixture());
+
+	assert.match(
+		html,
+		/\.capture__figure img \{[^}]*height: 665px;[^}]*object-fit: cover;[^}]*object-position: top center;[^}]*\}/
+	);
+	assert.match(html, /class="capture__lightbox-link" data-lightbox-image/);
+	assert.match(html, /class="lightbox" role="dialog" aria-modal="true"/);
+	assert.match(html, /\.lightbox__body \{ flex: 1; overflow: auto; padding: 16px; \}/);
+	assert.match(html, /event\.preventDefault\(\);\s*openLightbox\(link\);/);
+	assert.match(html, /image\.src = link\.href/);
+	assert.match(html, /event\.key === 'Escape'/);
+});
+
 test('non-curated pages keep generated screen-state criteria', () => {
 	const html = renderReportingReviewHtml(manifestFixture());
 	const homeIndex = html.indexOf('Home page');


### PR DESCRIPTION
## Summary
- crop report-site screenshot previews to a consistent visible 665px height
- open full screenshots in a scrollable modal lightbox from each thumbnail
- keep the generated reports-site artifact in sync and add renderer coverage

## Validation
- node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js
- node scripts/validate-reports-site.mjs
- Playwright browser check: first thumbnail rendered at exactly 665px, modal opened, full image was scrollable, Escape closed it
- npm run lint -- --quiet
- npm run validate