### PR TITLE
Fix multi-step report screenshot ratio

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.json
+++ b/docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.json
@@ -1,0 +1,81 @@
+{
+	"date": "2026-07-01",
+	"branch": "fix/report-multistep-screenshot-ratio",
+	"traceRequired": true,
+	"taskSummary": "Update report-site screenshots inside multi-flow process pages so each image fills its state-card column and crops to a 3:2 landscape ratio.",
+	"operatingModelFilesLoaded": [
+		"AGENTS.md",
+		".agent-operating-model/orchestration.xml",
+		".agent-operating-model/bundle-registry.json",
+		".agent-operating-model/task-signal-catalog.json",
+		".agent-operating-model/selection-rules.json",
+		".agent-operating-model/bootstrap-checklist.md",
+		".agent-operating-model/precedence-policy.md",
+		".agent-operating-model/trace-policy.md",
+		".agent-operating-model/trace-layers.md",
+		".agent-operating-model/behavioural-evals.json",
+		".agent-operating-model/github-mutation-policy.md",
+		"/Users/kevin.rapley/.hermes/skills/github/github-diamond-standard/SKILL.md"
+	],
+	"selectedBundles": [
+		{
+			"id": "github-diamond",
+			"canonicalPath": ".agent-operating-model/bundles/github/"
+		},
+		{
+			"id": "researchops-developer-control",
+			"canonicalPath": ".agent-operating-model/bundles/researchops-developer-control/"
+		},
+		{
+			"id": "multi-functional-team",
+			"canonicalPath": ".agent-operating-model/bundles/multi-functional-team/"
+		},
+		{
+			"id": "govuk-design-system",
+			"canonicalPath": ".agent-operating-model/bundles/govuk-design-system/"
+		}
+	],
+	"skippedBundles": [
+		"cloudflare",
+		"openai-platform",
+		"mcp-agent-tooling",
+		"airtable-public-api",
+		"mural-public-api"
+	],
+	"filesModified": [
+		"scripts/render-reporting-review-site.mjs",
+		"scripts/visual-walkthrough.mjs",
+		"reports-site/index.html",
+		"tests/reporting-review-generation-model.test.js",
+		"docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.md",
+		"docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.json"
+	],
+	"validation": [
+		{
+			"command": "node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js",
+			"result": "passed"
+		},
+		{
+			"command": "node scripts/validate-reports-site.mjs",
+			"result": "passed",
+			"evidence": "Validated 46 pages, 81 states and 162 captures."
+		},
+		{
+			"command": "Playwright browser measurement against reports-site/index.html",
+			"result": "passed",
+			"evidence": "Ordinary thumbnails remained 665px high; the first multi-step thumbnail rendered 353px wide by 235px high with a 1.5 ratio and filled its crop link."
+		},
+		{
+			"command": "npm run lint -- --quiet",
+			"result": "passed",
+			"notes": "Existing ESLint-env deprecation warnings were reported."
+		},
+		{
+			"command": "npm run validate",
+			"result": "passed"
+		}
+	],
+	"residualRisks": [
+		"The 3:2 crop cuts vertical full-page screenshots more aggressively, but the full image remains available in the lightbox."
+	]
+}

--- a/docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.md
+++ b/docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.md
@@ -1,0 +1,75 @@
+# Report multi-step screenshot ratio
+
+Date: 2026-07-01
+Branch: `fix/report-multistep-screenshot-ratio`
+
+## Task
+
+Update report-site screenshots inside multi-flow process pages so each image fills its state-card column and crops to the same landscape ratio as the wider report thumbnails.
+
+## Trace decision
+
+The active branch prefix `fix/` requires an auditable trace for repository-affecting work.
+
+## Operating model
+
+Loaded:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/bootstrap-checklist.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+- `.agent-operating-model/trace-layers.md`
+- `.agent-operating-model/behavioural-evals.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `/Users/kevin.rapley/.hermes/skills/github/github-diamond-standard/SKILL.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `govuk-design-system` at `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped bundles:
+
+- `cloudflare`: no Worker, Pages deployment, binding or runtime configuration changed.
+- `openai-platform`: no OpenAI API integration changed.
+- `mcp-agent-tooling`: no MCP tooling changed.
+- `airtable-public-api`: no Airtable API implementation changed.
+- `mural-public-api`: no Mural API implementation changed.
+
+## Files modified
+
+- `scripts/render-reporting-review-site.mjs`
+- `scripts/visual-walkthrough.mjs`
+- `reports-site/index.html`
+- `tests/reporting-review-generation-model.test.js`
+- `docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.md`
+- `docs/agent-audit/reasoning/2026/07/01/report-multistep-screenshot-ratio.json`
+
+## Work done
+
+- Added a multi-step-only screenshot thumbnail rule.
+- Kept ordinary screenshots on the existing 665px crop.
+- Set multi-step screenshot links to a `3 / 2` aspect ratio with hidden overflow.
+- Set multi-step images to fill that crop box at the state-card column width.
+- Applied the same rule to the source visual walkthrough renderer.
+- Regenerated the committed `reports-site/index.html` artefact.
+- Added renderer coverage for the multi-step crop rule.
+
+## Validation
+
+- `node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js`: passed.
+- `node scripts/validate-reports-site.mjs`: passed, validating 46 pages, 81 states and 162 captures.
+- Playwright browser measurement: passed. Ordinary thumbnails remained 665px high; the first multi-step thumbnail rendered 353px wide by 235px high with a 1.5 ratio and filled its crop link.
+- `npm run lint -- --quiet`: passed with existing ESLint-env deprecation warnings only.
+- `npm run validate`: passed.
+
+## Residual risk
+
+The multi-step crop ratio is intentionally fixed at `3 / 2` to match the landscape feel of the wider report thumbnails. It crops vertical full-page screenshots more aggressively, but the full image remains available in the lightbox.

--- a/reports-site/index.html
+++ b/reports-site/index.html
@@ -43,6 +43,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 .capture__lightbox-link { display: block; }
 .capture__lightbox-link:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 .capture__figure img { border: 1px solid #d8d8d8; box-sizing: border-box; display: block; height: 665px; max-width: 100%; object-fit: cover; object-position: top center; width: 100%; }
+.page-card--multi-step .capture__lightbox-link { aspect-ratio: 3 / 2; overflow: hidden; width: 100%; }
+.page-card--multi-step .capture__figure img { height: 100%; max-width: none; }
 .has-lightbox { overflow: hidden; }
 .lightbox { background: rgba(11, 12, 12, 0.75); bottom: 0; left: 0; padding: 24px; position: fixed; right: 0; top: 0; z-index: 1000; }
 .lightbox__panel { background: #fff; display: flex; flex-direction: column; height: 100%; margin: 0 auto; max-width: 1200px; }

--- a/scripts/render-reporting-review-site.mjs
+++ b/scripts/render-reporting-review-site.mjs
@@ -391,6 +391,8 @@ h3, h4, h5 { margin: 0 0 6px; }
 .capture__lightbox-link { display: block; }
 .capture__lightbox-link:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 .capture__figure img { border: 1px solid #d8d8d8; box-sizing: border-box; display: block; height: 665px; max-width: 100%; object-fit: cover; object-position: top center; width: 100%; }
+.page-card--multi-step .capture__lightbox-link { aspect-ratio: 3 / 2; overflow: hidden; width: 100%; }
+.page-card--multi-step .capture__figure img { height: 100%; max-width: none; }
 .has-lightbox { overflow: hidden; }
 .lightbox { background: rgba(11, 12, 12, 0.75); bottom: 0; left: 0; padding: 24px; position: fixed; right: 0; top: 0; z-index: 1000; }
 .lightbox__panel { background: #fff; display: flex; flex-direction: column; height: 100%; margin: 0 auto; max-width: 1200px; }

--- a/scripts/visual-walkthrough.mjs
+++ b/scripts/visual-walkthrough.mjs
@@ -883,6 +883,8 @@ function renderHtml(manifest) {
 		.capture__lightbox-link { display: block; }
 		.capture__lightbox-link:focus { outline: 3px solid #ffdd00; outline-offset: 2px; }
 		.capture img { box-sizing: border-box; display: block; width: 100%; height: 665px; object-fit: cover; object-position: top center; }
+		.page-card--multi-step .capture__lightbox-link { aspect-ratio: 3 / 2; overflow: hidden; width: 100%; }
+		.page-card--multi-step .capture img { height: 100%; }
 		.capture figcaption { border-top: 1px solid #e5e5e5; color: #444; font-weight: 700; padding: 8px 12px; }
 		.failed { border-color: #d4351c; }
 		.failed .state__header, .failed .capture__header { background: #fff4f2; }

--- a/tests/reporting-review-generation-model.test.js
+++ b/tests/reporting-review-generation-model.test.js
@@ -214,6 +214,19 @@ test('rendered report crops screenshot thumbnails and opens full images in a lig
 	assert.match(html, /!event\.shiftKey && document\.activeElement === last/);
 });
 
+test('rendered report constrains multi-step screenshots to their column ratio', () => {
+	const html = renderReportingReviewHtml(manifestFixture());
+
+	assert.match(
+		html,
+		/\.page-card--multi-step \.capture__lightbox-link \{ aspect-ratio: 3 \/ 2; overflow: hidden; width: 100%; \}/
+	);
+	assert.match(
+		html,
+		/\.page-card--multi-step \.capture__figure img \{ height: 100%; max-width: none; \}/
+	);
+});
+
 test('non-curated pages keep generated screen-state criteria', () => {
 	const html = renderReportingReviewHtml(manifestFixture());
 	const homeIndex = html.indexOf('Home page');


### PR DESCRIPTION
## Summary
- make multi-step report screenshots fill their state-card column
- crop multi-step thumbnails to a 3:2 landscape ratio instead of the fixed 665px height
- keep ordinary report screenshots on the existing 665px crop
- regenerate the committed reports-site artefact and add renderer coverage

## Validation
- node --test tests/reporting-review-generation-model.test.js tests/reports-site-validation.test.js tests/reporting-site-deploy-route-state.test.js
- node scripts/validate-reports-site.mjs
- Playwright browser measurement: ordinary thumbnail remained 665px high; first multi-step thumbnail rendered 353px by 235px with a 1.5 ratio and filled its crop link
- npm run lint -- --quiet
- npm run validate
- npm run trace:coverage