### PR TITLE
Remove participant consent back action

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/01/study-session-govuk-layout.json
+++ b/docs/agent-audit/reasoning/2026/07/01/study-session-govuk-layout.json
@@ -82,7 +82,7 @@
     "Adjusted study session GOV.UK summary-list rows so labels and values use the full datalist width.",
     "Follow-up review fixes added authenticated API fetches, routed session note saves through the configured API origin, removed legacy sid as a session-note id fallback, and fell back to Airtable when the D1 participant consent cache is empty.",
     "Updated the D1 migration ordering policy to identify 0024 as the next main migration prefix after 0023_session_consent_and_notes.sql.",
-    "Restored the participant consent page contract expected by the wider GOV.UK route-state suite: GOV.UK table stylesheet plus the Back to Study action."
+    "Updated the participant consent page contract so it excludes the Back to Study action and does not load the extra GOV.UK table stylesheet."
   ],
   "validation": [
     {

--- a/docs/agent-audit/reasoning/2026/07/01/study-session-govuk-layout.md
+++ b/docs/agent-audit/reasoning/2026/07/01/study-session-govuk-layout.md
@@ -114,7 +114,7 @@
 - Adjusted study session GOV.UK summary-list rows so consent summary labels and values use the full datalist width instead of inheriting cramped default key/value proportions inside a half-width grid column.
 - Follow-up review fixes included authenticated `fetch` calls for participant and note APIs, posting session notes through the configured API origin, removing the legacy `sid` fallback as a session-note id, and falling back to Airtable when the D1 participant consent cache is empty.
 - Updated the D1 migration ordering policy so the next main prefix after `0023_session_consent_and_notes.sql` is `0024`.
-- Restored the participant consent generated page contract expected by the wider GOV.UK route-state suite: the page includes the GOV.UK table stylesheet and a `Back to Study` action hydrated by the participant consent route controller.
+- Updated the participant consent generated page contract so the page does not include a `Back to Study` action and relies on the GOV.UK frontend styles plus the participant consent stylesheet.
 
 ## Validation
 

--- a/docs/agent-audit/reasoning/2026/07/02/study-session-participant-consent-govuk-layout.json
+++ b/docs/agent-audit/reasoning/2026/07/02/study-session-participant-consent-govuk-layout.json
@@ -4,7 +4,7 @@
   "traceRequired": true,
   "taskSummary": "Move Study session and participant consent routes onto GOV.UK/Nunjucks layouts with D1-backed data access and browser-comment refinements.",
   "implementationHighlights": [
-    "Restored the participant consent Back to Study action and GOV.UK table stylesheet to satisfy the GOV.UK breadcrumb/back-link and table route-state contracts.",
+    "Removed the participant consent Back to Study action and updated route-state contracts so it does not return.",
     "Addressed Codex review comments for session API credentials, D1-empty Airtable consent fallback and legacy sid no longer being treated as a session-note id.",
     "Updated D1 migration ordering documentation so the next main migration prefix is 0024."
   ],

--- a/public/css/participant-consent.css
+++ b/public/css/participant-consent.css
@@ -120,10 +120,13 @@
 
 .participant-consent-item .govuk-radios--inline .govuk-radios__item {
 	display: inline-flex;
+	float: none;
+	clear: none;
 	gap: 8px;
 	align-items: center;
 	min-height: 44px;
 	margin-right: 0;
+	margin-bottom: 0;
 	padding-left: 0;
 	}
 
@@ -153,6 +156,7 @@
 	display: inline-flex;
 	align-items: center;
 	min-height: 44px;
+	margin-top: -5px;
 	padding: 0;
 	}
 

--- a/public/pages/study/participant-consent/index.html
+++ b/public/pages/study/participant-consent/index.html
@@ -7,7 +7,6 @@
 		<link rel="stylesheet" href="/assets/govuk/govuk-frontend.css" media="screen" />
 
 		<meta property="schema:name" content="Participant consent - ResearchOps" />
-		<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen" />
 		<link rel="stylesheet" href="/css/participant-consent.css" media="screen" />
 		<link rel="stylesheet" href="/css/daas-brand-panel.css?v=leds-brand-panel-20260624" media="screen" />
 		<link rel="modulepreload" href="/js/study-route-context.js" />
@@ -52,19 +51,6 @@
 						src="/images/brands/leds-logo-white.svg"
 						alt="Law Enforcement Data Service"
 					/>
-				</div>
-
-				<div class="govuk-button-group">
-					<a
-						href="/pages/study/"
-						role="button"
-						draggable="false"
-						class="govuk-button govuk-button--secondary"
-						data-module="govuk-button"
-						id="back-to-study"
-					>
-						Back to Study
-					</a>
 				</div>
 
 				<div

--- a/src/govuk/templates/pages/study-participant-consent.njk
+++ b/src/govuk/templates/pages/study-participant-consent.njk
@@ -13,7 +13,6 @@
 
 {% block head %}
 	<meta property="schema:name" content="Participant consent - ResearchOps">
-	<link rel="stylesheet" href="/css/govuk/govuk-tables.css" media="screen">
 	<link rel="stylesheet" href="/css/participant-consent.css" media="screen">
 	<link rel="stylesheet" href="/css/daas-brand-panel.css?v=leds-brand-panel-20260624" media="screen">
 	<link rel="modulepreload" href="/js/study-route-context.js">
@@ -33,17 +32,6 @@
 	}) }}
 
 	{{ daasBrandPanel() }}
-
-	<div class="govuk-button-group">
-		{{ govukButton({
-			text: "Back to Study",
-			href: "/pages/study/",
-			classes: "govuk-button--secondary",
-			attributes: {
-				id: "back-to-study"
-			}
-		}) }}
-	</div>
 
 	<div id="consent-error" class="govuk-error-summary participant-consent-error" tabindex="-1" hidden aria-hidden="true" data-module="govuk-error-summary">
 		<div role="alert">

--- a/src/styles/participant-consent.scss
+++ b/src/styles/participant-consent.scss
@@ -149,10 +149,13 @@
 // prettier-ignore
 .participant-consent-item .govuk-radios--inline .govuk-radios__item {
 	display: inline-flex;
+	float: none;
+	clear: none;
 	gap: 8px;
 	align-items: center;
 	min-height: 44px;
 	margin-right: 0;
+	margin-bottom: 0;
 	padding-left: 0;
 }
 
@@ -186,6 +189,7 @@
 	display: inline-flex;
 	align-items: center;
 	min-height: 44px;
+	margin-top: -5px;
 	padding: 0;
 }
 

--- a/tests/govuk-breadcrumb-back-link-route-state.test.js
+++ b/tests/govuk-breadcrumb-back-link-route-state.test.js
@@ -48,7 +48,7 @@ const breadcrumbPages = [
 	{
 		label: "Participant Consent route",
 		path: "public/pages/study/participant-consent/index.html",
-		requiredIds: ["breadcrumb-project", "breadcrumb-study", "back-to-study"],
+		requiredIds: ["breadcrumb-project", "breadcrumb-study"],
 		currentText: "Participant consent"
 	},
 	{
@@ -157,5 +157,5 @@ includes(consentFormsPage, "id=\"back-to-study\"", "Consent Forms route");
 includesNormalised(consentFormsPage, "Back to Study", "Consent Forms route");
 
 const participantConsentPage = fs.readFileSync("public/pages/study/participant-consent/index.html", "utf8");
-includes(participantConsentPage, "id=\"back-to-study\"", "Participant Consent route");
-includesNormalised(participantConsentPage, "Back to Study", "Participant Consent route");
+excludes(participantConsentPage, "id=\"back-to-study\"", "Participant Consent route");
+excludes(participantConsentPage, "Back to Study", "Participant Consent route");

--- a/tests/govuk-forms-application-route-state.test.js
+++ b/tests/govuk-forms-application-route-state.test.js
@@ -79,10 +79,10 @@ const participantConsentTemplate = read("src/govuk/templates/pages/study-partici
 includes(participantConsentPage, "href=\"/assets/govuk/govuk-frontend.css\"", "Participant consent route");
 includes(participantConsentPage, "href=\"/css/participant-consent.css\"", "Participant consent route");
 excludes(participantConsentPage, "href=\"/css/govuk/govuk-forms.css\"", "Participant consent route");
-includes(participantConsentPage, "href=\"/css/govuk/govuk-tables.css\"", "Participant consent route");
+excludes(participantConsentPage, "href=\"/css/govuk/govuk-tables.css\"", "Participant consent route");
 includes(participantConsentTemplate, "govukSelect({", "Participant consent template");
 includes(participantConsentTemplate, "govukInput({", "Participant consent template");
-includes(participantConsentPage, "id=\"back-to-study\"", "Participant consent route");
+excludes(participantConsentPage, "id=\"back-to-study\"", "Participant consent route");
 
 const synthesizePage = read("public/pages/study/synthesis/index.html");
 const synthesizeTemplate = read("src/govuk/templates/pages/study-synthesis.njk");

--- a/tests/govuk-tables-summary-lists-application-route-state.test.js
+++ b/tests/govuk-tables-summary-lists-application-route-state.test.js
@@ -69,7 +69,7 @@ includes(participantsPageSource, "<tbody id=\"sessions-tbody\" class=\"govuk-tab
 excludes(participantsPageSource, "role=\"table\"", "participants page");
 excludes(participantsPageSource, "role=\"columnheader\"", "participants page");
 
-includes(participantConsentPageSource, "href=\"/css/govuk/govuk-tables.css\"", "participant consent page");
+excludes(participantConsentPageSource, "href=\"/css/govuk/govuk-tables.css\"", "participant consent page");
 includes(participantConsentPageSource, "class=\"govuk-table participant-consent-table\"", "participant consent page");
 includes(participantConsentPageSource, "<tbody id=\"participant-consent-tbody\" class=\"govuk-table__body\">", "participant consent page");
 includes(participantConsentPageSource, "class=\"govuk-summary-list participant-consent-summary\"", "participant consent page");

--- a/tests/participant-consent-route-state.test.js
+++ b/tests/participant-consent-route-state.test.js
@@ -40,15 +40,15 @@ includes(rendererSource, "output: 'public/pages/study/participant-consent/index.
 
 includes(pageSource, "Participant consent - ResearchOps Demo Suite", "participant consent page");
 includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "participant consent page");
-includes(pageSource, "href=\"/css/govuk/govuk-tables.css\"", "participant consent page");
 includes(pageSource, "href=\"/css/participant-consent.css\"", "participant consent page");
 excludes(pageSource, "href=\"/css/govuk/govuk-forms.css\"", "participant consent page");
+excludes(pageSource, "href=\"/css/govuk/govuk-tables.css\"", "participant consent page");
 includes(pageSource, "src=\"/js/participant-consent-route-loader.js?v=study-record-id-routing-20260518\"", "participant consent page");
 includes(pageSource, "href=\"/js/study-route-context.js\"", "participant consent page");
 includes(pageSource, "data-study-subpage-template=\"participant-consent\"", "participant consent page");
 includes(pageSource, "id=\"breadcrumb-project\"", "participant consent page");
 includes(pageSource, "id=\"breadcrumb-study\"", "participant consent page");
-includes(pageSource, "id=\"back-to-study\"", "participant consent page");
+excludes(pageSource, "id=\"back-to-study\"", "participant consent page");
 includes(pageSource, "id=\"no-context-state\"", "participant consent page");
 includes(pageSource, "The participant consent page needs a Study record ID in the URL.", "participant consent page");
 includes(pageSource, "id=\"participant-consent-form\"", "participant consent page");


### PR DESCRIPTION
## Summary
- Remove the participant consent `Back to Study` action from the Nunjucks template and generated page.
- Update route-state tests so participant consent explicitly excludes `back-to-study` and does not load the extra GOV.UK table stylesheet.
- Keep the participant consent control alignment fixes for the inline radio row and withdrawal checkbox label.

## Validation
- `node --import ./tests/helpers/generated-govuk-page-source.mjs --test tests/participant-consent-route-state.test.js tests/govuk-forms-application-route-state.test.js tests/govuk-breadcrumb-back-link-route-state.test.js tests/govuk-tables-summary-lists-application-route-state.test.js tests/study-child-route-state.test.js`
- `npm run format:check`
- `npm run trace:coverage`
- Browser preview confirmed no `#back-to-study`, no visible “Back to Study” text, aligned radio row, and withdrawal checkbox label `margin-top: -5px`.

Local preview: http://127.0.0.1:4174/pages/study/participant-consent/?id=recVisualStudy001&session=recVisualSession001&participant=d1ptp_visual_001