### PR TITLE
Fix participant consent walkthrough waits

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/02/study-session-participant-consent-govuk-layout.json
+++ b/docs/agent-audit/reasoning/2026/07/02/study-session-participant-consent-govuk-layout.json
@@ -6,7 +6,8 @@
   "implementationHighlights": [
     "Removed the participant consent Back to Study action and updated route-state contracts so it does not return.",
     "Addressed Codex review comments for session API credentials, D1-empty Airtable consent fallback and legacy sid no longer being treated as a session-note id.",
-    "Updated D1 migration ordering documentation so the next main migration prefix is 0024."
+    "Updated D1 migration ordering documentation so the next main migration prefix is 0024.",
+    "Fixed manual visual walkthrough CI waits to use the current participant consent route, visible page-state containers and the operational participant fixture id."
   ],
   "selectedBundles": [
     {
@@ -59,6 +60,19 @@
       "command": "Browser preview verification",
       "result": "passed",
       "evidence": "Loaded participant consent verified at 641px viewport with aligned radio row, stacked tag gap and withdrawal checkbox label margin-top -5px."
+    },
+    {
+      "command": "node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js",
+      "result": "passed with 13 tests passing and 0 failing"
+    },
+    {
+      "command": "node --test tests/visual-walkthrough-registry-coverage.test.js tests/govuk-frontend-service-pages-route-state.test.js",
+      "result": "passed with 2 tests passing and 0 failing"
+    },
+    {
+      "command": "Targeted Playwright capture using captureState against http://127.0.0.1:4174",
+      "result": "passed",
+      "evidence": "Captured study-session/default and study-participant-consent/default, no-published-consent-form, no-participants and participant-selected across desktop and mobile."
     }
   ]
 }

--- a/docs/agent-audit/reasoning/2026/07/02/study-session-participant-consent-govuk-layout.md
+++ b/docs/agent-audit/reasoning/2026/07/02/study-session-participant-consent-govuk-layout.md
@@ -36,6 +36,9 @@ Selected bundles:
 - Applied browser-comment refinements for human-readable dates, stacked GOV.UK tags, radio alignment and withdrawal checkbox label alignment.
 - Addressed Codex review comments for session API credentials, D1-empty Airtable consent fallback and legacy `sid` no longer being treated as a session-note id.
 - Updated D1 migration ordering documentation so the next main migration prefix is `0024`.
+- Fixed the manual visual walkthrough CI waits after the participant consent status text was removed from the UI.
+- Updated the Study session walkthrough fixture to wait for and select the operational participant id that exists in the mock data.
+- Updated participant consent walkthrough fixtures to use the current `?id=` route parameter and wait for visible GOV.UK state containers instead of hidden duplicate text.
 
 ## Validation
 
@@ -45,3 +48,6 @@ Selected bundles:
 - `npm run build:govuk-pages && npm test`: passed with 272 tests passing and 0 failing.
 - `npm run format:check`: passed.
 - Browser preview at `http://127.0.0.1:4174/pages/study/participant-consent/?id=recVisualStudy001&session=recVisualSession001&participant=d1ptp_visual_001`: verified loaded participant consent, radio alignment, `row-gap: 12px` on stacked tags and `margin-top: -5px` on the withdrawal checkbox label.
+- `node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js`: passed with 13 tests passing and 0 failing.
+- `node --test tests/visual-walkthrough-registry-coverage.test.js tests/govuk-frontend-service-pages-route-state.test.js`: passed with 2 tests passing and 0 failing.
+- Targeted Playwright capture using `captureState` against local preview `http://127.0.0.1:4174`: passed for `study-session/default` and `study-participant-consent/default`, `no-published-consent-form`, `no-participants` and `participant-selected` across desktop and mobile.

--- a/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
+++ b/tests/qa-bdd-authenticated-walkthrough-route-state.test.js
@@ -10,6 +10,7 @@ import {
 	operationalJournalMemos,
 	operationalPaths,
 } from '../visual-walkthrough.operational-fixtures.mjs';
+import { participantConsentPath } from '../visual-walkthrough.participant-consent-fixtures.mjs';
 import { repositoryStaticPages } from '../src/govuk/data/repository-page.mjs';
 
 const featureSource = fs.readFileSync('features/authenticated-walkthrough.feature', 'utf8');
@@ -219,10 +220,14 @@ test('data-dependent walkthrough pages keep operational defaults and explicit er
 	assert.equal(stateIds('study-guides').has('empty-guide-source-error'), true);
 
 	assert.deepEqual(pages.get('study-session').defaultState.actions.slice(0, 2), [
-		{ type: 'waitForSelector', selector: '#participant-select option[value="ptp_001"]', state: 'attached' },
-		{ type: 'select', selector: '#participant-select', value: 'ptp_001' },
+		{ type: 'waitForSelector', selector: '#participant-select option[value="recVisualParticipant001"]', state: 'attached' },
+		{ type: 'select', selector: '#participant-select', value: 'recVisualParticipant001' },
 	]);
 	assert.equal(stateIds('study-session').has('participant-consent-gate'), true);
+
+	assert.equal(participantConsentPath, '/pages/study/participant-consent/?id=recVisualConsentStudy001');
+	assert.equal(participantConsentPath.includes('pid='), false);
+	assert.equal(participantConsentPath.includes('sid='), false);
 
 	assert.equal(pages.get('team-access-requests').defaultState.path, operationalPaths.teamAccessRequests);
 	assert.equal(stateIds('team-access-requests').has('decision-error'), true);

--- a/visual-walkthrough.config.mjs
+++ b/visual-walkthrough.config.mjs
@@ -408,8 +408,8 @@ const studySessionPage = {
 		description: 'Session workspace captured with a selected participant and ready consent status.',
 		path: operationalPaths.studySession,
 		actions: [
-			{ type: 'waitForSelector', selector: '#participant-select option[value="ptp_001"]', state: 'attached' },
-			{ type: 'select', selector: '#participant-select', value: 'ptp_001' },
+			{ type: 'waitForSelector', selector: '#participant-select option[value="recVisualParticipant001"]', state: 'attached' },
+			{ type: 'select', selector: '#participant-select', value: 'recVisualParticipant001' },
 			{ type: 'waitForText', text: 'Ready for session' },
 		],
 	},

--- a/visual-walkthrough.participant-consent-fixtures.mjs
+++ b/visual-walkthrough.participant-consent-fixtures.mjs
@@ -7,7 +7,7 @@
 
 export const participantConsentProjectId = 'recVisualConsentProject001';
 export const participantConsentStudyId = 'recVisualConsentStudy001';
-export const participantConsentPath = `/pages/study/participant-consent/?pid=${participantConsentProjectId}&sid=${participantConsentStudyId}`;
+export const participantConsentPath = `/pages/study/participant-consent/?id=${participantConsentStudyId}`;
 
 const projectsRoute = /\/api\/projects(?:\?.*)?$/;
 const studiesRoute = /\/api\/studies(?:\?.*)?$/;

--- a/visual-walkthrough.participant-consent-states.mjs
+++ b/visual-walkthrough.participant-consent-states.mjs
@@ -21,8 +21,9 @@ export const participantConsentDefaultState = {
 	mockRoutes: participantConsentMockRoutes(),
 	actions: [
 		{
-			type: 'waitForText',
-			text: 'Participant consent loaded.',
+			type: 'waitForSelector',
+			selector: '#consent-workspace:not([hidden])',
+			state: 'visible',
 		},
 		{
 			type: 'waitForText',
@@ -57,8 +58,9 @@ export const participantConsentVisualStates = [
 		mockRoutes: participantConsentMockRoutes({ consentForms: [] }),
 		actions: [
 			{
-				type: 'waitForText',
-				text: 'Create and publish a consent form before recording participant consent',
+				type: 'waitForSelector',
+				selector: '#no-consent-form-state:not([hidden])',
+				state: 'visible',
 			},
 			{
 				type: 'waitForText',
@@ -78,8 +80,9 @@ export const participantConsentVisualStates = [
 		}),
 		actions: [
 			{
-				type: 'waitForText',
-				text: 'Add participants before recording consent',
+				type: 'waitForSelector',
+				selector: '#no-participants-state:not([hidden])',
+				state: 'visible',
 			},
 			{
 				type: 'waitForText',
@@ -96,8 +99,9 @@ export const participantConsentVisualStates = [
 		mockRoutes: participantConsentMockRoutes(),
 		actions: [
 			{
-				type: 'waitForText',
-				text: 'Participant consent loaded.',
+				type: 'waitForSelector',
+				selector: '#consent-workspace:not([hidden])',
+				state: 'visible',
 			},
 			{
 				type: 'click',


### PR DESCRIPTION
## Summary
- update the participant consent visual walkthrough to use the current ?id= route fixture
- wait for visible participant consent state containers instead of removed or hidden status text
- select the operational study-session participant id that exists in walkthrough mock data

## Validation
- node --test tests/qa-bdd-authenticated-walkthrough-route-state.test.js
- node --test tests/visual-walkthrough-registry-coverage.test.js tests/govuk-frontend-service-pages-route-state.test.js
- npm run format:check
- npm run trace:coverage
- targeted Playwright capture using captureState against http://127.0.0.1:4174 for the failing study-session and participant-consent states across desktop and mobile