### PR TITLE
Fix Sourcebook Pages deploy fallback index

### DIFF
--- a/.github/workflows/deploy-sourcebook.yml
+++ b/.github/workflows/deploy-sourcebook.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docs/devops/sourcebook/**"
+      - ".github/workflows/deploy-sourcebook.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-sourcebook.yml
+++ b/.github/workflows/deploy-sourcebook.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Ensure site has an index
         run: |
           if [ ! -f "docs/devops/sourcebook/index.html" ]; then
-            cat > docs/devops/sourcebook/index.html <<'HTML'
-            <!doctype html><meta charset="utf-8">
-            <title>Sourcebook</title>
-            <h1>Sourcebook site not generated for this run.</h1>
-            HTML
+            {
+              printf '%s\n' '<!doctype html><meta charset="utf-8">'
+              printf '%s\n' '<title>Sourcebook</title>'
+              printf '%s\n' '<h1>Sourcebook site not generated for this run.</h1>'
+            } > docs/devops/sourcebook/index.html
           fi
 
       - name: Publish to Cloudflare Pages

--- a/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json
+++ b/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json
@@ -1,0 +1,66 @@
+{
+  "date": "2026-07-02",
+  "branch": "fix/sourcebook-deploy-heredoc",
+  "traceRequired": true,
+  "task": "Fix Sourcebook Cloudflare Pages deployment fallback index heredoc failure.",
+  "sourceEvidence": {
+    "attachedLog": "/Users/kevin.rapley/.codex/attachments/c2ff4399-113b-4282-a6e5-9180bc02760e/pasted-text.txt",
+    "workflow": ".github/workflows/deploy-sourcebook.yml",
+    "mainCommitInFailingRun": "9bbd5eceb43e002f99b3eb479e20db280e8d2faa",
+    "failure": "Bash did not recognise the indented heredoc terminator in the YAML run block."
+  },
+  "selectedBundles": [
+    {
+      "id": "github-diamond",
+      "path": ".agent-operating-model/bundles/github/"
+    },
+    {
+      "id": "researchops-developer-control",
+      "path": ".agent-operating-model/bundles/researchops-developer-control/"
+    },
+    {
+      "id": "multi-functional-team",
+      "path": ".agent-operating-model/bundles/multi-functional-team/"
+    },
+    {
+      "id": "cloudflare",
+      "path": ".agent-operating-model/bundles/cloudflare/"
+    }
+  ],
+  "skippedBundles": [
+    "govuk-design-system",
+    "openai-platform",
+    "mcp-agent-tooling",
+    "airtable-public-api",
+    "mural-public-api"
+  ],
+  "filesModified": [
+    ".github/workflows/deploy-sourcebook.yml",
+    "tests/cloudflare-pages-output-dir.test.js",
+    "docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md",
+    "docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json"
+  ],
+  "validation": [
+    {
+      "command": "node --test tests/cloudflare-pages-output-dir.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "npm run format -c",
+      "result": "passed"
+    },
+    {
+      "command": "npm run trace:coverage",
+      "result": "passed"
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed"
+    },
+    {
+      "command": "npm run validate",
+      "result": "passed"
+    }
+  ],
+  "residualRisk": "The failure occurred on main. The repair is staged on a follow-up PR branch and will only affect main after merge."
+}

--- a/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json
+++ b/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json
@@ -40,6 +40,7 @@
     "docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md",
     "docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json"
   ],
+  "workflowTriggerChange": "The Sourcebook deploy workflow now includes .github/workflows/deploy-sourcebook.yml in its push path filter so workflow-only fixes can trigger deployment after merge.",
   "validation": [
     {
       "command": "node --test tests/cloudflare-pages-output-dir.test.js",

--- a/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md
+++ b/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md
@@ -1,0 +1,64 @@
+# Sourcebook deploy heredoc fix trace
+
+Date: 2026-07-02
+Branch: `fix/sourcebook-deploy-heredoc`
+Trace requirement: required by `fix/` branch prefix.
+
+## Task
+
+Fix the Sourcebook Cloudflare Pages deployment failure reported from GitHub Actions. The attached runner log showed the `Deploy Sourcebook to Cloudflare Pages` workflow failing in the fallback index step before Cloudflare Pages publish started.
+
+## Operating model
+
+Loaded repository operating-model sources:
+
+- `AGENTS.md`
+- `.agent-operating-model/orchestration.xml`
+- `.agent-operating-model/bundle-registry.json`
+- `.agent-operating-model/task-signal-catalog.json`
+- `.agent-operating-model/selection-rules.json`
+- `.agent-operating-model/github-mutation-policy.md`
+- `.agent-operating-model/precedence-policy.md`
+- `.agent-operating-model/trace-policy.md`
+
+Selected bundles:
+
+- `github-diamond` at `.agent-operating-model/bundles/github/`
+- `researchops-developer-control` at `.agent-operating-model/bundles/researchops-developer-control/`
+- `multi-functional-team` at `.agent-operating-model/bundles/multi-functional-team/`
+- `cloudflare` at `.agent-operating-model/bundles/cloudflare/`
+
+Skipped conditional bundles: `govuk-design-system`, `openai-platform`, `mcp-agent-tooling`, `airtable-public-api`, `mural-public-api`.
+
+Precedence: GitHub Diamond governs repository safety, branch hygiene, PR discipline and CI evidence. ResearchOps Developer Control governs repository conventions. Multi-Functional Team governs service assurance framing. Cloudflare governs Pages deployment behaviour.
+
+## Evidence
+
+- Attached GitHub Actions log: `Deploy Sourcebook to Cloudflare Pages` ran on `main` at `9bbd5eceb43e002f99b3eb479e20db280e8d2faa`.
+- The failing shell step printed an indented heredoc terminator `HTML`.
+- Bash reported: `here-document at line 2 delimited by end-of-file (wanted 'HTML')` and `syntax error: unexpected end of file`.
+- `.github/workflows/deploy-sourcebook.yml` contained `cat > docs/devops/sourcebook/index.html <<'HTML'` inside a YAML `run: |` block with the `HTML` terminator indented.
+
+## Changes made
+
+- Replaced the workflow heredoc with a small grouped `printf` block so the fallback `index.html` can be written without heredoc indentation sensitivity.
+- Extended `tests/cloudflare-pages-output-dir.test.js` to assert:
+  - the Sourcebook workflow still targets the `reops-sourcebook` Pages project
+  - the workflow publishes `./docs/devops/sourcebook`
+  - the fallback index step runs before `cloudflare/pages-action@v1`
+  - the fallback guard does not use the failed heredoc pattern
+  - the fallback guard writes the expected doctype line with `printf`
+
+## Validation
+
+Passed:
+
+- `node --test tests/cloudflare-pages-output-dir.test.js`
+- `npm run format -c`
+- `npm run trace:coverage`
+- `git diff --check`
+- `npm run validate`
+
+## Residual risk
+
+The attached failing run was on `main`; this fix is delivered through a follow-up PR rather than by pushing directly to `main`.

--- a/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md
+++ b/docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md
@@ -42,9 +42,11 @@ Precedence: GitHub Diamond governs repository safety, branch hygiene, PR discipl
 ## Changes made
 
 - Replaced the workflow heredoc with a small grouped `printf` block so the fallback `index.html` can be written without heredoc indentation sensitivity.
+- Added `.github/workflows/deploy-sourcebook.yml` to the workflow path filter so changing the deploy workflow can trigger a Sourcebook deploy on merge.
 - Extended `tests/cloudflare-pages-output-dir.test.js` to assert:
   - the Sourcebook workflow still targets the `reops-sourcebook` Pages project
   - the workflow publishes `./docs/devops/sourcebook`
+  - the workflow runs when its own deploy rules change
   - the fallback index step runs before `cloudflare/pages-action@v1`
   - the fallback guard does not use the failed heredoc pattern
   - the fallback guard writes the expected doctype line with `printf`

--- a/tests/cloudflare-pages-output-dir.test.js
+++ b/tests/cloudflare-pages-output-dir.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const wranglerConfig = fs.readFileSync('wrangler.toml', 'utf8');
+const sourcebookDeployWorkflow = fs.readFileSync('.github/workflows/deploy-sourcebook.yml', 'utf8');
 
 assert.match(
 	wranglerConfig,
@@ -13,4 +14,34 @@ assert.doesNotMatch(
 	wranglerConfig,
 	/^pages_build_output_dir\s*=\s*["']docs\/agent-operating-model["']$/m,
 	'The root Pages config must not point the app preview at agent documentation.'
+);
+
+assert.match(
+	sourcebookDeployWorkflow,
+	/projectName:\s*reops-sourcebook/,
+	'The Sourcebook workflow must publish to the dedicated Sourcebook Pages project.'
+);
+
+assert.match(
+	sourcebookDeployWorkflow,
+	/directory:\s*\.\/docs\/devops\/sourcebook/,
+	'The Sourcebook workflow must publish the generated Sourcebook site, not the root app output.'
+);
+
+assert.ok(
+	sourcebookDeployWorkflow.indexOf('Ensure site has an index') <
+		sourcebookDeployWorkflow.indexOf('cloudflare/pages-action@v1'),
+	'The Sourcebook fallback index must be created before Cloudflare Pages publish runs.'
+);
+
+assert.doesNotMatch(
+	sourcebookDeployWorkflow,
+	/<<['-]?HTML/,
+	'The Sourcebook fallback index guard must not use an indented heredoc in a YAML run block.'
+);
+
+assert.match(
+	sourcebookDeployWorkflow,
+	/printf '%s\\n' '<!doctype html><meta charset="utf-8">'/,
+	'The Sourcebook fallback index guard must write a valid HTML index without relying on heredoc indentation.'
 );

--- a/tests/cloudflare-pages-output-dir.test.js
+++ b/tests/cloudflare-pages-output-dir.test.js
@@ -28,6 +28,12 @@ assert.match(
 	'The Sourcebook workflow must publish the generated Sourcebook site, not the root app output.'
 );
 
+assert.match(
+	sourcebookDeployWorkflow,
+	/- "\.github\/workflows\/deploy-sourcebook\.yml"/,
+	'The Sourcebook workflow must run when its own deploy rules change.'
+);
+
 assert.ok(
 	sourcebookDeployWorkflow.indexOf('Ensure site has an index') <
 		sourcebookDeployWorkflow.indexOf('cloudflare/pages-action@v1'),


### PR DESCRIPTION
## Summary
- replace the Sourcebook Pages fallback index heredoc with a printf block so the GitHub Actions shell step no longer fails on an indented heredoc terminator
- add the deploy workflow file to its own path filter so merging this workflow repair triggers the Sourcebook deploy
- extend the Cloudflare Pages output-dir test to cover the Sourcebook deploy workflow target, trigger path, ordering and fallback index guard
- add the required audit trace for the fix branch

## Validation
- npx prettier --check .github/workflows/deploy-sourcebook.yml tests/cloudflare-pages-output-dir.test.js docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json
- node --test tests/cloudflare-pages-output-dir.test.js
- npm run trace:coverage
- git diff --check
- npm run validate

## Trace
- docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.md
- docs/agent-audit/reasoning/2026/07/02/sourcebook-deploy-heredoc-fix.json

## Notes
This follows up PR #456, which is already merged. The attached failing runner log is from merge commit 9bbd5eceb43e002f99b3eb479e20db280e8d2faa on main.