### PR TITLE
Add Sourcebook assurance to participant consent

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json
+++ b/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json
@@ -34,7 +34,8 @@
     "Added responsive layout rules so Sourcebook context uses a right rail only at desktop widths and stacks cleanly on tablet and mobile.",
     "Refined Sourcebook component tag colours and narrow-width table layouts for accessible contrast and readable mobile presentation.",
     "Regenerated GOV.UK pages and generated CSS outputs.",
-    "Fixed the PR CI failure by removing trailing spaces from optional Sourcebook component class output and strengthening the participant-consent ledger ordering assertion against freshly rendered Nunjucks output."
+    "Fixed the PR CI failure by removing trailing spaces from optional Sourcebook component class output and strengthening the participant-consent ledger ordering assertion against freshly rendered Nunjucks output.",
+    "Addressed Codex review thread discussion_r3522161402 by evaluating participant Sourcebook readiness against the current published consent form while preserving the saved record form for display and editing."
   ],
   "validation": [
     {
@@ -93,6 +94,36 @@
       "command": "npm run audit:security",
       "result": "passed",
       "details": "npm audit findings remained advisory under repository policy."
+    },
+    {
+      "command": "node --test tests/participant-consent-route-state.test.js",
+      "result": "passed",
+      "details": "Review-thread fix validation."
+    },
+    {
+      "command": "npx prettier -c public/js/participant-consent-page.js tests/participant-consent-route-state.test.js docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json",
+      "result": "passed",
+      "details": "Review-thread fix validation."
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed",
+      "details": "Review-thread fix validation."
+    },
+    {
+      "command": "npm test",
+      "result": "passed",
+      "details": "353 tests passed after the review-thread fix."
+    },
+    {
+      "command": "npm run validate",
+      "result": "passed",
+      "details": "Review-thread fix validation."
+    },
+    {
+      "command": "npm run trace:coverage",
+      "result": "passed",
+      "details": "Review-thread fix validation."
     }
   ],
   "residualRisk": ["Full CI remains the merge gate."]

--- a/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json
+++ b/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json
@@ -1,0 +1,75 @@
+{
+  "date": "2026-07-04",
+  "branch": "feature/manage-participant-consent-sourcebook",
+  "task": "Create a ready-for-review PR for adding Sourcebook components to the manage participant consent page after PR #462 merged to main.",
+  "operatingModel": {
+    "loaded": [
+      "AGENTS.md",
+      ".agent-operating-model/orchestration.xml",
+      ".agent-operating-model/bundle-registry.json",
+      ".agent-operating-model/task-signal-catalog.json",
+      ".agent-operating-model/selection-rules.json",
+      ".agent-operating-model/precedence-policy.md"
+    ],
+    "selectedBundles": [
+      ".agent-operating-model/bundles/github/",
+      ".agent-operating-model/bundles/researchops-developer-control/",
+      ".agent-operating-model/bundles/multi-functional-team/",
+      ".agent-operating-model/bundles/govuk-design-system/"
+    ],
+    "skippedBundles": [
+      ".agent-operating-model/bundles/cloudflare/",
+      ".agent-operating-model/bundles/openai/",
+      ".agent-operating-model/bundles/mcp-agent-tooling/",
+      ".agent-operating-model/bundles/airtable-public-api/",
+      ".agent-operating-model/bundles/mural-public-api/"
+    ],
+    "traceDecision": "Trace required because the repository-affecting work is on feature/manage-participant-consent-sourcebook."
+  },
+  "changes": [
+    "Created feature/manage-participant-consent-sourcebook from origin/main after PR #462 merged.",
+    "Added route mapping for /pages/study/participant-consent/ to REC-ADMN 3.1.1.",
+    "Added Sourcebook context, evidence ledger and consent assurance gate to the participant consent page.",
+    "Added participant-aware ledger and gate updates to the participant consent page controller.",
+    "Added responsive layout rules so Sourcebook context uses a right rail only at desktop widths and stacks cleanly on tablet and mobile.",
+    "Refined Sourcebook component tag colours and narrow-width table layouts for accessible contrast and readable mobile presentation.",
+    "Regenerated GOV.UK pages and generated CSS outputs."
+  ],
+  "validation": [
+    {
+      "command": "npm run build:generated-css",
+      "result": "passed"
+    },
+    {
+      "command": "npm run build:govuk-pages",
+      "result": "passed"
+    },
+    {
+      "command": "node --test tests/participant-consent-route-state.test.js tests/sourcebook-context-route-state.test.js tests/search-page-route-state.test.js tests/consent-page-route-state.test.js tests/auth-team-access-request-route-state.test.js tests/auth-role-assignment-ui-route-state.test.js tests/sourcebook-api.test.js tests/sourcebook-api-route-state.test.js",
+      "result": "passed",
+      "details": "27 tests passed."
+    },
+    {
+      "command": "Playwright rendered checks at 1272x739, 1100x900, 900x900, 700x900, 470x858, 390x858 and 319x858",
+      "result": "passed",
+      "details": "Confirmed desktop Sourcebook rail, tablet/mobile Sourcebook context, 50/50 summary split at 470px, and stacked participant table labels on phone widths."
+    },
+    {
+      "command": "git diff --name-only --diff-filter=ACM origin/main | rg -v '\\.njk$' | xargs npx prettier -c",
+      "result": "passed"
+    },
+    {
+      "command": "npm run trace:coverage",
+      "result": "passed"
+    },
+    {
+      "command": "git diff --check",
+      "result": "passed"
+    },
+    {
+      "command": "npm run validate",
+      "result": "passed"
+    }
+  ],
+  "residualRisk": ["Full CI remains the merge gate."]
+}

--- a/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json
+++ b/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json
@@ -33,7 +33,8 @@
     "Added participant-aware ledger and gate updates to the participant consent page controller.",
     "Added responsive layout rules so Sourcebook context uses a right rail only at desktop widths and stacks cleanly on tablet and mobile.",
     "Refined Sourcebook component tag colours and narrow-width table layouts for accessible contrast and readable mobile presentation.",
-    "Regenerated GOV.UK pages and generated CSS outputs."
+    "Regenerated GOV.UK pages and generated CSS outputs.",
+    "Fixed the PR CI failure by removing trailing spaces from optional Sourcebook component class output and strengthening the participant-consent ledger ordering assertion against freshly rendered Nunjucks output."
   ],
   "validation": [
     {
@@ -69,6 +70,29 @@
     {
       "command": "npm run validate",
       "result": "passed"
+    },
+    {
+      "command": "npm test",
+      "result": "passed",
+      "details": "353 tests passed after the CI-fix patch."
+    },
+    {
+      "command": "npm run lint",
+      "result": "passed",
+      "details": "Ignored local Wrangler temp output was removed before rerunning lint."
+    },
+    {
+      "command": "npm run format:check",
+      "result": "passed"
+    },
+    {
+      "command": "npm run audit:performance --if-present",
+      "result": "passed"
+    },
+    {
+      "command": "npm run audit:security",
+      "result": "passed",
+      "details": "npm audit findings remained advisory under repository policy."
     }
   ],
   "residualRisk": ["Full CI remains the merge gate."]

--- a/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md
+++ b/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md
@@ -38,6 +38,7 @@ Skipped:
 - Added responsive layout rules so Sourcebook context uses a right rail only at desktop widths and stacks cleanly on tablet and mobile.
 - Refined Sourcebook component tag colours and narrow-width table layouts for accessible contrast and readable mobile presentation.
 - Regenerated GOV.UK pages and generated CSS outputs.
+- Fixed the PR CI failure by removing trailing spaces from optional Sourcebook component class output and strengthening the participant-consent ledger ordering assertion against freshly rendered Nunjucks output.
 
 ## Validation
 
@@ -49,6 +50,11 @@ Skipped:
 - `npm run trace:coverage` passed.
 - `git diff --check` passed.
 - `npm run validate` passed.
+- `npm test` passed with 353 tests after the CI-fix patch.
+- `npm run lint` passed after removing ignored local Wrangler temp output.
+- `npm run format:check` passed.
+- `npm run audit:performance --if-present` passed.
+- `npm run audit:security` passed; npm audit findings remained advisory under repository policy.
 
 ## Residual Risk
 

--- a/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md
+++ b/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md
@@ -39,6 +39,7 @@ Skipped:
 - Refined Sourcebook component tag colours and narrow-width table layouts for accessible contrast and readable mobile presentation.
 - Regenerated GOV.UK pages and generated CSS outputs.
 - Fixed the PR CI failure by removing trailing spaces from optional Sourcebook component class output and strengthening the participant-consent ledger ordering assertion against freshly rendered Nunjucks output.
+- Addressed Codex review thread `discussion_r3522161402` by evaluating participant Sourcebook readiness against the current published consent form while preserving the saved record form for display and editing.
 
 ## Validation
 
@@ -55,6 +56,12 @@ Skipped:
 - `npm run format:check` passed.
 - `npm run audit:performance --if-present` passed.
 - `npm run audit:security` passed; npm audit findings remained advisory under repository policy.
+- `node --test tests/participant-consent-route-state.test.js` passed after the review-thread fix.
+- `npx prettier -c public/js/participant-consent-page.js tests/participant-consent-route-state.test.js docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.json` passed.
+- `git diff --check` passed after the review-thread fix.
+- `npm test` passed with 353 tests after the review-thread fix.
+- `npm run validate` passed after the review-thread fix.
+- `npm run trace:coverage` passed after the review-thread fix.
 
 ## Residual Risk
 

--- a/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md
+++ b/docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md
@@ -1,0 +1,55 @@
+# Manage Participant Consent Sourcebook PR Trace
+
+Date: 2026-07-04
+Branch: `feature/manage-participant-consent-sourcebook`
+Task: Create a ready-for-review PR for adding Sourcebook components to the manage participant consent page after PR #462 merged to `main`.
+
+## Operating Model Bootstrap
+
+- Loaded `AGENTS.md`.
+- Loaded `.agent-operating-model/orchestration.xml`.
+- Loaded `.agent-operating-model/bundle-registry.json`.
+- Loaded `.agent-operating-model/task-signal-catalog.json`.
+- Loaded `.agent-operating-model/selection-rules.json`.
+- Loaded `.agent-operating-model/precedence-policy.md`.
+- Verified selected bundle directories contain `prompt.spec.yaml` and `prompt.body.xml`.
+
+## Selected Bundles
+
+- `.agent-operating-model/bundles/github/` (`github-diamond`)
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped:
+
+- `cloudflare`: no Worker runtime, binding or deployment change.
+- `openai-platform`: no OpenAI API or model integration change.
+- `mcp-agent-tooling`: no MCP protocol, tool or resource change.
+- `airtable-public-api`: no Airtable API integration change.
+- `mural-public-api`: no Mural API integration change.
+
+## Implementation Summary
+
+- Created `feature/manage-participant-consent-sourcebook` from `origin/main` after PR #462 merged.
+- Added route mapping for `/pages/study/participant-consent/` to `REC-ADMN 3.1.1`.
+- Added Sourcebook context, evidence ledger and consent assurance gate to the participant consent page.
+- Added participant-aware ledger and gate updates to the participant consent page controller.
+- Added responsive layout rules so Sourcebook context uses a right rail only at desktop widths and stacks cleanly on tablet and mobile.
+- Refined Sourcebook component tag colours and narrow-width table layouts for accessible contrast and readable mobile presentation.
+- Regenerated GOV.UK pages and generated CSS outputs.
+
+## Validation
+
+- `npm run build:generated-css` passed.
+- `npm run build:govuk-pages` passed.
+- `node --test tests/participant-consent-route-state.test.js tests/sourcebook-context-route-state.test.js tests/search-page-route-state.test.js tests/consent-page-route-state.test.js tests/auth-team-access-request-route-state.test.js tests/auth-role-assignment-ui-route-state.test.js tests/sourcebook-api.test.js tests/sourcebook-api-route-state.test.js` passed with 27 tests.
+- Playwright rendered checks passed at `1272x739`, `1100x900`, `900x900`, `700x900`, `470x858`, `390x858` and `319x858`.
+- `git diff --name-only --diff-filter=ACM origin/main | rg -v '\.njk$' | xargs npx prettier -c` passed.
+- `npm run trace:coverage` passed.
+- `git diff --check` passed.
+- `npm run validate` passed.
+
+## Residual Risk
+
+- Full CI remains the merge gate.

--- a/public/css/account-team-access.css
+++ b/public/css/account-team-access.css
@@ -22,6 +22,10 @@
 	border-left-color: #d4351c;
 	}
 
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+	}
+
 .sourcebook-gate--ready {
 	border-left-color: #00703c;
 	}
@@ -39,16 +43,24 @@
 	margin-bottom: 15px;
 	}
 
-.sourcebook-gate__tag--blocked, .sourcebook-gate__check-tag--unmet {
-	background: #d4351c;
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked, .sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--ready, .sourcebook-gate__check-tag--met {
+.sourcebook-gate .sourcebook-gate__check--governance-action .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
 	background: #00703c;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--not-applicable {
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
 	background: #505a5f;
+	color: #ffffff;
 	}
 
 .sourcebook-gate__checks {
@@ -203,6 +215,15 @@
 	line-height: 1.25;
 	}
 
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
 .sourcebook-evidence-ledger__clauses {
 	margin-bottom: 0;
 	}
@@ -219,11 +240,59 @@
 	white-space: nowrap;
 	}
 
-.sourcebook-evidence-ledger__tag--needed {
-	background: #b58840;
-	color: #0b0c0c;
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-evidence-ledger__tag--present {
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
 	background: #00703c;
+	color: #ffffff;
+	}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+		}
+	.sourcebook-gate__check-label, .sourcebook-gate__check-detail {
+		display: block;
+		}
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+		}
+	.sourcebook-evidence-ledger__table, .sourcebook-evidence-ledger__table .govuk-table__body, .sourcebook-evidence-ledger__table .govuk-table__row, .sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before, .sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: "Sourcebook clause";
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: "Status";
+		}
 	}

--- a/public/css/auth-role-assignments.css
+++ b/public/css/auth-role-assignments.css
@@ -22,6 +22,10 @@
 	border-left-color: #d4351c;
 	}
 
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+	}
+
 .sourcebook-gate--ready {
 	border-left-color: #00703c;
 	}
@@ -39,16 +43,24 @@
 	margin-bottom: 15px;
 	}
 
-.sourcebook-gate__tag--blocked, .sourcebook-gate__check-tag--unmet {
-	background: #d4351c;
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked, .sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--ready, .sourcebook-gate__check-tag--met {
+.sourcebook-gate .sourcebook-gate__check--governance-action .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
 	background: #00703c;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--not-applicable {
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
 	background: #505a5f;
+	color: #ffffff;
 	}
 
 .sourcebook-gate__checks {
@@ -203,6 +215,15 @@
 	line-height: 1.25;
 	}
 
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
 .sourcebook-evidence-ledger__clauses {
 	margin-bottom: 0;
 	}
@@ -219,13 +240,61 @@
 	white-space: nowrap;
 	}
 
-.sourcebook-evidence-ledger__tag--needed {
-	background: #b58840;
-	color: #0b0c0c;
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-evidence-ledger__tag--present {
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
 	background: #00703c;
+	color: #ffffff;
+	}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+		}
+	.sourcebook-gate__check-label, .sourcebook-gate__check-detail {
+		display: block;
+		}
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+		}
+	.sourcebook-evidence-ledger__table, .sourcebook-evidence-ledger__table .govuk-table__body, .sourcebook-evidence-ledger__table .govuk-table__row, .sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before, .sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: "Sourcebook clause";
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: "Status";
+		}
 	}
 
 .govuk-\!-width-two-thirds, [class~="govuk-!-width-two-thirds"] {

--- a/public/css/consent.css
+++ b/public/css/consent.css
@@ -21,6 +21,10 @@
 	border-left-color: #d4351c;
 	}
 
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+	}
+
 .sourcebook-gate--ready {
 	border-left-color: #00703c;
 	}
@@ -38,16 +42,24 @@
 	margin-bottom: 15px;
 	}
 
-.sourcebook-gate__tag--blocked, .sourcebook-gate__check-tag--unmet {
-	background: #d4351c;
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked, .sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--ready, .sourcebook-gate__check-tag--met {
+.sourcebook-gate .sourcebook-gate__check--governance-action .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
 	background: #00703c;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--not-applicable {
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
 	background: #505a5f;
+	color: #ffffff;
 	}
 
 .sourcebook-gate__checks {
@@ -202,6 +214,15 @@
 	line-height: 1.25;
 	}
 
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
 .sourcebook-evidence-ledger__clauses {
 	margin-bottom: 0;
 	}
@@ -218,13 +239,61 @@
 	white-space: nowrap;
 	}
 
-.sourcebook-evidence-ledger__tag--needed {
-	background: #b58840;
-	color: #0b0c0c;
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-evidence-ledger__tag--present {
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
 	background: #00703c;
+	color: #ffffff;
+	}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+		}
+	.sourcebook-gate__check-label, .sourcebook-gate__check-detail {
+		display: block;
+		}
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+		}
+	.sourcebook-evidence-ledger__table, .sourcebook-evidence-ledger__table .govuk-table__body, .sourcebook-evidence-ledger__table .govuk-table__row, .sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before, .sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: "Sourcebook clause";
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: "Status";
+		}
 	}
 
 .researchops-utility-page [hidden] {

--- a/public/css/notes.css
+++ b/public/css/notes.css
@@ -21,6 +21,10 @@
 	border-left-color: #d4351c;
 	}
 
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+	}
+
 .sourcebook-gate--ready {
 	border-left-color: #00703c;
 	}
@@ -38,16 +42,24 @@
 	margin-bottom: 15px;
 	}
 
-.sourcebook-gate__tag--blocked, .sourcebook-gate__check-tag--unmet {
-	background: #d4351c;
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked, .sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--ready, .sourcebook-gate__check-tag--met {
+.sourcebook-gate .sourcebook-gate__check--governance-action .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
 	background: #00703c;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--not-applicable {
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
 	background: #505a5f;
+	color: #ffffff;
 	}
 
 .sourcebook-gate__checks {
@@ -202,6 +214,15 @@
 	line-height: 1.25;
 	}
 
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
 .sourcebook-evidence-ledger__clauses {
 	margin-bottom: 0;
 	}
@@ -218,13 +239,61 @@
 	white-space: nowrap;
 	}
 
-.sourcebook-evidence-ledger__tag--needed {
-	background: #b58840;
-	color: #0b0c0c;
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-evidence-ledger__tag--present {
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
 	background: #00703c;
+	color: #ffffff;
+	}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+		}
+	.sourcebook-gate__check-label, .sourcebook-gate__check-detail {
+		display: block;
+		}
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+		}
+	.sourcebook-evidence-ledger__table, .sourcebook-evidence-ledger__table .govuk-table__body, .sourcebook-evidence-ledger__table .govuk-table__row, .sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before, .sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: "Sourcebook clause";
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: "Status";
+		}
 	}
 
 .researchops-utility-page [hidden] {

--- a/public/css/participant-consent.css
+++ b/public/css/participant-consent.css
@@ -1,3 +1,290 @@
+.sourcebook-gate {
+	max-width: 760px;
+	margin: 30px 0;
+	padding: 20px;
+	border-left: 5px solid #505a5f;
+	background: #f3f2f1;
+	}
+
+.sourcebook-gate--blocked {
+	border-left-color: #d4351c;
+	}
+
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+	}
+
+.sourcebook-gate--ready {
+	border-left-color: #00703c;
+	}
+
+.sourcebook-gate__caption {
+	margin-bottom: 5px;
+	color: #505a5f;
+	}
+
+.sourcebook-gate__title, .sourcebook-gate__summary, .sourcebook-gate__action, .sourcebook-gate__checks {
+	margin-bottom: 15px;
+	}
+
+.sourcebook-gate__tag {
+	margin-bottom: 15px;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked, .sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .sourcebook-gate__check--governance-action .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
+	background: #00703c;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
+	background: #505a5f;
+	color: #ffffff;
+	}
+
+.sourcebook-gate__checks {
+	padding-left: 0;
+	list-style: none;
+	}
+
+.sourcebook-gate__check {
+	display: grid;
+	grid-template-columns: minmax(160px, 1fr) auto;
+	gap: 5px 15px;
+	padding: 12px 0;
+	border-top: 1px solid #b1b4b6;
+	}
+
+.sourcebook-gate__check-label {
+	font-weight: 700;
+	}
+
+.sourcebook-gate__check-detail {
+	grid-column: 1/-1;
+	color: #505a5f;
+	}
+
+.sourcebook-gate__check-tag {
+	justify-self: end;
+	white-space: nowrap;
+	}
+
+.sourcebook-gate__checks:last-child, .sourcebook-gate__check:last-child, .sourcebook-gate__action:last-child {
+	margin-bottom: 0;
+	}
+
+.sourcebook-context {
+	max-width: 760px;
+	margin: 30px 0;
+	padding: 20px;
+	border-left: 5px solid #1d70b8;
+	background: #f3f2f1;
+	}
+
+.sourcebook-context__caption {
+	margin-bottom: 5px;
+	color: #505a5f;
+	}
+
+.sourcebook-context__title, .sourcebook-context__summary, .sourcebook-context__list {
+	margin-bottom: 15px;
+	}
+
+.sourcebook-context__list {
+	padding-left: 0;
+	list-style: none;
+	}
+
+.sourcebook-context__item {
+	margin-bottom: 15px;
+	padding-top: 15px;
+	border-top: 1px solid #b1b4b6;
+	}
+
+.sourcebook-context__item:first-child {
+	padding-top: 0;
+	border-top: 0;
+	}
+
+.sourcebook-context__item:last-child {
+	margin-bottom: 0;
+	}
+
+.sourcebook-context__clause {
+	display: flex;
+	gap: 12px;
+	align-items: flex-start;
+	}
+
+.sourcebook-context__badge {
+	display: inline-flex;
+	min-width: 32px;
+	min-height: 32px;
+	align-items: center;
+	justify-content: center;
+	background: #1d70b8;
+	color: #ffffff;
+	font-weight: 700;
+	line-height: 1;
+	}
+
+.sourcebook-context__badge--rule {
+	background: #d4351c;
+	}
+
+.sourcebook-context__badge--principle {
+	background: #1d70b8;
+	}
+
+.sourcebook-context__badge--guidance {
+	background: #00703c;
+	}
+
+.sourcebook-context__badge--conduct {
+	background: #4c2c92;
+	}
+
+.sourcebook-context__meta {
+	margin: 0 0 5px;
+	color: #505a5f;
+	font-size: 16px;
+	line-height: 1.25;
+	}
+
+.sourcebook-context__clause-title {
+	margin-bottom: 10px;
+	}
+
+.sourcebook-context__text, .sourcebook-context__condition {
+	margin-bottom: 10px;
+	}
+
+.sourcebook-context__condition:last-child, .sourcebook-context__text:last-child {
+	margin-bottom: 0;
+	}
+
+.sourcebook-evidence-ledger {
+	max-width: 760px;
+	margin: 30px 0;
+	}
+
+.sourcebook-evidence-ledger__caption {
+	margin-bottom: 5px;
+	color: #505a5f;
+	}
+
+.sourcebook-evidence-ledger__title, .sourcebook-evidence-ledger__summary {
+	margin-bottom: 15px;
+	}
+
+.sourcebook-evidence-ledger__table {
+	margin-bottom: 0;
+	}
+
+.sourcebook-evidence-ledger__evidence-label, .sourcebook-evidence-ledger__clause-title {
+	display: block;
+	}
+
+.sourcebook-evidence-ledger__evidence-id {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
+.sourcebook-evidence-ledger__clauses {
+	margin-bottom: 0;
+	}
+
+.sourcebook-evidence-ledger__clauses li {
+	margin-bottom: 10px;
+	}
+
+.sourcebook-evidence-ledger__clauses li:last-child {
+	margin-bottom: 0;
+	}
+
+.sourcebook-evidence-ledger__tag {
+	white-space: nowrap;
+	}
+
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
+	background: #00703c;
+	color: #ffffff;
+	}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+		}
+	.sourcebook-gate__check-label, .sourcebook-gate__check-detail {
+		display: block;
+		}
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+		}
+	.sourcebook-evidence-ledger__table, .sourcebook-evidence-ledger__table .govuk-table__body, .sourcebook-evidence-ledger__table .govuk-table__row, .sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before, .sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: "Sourcebook clause";
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: "Status";
+		}
+	}
+
 .participant-consent-page [hidden] {
 	display: none;
 	}
@@ -14,7 +301,58 @@
 
 .participant-consent-workspace {
 	display: grid;
+	grid-template-columns: minmax(0, 1fr);
 	gap: 24px;
+	align-items: start;
+	}
+
+.participant-consent-workspace__main {
+	display: grid;
+	gap: 24px;
+	min-width: 0;
+	max-width: 100%;
+	}
+
+.participant-consent-workspace__main > * {
+	box-sizing: border-box;
+	min-width: 0;
+	max-width: 100%;
+	}
+
+.participant-consent-workspace__main .sourcebook-evidence-ledger {
+	overflow-x: auto;
+	}
+
+.participant-consent-workspace__mobile-context {
+	display: block;
+	}
+
+.participant-consent-workspace__aside {
+	display: none;
+	min-width: 0;
+	}
+
+.participant-consent-workspace__aside .sourcebook-context {
+	position: sticky;
+	top: 24px;
+	max-width: none;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 16px;
+	}
+
+.participant-consent-workspace__aside .sourcebook-context__clause {
+	display: grid;
+	grid-template-columns: 32px minmax(0, 1fr);
+	}
+
+.participant-consent-workspace__aside .sourcebook-context__title {
+	font-size: 21px;
+	line-height: 1.25;
+	}
+
+.participant-consent-workspace__aside .sourcebook-context__meta, .participant-consent-workspace__aside .sourcebook-context__text, .participant-consent-workspace__aside .sourcebook-context__condition {
+	overflow-wrap: anywhere;
 	}
 
 .participant-consent-panel {
@@ -36,25 +374,26 @@
 	margin-bottom: 0;
 	}
 
-.participant-consent-summary__row {
+.participant-consent-summary__row, .participant-consent-summary .govuk-summary-list__row {
 	display: grid;
 	gap: 16px;
-	grid-template-columns: 140px minmax(0, 1fr);
+	grid-template-columns: minmax(150px, 30%) minmax(0, 1fr);
 	align-items: baseline;
 	border-bottom: 0;
 	margin-bottom: 8px;
 	}
 
-.participant-consent-summary__key {
+.participant-consent-summary__key, .participant-consent-summary .govuk-summary-list__key {
 	width: auto;
 	margin-bottom: 0;
 	padding: 0;
 	font-weight: 700;
 	}
 
-.participant-consent-summary__value {
+.participant-consent-summary__value, .participant-consent-summary .govuk-summary-list__value {
 	margin: 0;
 	padding: 0;
+	overflow-wrap: anywhere;
 	}
 
 .table-wrap {
@@ -160,6 +499,19 @@
 	padding: 0;
 	}
 
+@media (min-width: 1100px) {
+	.participant-consent-workspace {
+		grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+		gap: 32px;
+		}
+	.participant-consent-workspace__mobile-context {
+		display: none;
+		}
+	.participant-consent-workspace__aside {
+		display: block;
+		}
+	}
+
 @media (max-width: 699px) {
 	.participant-consent-page .govuk-heading-l {
 		font-size: 32px;
@@ -175,6 +527,10 @@
 	.participant-consent-workspace {
 		gap: 18px;
 		}
+	.participant-consent-workspace__main {
+		display: grid;
+		gap: 18px;
+		}
 	.participant-consent-panel {
 		position: relative;
 		clear: both;
@@ -182,12 +538,9 @@
 		margin-bottom: 18px;
 		padding-top: 16px;
 		}
-	.participant-consent-summary__row {
-		grid-template-columns: minmax(118px, 38%) minmax(0, 1fr);
+	.participant-consent-summary__row, .participant-consent-summary .govuk-summary-list__row {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 		gap: 10px;
-		}
-	.participant-consent-summary__value {
-		overflow-wrap: anywhere;
 		}
 	.participant-consent-panel__header {
 		display: block;
@@ -285,6 +638,24 @@
 	}
 
 @media (max-width: 430px) {
+	.participant-consent-summary__row, .participant-consent-summary .govuk-summary-list__row {
+		display: block;
+		}
+	.participant-consent-summary__key, .participant-consent-summary .govuk-summary-list__key {
+		margin-bottom: 5px;
+		}
+	.participant-consent-table .govuk-table__header, .participant-consent-table .govuk-table__cell, .participant-consent-table .govuk-table__row > :nth-child(5) {
+		padding: 10px 12px;
+		}
+	.participant-consent-table .govuk-table__header::before, .participant-consent-table .govuk-table__cell::before, .participant-consent-table .govuk-table__row > .govuk-table__header::before {
+		position: static;
+		display: block;
+		width: auto;
+		margin-bottom: 5px;
+		}
+	.participant-consent-table .govuk-table__row > .govuk-table__header {
+		display: block;
+		}
 	.participant-consent-form__actions, .participant-consent-item .govuk-radios--inline {
 		display: block;
 		}

--- a/public/css/search.css
+++ b/public/css/search.css
@@ -21,6 +21,10 @@
 	border-left-color: #d4351c;
 	}
 
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+	}
+
 .sourcebook-gate--ready {
 	border-left-color: #00703c;
 	}
@@ -38,16 +42,24 @@
 	margin-bottom: 15px;
 	}
 
-.sourcebook-gate__tag--blocked, .sourcebook-gate__check-tag--unmet {
-	background: #d4351c;
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked, .sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--ready, .sourcebook-gate__check-tag--met {
+.sourcebook-gate .sourcebook-gate__check--governance-action .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
 	background: #00703c;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--not-applicable {
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
 	background: #505a5f;
+	color: #ffffff;
 	}
 
 .sourcebook-gate__checks {
@@ -202,6 +214,15 @@
 	line-height: 1.25;
 	}
 
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
 .sourcebook-evidence-ledger__clauses {
 	margin-bottom: 0;
 	}
@@ -218,13 +239,61 @@
 	white-space: nowrap;
 	}
 
-.sourcebook-evidence-ledger__tag--needed {
-	background: #b58840;
-	color: #0b0c0c;
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-evidence-ledger__tag--present {
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
 	background: #00703c;
+	color: #ffffff;
+	}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+		}
+	.sourcebook-gate__check-label, .sourcebook-gate__check-detail {
+		display: block;
+		}
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+		}
+	.sourcebook-evidence-ledger__table, .sourcebook-evidence-ledger__table .govuk-table__body, .sourcebook-evidence-ledger__table .govuk-table__row, .sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before, .sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: "Sourcebook clause";
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: "Status";
+		}
 	}
 
 .researchops-utility-page [hidden] {

--- a/public/css/sessions.css
+++ b/public/css/sessions.css
@@ -21,6 +21,10 @@
 	border-left-color: #d4351c;
 	}
 
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+	}
+
 .sourcebook-gate--ready {
 	border-left-color: #00703c;
 	}
@@ -38,16 +42,24 @@
 	margin-bottom: 15px;
 	}
 
-.sourcebook-gate__tag--blocked, .sourcebook-gate__check-tag--unmet {
-	background: #d4351c;
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked, .sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--ready, .sourcebook-gate__check-tag--met {
+.sourcebook-gate .sourcebook-gate__check--governance-action .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+	}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready, .sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
 	background: #00703c;
+	color: #ffffff;
 	}
 
-.sourcebook-gate__tag--not-applicable {
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
 	background: #505a5f;
+	color: #ffffff;
 	}
 
 .sourcebook-gate__checks {
@@ -202,6 +214,15 @@
 	line-height: 1.25;
 	}
 
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+	}
+
 .sourcebook-evidence-ledger__clauses {
 	margin-bottom: 0;
 	}
@@ -218,13 +239,61 @@
 	white-space: nowrap;
 	}
 
-.sourcebook-evidence-ledger__tag--needed {
-	background: #b58840;
-	color: #0b0c0c;
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
 	}
 
-.sourcebook-evidence-ledger__tag--present {
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
 	background: #00703c;
+	color: #ffffff;
+	}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+		}
+	.sourcebook-gate__check-label, .sourcebook-gate__check-detail {
+		display: block;
+		}
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+		}
+	.sourcebook-evidence-ledger__table, .sourcebook-evidence-ledger__table .govuk-table__body, .sourcebook-evidence-ledger__table .govuk-table__row, .sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__header, .sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before, .sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: "Sourcebook clause";
+		}
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: "Status";
+		}
 	}
 
 .researchops-utility-page [hidden] {

--- a/public/js/participant-consent-page.js
+++ b/public/js/participant-consent-page.js
@@ -487,8 +487,10 @@ function selectParticipant(participantId) {
 	const participant = state.participants.find(item => item.id === participantId);
 	if (!participant) return;
 	const record = consentRecordForParticipant(participantId);
-	const form = state.consentForms.find(item => item.id === record?.consentFormId) || latestPublishedForm();
-	const status = statusForParticipant(participant, record, form);
+	const recordForm = state.consentForms.find(item => item.id === record?.consentFormId);
+	const currentForm = latestPublishedForm();
+	const form = recordForm || currentForm;
+	const status = statusForParticipant(participant, record, currentForm);
 	setHidden("#consent-record-panel", false);
 	setText("#record-consent-title", record ? `Review consent for ${participant.display_name}` : `Record consent for ${participant.display_name}`);
 	setText(
@@ -505,7 +507,7 @@ function selectParticipant(participantId) {
 	$("#withdrawal-reason").value = record?.withdrawalReason || "";
 	renderFormOptions(form?.id || "");
 	renderConsentItems(record, form);
-	updateSourcebookAssurance(participant, record, form);
+	updateSourcebookAssurance(participant, record, currentForm);
 	const currentRoute = route("/pages/study/participant-consent/", {
 		id: state.studyId,
 		session: state.sessionId,

--- a/public/js/participant-consent-page.js
+++ b/public/js/participant-consent-page.js
@@ -187,7 +187,7 @@ function statusForParticipant(participant, record = consentRecordForParticipant(
 }
 
 function permissionTags(record, form = latestPublishedForm()) {
-	if (!record) return [{ text: "No permissions recorded", classes: "govuk-tag--grey" }];
+	if (!record) return [{ text: "No consent response recorded", classes: "govuk-tag--grey" }];
 	if (record.withdrawn) return [{ text: "Do not proceed", classes: "govuk-tag--red" }];
 	return consentItemsForForm(form)
 		.filter(item => !item.required)
@@ -204,7 +204,7 @@ function shortPermissionLabel(item = {}) {
 	const id = normaliseStatus(item.id);
 	const labels = {
 		recording: "Recording",
-		observers: "Observers",
+		observers: "Observer consent",
 		transcription: "Transcription"
 	};
 	if (labels[id]) return labels[id];
@@ -229,6 +229,128 @@ function formatConsentTime(value) {
 		timeZone: "Europe/London",
 		timeZoneName: "short"
 	}).format(date);
+}
+
+function setSourcebookStatusClass(element, prefix, status) {
+	if (!element) return;
+	for (const className of [...element.classList]) {
+		if (className.startsWith(prefix)) element.classList.remove(className);
+	}
+	element.classList.add(`${prefix}${status}`);
+}
+
+function updateGateCheck(id, { label, status, statusLabel, detail }) {
+	const check = document.querySelector(`[data-sourcebook-check="${id}"]`);
+	if (!check) return;
+	setSourcebookStatusClass(check, "sourcebook-gate__check--", status);
+	const labelElement = $(".sourcebook-gate__check-label", check);
+	const statusElement = $("[data-sourcebook-check-status]", check);
+	const detailElement = $("[data-sourcebook-check-detail]", check);
+	if (labelElement) labelElement.textContent = label;
+	if (statusElement) {
+		statusElement.textContent = statusLabel;
+		setSourcebookStatusClass(statusElement, "sourcebook-gate__check-tag--", status);
+	}
+	if (detailElement) detailElement.textContent = detail;
+}
+
+function updateLedgerRow(id, { label, evidenceId, status, statusLabel, detail }) {
+	const row = document.querySelector(`[data-sourcebook-evidence-id="${id}"]`);
+	if (!row) return;
+	setSourcebookStatusClass(row, "sourcebook-evidence-ledger__row--", status);
+	const labelElement = $(".sourcebook-evidence-ledger__evidence-label", row);
+	const idElement = $(".sourcebook-evidence-ledger__evidence-id", row);
+	const statusElement = $(".sourcebook-evidence-ledger__tag", row);
+	let detailElement = $(".sourcebook-evidence-ledger__evidence-detail", row);
+	if (!detailElement) {
+		detailElement = document.createElement("span");
+		detailElement.className = "sourcebook-evidence-ledger__evidence-detail";
+		idElement?.after(detailElement);
+	}
+	if (labelElement) labelElement.textContent = label;
+	if (idElement) idElement.textContent = evidenceId;
+	if (detailElement) detailElement.textContent = detail;
+	if (statusElement) {
+		statusElement.textContent = statusLabel;
+		setSourcebookStatusClass(statusElement, "sourcebook-evidence-ledger__tag--", status);
+	}
+}
+
+function updateSourcebookAssurance(participant = null, record = null, form = latestPublishedForm()) {
+	const participantName = participant?.display_name || participant?.name || "the selected participant";
+	const participantSelected = !!participant;
+	const status = participantSelected ? statusForParticipant(participant, record, form) : "";
+	const consentRecordPresent = !!record;
+	const ready = status === "Ready for session";
+	const gate = $("[data-sourcebook-gate]");
+	const gateStatus = $("[data-sourcebook-gate-status]");
+	const gateSummary = $("[data-sourcebook-gate-summary]");
+	const gateAction = $("[data-sourcebook-gate-action]");
+
+	if (gate) {
+		const variant = ready ? "ready" : "attention";
+		setSourcebookStatusClass(gate, "sourcebook-gate--", variant);
+	}
+	if (gateStatus) {
+		gateStatus.textContent = ready ? "Consent evidence complete" : "Consent evidence incomplete";
+		setSourcebookStatusClass(gateStatus, "sourcebook-gate__tag--", ready ? "ready" : "attention");
+	}
+	if (gateSummary) {
+		gateSummary.textContent = participantSelected
+			? `${participantName} is ready only when the current consent form and all required consent statements are recorded.`
+			: "A participant is ready only when a published consent form version is selected and all required consent statements are recorded.";
+	}
+	if (gateAction) {
+		gateAction.textContent = ready
+			? `${participantName} can be treated as ready for research.`
+			: "Complete required consent before treating this participant as ready.";
+	}
+
+	updateGateCheck("sourcebook-context", {
+		label: "Sourcebook rule",
+		status: "met",
+		statusLabel: "Mapped",
+		detail: "REC-ADMN 3.1.1 is the governing clause for recorded informed consent."
+	});
+	updateGateCheck("evidence-readiness", {
+		label: "Consent record",
+		status: consentRecordPresent ? "met" : "unmet",
+		statusLabel: consentRecordPresent ? "Present" : "Needed",
+		detail: participantSelected
+			? consentRecordPresent
+				? `A consent record exists for ${participantName}.`
+				: `No consent record has been saved for ${participantName}.`
+			: "Select a participant to check their consent record evidence."
+	});
+	updateGateCheck("governance-action", {
+		label: "Participant readiness",
+		status: ready ? "met" : "unmet",
+		statusLabel: ready ? "Ready" : "Incomplete",
+		detail: participantSelected
+			? ready
+				? "All required consent statements are agreed for the current form version."
+				: "Required consent evidence is missing or incomplete, so this participant is not ready for a session."
+			: "Readiness is checked once a participant is selected."
+	});
+
+	updateLedgerRow("consent-form", {
+		label: "Current consent form version",
+		evidenceId: form ? `version-${form.version || 1}` : "consent-form",
+		status: form ? "present" : "needed",
+		statusLabel: form ? "Present" : "Needed",
+		detail: form ? `${form.title || "Published consent form"} — version ${form.version || 1}` : "Publish a consent form before recording consent."
+	});
+	updateLedgerRow("consent-log", {
+		label: participantSelected ? `Consent record for ${participantName}` : "Participant consent record",
+		evidenceId: participantSelected ? `participant-${participant.id}` : "select-participant",
+		status: consentRecordPresent ? "present" : "needed",
+		statusLabel: consentRecordPresent ? "Present" : "Needed",
+		detail: participantSelected
+			? consentRecordPresent
+				? `Recorded ${formatConsentTime(record.recordedAt)}. Current status: ${status}.`
+				: "Save a consent response to create this evidence."
+			: "Select a participant to see whether their consent record is present."
+	});
 }
 
 function updateRoutes() {
@@ -366,9 +488,15 @@ function selectParticipant(participantId) {
 	if (!participant) return;
 	const record = consentRecordForParticipant(participantId);
 	const form = state.consentForms.find(item => item.id === record?.consentFormId) || latestPublishedForm();
+	const status = statusForParticipant(participant, record, form);
 	setHidden("#consent-record-panel", false);
 	setText("#record-consent-title", record ? `Review consent for ${participant.display_name}` : `Record consent for ${participant.display_name}`);
-	setText("#record-consent-hint", "Consent can be reviewed, updated or withdrawn. Required consent is needed before a session can start.");
+	setText(
+		"#record-consent-hint",
+		status === "Ready for session"
+			? "Review the consent record before changing this participant's readiness."
+			: "Complete the required statements before saving this participant as ready for research."
+	);
 	$("#participant-id").value = participantId;
 	$("#consent-record-id").value = record?.id || "";
 	$("#capture-method").value = record?.captureMethod || "";
@@ -377,6 +505,7 @@ function selectParticipant(participantId) {
 	$("#withdrawal-reason").value = record?.withdrawalReason || "";
 	renderFormOptions(form?.id || "");
 	renderConsentItems(record, form);
+	updateSourcebookAssurance(participant, record, form);
 	const currentRoute = route("/pages/study/participant-consent/", {
 		id: state.studyId,
 		session: state.sessionId,
@@ -455,6 +584,7 @@ async function saveConsent(event) {
 		setHidden("#consent-record-panel", true);
 		renderSummary();
 		renderParticipantTable();
+		updateSourcebookAssurance(participant, saved, form);
 	} catch (error) {
 		console.error("[participant-consent] save failed", error);
 		showErrors(["Could not save participant consent. Check the service connection and try again."]);
@@ -530,6 +660,7 @@ async function init() {
 		renderPageState();
 		renderSummary();
 		renderParticipantTable();
+		updateSourcebookAssurance();
 		if (state.routeParticipantId) {
 			const routeParticipant = state.participants.find(participant => participantMatchesIdentifier(participant, state.routeParticipantId));
 			if (routeParticipant) selectParticipant(routeParticipant.id);

--- a/public/pages/account/team-access/index.html
+++ b/public/pages/account/team-access/index.html
@@ -48,41 +48,74 @@
 							<li>You cannot use this team’s research records until your request is approved.</li>
 						</ul>
 
-						<section class="sourcebook-gate sourcebook-gate--blocked" aria-labelledby="sourcebook-gate-title">
+						<section
+							class="sourcebook-gate sourcebook-gate--blocked"
+							aria-labelledby="sourcebook-gate-title"
+							data-sourcebook-gate
+						>
 							<div class="sourcebook-gate__header">
 								<p class="govuk-caption-m sourcebook-gate__caption">Sourcebook gate</p>
 								<h2 class="govuk-heading-m sourcebook-gate__title" id="sourcebook-gate-title">
 									Sourcebook gate for access requests
 								</h2>
-								<strong class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--blocked">Evidence needed</strong>
-								<p class="govuk-body sourcebook-gate__summary">
+								<strong
+									class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--blocked"
+									data-sourcebook-gate-status
+								>
+									Evidence needed
+								</strong>
+								<p class="govuk-body sourcebook-gate__summary" data-sourcebook-gate-summary>
 									Do not widen access until the Sourcebook clause and required access evidence are in place.
 								</p>
 								<p class="govuk-body sourcebook-gate__action">
-									<strong>Add evidence before continuing</strong>
+									<strong data-sourcebook-gate-action>Add evidence before continuing</strong>
 								</p>
 							</div>
 							<ul class="govuk-list sourcebook-gate__checks">
-								<li class="sourcebook-gate__check sourcebook-gate__check--met">
+								<li
+									class="sourcebook-gate__check sourcebook-gate__check--met sourcebook-gate__check--sourcebook-context"
+									data-sourcebook-check="sourcebook-context"
+								>
 									<span class="sourcebook-gate__check-label">Sourcebook context</span>
-									<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--met">Matched</strong>
-									<span class="sourcebook-gate__check-detail">1 clause matched this route.</span>
+									<strong
+										class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--met"
+										data-sourcebook-check-status
+									>
+										Matched
+									</strong>
+									<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
+										1 clause matched this route.
+									</span>
 								</li>
 
-								<li class="sourcebook-gate__check sourcebook-gate__check--unmet">
+								<li
+									class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--evidence-readiness"
+									data-sourcebook-check="evidence-readiness"
+								>
 									<span class="sourcebook-gate__check-label">Evidence readiness</span>
-									<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet">
+									<strong
+										class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+										data-sourcebook-check-status
+									>
 										Evidence needed
 									</strong>
-									<span class="sourcebook-gate__check-detail">2 evidence items needed.</span>
+									<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
+										2 evidence items needed.
+									</span>
 								</li>
 
-								<li class="sourcebook-gate__check sourcebook-gate__check--unmet">
+								<li
+									class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--governance-action"
+									data-sourcebook-check="governance-action"
+								>
 									<span class="sourcebook-gate__check-label">Governance action</span>
-									<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet">
+									<strong
+										class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+										data-sourcebook-check-status
+									>
 										Pause for evidence
 									</strong>
-									<span class="sourcebook-gate__check-detail">
+									<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
 										Add the required evidence before treating this workflow as Sourcebook-ready.
 									</span>
 								</li>
@@ -126,7 +159,11 @@
 							</ol>
 						</aside>
 
-						<section class="sourcebook-evidence-ledger" aria-labelledby="sourcebook-evidence-ledger-title">
+						<section
+							class="sourcebook-evidence-ledger"
+							aria-labelledby="sourcebook-evidence-ledger-title"
+							id="sourcebook-evidence-ledger"
+						>
 							<div class="sourcebook-evidence-ledger__header">
 								<p class="govuk-caption-m sourcebook-evidence-ledger__caption">Evidence ledger</p>
 								<h2 class="govuk-heading-m sourcebook-evidence-ledger__title" id="sourcebook-evidence-ledger-title">
@@ -148,7 +185,10 @@
 									</tr>
 								</thead>
 								<tbody class="govuk-table__body">
-									<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed">
+									<tr
+										class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed"
+										data-sourcebook-evidence-id="access-request"
+									>
 										<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
 											<span class="sourcebook-evidence-ledger__evidence-label">Access Request</span>
 											<span class="sourcebook-evidence-ledger__evidence-id">access-request</span>
@@ -172,7 +212,10 @@
 										</td>
 									</tr>
 
-									<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed">
+									<tr
+										class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed"
+										data-sourcebook-evidence-id="role-permission-model"
+									>
 										<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
 											<span class="sourcebook-evidence-ledger__evidence-label">Role Permission Model</span>
 											<span class="sourcebook-evidence-ledger__evidence-id">role-permission-model</span>

--- a/public/pages/consent/index.html
+++ b/public/pages/consent/index.html
@@ -40,41 +40,69 @@
 					</div>
 				</header>
 
-				<section class="sourcebook-gate sourcebook-gate--blocked" aria-labelledby="sourcebook-gate-title">
+				<section
+					class="sourcebook-gate sourcebook-gate--blocked"
+					aria-labelledby="sourcebook-gate-title"
+					data-sourcebook-gate
+				>
 					<div class="sourcebook-gate__header">
 						<p class="govuk-caption-m sourcebook-gate__caption">Sourcebook gate</p>
 						<h2 class="govuk-heading-m sourcebook-gate__title" id="sourcebook-gate-title">
 							Sourcebook gate for consent
 						</h2>
-						<strong class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--blocked">Evidence needed</strong>
-						<p class="govuk-body sourcebook-gate__summary">
+						<strong class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--blocked" data-sourcebook-gate-status>
+							Evidence needed
+						</strong>
+						<p class="govuk-body sourcebook-gate__summary" data-sourcebook-gate-summary>
 							Do not treat consent as governed until the Sourcebook clause and required consent evidence are in place.
 						</p>
 						<p class="govuk-body sourcebook-gate__action">
-							<strong>Add evidence before continuing</strong>
+							<strong data-sourcebook-gate-action>Add evidence before continuing</strong>
 						</p>
 					</div>
 					<ul class="govuk-list sourcebook-gate__checks">
-						<li class="sourcebook-gate__check sourcebook-gate__check--met">
+						<li
+							class="sourcebook-gate__check sourcebook-gate__check--met sourcebook-gate__check--sourcebook-context"
+							data-sourcebook-check="sourcebook-context"
+						>
 							<span class="sourcebook-gate__check-label">Sourcebook context</span>
-							<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--met">Matched</strong>
-							<span class="sourcebook-gate__check-detail">1 clause matched this route.</span>
+							<strong
+								class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--met"
+								data-sourcebook-check-status
+							>
+								Matched
+							</strong>
+							<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
+								1 clause matched this route.
+							</span>
 						</li>
 
-						<li class="sourcebook-gate__check sourcebook-gate__check--unmet">
+						<li
+							class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--evidence-readiness"
+							data-sourcebook-check="evidence-readiness"
+						>
 							<span class="sourcebook-gate__check-label">Evidence readiness</span>
-							<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet">
+							<strong
+								class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+								data-sourcebook-check-status
+							>
 								Evidence needed
 							</strong>
-							<span class="sourcebook-gate__check-detail">2 evidence items needed.</span>
+							<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>2 evidence items needed.</span>
 						</li>
 
-						<li class="sourcebook-gate__check sourcebook-gate__check--unmet">
+						<li
+							class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--governance-action"
+							data-sourcebook-check="governance-action"
+						>
 							<span class="sourcebook-gate__check-label">Governance action</span>
-							<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet">
+							<strong
+								class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+								data-sourcebook-check-status
+							>
 								Pause for evidence
 							</strong>
-							<span class="sourcebook-gate__check-detail">
+							<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
 								Add the required evidence before treating this workflow as Sourcebook-ready.
 							</span>
 						</li>
@@ -119,7 +147,11 @@
 					</ol>
 				</aside>
 
-				<section class="sourcebook-evidence-ledger" aria-labelledby="sourcebook-evidence-ledger-title">
+				<section
+					class="sourcebook-evidence-ledger"
+					aria-labelledby="sourcebook-evidence-ledger-title"
+					id="sourcebook-evidence-ledger"
+				>
 					<div class="sourcebook-evidence-ledger__header">
 						<p class="govuk-caption-m sourcebook-evidence-ledger__caption">Evidence ledger</p>
 						<h2 class="govuk-heading-m sourcebook-evidence-ledger__title" id="sourcebook-evidence-ledger-title">
@@ -139,7 +171,10 @@
 							</tr>
 						</thead>
 						<tbody class="govuk-table__body">
-							<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed">
+							<tr
+								class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed"
+								data-sourcebook-evidence-id="consent-form"
+							>
 								<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
 									<span class="sourcebook-evidence-ledger__evidence-label">Consent Form</span>
 									<span class="sourcebook-evidence-ledger__evidence-id">consent-form</span>
@@ -163,7 +198,10 @@
 								</td>
 							</tr>
 
-							<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed">
+							<tr
+								class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed"
+								data-sourcebook-evidence-id="consent-log"
+							>
 								<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
 									<span class="sourcebook-evidence-ledger__evidence-label">Consent Log</span>
 									<span class="sourcebook-evidence-ledger__evidence-id">consent-log</span>

--- a/public/pages/study/participant-consent/index.html
+++ b/public/pages/study/participant-consent/index.html
@@ -74,8 +74,7 @@
 						<p id="study-context" class="govuk-caption-m">Study</p>
 						<h1 class="govuk-heading-l">Manage participant consent</h1>
 						<p class="govuk-body participant-consent-context govuk-!-width-two-thirds">
-							Record, review or withdraw participant consent for this study. Consent is recorded against a specific
-							published consent form version.
+							Record, review or withdraw consent for this study. Consent is recorded against a published form version.
 						</p>
 					</div>
 				</header>
@@ -130,178 +129,431 @@
 				</section>
 
 				<section id="consent-workspace" class="participant-consent-workspace" hidden>
-					<section class="participant-consent-panel" aria-labelledby="consent-summary-title">
-						<h2 id="consent-summary-title" class="govuk-heading-m">Consent coverage</h2>
+					<div class="participant-consent-workspace__main">
+						<section class="participant-consent-panel" aria-labelledby="consent-summary-title">
+							<h2 id="consent-summary-title" class="govuk-heading-m">Consent summary</h2>
 
-						<dl class="govuk-summary-list participant-consent-summary">
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Form version</dt>
-								<dd class="govuk-summary-list__value">
-									<span id="summary-published-form">-</span>
-								</dd>
-							</div>
+							<dl class="govuk-summary-list participant-consent-summary">
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Form version</dt>
+									<dd class="govuk-summary-list__value">
+										<span id="summary-published-form">-</span>
+									</dd>
+								</div>
 
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Participants</dt>
-								<dd class="govuk-summary-list__value">
-									<span id="summary-participants">-</span>
-								</dd>
-							</div>
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Participants</dt>
+									<dd class="govuk-summary-list__value">
+										<span id="summary-participants">-</span>
+									</dd>
+								</div>
 
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Ready</dt>
-								<dd class="govuk-summary-list__value">
-									<span id="summary-ready">-</span>
-								</dd>
-							</div>
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Ready for session</dt>
+									<dd class="govuk-summary-list__value">
+										<span id="summary-ready">-</span>
+									</dd>
+								</div>
 
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Needs action</dt>
-								<dd class="govuk-summary-list__value">
-									<span id="summary-action-needed">-</span>
-								</dd>
-							</div>
-						</dl>
-					</section>
+								<div class="govuk-summary-list__row">
+									<dt class="govuk-summary-list__key">Consent not complete</dt>
+									<dd class="govuk-summary-list__value">
+										<span id="summary-action-needed">-</span>
+									</dd>
+								</div>
+							</dl>
+						</section>
 
-					<section class="participant-consent-panel" aria-labelledby="participants-consent-title">
-						<div class="participant-consent-panel__header">
-							<div>
-								<h2 id="participants-consent-title" class="govuk-heading-m">Participants</h2>
-								<p class="govuk-body">
-									Select a participant to record or review consent. Status is shown in text and does not rely on colour.
-								</p>
-							</div>
+						<div class="participant-consent-workspace__mobile-context">
+							<aside
+								class="sourcebook-context sourcebook-context--mobile"
+								aria-labelledby="sourcebook-context-mobile-title"
+							>
+								<div class="sourcebook-context__header">
+									<p class="govuk-caption-m sourcebook-context__caption">Sourcebook</p>
+									<h2 class="govuk-heading-m sourcebook-context__title" id="sourcebook-context-mobile-title">
+										Why this page is governed
+									</h2>
+									<p class="govuk-body sourcebook-context__summary">
+										Before marking a participant ready, check that informed consent has been recorded against the
+										current consent form.
+									</p>
+								</div>
+								<ol class="govuk-list sourcebook-context__list">
+									<li class="sourcebook-context__item sourcebook-context__item--rule">
+										<div class="sourcebook-context__clause">
+											<span class="sourcebook-context__badge sourcebook-context__badge--rule" aria-label="Rule">R</span>
+											<div>
+												<p class="sourcebook-context__meta">REC-ADMN 3.1.1 · Recruitment and administration</p>
+												<h3 class="govuk-heading-s sourcebook-context__clause-title">
+													<a class="govuk-link" href="/pages/sourcebook/recruitment-and-administration/#rec-admn-3-1-1">
+														Record informed consent before research participation
+													</a>
+												</h3>
+												<p class="govuk-body-s sourcebook-context__text">
+													Participants must receive clear study information and give recorded informed consent before
+													taking part, including consent choices for recording, quotation and future contact.
+												</p>
+
+												<p class="govuk-body-s sourcebook-context__condition">
+													<strong>Relevant to:</strong>
+
+													Participant consent recording
+												</p>
+											</div>
+										</div>
+									</li>
+								</ol>
+							</aside>
 						</div>
 
-						<div class="table-wrap">
-							<table class="govuk-table participant-consent-table" aria-label="Participant consent">
+						<section class="participant-consent-panel" aria-labelledby="participants-consent-title">
+							<div class="participant-consent-panel__header">
+								<div>
+									<h2 id="participants-consent-title" class="govuk-heading-m">Participants</h2>
+									<p class="govuk-body">
+										Select a participant to record or review consent. Status is shown in text and does not rely on
+										colour.
+									</p>
+								</div>
+							</div>
+
+							<div class="table-wrap">
+								<table class="govuk-table participant-consent-table" aria-label="Participant consent">
+									<thead class="govuk-table__head">
+										<tr class="govuk-table__row">
+											<th scope="col" class="govuk-table__header">Participant</th>
+											<th scope="col" class="govuk-table__header">Consent status</th>
+											<th scope="col" class="govuk-table__header">Permissions</th>
+											<th scope="col" class="govuk-table__header">Recorded</th>
+											<th scope="col" class="govuk-table__header">
+												<span class="govuk-visually-hidden">Actions</span>
+											</th>
+										</tr>
+									</thead>
+									<tbody id="participant-consent-tbody" class="govuk-table__body">
+										<tr class="govuk-table__row">
+											<td class="govuk-table__cell" colspan="5">Loading participants.</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</section>
+
+						<section
+							id="consent-record-panel"
+							class="participant-consent-panel"
+							aria-labelledby="record-consent-title"
+							hidden
+						>
+							<h2 id="record-consent-title" class="govuk-heading-m">Record participant consent</h2>
+							<p id="record-consent-hint" class="govuk-body">Choose a participant to record or review consent.</p>
+
+							<section
+								class="sourcebook-gate sourcebook-gate--blocked sourcebook-gate--attention"
+								aria-labelledby="sourcebook-gate-title"
+								data-sourcebook-gate
+							>
+								<div class="sourcebook-gate__header">
+									<p class="govuk-caption-m sourcebook-gate__caption">Readiness check</p>
+									<h2 class="govuk-heading-m sourcebook-gate__title" id="sourcebook-gate-title">
+										Consent assurance requirements
+									</h2>
+									<strong
+										class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--blocked"
+										data-sourcebook-gate-status
+									>
+										Consent evidence incomplete
+									</strong>
+									<p class="govuk-body sourcebook-gate__summary" data-sourcebook-gate-summary>
+										A participant is ready only when a published consent form version is selected and all required
+										consent statements are recorded.
+									</p>
+									<p class="govuk-body sourcebook-gate__action">
+										<strong data-sourcebook-gate-action>
+											Complete required consent before treating this participant as ready.
+										</strong>
+									</p>
+								</div>
+								<ul class="govuk-list sourcebook-gate__checks">
+									<li
+										class="sourcebook-gate__check sourcebook-gate__check--met sourcebook-gate__check--sourcebook-context"
+										data-sourcebook-check="sourcebook-context"
+									>
+										<span class="sourcebook-gate__check-label">Sourcebook context</span>
+										<strong
+											class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--met"
+											data-sourcebook-check-status
+										>
+											Matched
+										</strong>
+										<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
+											1 clause matched this route.
+										</span>
+									</li>
+
+									<li
+										class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--evidence-readiness"
+										data-sourcebook-check="evidence-readiness"
+									>
+										<span class="sourcebook-gate__check-label">Evidence readiness</span>
+										<strong
+											class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+											data-sourcebook-check-status
+										>
+											Evidence needed
+										</strong>
+										<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
+											1 evidence item needed.
+										</span>
+									</li>
+
+									<li
+										class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--governance-action"
+										data-sourcebook-check="governance-action"
+									>
+										<span class="sourcebook-gate__check-label">Governance action</span>
+										<strong
+											class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+											data-sourcebook-check-status
+										>
+											Pause for evidence
+										</strong>
+										<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
+											Add the required evidence before treating this workflow as Sourcebook-ready.
+										</span>
+									</li>
+								</ul>
+							</section>
+
+							<form id="participant-consent-form" novalidate>
+								<input id="participant-id" type="hidden" />
+								<input id="consent-record-id" type="hidden" />
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="consent-form-select">Consent form version</label>
+
+									<div id="consent-form-select-hint" class="govuk-hint">
+										Use the published consent form shown, sent or read to the participant.
+									</div>
+
+									<select
+										class="govuk-select"
+										id="consent-form-select"
+										name="consentFormId"
+										aria-describedby="consent-form-select-hint"
+									>
+										<option value="">Loading published consent forms</option>
+									</select>
+								</div>
+
+								<fieldset class="govuk-fieldset participant-consent-items" aria-describedby="consent-items-hint">
+									<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Consent statements</legend>
+									<div id="consent-items-hint" class="govuk-hint">
+										Required statements must be agreed before a participant is ready for a session. Optional declined
+										permissions should still be visible to the research team.
+									</div>
+									<div id="consent-items-list"></div>
+								</fieldset>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="capture-method">Capture method</label>
+
+									<select class="govuk-select" id="capture-method" name="captureMethod">
+										<option value="">Select a capture method</option>
+
+										<option value="Verbal">Verbal</option>
+
+										<option value="Signed form">Signed form</option>
+
+										<option value="Email">Email</option>
+
+										<option value="Imported">Imported</option>
+									</select>
+								</div>
+
+								<div class="govuk-form-group">
+									<label class="govuk-label" for="recorded-by">Recorded by</label>
+
+									<input class="govuk-input" id="recorded-by" name="recordedBy" type="text" autocomplete="name" />
+								</div>
+
+								<details class="govuk-details participant-consent-withdrawal">
+									<summary class="govuk-details__summary">
+										<span class="govuk-details__summary-text">Record withdrawal or do not proceed</span>
+									</summary>
+									<div class="govuk-details__text">
+										<div class="govuk-form-group">
+											<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+												<div class="govuk-checkboxes__item">
+													<input
+														class="govuk-checkboxes__input"
+														id="consent-withdrawn"
+														name="consentWithdrawn"
+														type="checkbox"
+														value="yes"
+														id="consent-withdrawn"
+													/>
+													<label class="govuk-label govuk-checkboxes__label" for="consent-withdrawn">
+														Consent has been withdrawn or the session should not proceed
+													</label>
+												</div>
+											</div>
+										</div>
+
+										<div class="govuk-form-group">
+											<label class="govuk-label" for="withdrawal-reason">Reason or note</label>
+
+											<textarea
+												class="govuk-textarea"
+												id="withdrawal-reason"
+												name="withdrawalReason"
+												rows="3"
+											></textarea>
+										</div>
+									</div>
+								</details>
+
+								<div class="govuk-button-group participant-consent-form__actions">
+									<button type="submit" class="govuk-button" data-module="govuk-button" id="save-participant-consent">
+										Save consent response
+									</button>
+
+									<button
+										type="button"
+										class="govuk-button govuk-button--secondary"
+										data-module="govuk-button"
+										id="cancel-participant-consent"
+									>
+										Cancel
+									</button>
+								</div>
+							</form>
+						</section>
+
+						<section
+							class="sourcebook-evidence-ledger"
+							aria-labelledby="sourcebook-evidence-ledger-title"
+							id="sourcebook-evidence-ledger"
+						>
+							<div class="sourcebook-evidence-ledger__header">
+								<p class="govuk-caption-m sourcebook-evidence-ledger__caption">Evidence</p>
+								<h2 class="govuk-heading-m sourcebook-evidence-ledger__title" id="sourcebook-evidence-ledger-title">
+									Consent evidence
+								</h2>
+								<p class="govuk-body sourcebook-evidence-ledger__summary">
+									Check the evidence held for the selected participant before treating them as ready for research.
+								</p>
+							</div>
+							<table class="govuk-table sourcebook-evidence-ledger__table">
+								<caption class="govuk-table__caption govuk-visually-hidden">Consent evidence</caption>
 								<thead class="govuk-table__head">
 									<tr class="govuk-table__row">
-										<th scope="col" class="govuk-table__header">Participant</th>
-										<th scope="col" class="govuk-table__header">Consent status</th>
-										<th scope="col" class="govuk-table__header">Permissions</th>
-										<th scope="col" class="govuk-table__header">Recorded</th>
-										<th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+										<th scope="col" class="govuk-table__header">Evidence</th>
+										<th scope="col" class="govuk-table__header">Sourcebook clause</th>
+										<th scope="col" class="govuk-table__header">Status</th>
 									</tr>
 								</thead>
-								<tbody id="participant-consent-tbody" class="govuk-table__body">
-									<tr class="govuk-table__row">
-										<td class="govuk-table__cell" colspan="5">Loading participants.</td>
+								<tbody class="govuk-table__body">
+									<tr
+										class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--present"
+										data-sourcebook-evidence-id="consent-form"
+									>
+										<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
+											<span class="sourcebook-evidence-ledger__evidence-label">Consent Form</span>
+											<span class="sourcebook-evidence-ledger__evidence-id">consent-form</span>
+										</th>
+										<td class="govuk-table__cell">
+											<ul class="govuk-list sourcebook-evidence-ledger__clauses">
+												<li>
+													<a class="govuk-link" href="/pages/sourcebook/recruitment-and-administration/#rec-admn-3-1-1">
+														REC-ADMN 3.1.1
+													</a>
+													<span class="sourcebook-evidence-ledger__clause-title">
+														Record informed consent before research participation
+													</span>
+												</li>
+											</ul>
+										</td>
+										<td class="govuk-table__cell">
+											<strong
+												class="govuk-tag sourcebook-evidence-ledger__tag sourcebook-evidence-ledger__tag--present"
+											>
+												Present
+											</strong>
+										</td>
+									</tr>
+
+									<tr
+										class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed"
+										data-sourcebook-evidence-id="consent-log"
+									>
+										<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
+											<span class="sourcebook-evidence-ledger__evidence-label">Consent Log</span>
+											<span class="sourcebook-evidence-ledger__evidence-id">consent-log</span>
+										</th>
+										<td class="govuk-table__cell">
+											<ul class="govuk-list sourcebook-evidence-ledger__clauses">
+												<li>
+													<a class="govuk-link" href="/pages/sourcebook/recruitment-and-administration/#rec-admn-3-1-1">
+														REC-ADMN 3.1.1
+													</a>
+													<span class="sourcebook-evidence-ledger__clause-title">
+														Record informed consent before research participation
+													</span>
+												</li>
+											</ul>
+										</td>
+										<td class="govuk-table__cell">
+											<strong class="govuk-tag sourcebook-evidence-ledger__tag sourcebook-evidence-ledger__tag--needed">
+												Needed
+											</strong>
+										</td>
 									</tr>
 								</tbody>
 							</table>
-						</div>
-					</section>
+						</section>
+					</div>
 
-					<section
-						id="consent-record-panel"
-						class="participant-consent-panel"
-						aria-labelledby="record-consent-title"
-						hidden
-					>
-						<h2 id="record-consent-title" class="govuk-heading-m">Record participant consent</h2>
-						<p id="record-consent-hint" class="govuk-body">Choose a participant to record or review consent.</p>
-
-						<form id="participant-consent-form" novalidate>
-							<input id="participant-id" type="hidden" />
-							<input id="consent-record-id" type="hidden" />
-
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="consent-form-select">Consent form version</label>
-
-								<div id="consent-form-select-hint" class="govuk-hint">
-									Use the published consent form shown, sent or read to the participant.
-								</div>
-
-								<select
-									class="govuk-select"
-									id="consent-form-select"
-									name="consentFormId"
-									aria-describedby="consent-form-select-hint"
-								>
-									<option value="">Loading published consent forms</option>
-								</select>
+					<div class="participant-consent-workspace__aside">
+						<aside class="sourcebook-context" aria-labelledby="sourcebook-context-title">
+							<div class="sourcebook-context__header">
+								<p class="govuk-caption-m sourcebook-context__caption">Sourcebook</p>
+								<h2 class="govuk-heading-m sourcebook-context__title" id="sourcebook-context-title">
+									Why this page is governed
+								</h2>
+								<p class="govuk-body sourcebook-context__summary">
+									Before marking a participant ready, check that informed consent has been recorded against the current
+									consent form.
+								</p>
 							</div>
+							<ol class="govuk-list sourcebook-context__list">
+								<li class="sourcebook-context__item sourcebook-context__item--rule">
+									<div class="sourcebook-context__clause">
+										<span class="sourcebook-context__badge sourcebook-context__badge--rule" aria-label="Rule">R</span>
+										<div>
+											<p class="sourcebook-context__meta">REC-ADMN 3.1.1 · Recruitment and administration</p>
+											<h3 class="govuk-heading-s sourcebook-context__clause-title">
+												<a class="govuk-link" href="/pages/sourcebook/recruitment-and-administration/#rec-admn-3-1-1">
+													Record informed consent before research participation
+												</a>
+											</h3>
+											<p class="govuk-body-s sourcebook-context__text">
+												Participants must receive clear study information and give recorded informed consent before
+												taking part, including consent choices for recording, quotation and future contact.
+											</p>
 
-							<fieldset class="govuk-fieldset participant-consent-items" aria-describedby="consent-items-hint">
-								<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Consent statements</legend>
-								<div id="consent-items-hint" class="govuk-hint">
-									Required statements must be agreed before a participant is ready for a session. Optional declined
-									permissions should still be visible to the research team.
-								</div>
-								<div id="consent-items-list"></div>
-							</fieldset>
+											<p class="govuk-body-s sourcebook-context__condition">
+												<strong>Relevant to:</strong>
 
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="capture-method">Capture method</label>
-
-								<select class="govuk-select" id="capture-method" name="captureMethod">
-									<option value="">Select a capture method</option>
-
-									<option value="Verbal">Verbal</option>
-
-									<option value="Signed form">Signed form</option>
-
-									<option value="Email">Email</option>
-
-									<option value="Imported">Imported</option>
-								</select>
-							</div>
-
-							<div class="govuk-form-group">
-								<label class="govuk-label" for="recorded-by">Recorded by</label>
-
-								<input class="govuk-input" id="recorded-by" name="recordedBy" type="text" autocomplete="name" />
-							</div>
-
-							<details class="govuk-details participant-consent-withdrawal">
-								<summary class="govuk-details__summary">
-									<span class="govuk-details__summary-text">Record withdrawal or do not proceed</span>
-								</summary>
-								<div class="govuk-details__text">
-									<div class="govuk-form-group">
-										<div class="govuk-checkboxes" data-module="govuk-checkboxes">
-											<div class="govuk-checkboxes__item">
-												<input
-													class="govuk-checkboxes__input"
-													id="consent-withdrawn"
-													name="consentWithdrawn"
-													type="checkbox"
-													value="yes"
-													id="consent-withdrawn"
-												/>
-												<label class="govuk-label govuk-checkboxes__label" for="consent-withdrawn">
-													Consent has been withdrawn or the session should not proceed
-												</label>
-											</div>
+												Participant consent recording
+											</p>
 										</div>
 									</div>
-
-									<div class="govuk-form-group">
-										<label class="govuk-label" for="withdrawal-reason">Reason or note</label>
-
-										<textarea class="govuk-textarea" id="withdrawal-reason" name="withdrawalReason" rows="3"></textarea>
-									</div>
-								</div>
-							</details>
-
-							<div class="govuk-button-group participant-consent-form__actions">
-								<button type="submit" class="govuk-button" data-module="govuk-button" id="save-participant-consent">
-									Save consent response
-								</button>
-
-								<button
-									type="button"
-									class="govuk-button govuk-button--secondary"
-									data-module="govuk-button"
-									id="cancel-participant-consent"
-								>
-									Cancel
-								</button>
-							</div>
-						</form>
-					</section>
+								</li>
+							</ol>
+						</aside>
+					</div>
 				</section>
 			</div>
 		</main>

--- a/public/pages/team/role-assignments/index.html
+++ b/public/pages/team/role-assignments/index.html
@@ -56,41 +56,69 @@
 					</div>
 				</header>
 
-				<section class="sourcebook-gate sourcebook-gate--blocked" aria-labelledby="sourcebook-gate-title">
+				<section
+					class="sourcebook-gate sourcebook-gate--blocked"
+					aria-labelledby="sourcebook-gate-title"
+					data-sourcebook-gate
+				>
 					<div class="sourcebook-gate__header">
 						<p class="govuk-caption-m sourcebook-gate__caption">Sourcebook gate</p>
 						<h2 class="govuk-heading-m sourcebook-gate__title" id="sourcebook-gate-title">
 							Sourcebook gate for role assignment
 						</h2>
-						<strong class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--blocked">Evidence needed</strong>
-						<p class="govuk-body sourcebook-gate__summary">
+						<strong class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--blocked" data-sourcebook-gate-status>
+							Evidence needed
+						</strong>
+						<p class="govuk-body sourcebook-gate__summary" data-sourcebook-gate-summary>
 							Do not assign role permissions until the Sourcebook clause and required access evidence are in place.
 						</p>
 						<p class="govuk-body sourcebook-gate__action">
-							<strong>Add evidence before continuing</strong>
+							<strong data-sourcebook-gate-action>Add evidence before continuing</strong>
 						</p>
 					</div>
 					<ul class="govuk-list sourcebook-gate__checks">
-						<li class="sourcebook-gate__check sourcebook-gate__check--met">
+						<li
+							class="sourcebook-gate__check sourcebook-gate__check--met sourcebook-gate__check--sourcebook-context"
+							data-sourcebook-check="sourcebook-context"
+						>
 							<span class="sourcebook-gate__check-label">Sourcebook context</span>
-							<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--met">Matched</strong>
-							<span class="sourcebook-gate__check-detail">1 clause matched this route.</span>
+							<strong
+								class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--met"
+								data-sourcebook-check-status
+							>
+								Matched
+							</strong>
+							<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
+								1 clause matched this route.
+							</span>
 						</li>
 
-						<li class="sourcebook-gate__check sourcebook-gate__check--unmet">
+						<li
+							class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--evidence-readiness"
+							data-sourcebook-check="evidence-readiness"
+						>
 							<span class="sourcebook-gate__check-label">Evidence readiness</span>
-							<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet">
+							<strong
+								class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+								data-sourcebook-check-status
+							>
 								Evidence needed
 							</strong>
-							<span class="sourcebook-gate__check-detail">2 evidence items needed.</span>
+							<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>2 evidence items needed.</span>
 						</li>
 
-						<li class="sourcebook-gate__check sourcebook-gate__check--unmet">
+						<li
+							class="sourcebook-gate__check sourcebook-gate__check--unmet sourcebook-gate__check--governance-action"
+							data-sourcebook-check="governance-action"
+						>
 							<span class="sourcebook-gate__check-label">Governance action</span>
-							<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet">
+							<strong
+								class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--unmet"
+								data-sourcebook-check-status
+							>
 								Pause for evidence
 							</strong>
-							<span class="sourcebook-gate__check-detail">
+							<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>
 								Add the required evidence before treating this workflow as Sourcebook-ready.
 							</span>
 						</li>
@@ -134,7 +162,11 @@
 					</ol>
 				</aside>
 
-				<section class="sourcebook-evidence-ledger" aria-labelledby="sourcebook-evidence-ledger-title">
+				<section
+					class="sourcebook-evidence-ledger"
+					aria-labelledby="sourcebook-evidence-ledger-title"
+					id="sourcebook-evidence-ledger"
+				>
 					<div class="sourcebook-evidence-ledger__header">
 						<p class="govuk-caption-m sourcebook-evidence-ledger__caption">Evidence ledger</p>
 						<h2 class="govuk-heading-m sourcebook-evidence-ledger__title" id="sourcebook-evidence-ledger-title">
@@ -154,7 +186,10 @@
 							</tr>
 						</thead>
 						<tbody class="govuk-table__body">
-							<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed">
+							<tr
+								class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed"
+								data-sourcebook-evidence-id="access-request"
+							>
 								<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
 									<span class="sourcebook-evidence-ledger__evidence-label">Access Request</span>
 									<span class="sourcebook-evidence-ledger__evidence-id">access-request</span>
@@ -178,7 +213,10 @@
 								</td>
 							</tr>
 
-							<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed">
+							<tr
+								class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--needed"
+								data-sourcebook-evidence-id="role-permission-model"
+							>
 								<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
 									<span class="sourcebook-evidence-ledger__evidence-label">Role Permission Model</span>
 									<span class="sourcebook-evidence-ledger__evidence-id">role-permission-model</span>

--- a/scripts/govuk/render-govuk-pages.mjs
+++ b/scripts/govuk/render-govuk-pages.mjs
@@ -686,6 +686,50 @@ export const govukPages = [
 			serviceName: 'ResearchOps Demo Suite',
 			activeNavigation: 'Projects',
 			navigation: projectNavigation,
+			sourcebookContext: sourcebookContextForRoute({
+				route: '/pages/study/participant-consent/',
+				condition: 'participant-consent-recording',
+				title: 'Why this page is governed',
+				summary:
+					'Before marking a participant ready, check that informed consent has been recorded against the current consent form.',
+				caption: 'Sourcebook',
+				conditionLabel: 'Relevant to:',
+			}),
+			sourcebookMobileContext: sourcebookContextForRoute({
+				route: '/pages/study/participant-consent/',
+				condition: 'participant-consent-recording',
+				title: 'Why this page is governed',
+				summary:
+					'Before marking a participant ready, check that informed consent has been recorded against the current consent form.',
+				id: 'sourcebook-context-mobile-title',
+				classes: 'sourcebook-context--mobile',
+				caption: 'Sourcebook',
+				conditionLabel: 'Relevant to:',
+			}),
+			sourcebookEvidenceLedger: sourcebookEvidenceLedgerForRoute({
+				route: '/pages/study/participant-consent/',
+				condition: 'participant-consent-recording',
+				title: 'Consent evidence',
+				summary:
+					'Check the evidence held for the selected participant before treating them as ready for research.',
+				caption: 'Evidence',
+				providedEvidence: ['consent-form'],
+			}),
+			sourcebookGate: sourcebookGateForRoute({
+				route: '/pages/study/participant-consent/',
+				condition: 'participant-consent-recording',
+				title: 'Consent assurance requirements',
+				summary:
+					'A participant is ready only when a published consent form version is selected and all required consent statements are recorded.',
+				caption: 'Readiness check',
+				classes: 'sourcebook-gate--attention',
+				blockedStatusLabel: 'Consent evidence incomplete',
+				blockedPrimaryAction:
+					'Complete required consent before treating this participant as ready.',
+				readyStatusLabel: 'Consent evidence complete',
+				readyPrimaryAction: 'Participant can be treated as ready for research.',
+				providedEvidence: ['consent-form'],
+			}),
 		},
 	},
 	{

--- a/sourcebook/sourcebook-route-mappings.json
+++ b/sourcebook/sourcebook-route-mappings.json
@@ -11,6 +11,17 @@
 		"strength": "required"
 	},
 	{
+		"id": "map_study_participant_consent",
+		"route": "/pages/study/participant-consent/",
+		"clauseId": "REC-ADMN 3.1.1",
+		"condition": {
+			"id": "participant-consent-recording",
+			"label": "Participant consent recording",
+			"description": "Surface when participant consent is recorded, reviewed or withdrawn before research participation."
+		},
+		"strength": "required"
+	},
+	{
 		"id": "map_session_reminders",
 		"route": "/pages/sessions/",
 		"clauseId": "REC-ADMN 5.1.2",

--- a/src/govuk/data/sourcebook.mjs
+++ b/src/govuk/data/sourcebook.mjs
@@ -149,6 +149,10 @@ function sourcebookEvidenceLedgerItem({ evidenceId, clause, providedEvidence }) 
 export function sourcebookContextForRoute({
 	route,
 	condition,
+	id,
+	classes = '',
+	caption = 'Sourcebook',
+	conditionLabel = 'Applies when:',
 	title = 'Sourcebook context',
 	summary = 'Relevant Sourcebook clauses for this task.',
 	limit = 3,
@@ -174,6 +178,10 @@ export function sourcebookContextForRoute({
 		.slice(0, limit);
 
 	return {
+		id,
+		classes,
+		caption,
+		conditionLabel,
 		title,
 		summary,
 		route: routeValue,
@@ -185,6 +193,10 @@ export function sourcebookContextForRoute({
 export function sourcebookEvidenceLedgerForRoute({
 	route,
 	condition,
+	id,
+	sectionId,
+	classes = '',
+	caption = 'Evidence ledger',
 	title = 'Sourcebook evidence ledger',
 	summary = 'Evidence required by Sourcebook clauses for this task.',
 	providedEvidence = [],
@@ -221,6 +233,10 @@ export function sourcebookEvidenceLedgerForRoute({
 
 	const items = [...evidenceById.values()];
 	return {
+		id,
+		sectionId,
+		classes,
+		caption,
 		title,
 		summary,
 		route: context.route,
@@ -271,9 +287,18 @@ function sourcebookGateChecks({ context, ledger }) {
 export function sourcebookGateForRoute({
 	route,
 	condition,
+	id,
+	classes = '',
+	caption = 'Sourcebook gate',
 	title = 'Sourcebook gate',
 	summary = 'Checks whether this task has the Sourcebook context and evidence needed before it proceeds.',
 	providedEvidence = [],
+	readyStatusLabel = 'Ready to proceed',
+	blockedStatusLabel = 'Evidence needed',
+	notApplicableStatusLabel = 'No gate required',
+	readyPrimaryAction = 'Proceed with controls',
+	blockedPrimaryAction = 'Add evidence before continuing',
+	notApplicablePrimaryAction = 'Check Sourcebook scope',
 	limit = 3,
 } = {}) {
 	const context = sourcebookContextForRoute({ route, condition, limit });
@@ -291,6 +316,9 @@ export function sourcebookGateForRoute({
 	const status = !hasContext ? 'not-applicable' : evidenceReady ? 'ready' : 'blocked';
 
 	return {
+		id,
+		classes,
+		caption,
 		title,
 		summary,
 		route: context.route,
@@ -298,10 +326,10 @@ export function sourcebookGateForRoute({
 		status,
 		statusLabel:
 			status === 'ready'
-				? 'Ready to proceed'
+				? readyStatusLabel
 				: status === 'blocked'
-					? 'Evidence needed'
-					: 'No gate required',
+					? blockedStatusLabel
+					: notApplicableStatusLabel,
 		decision:
 			status === 'ready'
 				? 'proceed-with-controls'
@@ -310,10 +338,10 @@ export function sourcebookGateForRoute({
 					: 'check-sourcebook-scope',
 		primaryAction:
 			status === 'ready'
-				? 'Proceed with controls'
+				? readyPrimaryAction
 				: status === 'blocked'
-					? 'Add evidence before continuing'
-					: 'Check Sourcebook scope',
+					? blockedPrimaryAction
+					: notApplicablePrimaryAction,
 		checks,
 		context,
 		evidenceLedger,

--- a/src/govuk/templates/macros/sourcebook-context.njk
+++ b/src/govuk/templates/macros/sourcebook-context.njk
@@ -1,6 +1,6 @@
 {% macro SourcebookContext(params) %}
 	{% if params.items is defined and params.items.length %}
-		<aside class="sourcebook-context {{ params.classes | default('') }}" aria-labelledby="{{ params.id | default('sourcebook-context-title') }}">
+		<aside class="sourcebook-context{% if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="{{ params.id | default('sourcebook-context-title') }}">
 			<div class="sourcebook-context__header">
 				<p class="govuk-caption-m sourcebook-context__caption">{{ params.caption | default('Sourcebook') }}</p>
 				<h2 class="govuk-heading-m sourcebook-context__title" id="{{ params.id | default('sourcebook-context-title') }}">{{ params.title }}</h2>

--- a/src/govuk/templates/macros/sourcebook-context.njk
+++ b/src/govuk/templates/macros/sourcebook-context.njk
@@ -1,8 +1,8 @@
 {% macro SourcebookContext(params) %}
 	{% if params.items is defined and params.items.length %}
-		<aside class="sourcebook-context" aria-labelledby="{{ params.id | default('sourcebook-context-title') }}">
+		<aside class="sourcebook-context {{ params.classes | default('') }}" aria-labelledby="{{ params.id | default('sourcebook-context-title') }}">
 			<div class="sourcebook-context__header">
-				<p class="govuk-caption-m sourcebook-context__caption">Sourcebook</p>
+				<p class="govuk-caption-m sourcebook-context__caption">{{ params.caption | default('Sourcebook') }}</p>
 				<h2 class="govuk-heading-m sourcebook-context__title" id="{{ params.id | default('sourcebook-context-title') }}">{{ params.title }}</h2>
 				<p class="govuk-body sourcebook-context__summary">{{ params.summary }}</p>
 			</div>
@@ -19,7 +19,7 @@
 								<p class="govuk-body-s sourcebook-context__text">{{ item.text }}</p>
 								{% if item.conditions is defined and item.conditions.length %}
 									<p class="govuk-body-s sourcebook-context__condition">
-										<strong>Applies when:</strong>
+										<strong>{{ params.conditionLabel | default('Applies when:') }}</strong>
 										{% for condition in item.conditions %}
 											{{ condition.label }}{% if not loop.last %}, {% endif %}
 										{% endfor %}

--- a/src/govuk/templates/macros/sourcebook-evidence-ledger.njk
+++ b/src/govuk/templates/macros/sourcebook-evidence-ledger.njk
@@ -1,8 +1,8 @@
 {% macro SourcebookEvidenceLedger(params) %}
 	{% if params.items is defined and params.items.length %}
-		<section class="sourcebook-evidence-ledger" aria-labelledby="{{ params.id | default('sourcebook-evidence-ledger-title') }}">
+		<section class="sourcebook-evidence-ledger {{ params.classes | default('') }}" aria-labelledby="{{ params.id | default('sourcebook-evidence-ledger-title') }}" id="{{ params.sectionId | default('sourcebook-evidence-ledger') }}">
 			<div class="sourcebook-evidence-ledger__header">
-				<p class="govuk-caption-m sourcebook-evidence-ledger__caption">Evidence ledger</p>
+				<p class="govuk-caption-m sourcebook-evidence-ledger__caption">{{ params.caption | default('Evidence ledger') }}</p>
 				<h2 class="govuk-heading-m sourcebook-evidence-ledger__title" id="{{ params.id | default('sourcebook-evidence-ledger-title') }}">{{ params.title }}</h2>
 				<p class="govuk-body sourcebook-evidence-ledger__summary">{{ params.summary }}</p>
 			</div>
@@ -17,10 +17,13 @@
 				</thead>
 				<tbody class="govuk-table__body">
 					{% for item in params.items %}
-						<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--{{ item.status }}">
+						<tr class="govuk-table__row sourcebook-evidence-ledger__row sourcebook-evidence-ledger__row--{{ item.status }}" data-sourcebook-evidence-id="{{ item.id }}">
 							<th scope="row" class="govuk-table__header sourcebook-evidence-ledger__evidence">
 								<span class="sourcebook-evidence-ledger__evidence-label">{{ item.label }}</span>
 								<span class="sourcebook-evidence-ledger__evidence-id">{{ item.id }}</span>
+								{% if item.detail %}
+									<span class="sourcebook-evidence-ledger__evidence-detail">{{ item.detail }}</span>
+								{% endif %}
 							</th>
 							<td class="govuk-table__cell">
 								<ul class="govuk-list sourcebook-evidence-ledger__clauses">

--- a/src/govuk/templates/macros/sourcebook-evidence-ledger.njk
+++ b/src/govuk/templates/macros/sourcebook-evidence-ledger.njk
@@ -1,6 +1,6 @@
 {% macro SourcebookEvidenceLedger(params) %}
 	{% if params.items is defined and params.items.length %}
-		<section class="sourcebook-evidence-ledger {{ params.classes | default('') }}" aria-labelledby="{{ params.id | default('sourcebook-evidence-ledger-title') }}" id="{{ params.sectionId | default('sourcebook-evidence-ledger') }}">
+		<section class="sourcebook-evidence-ledger{% if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="{{ params.id | default('sourcebook-evidence-ledger-title') }}" id="{{ params.sectionId | default('sourcebook-evidence-ledger') }}">
 			<div class="sourcebook-evidence-ledger__header">
 				<p class="govuk-caption-m sourcebook-evidence-ledger__caption">{{ params.caption | default('Evidence ledger') }}</p>
 				<h2 class="govuk-heading-m sourcebook-evidence-ledger__title" id="{{ params.id | default('sourcebook-evidence-ledger-title') }}">{{ params.title }}</h2>

--- a/src/govuk/templates/macros/sourcebook-gate.njk
+++ b/src/govuk/templates/macros/sourcebook-gate.njk
@@ -1,21 +1,21 @@
 {% macro SourcebookGate(params) %}
 	{% if params.checks is defined and params.checks.length %}
-		<section class="sourcebook-gate sourcebook-gate--{{ params.status }}" aria-labelledby="{{ params.id | default('sourcebook-gate-title') }}">
+		<section class="sourcebook-gate sourcebook-gate--{{ params.status }} {{ params.classes | default('') }}" aria-labelledby="{{ params.id | default('sourcebook-gate-title') }}" data-sourcebook-gate>
 			<div class="sourcebook-gate__header">
-				<p class="govuk-caption-m sourcebook-gate__caption">Sourcebook gate</p>
+				<p class="govuk-caption-m sourcebook-gate__caption">{{ params.caption | default('Sourcebook gate') }}</p>
 				<h2 class="govuk-heading-m sourcebook-gate__title" id="{{ params.id | default('sourcebook-gate-title') }}">{{ params.title }}</h2>
-				<strong class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--{{ params.status }}">{{ params.statusLabel }}</strong>
-				<p class="govuk-body sourcebook-gate__summary">{{ params.summary }}</p>
+				<strong class="govuk-tag sourcebook-gate__tag sourcebook-gate__tag--{{ params.status }}" data-sourcebook-gate-status>{{ params.statusLabel }}</strong>
+				<p class="govuk-body sourcebook-gate__summary" data-sourcebook-gate-summary>{{ params.summary }}</p>
 				<p class="govuk-body sourcebook-gate__action">
-					<strong>{{ params.primaryAction }}</strong>
+					<strong data-sourcebook-gate-action>{{ params.primaryAction }}</strong>
 				</p>
 			</div>
 			<ul class="govuk-list sourcebook-gate__checks">
 				{% for check in params.checks %}
-					<li class="sourcebook-gate__check sourcebook-gate__check--{{ check.status }}">
+					<li class="sourcebook-gate__check sourcebook-gate__check--{{ check.status }} sourcebook-gate__check--{{ check.id }}" data-sourcebook-check="{{ check.id }}">
 						<span class="sourcebook-gate__check-label">{{ check.label }}</span>
-						<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--{{ check.status }}">{{ check.statusLabel }}</strong>
-						<span class="sourcebook-gate__check-detail">{{ check.detail }}</span>
+						<strong class="govuk-tag sourcebook-gate__check-tag sourcebook-gate__check-tag--{{ check.status }}" data-sourcebook-check-status>{{ check.statusLabel }}</strong>
+						<span class="sourcebook-gate__check-detail" data-sourcebook-check-detail>{{ check.detail }}</span>
 					</li>
 				{% endfor %}
 			</ul>

--- a/src/govuk/templates/macros/sourcebook-gate.njk
+++ b/src/govuk/templates/macros/sourcebook-gate.njk
@@ -1,6 +1,6 @@
 {% macro SourcebookGate(params) %}
 	{% if params.checks is defined and params.checks.length %}
-		<section class="sourcebook-gate sourcebook-gate--{{ params.status }} {{ params.classes | default('') }}" aria-labelledby="{{ params.id | default('sourcebook-gate-title') }}" data-sourcebook-gate>
+		<section class="sourcebook-gate sourcebook-gate--{{ params.status }}{% if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="{{ params.id | default('sourcebook-gate-title') }}" data-sourcebook-gate>
 			<div class="sourcebook-gate__header">
 				<p class="govuk-caption-m sourcebook-gate__caption">{{ params.caption | default('Sourcebook gate') }}</p>
 				<h2 class="govuk-heading-m sourcebook-gate__title" id="{{ params.id | default('sourcebook-gate-title') }}">{{ params.title }}</h2>

--- a/src/govuk/templates/pages/study-participant-consent.njk
+++ b/src/govuk/templates/pages/study-participant-consent.njk
@@ -8,6 +8,9 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "macros/daas-brand-panel.njk" import daasBrandPanel %}
+{% from "macros/sourcebook-context.njk" import SourcebookContext %}
+{% from "macros/sourcebook-evidence-ledger.njk" import SourcebookEvidenceLedger %}
+{% from "macros/sourcebook-gate.njk" import SourcebookGate %}
 
 {% set studyPageScriptVersion = "study-record-id-routing-20260518" %}
 
@@ -46,7 +49,7 @@
 		<div>
 			<p id="study-context" class="govuk-caption-m">Study</p>
 			<h1 class="govuk-heading-l">Manage participant consent</h1>
-			<p class="govuk-body participant-consent-context govuk-!-width-two-thirds">Record, review or withdraw participant consent for this study. Consent is recorded against a specific published consent form version.</p>
+			<p class="govuk-body participant-consent-context govuk-!-width-two-thirds">Record, review or withdraw consent for this study. Consent is recorded against a published form version.</p>
 		</div>
 	</header>
 
@@ -78,52 +81,59 @@
 	</section>
 
 	<section id="consent-workspace" class="participant-consent-workspace" hidden>
-		<section class="participant-consent-panel" aria-labelledby="consent-summary-title">
-			<h2 id="consent-summary-title" class="govuk-heading-m">Consent coverage</h2>
-			{{ govukSummaryList({
-				classes: "participant-consent-summary",
-				rows: [
-					{ key: { text: "Form version" }, value: { html: '<span id="summary-published-form">-</span>' } },
-					{ key: { text: "Participants" }, value: { html: '<span id="summary-participants">-</span>' } },
-					{ key: { text: "Ready" }, value: { html: '<span id="summary-ready">-</span>' } },
-					{ key: { text: "Needs action" }, value: { html: '<span id="summary-action-needed">-</span>' } }
-				]
-			}) }}
-		</section>
+		<div class="participant-consent-workspace__main">
+			<section class="participant-consent-panel" aria-labelledby="consent-summary-title">
+				<h2 id="consent-summary-title" class="govuk-heading-m">Consent summary</h2>
+				{{ govukSummaryList({
+					classes: "participant-consent-summary",
+					rows: [
+						{ key: { text: "Form version" }, value: { html: '<span id="summary-published-form">-</span>' } },
+						{ key: { text: "Participants" }, value: { html: '<span id="summary-participants">-</span>' } },
+						{ key: { text: "Ready for session" }, value: { html: '<span id="summary-ready">-</span>' } },
+						{ key: { text: "Consent not complete" }, value: { html: '<span id="summary-action-needed">-</span>' } }
+					]
+				}) }}
+			</section>
 
-		<section class="participant-consent-panel" aria-labelledby="participants-consent-title">
-			<div class="participant-consent-panel__header">
-				<div>
-					<h2 id="participants-consent-title" class="govuk-heading-m">Participants</h2>
-					<p class="govuk-body">Select a participant to record or review consent. Status is shown in text and does not rely on colour.</p>
+			<div class="participant-consent-workspace__mobile-context">
+				{{ SourcebookContext(sourcebookMobileContext) }}
+			</div>
+
+			<section class="participant-consent-panel" aria-labelledby="participants-consent-title">
+				<div class="participant-consent-panel__header">
+					<div>
+						<h2 id="participants-consent-title" class="govuk-heading-m">Participants</h2>
+						<p class="govuk-body">Select a participant to record or review consent. Status is shown in text and does not rely on colour.</p>
+					</div>
 				</div>
-			</div>
 
-			<div class="table-wrap">
-				<table class="govuk-table participant-consent-table" aria-label="Participant consent">
-					<thead class="govuk-table__head">
-						<tr class="govuk-table__row">
-							<th scope="col" class="govuk-table__header">Participant</th>
-							<th scope="col" class="govuk-table__header">Consent status</th>
-							<th scope="col" class="govuk-table__header">Permissions</th>
-							<th scope="col" class="govuk-table__header">Recorded</th>
-							<th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
-						</tr>
-					</thead>
-					<tbody id="participant-consent-tbody" class="govuk-table__body">
-						<tr class="govuk-table__row">
-							<td class="govuk-table__cell" colspan="5">Loading participants.</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
-		</section>
+				<div class="table-wrap">
+					<table class="govuk-table participant-consent-table" aria-label="Participant consent">
+						<thead class="govuk-table__head">
+							<tr class="govuk-table__row">
+								<th scope="col" class="govuk-table__header">Participant</th>
+								<th scope="col" class="govuk-table__header">Consent status</th>
+								<th scope="col" class="govuk-table__header">Permissions</th>
+								<th scope="col" class="govuk-table__header">Recorded</th>
+								<th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+							</tr>
+						</thead>
+						<tbody id="participant-consent-tbody" class="govuk-table__body">
+							<tr class="govuk-table__row">
+								<td class="govuk-table__cell" colspan="5">Loading participants.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
 
-		<section id="consent-record-panel" class="participant-consent-panel" aria-labelledby="record-consent-title" hidden>
-			<h2 id="record-consent-title" class="govuk-heading-m">Record participant consent</h2>
-			<p id="record-consent-hint" class="govuk-body">Choose a participant to record or review consent.</p>
+			<section id="consent-record-panel" class="participant-consent-panel" aria-labelledby="record-consent-title" hidden>
+				<h2 id="record-consent-title" class="govuk-heading-m">Record participant consent</h2>
+				<p id="record-consent-hint" class="govuk-body">Choose a participant to record or review consent.</p>
 
-			<form id="participant-consent-form" novalidate>
+				{{ SourcebookGate(sourcebookGate) }}
+
+				<form id="participant-consent-form" novalidate>
 				<input id="participant-id" type="hidden">
 				<input id="consent-record-id" type="hidden">
 
@@ -199,7 +209,14 @@
 					}) }}
 				</div>
 			</form>
-		</section>
+			</section>
+
+			{{ SourcebookEvidenceLedger(sourcebookEvidenceLedger) }}
+		</div>
+
+		<div class="participant-consent-workspace__aside">
+			{{ SourcebookContext(sourcebookContext) }}
+		</div>
 	</section>
 </div>
 {% endblock %}

--- a/src/styles/_sourcebook-context.scss
+++ b/src/styles/_sourcebook-context.scss
@@ -10,6 +10,10 @@
 	border-left-color: #d4351c;
 }
 
+.sourcebook-gate--attention {
+	border-left-color: #1d70b8;
+}
+
 .sourcebook-gate--ready {
 	border-left-color: #00703c;
 }
@@ -30,18 +34,29 @@
 	margin-bottom: 15px;
 }
 
-.sourcebook-gate__tag--blocked,
-.sourcebook-gate__check-tag--unmet {
-	background: #d4351c;
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--blocked,
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--attention,
+.sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
 }
 
-.sourcebook-gate__tag--ready,
-.sourcebook-gate__check-tag--met {
+.sourcebook-gate
+	.sourcebook-gate__check--governance-action
+	.govuk-tag.sourcebook-gate__check-tag--unmet {
+	background: #1d70b8;
+	color: #ffffff;
+}
+
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--ready,
+.sourcebook-gate .govuk-tag.sourcebook-gate__check-tag--met {
 	background: #00703c;
+	color: #ffffff;
 }
 
-.sourcebook-gate__tag--not-applicable {
+.sourcebook-gate .govuk-tag.sourcebook-gate__tag--not-applicable {
 	background: #505a5f;
+	color: #ffffff;
 }
 
 .sourcebook-gate__checks {
@@ -204,6 +219,15 @@
 	line-height: 1.25;
 }
 
+.sourcebook-evidence-ledger__evidence-detail {
+	display: block;
+	margin-top: 5px;
+	color: #505a5f;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.25;
+}
+
 .sourcebook-evidence-ledger__clauses {
 	margin-bottom: 0;
 }
@@ -220,11 +244,75 @@
 	white-space: nowrap;
 }
 
-.sourcebook-evidence-ledger__tag--needed {
-	background: #b58840;
-	color: #0b0c0c;
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--needed {
+	background: #1d70b8;
+	color: #ffffff;
 }
 
-.sourcebook-evidence-ledger__tag--present {
+.sourcebook-evidence-ledger .govuk-tag.sourcebook-evidence-ledger__tag--present {
 	background: #00703c;
+	color: #ffffff;
+}
+
+@media (max-width: 760px) {
+	.sourcebook-gate__check {
+		display: block;
+	}
+
+	.sourcebook-gate__check-label,
+	.sourcebook-gate__check-detail {
+		display: block;
+	}
+
+	.sourcebook-gate__check-tag {
+		justify-self: start;
+		margin: 5px 0;
+		white-space: normal;
+	}
+
+	.sourcebook-evidence-ledger__table,
+	.sourcebook-evidence-ledger__table .govuk-table__body,
+	.sourcebook-evidence-ledger__table .govuk-table__row,
+	.sourcebook-evidence-ledger__table .govuk-table__header,
+	.sourcebook-evidence-ledger__table .govuk-table__cell {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+	}
+
+	.sourcebook-evidence-ledger__table .govuk-table__head {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.sourcebook-evidence-ledger__table .govuk-table__row {
+		border-top: 1px solid #b1b4b6;
+		padding: 12px 0;
+	}
+
+	.sourcebook-evidence-ledger__table .govuk-table__header,
+	.sourcebook-evidence-ledger__table .govuk-table__cell {
+		border-bottom: 0;
+		padding: 0 0 10px;
+	}
+
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before,
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 700;
+	}
+
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(1)::before {
+		content: 'Sourcebook clause';
+	}
+
+	.sourcebook-evidence-ledger__table .govuk-table__cell:nth-of-type(2)::before {
+		content: 'Status';
+	}
 }

--- a/src/styles/participant-consent.scss
+++ b/src/styles/participant-consent.scss
@@ -1,4 +1,7 @@
 // prettier-ignore
+@use 'sourcebook-context';
+
+// prettier-ignore
 .participant-consent-page [hidden] {
 	display: none;
 }
@@ -18,7 +21,69 @@
 // prettier-ignore
 .participant-consent-workspace {
 	display: grid;
+	grid-template-columns: minmax(0, 1fr);
 	gap: 24px;
+	align-items: start;
+}
+
+// prettier-ignore
+.participant-consent-workspace__main {
+	display: grid;
+	gap: 24px;
+	min-width: 0;
+	max-width: 100%;
+}
+
+// prettier-ignore
+.participant-consent-workspace__main > * {
+	box-sizing: border-box;
+	min-width: 0;
+	max-width: 100%;
+}
+
+// prettier-ignore
+.participant-consent-workspace__main .sourcebook-evidence-ledger {
+	overflow-x: auto;
+}
+
+// prettier-ignore
+.participant-consent-workspace__mobile-context {
+	display: block;
+}
+
+// prettier-ignore
+.participant-consent-workspace__aside {
+	display: none;
+	min-width: 0;
+}
+
+// prettier-ignore
+.participant-consent-workspace__aside .sourcebook-context {
+	position: sticky;
+	top: 24px;
+	max-width: none;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 16px;
+}
+
+// prettier-ignore
+.participant-consent-workspace__aside .sourcebook-context__clause {
+	display: grid;
+	grid-template-columns: 32px minmax(0, 1fr);
+}
+
+// prettier-ignore
+.participant-consent-workspace__aside .sourcebook-context__title {
+	font-size: 21px;
+	line-height: 1.25;
+}
+
+// prettier-ignore
+.participant-consent-workspace__aside .sourcebook-context__meta,
+.participant-consent-workspace__aside .sourcebook-context__text,
+.participant-consent-workspace__aside .sourcebook-context__condition {
+	overflow-wrap: anywhere;
 }
 
 // prettier-ignore
@@ -44,17 +109,19 @@
 }
 
 // prettier-ignore
-.participant-consent-summary__row {
+.participant-consent-summary__row,
+.participant-consent-summary .govuk-summary-list__row {
 	display: grid;
 	gap: 16px;
-	grid-template-columns: 140px minmax(0, 1fr);
+	grid-template-columns: minmax(150px, 30%) minmax(0, 1fr);
 	align-items: baseline;
 	border-bottom: 0;
 	margin-bottom: 8px;
 }
 
 // prettier-ignore
-.participant-consent-summary__key {
+.participant-consent-summary__key,
+.participant-consent-summary .govuk-summary-list__key {
 	width: auto;
 	margin-bottom: 0;
 	padding: 0;
@@ -62,9 +129,11 @@
 }
 
 // prettier-ignore
-.participant-consent-summary__value {
+.participant-consent-summary__value,
+.participant-consent-summary .govuk-summary-list__value {
 	margin: 0;
 	padding: 0;
+	overflow-wrap: anywhere;
 }
 
 // prettier-ignore
@@ -193,6 +262,24 @@
 	padding: 0;
 }
 
+@media (min-width: 1100px) {
+	// prettier-ignore
+	.participant-consent-workspace {
+		grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+		gap: 32px;
+	}
+
+	// prettier-ignore
+	.participant-consent-workspace__mobile-context {
+		display: none;
+	}
+
+	// prettier-ignore
+	.participant-consent-workspace__aside {
+		display: block;
+	}
+}
+
 @media (max-width: 699px) {
 	// prettier-ignore
 	.participant-consent-page .govuk-heading-l {
@@ -217,6 +304,12 @@
 	}
 
 	// prettier-ignore
+	.participant-consent-workspace__main {
+		display: grid;
+		gap: 18px;
+	}
+
+	// prettier-ignore
 	.participant-consent-panel {
 		position: relative;
 		clear: both;
@@ -226,14 +319,10 @@
 	}
 
 	// prettier-ignore
-	.participant-consent-summary__row {
-		grid-template-columns: minmax(118px, 38%) minmax(0, 1fr);
+	.participant-consent-summary__row,
+	.participant-consent-summary .govuk-summary-list__row {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 		gap: 10px;
-	}
-
-	// prettier-ignore
-	.participant-consent-summary__value {
-		overflow-wrap: anywhere;
 	}
 
 	// prettier-ignore
@@ -378,6 +467,40 @@
 }
 
 @media (max-width: 430px) {
+	// prettier-ignore
+	.participant-consent-summary__row,
+	.participant-consent-summary .govuk-summary-list__row {
+		display: block;
+	}
+
+	// prettier-ignore
+	.participant-consent-summary__key,
+	.participant-consent-summary .govuk-summary-list__key {
+		margin-bottom: 5px;
+	}
+
+	// prettier-ignore
+	.participant-consent-table .govuk-table__header,
+	.participant-consent-table .govuk-table__cell,
+	.participant-consent-table .govuk-table__row > :nth-child(5) {
+		padding: 10px 12px;
+	}
+
+	// prettier-ignore
+	.participant-consent-table .govuk-table__header::before,
+	.participant-consent-table .govuk-table__cell::before,
+	.participant-consent-table .govuk-table__row > .govuk-table__header::before {
+		position: static;
+		display: block;
+		width: auto;
+		margin-bottom: 5px;
+	}
+
+	// prettier-ignore
+	.participant-consent-table .govuk-table__row > .govuk-table__header {
+		display: block;
+	}
+
 	// prettier-ignore
 	.participant-consent-form__actions,
 	.participant-consent-item .govuk-radios--inline {

--- a/tests/participant-consent-route-state.test.js
+++ b/tests/participant-consent-route-state.test.js
@@ -148,6 +148,10 @@ includes(controllerSource, "function updateSourcebookAssurance", "participant co
 includes(controllerSource, "function updateLedgerRow", "participant consent controller");
 includes(controllerSource, "Consent evidence incomplete", "participant consent controller");
 includes(controllerSource, "Consent record for", "participant consent controller");
+includes(controllerSource, "const recordForm = state.consentForms.find(item => item.id === record?.consentFormId);", "participant consent controller");
+includes(controllerSource, "const currentForm = latestPublishedForm();", "participant consent controller");
+includes(controllerSource, "const status = statusForParticipant(participant, record, currentForm);", "participant consent controller");
+includes(controllerSource, "updateSourcebookAssurance(participant, record, currentForm);", "participant consent controller");
 includes(controllerSource, "function statusForParticipant", "participant consent controller");
 includes(controllerSource, "function renderParticipantTable", "participant consent controller");
 includes(controllerSource, "function renderConsentItems", "participant consent controller");

--- a/tests/participant-consent-route-state.test.js
+++ b/tests/participant-consent-route-state.test.js
@@ -90,10 +90,22 @@ includes(pageSource, "Consent Form", "participant consent page");
 includes(pageSource, "Consent Log", "participant consent page");
 includes(pageSource, "Present", "participant consent page");
 includes(pageSource, "Needed", "participant consent page");
+const participantsPanelIndex = pageSource.indexOf("id=\"participants-consent-title\"");
+const consentRecordPanelIndex = pageSource.indexOf("id=\"consent-record-panel\"");
+const evidenceLedgerIndex = pageSource.indexOf("class=\"sourcebook-evidence-ledger\"");
+const workspaceAsideIndex = pageSource.indexOf("participant-consent-workspace__aside");
+
+assert.ok(participantsPanelIndex > -1, "Expected the participant actions panel to be present.");
+assert.ok(consentRecordPanelIndex > -1, "Expected the consent record panel to be present.");
+assert.ok(evidenceLedgerIndex > -1, "Expected the sourcebook evidence ledger to be present.");
+assert.ok(workspaceAsideIndex > -1, "Expected the sourcebook aside to be present.");
 assert.ok(
-	pageSource.indexOf("id=\"consent-record-panel\"") <
-		pageSource.indexOf("class=\"sourcebook-evidence-ledger\""),
-	"Expected the sourcebook evidence ledger to be the last item in the main consent content."
+	participantsPanelIndex < consentRecordPanelIndex && consentRecordPanelIndex < evidenceLedgerIndex,
+	"Expected the sourcebook evidence ledger to follow the participant actions and consent record panels."
+);
+assert.ok(
+	evidenceLedgerIndex < workspaceAsideIndex,
+	"Expected the sourcebook evidence ledger to be the last item in the main consent content before the aside."
 );
 assert.ok(
 	pageSource.indexOf("sourcebook-context--mobile") <

--- a/tests/participant-consent-route-state.test.js
+++ b/tests/participant-consent-route-state.test.js
@@ -7,6 +7,7 @@ const rendererSource = fs.readFileSync("scripts/govuk/render-govuk-pages.mjs", "
 const loaderSource = fs.readFileSync("public/js/participant-consent-route-loader.js", "utf8");
 const controllerSource = fs.readFileSync("public/js/participant-consent-page.js", "utf8");
 const stylesheetSource = fs.readFileSync("src/styles/participant-consent.scss", "utf8");
+const generatedStylesheetSource = fs.readFileSync("public/css/participant-consent.css", "utf8");
 const generatedCssTargetsSource = fs.readFileSync("scripts/styles/generated-css-targets.mjs", "utf8");
 const fieldsSource = fs.readFileSync("infra/cloudflare/src/core/fields.js", "utf8");
 const serviceSource = fs.readFileSync("infra/cloudflare/src/service/participant-consent.js", "utf8");
@@ -35,8 +36,27 @@ for (const macro of [
 	includes(templateSource, macro, "participant consent template");
 }
 
+for (const macro of [
+	"macros/sourcebook-context.njk",
+	"macros/sourcebook-evidence-ledger.njk",
+	"macros/sourcebook-gate.njk",
+	"SourcebookContext(sourcebookContext)",
+	"SourcebookContext(sourcebookMobileContext)",
+	"SourcebookEvidenceLedger(sourcebookEvidenceLedger)",
+	"SourcebookGate(sourcebookGate)"
+]) {
+	includes(templateSource, macro, "participant consent template");
+}
+
 includes(rendererSource, "template: 'pages/study-participant-consent.njk'", "GOV.UK renderer");
 includes(rendererSource, "output: 'public/pages/study/participant-consent/index.html'", "GOV.UK renderer");
+includes(rendererSource, "route: '/pages/study/participant-consent/'", "GOV.UK renderer");
+includes(rendererSource, "condition: 'participant-consent-recording'", "GOV.UK renderer");
+includes(rendererSource, "providedEvidence: ['consent-form']", "GOV.UK renderer");
+includes(rendererSource, "Why this page is governed", "GOV.UK renderer");
+includes(rendererSource, "Consent evidence", "GOV.UK renderer");
+includes(rendererSource, "Consent assurance requirements", "GOV.UK renderer");
+includes(rendererSource, "Consent evidence incomplete", "GOV.UK renderer");
 
 includes(pageSource, "Participant consent - ResearchOps Demo Suite", "participant consent page");
 includes(pageSource, "href=\"/assets/govuk/govuk-frontend.css\"", "participant consent page");
@@ -55,6 +75,31 @@ includes(pageSource, "id=\"participant-consent-form\"", "participant consent pag
 includes(pageSource, "id=\"consent-form-select\"", "participant consent page");
 includes(pageSource, "name=\"consentFormId\"", "participant consent page");
 includes(pageSource, "Form version", "participant consent page");
+includes(pageSource, "participant-consent-workspace__main", "participant consent page");
+includes(pageSource, "participant-consent-workspace__aside", "participant consent page");
+includes(pageSource, "Consent summary", "participant consent page");
+includes(pageSource, "Ready for session", "participant consent page");
+includes(pageSource, "Consent not complete", "participant consent page");
+includes(pageSource, "Why this page is governed", "participant consent page");
+includes(pageSource, "Consent evidence", "participant consent page");
+includes(pageSource, "Consent assurance requirements", "participant consent page");
+includes(pageSource, "Consent evidence incomplete", "participant consent page");
+includes(pageSource, "REC-ADMN 3.1.1", "participant consent page");
+includes(pageSource, "Record informed consent before research participation", "participant consent page");
+includes(pageSource, "Consent Form", "participant consent page");
+includes(pageSource, "Consent Log", "participant consent page");
+includes(pageSource, "Present", "participant consent page");
+includes(pageSource, "Needed", "participant consent page");
+assert.ok(
+	pageSource.indexOf("id=\"consent-record-panel\"") <
+		pageSource.indexOf("class=\"sourcebook-evidence-ledger\""),
+	"Expected the sourcebook evidence ledger to be the last item in the main consent content."
+);
+assert.ok(
+	pageSource.indexOf("sourcebook-context--mobile") <
+		pageSource.indexOf("id=\"participants-consent-title\""),
+	"Expected the mobile Sourcebook context to appear before participant actions."
+);
 includes(pageSource, "id=\"capture-method\"", "participant consent page");
 includes(pageSource, "id=\"consent-withdrawn\"", "participant consent page");
 includes(pageSource, "id=\"withdrawal-reason\"", "participant consent page");
@@ -69,11 +114,28 @@ excludes(loaderSource, "study-canonical-url-bridge", "participant consent route 
 
 includes(generatedCssTargetsSource, "source: 'src/styles/participant-consent.scss'", "generated CSS targets");
 includes(generatedCssTargetsSource, "output: 'public/css/participant-consent.css'", "generated CSS targets");
+includes(stylesheetSource, "@use 'sourcebook-context';", "participant consent stylesheet");
+includes(stylesheetSource, ".participant-consent-workspace__mobile-context", "participant consent stylesheet");
+includes(stylesheetSource, ".participant-consent-workspace__aside .sourcebook-context", "participant consent stylesheet");
+includes(stylesheetSource, "@media (min-width: 1100px)", "participant consent stylesheet");
+includes(stylesheetSource, "grid-template-columns: minmax(0, 1fr) minmax(280px, 360px)", "participant consent stylesheet");
+includes(stylesheetSource, "grid-template-columns: minmax(0, 1fr);", "participant consent stylesheet");
+includes(stylesheetSource, "grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);", "participant consent stylesheet");
+includes(stylesheetSource, ".participant-consent-summary .govuk-summary-list__row {\n\t\tdisplay: block;", "participant consent stylesheet");
+includes(stylesheetSource, ".participant-consent-table .govuk-table__row > .govuk-table__header {\n\t\tdisplay: block;", "participant consent stylesheet");
 includes(stylesheetSource, ".participant-consent-page .govuk-select", "participant consent stylesheet");
 includes(stylesheetSource, ".participant-consent-withdrawal .govuk-checkboxes__item", "participant consent stylesheet");
 excludes(stylesheetSource, ".participant-consent-tag--warning", "participant consent stylesheet");
+includes(generatedStylesheetSource, ".sourcebook-context", "participant consent stylesheet");
+includes(generatedStylesheetSource, ".sourcebook-evidence-ledger", "participant consent stylesheet");
+includes(generatedStylesheetSource, ".sourcebook-gate", "participant consent stylesheet");
+includes(generatedStylesheetSource, ".sourcebook-gate--attention", "participant consent stylesheet");
 
 includes(controllerSource, "resolveStudyContextFromUrl", "participant consent controller");
+includes(controllerSource, "function updateSourcebookAssurance", "participant consent controller");
+includes(controllerSource, "function updateLedgerRow", "participant consent controller");
+includes(controllerSource, "Consent evidence incomplete", "participant consent controller");
+includes(controllerSource, "Consent record for", "participant consent controller");
 includes(controllerSource, "function statusForParticipant", "participant consent controller");
 includes(controllerSource, "function renderParticipantTable", "participant consent controller");
 includes(controllerSource, "function renderConsentItems", "participant consent controller");

--- a/tests/search-page-route-state.test.js
+++ b/tests/search-page-route-state.test.js
@@ -51,6 +51,9 @@ includes(templateSource, "govuk/components/button/macro.njk", "search template")
 includes(templateSource, "govukInput({", "search template");
 includes(templateSource, "govukSelect({", "search template");
 includes(templateSource, "govukButton({", "search template");
+excludes(templateSource, "SourcebookGate(sourcebookGate)", "search template");
+excludes(templateSource, "SourcebookContext(sourcebookContext)", "search template");
+excludes(templateSource, "SourcebookEvidenceLedger(sourcebookEvidenceLedger)", "search template");
 includes(rendererSource, "template: 'pages/search.njk'", "GOV.UK page renderer");
 includes(rendererSource, "output: 'public/pages/search/index.html'", "GOV.UK page renderer");
 includes(generatedCssTargetsSource, "name: 'Search utility route stylesheet'", "generated CSS targets");

--- a/tests/sourcebook-context-route-state.test.js
+++ b/tests/sourcebook-context-route-state.test.js
@@ -19,13 +19,13 @@ function includes(source, text, label) {
 test('SourcebookContext macro renders clause context from typed items', () => {
 	for (const text of [
 		'{% macro SourcebookContext(params) %}',
-		'class="sourcebook-context"',
+		'class="sourcebook-context {{ params.classes | default',
 		'aria-labelledby="{{ params.id | default',
-		'Sourcebook',
+		"params.caption | default('Sourcebook')",
 		'item.typeNotation',
 		'item.typeLabel',
 		'item.href',
-		'Applies when:',
+		"params.conditionLabel | default('Applies when:')",
 	]) {
 		includes(macroSource, text, 'SourcebookContext macro');
 	}
@@ -52,8 +52,10 @@ test('GOV.UK data layer resolves shared route mappings for pages', () => {
 test('SourcebookEvidenceLedger macro renders evidence rows from clauses', () => {
 	for (const text of [
 		'{% macro SourcebookEvidenceLedger(params) %}',
-		'class="sourcebook-evidence-ledger"',
-		'Evidence ledger',
+		'class="sourcebook-evidence-ledger {{ params.classes | default',
+		"params.caption | default('Evidence ledger')",
+		'data-sourcebook-evidence-id',
+		'item.detail',
 		'item.statusLabel',
 		'item.label',
 		'item.id',
@@ -67,8 +69,10 @@ test('SourcebookEvidenceLedger macro renders evidence rows from clauses', () => 
 test('SourcebookGate macro renders a decision from context and evidence checks', () => {
 	for (const text of [
 		'{% macro SourcebookGate(params) %}',
-		'class="sourcebook-gate sourcebook-gate--{{ params.status }}"',
-		'Sourcebook gate',
+		'class="sourcebook-gate sourcebook-gate--{{ params.status }} {{ params.classes | default',
+		"params.caption | default('Sourcebook gate')",
+		'data-sourcebook-gate',
+		'data-sourcebook-check',
 		'params.statusLabel',
 		'params.primaryAction',
 		'params.checks',
@@ -95,6 +99,7 @@ test('API and Nunjucks use the same route-to-clause mapping source', () => {
 
 	for (const expectedMapping of [
 		['/pages/consent/', 'REC-ADMN 3.1.1', 'consent-review'],
+		['/pages/study/participant-consent/', 'REC-ADMN 3.1.1', 'participant-consent-recording'],
 		['/pages/account/team-access/', 'INFRA-PROV 3.1.1', 'access-change'],
 		['/pages/team/role-assignments/', 'INFRA-PROV 3.1.1', 'permission-model-change'],
 	]) {

--- a/tests/sourcebook-context-route-state.test.js
+++ b/tests/sourcebook-context-route-state.test.js
@@ -19,7 +19,7 @@ function includes(source, text, label) {
 test('SourcebookContext macro renders clause context from typed items', () => {
 	for (const text of [
 		'{% macro SourcebookContext(params) %}',
-		'class="sourcebook-context {{ params.classes | default',
+		'class="sourcebook-context{% if params.classes %} {{ params.classes }}{% endif %}"',
 		'aria-labelledby="{{ params.id | default',
 		"params.caption | default('Sourcebook')",
 		'item.typeNotation',
@@ -52,7 +52,7 @@ test('GOV.UK data layer resolves shared route mappings for pages', () => {
 test('SourcebookEvidenceLedger macro renders evidence rows from clauses', () => {
 	for (const text of [
 		'{% macro SourcebookEvidenceLedger(params) %}',
-		'class="sourcebook-evidence-ledger {{ params.classes | default',
+		'class="sourcebook-evidence-ledger{% if params.classes %} {{ params.classes }}{% endif %}"',
 		"params.caption | default('Evidence ledger')",
 		'data-sourcebook-evidence-id',
 		'item.detail',
@@ -69,7 +69,7 @@ test('SourcebookEvidenceLedger macro renders evidence rows from clauses', () => 
 test('SourcebookGate macro renders a decision from context and evidence checks', () => {
 	for (const text of [
 		'{% macro SourcebookGate(params) %}',
-		'class="sourcebook-gate sourcebook-gate--{{ params.status }} {{ params.classes | default',
+		'class="sourcebook-gate sourcebook-gate--{{ params.status }}{% if params.classes %} {{ params.classes }}{% endif %}"',
 		"params.caption | default('Sourcebook gate')",
 		'data-sourcebook-gate',
 		'data-sourcebook-check',


### PR DESCRIPTION
## Summary
- add Sourcebook context, evidence ledger and gate to the manage participant consent page
- connect participant consent route mapping to REC-ADMN 3.1.1 and update gate/ledger state from participant consent data
- refine responsive Sourcebook and consent layouts for desktop rail, tablet stacking and mobile label/value stacking
- regenerate GOV.UK pages and generated CSS outputs

## Validation
- npm run build:generated-css
- npm run build:govuk-pages
- focused route-state/API tests: 27 passed
- Playwright rendered checks at 1272x739, 1100x900, 900x900, 700x900, 470x858, 390x858 and 319x858
- supported-file Prettier check
- npm run trace:coverage
- git diff --check
- npm run validate

## Audit trace
- docs/agent-audit/reasoning/2026/07/04/manage-participant-consent-sourcebook-pr-trace.md