### PR TITLE
Fix sign-in origin allowlist for ResearchOps custom domains

### DIFF
--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -90,6 +90,12 @@ import { recordProvenanceEvent } from "./provenance.js";
  * @property {string} [MURAL_REFLEXIVE_MURAL_ID]
  */
 
+const RESEARCHOPS_CUSTOM_ORIGINS = new Set([
+	"https://research-operations.com",
+	"https://www.research-operations.com",
+	"https://govuk.research-operations.com"
+]);
+
 function corsHeaders(env, origin) {
 	const allowed = (env.ALLOWED_ORIGINS || "")
 		.split(",")
@@ -100,7 +106,7 @@ function corsHeaders(env, origin) {
 		"Access-Control-Allow-Headers": "Content-Type, Authorization",
 		"Vary": "Origin"
 	};
-	if (origin && allowed.includes(origin)) h["Access-Control-Allow-Origin"] = origin;
+	if (origin && (allowed.includes(origin) || RESEARCHOPS_CUSTOM_ORIGINS.has(origin))) h["Access-Control-Allow-Origin"] = origin;
 	return h;
 }
 

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -31,6 +31,16 @@ function authErrorResponse(error) {
 	});
 }
 
+const RESEARCHOPS_CUSTOM_ORIGINS = new Set([
+	"https://research-operations.com",
+	"https://www.research-operations.com",
+	"https://govuk.research-operations.com"
+]);
+
+function isResearchOpsCustomDomainOrigin(origin) {
+	return RESEARCHOPS_CUSTOM_ORIGINS.has(origin);
+}
+
 function isResearchOpsPagesOrigin(origin) {
 	try {
 		const { hostname, protocol } = new URL(origin);
@@ -62,6 +72,7 @@ function resolveAllowedOrigin(env, request) {
 		const list = Array.isArray(raw) ? raw : String(raw || "").split(",").map(s => s.trim()).filter(Boolean);
 		if (!origin) return "*";
 		if (list.includes(origin)) return origin;
+		if (isResearchOpsCustomDomainOrigin(origin)) return origin;
 		if (isResearchOpsPagesOrigin(origin)) return origin;
 		if (isAllowedPreviewPagesOrigin(env, origin)) return origin;
 		return "null";
@@ -75,7 +86,7 @@ function isAllowedRequestOrigin(env, request) {
 	if (!origin) return true;
 	const raw = env.ALLOWED_ORIGINS;
 	const list = Array.isArray(raw) ? raw : String(raw || "").split(",").map(s => s.trim()).filter(Boolean);
-	return list.includes(origin) || isResearchOpsPagesOrigin(origin) || isAllowedPreviewPagesOrigin(env, origin);
+	return list.includes(origin) || isResearchOpsCustomDomainOrigin(origin) || isResearchOpsPagesOrigin(origin) || isAllowedPreviewPagesOrigin(env, origin);
 }
 
 function buildCorsHeaders(env, request) {

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -35,7 +35,7 @@ RESEARCHOPS_ALLOW_PAGES_PREVIEW_ORIGINS = "false"
 RESEARCHOPS_RETENTION_ENFORCEMENT_ENABLED = "true"
 RESEARCHOPS_RETENTION_GRACE_DAYS = "7"
 
-ALLOWED_ORIGINS = "https://researchops.pages.dev,https://rops-api.digikev-kevin-rapley.workers.dev,https://reops-sourcebook.pages.dev"
+ALLOWED_ORIGINS = "https://researchops.pages.dev,https://research-operations.com,https://www.research-operations.com,https://govuk.research-operations.com,https://rops-api.digikev-kevin-rapley.workers.dev,https://reops-sourcebook.pages.dev"
 
 # Airtable tables
 AIRTABLE_TABLE_AI_LOG            = "AI_Usage"

--- a/tests/worker-cors-origin-policy.test.js
+++ b/tests/worker-cors-origin-policy.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+import worker from '../infra/cloudflare/src/worker.js';
+
+const wrangler = fs.readFileSync('infra/cloudflare/wrangler.toml', 'utf8');
+
+const researchOpsCustomOrigins = [
+	'https://research-operations.com',
+	'https://www.research-operations.com',
+	'https://govuk.research-operations.com',
+];
+
+async function preflight(origin, env = {}) {
+	return worker.fetch(
+		new Request('https://rops-api.digikev-kevin-rapley.workers.dev/api/auth/email/start', {
+			method: 'OPTIONS',
+			headers: {
+				Origin: origin,
+				'Access-Control-Request-Method': 'POST',
+			},
+		}),
+		{
+			ALLOWED_ORIGINS: '',
+			RESEARCHOPS_ALLOW_PAGES_PREVIEW_ORIGINS: 'false',
+			...env,
+		},
+		{ waitUntil() {} }
+	);
+}
+
+function assertProductionConfigAllowsCustomDomains() {
+	for (const origin of researchOpsCustomOrigins) {
+		assert.match(wrangler, new RegExp(origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+	}
+}
+
+async function assertWorkerAllowsCustomDomainsWithoutConfigDrift() {
+	for (const origin of researchOpsCustomOrigins) {
+		const response = await preflight(origin);
+		assert.equal(response.status, 204);
+		assert.equal(response.headers.get('access-control-allow-origin'), origin);
+		assert.equal(response.headers.get('access-control-allow-credentials'), 'true');
+	}
+}
+
+async function assertWorkerRejectsUnknownBrowserOrigins() {
+	const response = await preflight('https://example.com');
+	assert.equal(response.status, 204);
+	assert.equal(response.headers.get('access-control-allow-origin'), 'null');
+}
+
+assertProductionConfigAllowsCustomDomains();
+await assertWorkerAllowsCustomDomainsWithoutConfigDrift();
+await assertWorkerRejectsUnknownBrowserOrigins();


### PR DESCRIPTION
## Summary
- allow ResearchOps custom domains in the production Worker origin allowlist
- add Worker runtime fallback for the ResearchOps public domains if config drifts
- add a regression test for the sign-in preflight origin policy

## Validation
- npm test -- tests/worker-cors-origin-policy.test.js
- node tests/auth-sign-in-route-state.test.js
- node tests/security-hardening-controls-route-state.test.js
- npm run format:check
- npm run lint

## Production note
Before the fix, the live Worker preflight for https://research-operations.com returned access-control-allow-origin: null, which matches the reported sign-in error.