### PR TITLE
Fix sign-in origin allowlist for ResearchOps custom domains

### DIFF
--- a/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.json
+++ b/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-07-04",
+  "branch": "fix/sign-in-origin",
+  "task": "Fix the production sign-in error where https://research-operations.com/pages/account/sign-in/ reported that the request origin was not allowed.",
+  "traceLayer": "operational",
+  "operatingModel": {
+    "loaded": [
+      "AGENTS.md",
+      ".agent-operating-model/orchestration.xml",
+      ".agent-operating-model/bundle-registry.json",
+      ".agent-operating-model/task-signal-catalog.json",
+      ".agent-operating-model/selection-rules.json",
+      ".agent-operating-model/precedence-policy.md",
+      ".agent-operating-model/github-mutation-policy.md",
+      ".agent-operating-model/trace-policy.md",
+      ".agent-operating-model/trace-layers.md"
+    ],
+    "selectedBundles": [
+      ".agent-operating-model/bundles/github/",
+      ".agent-operating-model/bundles/researchops-developer-control/",
+      ".agent-operating-model/bundles/multi-functional-team/",
+      ".agent-operating-model/bundles/cloudflare/",
+      ".agent-operating-model/bundles/govuk-design-system/"
+    ],
+    "skippedBundles": [
+      ".agent-operating-model/bundles/openai/",
+      ".agent-operating-model/bundles/mcp-agent-tooling/",
+      ".agent-operating-model/bundles/airtable-public-api/",
+      ".agent-operating-model/bundles/mural-public-api/"
+    ],
+    "traceDecision": "Trace required because the repository-affecting work is on fix/sign-in-origin."
+  },
+  "branchGovernance": {
+    "initialBranch": "hotfix/sign-in-origin",
+    "correctedBranch": "fix/sign-in-origin",
+    "supersededPullRequest": 465,
+    "reason": "User clarified the branch must use the fix/ prefix."
+  },
+  "evidence": [
+    "Live production Worker preflight returned access-control-allow-origin: null for https://research-operations.com.",
+    "Production wrangler.toml did not include ResearchOps public custom domains in ALLOWED_ORIGINS.",
+    "Worker trusted mutation checks rely on the request Origin being allowed."
+  ],
+  "changes": [
+    "Added ResearchOps public custom domains to production ALLOWED_ORIGINS.",
+    "Added Worker fallback for the same custom domains.",
+    "Added service CORS fallback for the same custom domains.",
+    "Added a regression test for sign-in preflight origin policy."
+  ],
+  "filesChanged": [
+    "infra/cloudflare/wrangler.toml",
+    "infra/cloudflare/src/worker.js",
+    "infra/cloudflare/src/service/index.js",
+    "tests/worker-cors-origin-policy.test.js",
+    "docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.md",
+    "docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.json"
+  ],
+  "validation": [
+    {
+      "command": "npm test -- tests/worker-cors-origin-policy.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "node tests/auth-sign-in-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "node tests/security-hardening-controls-route-state.test.js",
+      "result": "passed"
+    },
+    {
+      "command": "npm run format:check",
+      "result": "passed"
+    },
+    {
+      "command": "npm run lint",
+      "result": "passed",
+      "details": "Existing warnings only, no errors."
+    }
+  ],
+  "residualRisk": [
+    "The live production site will continue to reject the custom domain until the corrected Worker is deployed.",
+    "Full GitHub CI remains the merge gate."
+  ]
+}

--- a/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.json
+++ b/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.json
@@ -45,7 +45,8 @@
     "Added ResearchOps public custom domains to production ALLOWED_ORIGINS.",
     "Added Worker fallback for the same custom domains.",
     "Added service CORS fallback for the same custom domains.",
-    "Added a regression test for sign-in preflight origin policy."
+    "Added a regression test for sign-in preflight origin policy.",
+    "Addressed two GitHub Advanced Security review threads by replacing the test's dynamically constructed regular expression with exact string inclusion checks."
   ],
   "filesChanged": [
     "infra/cloudflare/wrangler.toml",
@@ -76,6 +77,10 @@
       "command": "npm run lint",
       "result": "passed",
       "details": "Existing warnings only, no errors."
+    },
+    {
+      "command": "npm run trace:coverage -- --date 2026-07-04",
+      "result": "passed"
     }
   ],
   "residualRisk": [

--- a/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.md
+++ b/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.md
@@ -53,6 +53,7 @@ Skipped:
 - Added Worker runtime fallback for those public ResearchOps custom domains so sign-in preflight and mutation checks remain allowed if config drifts.
 - Added service CORS fallback for the same custom domains.
 - Added a regression test that checks the production config includes the public domains, the Worker allows those origins for sign-in preflight, and an unknown origin remains rejected.
+- Addressed two GitHub Advanced Security review threads by replacing the test's dynamically constructed regular expression with exact string inclusion checks.
 
 ## Files Changed
 
@@ -70,6 +71,7 @@ Skipped:
 - `node tests/security-hardening-controls-route-state.test.js` passed.
 - `npm run format:check` passed.
 - `npm run lint` passed with existing warnings and no errors.
+- `npm run trace:coverage -- --date 2026-07-04` passed.
 
 ## Residual Risk
 

--- a/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.md
+++ b/docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.md
@@ -1,0 +1,77 @@
+# Sign-In Origin Allowlist Fix Trace
+
+Date: 2026-07-04
+Branch: `fix/sign-in-origin`
+Task: Fix the production sign-in error where `https://research-operations.com/pages/account/sign-in/` reported that the request origin was not allowed.
+
+## Operating Model Bootstrap
+
+- Loaded `AGENTS.md`.
+- Loaded `.agent-operating-model/orchestration.xml`.
+- Loaded `.agent-operating-model/bundle-registry.json`.
+- Loaded `.agent-operating-model/task-signal-catalog.json`.
+- Loaded `.agent-operating-model/selection-rules.json`.
+- Loaded `.agent-operating-model/precedence-policy.md`.
+- Loaded `.agent-operating-model/github-mutation-policy.md`.
+- Loaded `.agent-operating-model/trace-policy.md`.
+- Loaded `.agent-operating-model/trace-layers.md`.
+- Verified selected bundle directories contain `prompt.spec.yaml` and `prompt.body.xml`.
+
+## Selected Bundles
+
+- `.agent-operating-model/bundles/github/`
+- `.agent-operating-model/bundles/researchops-developer-control/`
+- `.agent-operating-model/bundles/multi-functional-team/`
+- `.agent-operating-model/bundles/cloudflare/`
+- `.agent-operating-model/bundles/govuk-design-system/`
+
+Skipped:
+
+- `.agent-operating-model/bundles/openai/`: no OpenAI API or model integration change.
+- `.agent-operating-model/bundles/mcp-agent-tooling/`: no MCP protocol, tool or resource change.
+- `.agent-operating-model/bundles/airtable-public-api/`: no Airtable API integration change.
+- `.agent-operating-model/bundles/mural-public-api/`: no Mural API integration change.
+
+## Branch Governance
+
+- Initial operational repair was isolated on `hotfix/sign-in-origin` from `origin/main` to avoid mixing with existing local feature work.
+- PR #465 was opened from `hotfix/sign-in-origin`.
+- The user clarified the branch must use `fix/`.
+- The local branch was renamed to `fix/sign-in-origin`.
+- Trace is required because the final branch starts with `fix/`.
+- PR #465 is superseded by the corrected `fix/` branch PR.
+
+## Evidence
+
+- Live preflight check against the production Worker returned `access-control-allow-origin: null` for `https://research-operations.com`.
+- `infra/cloudflare/wrangler.toml` allowed `https://researchops.pages.dev`, the Worker origin and Sourcebook origin, but did not include the public ResearchOps custom domains.
+- The sign-in page posts to `/api/auth/email/start`; Worker CORS and trusted mutation checks use `ALLOWED_ORIGINS` and custom origin helpers.
+
+## Implementation Summary
+
+- Added `https://research-operations.com`, `https://www.research-operations.com` and `https://govuk.research-operations.com` to production `ALLOWED_ORIGINS`.
+- Added Worker runtime fallback for those public ResearchOps custom domains so sign-in preflight and mutation checks remain allowed if config drifts.
+- Added service CORS fallback for the same custom domains.
+- Added a regression test that checks the production config includes the public domains, the Worker allows those origins for sign-in preflight, and an unknown origin remains rejected.
+
+## Files Changed
+
+- `infra/cloudflare/wrangler.toml`
+- `infra/cloudflare/src/worker.js`
+- `infra/cloudflare/src/service/index.js`
+- `tests/worker-cors-origin-policy.test.js`
+- `docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.md`
+- `docs/agent-audit/reasoning/2026/07/04/sign-in-origin-allowlist-fix.json`
+
+## Validation
+
+- `npm test -- tests/worker-cors-origin-policy.test.js` passed.
+- `node tests/auth-sign-in-route-state.test.js` passed.
+- `node tests/security-hardening-controls-route-state.test.js` passed.
+- `npm run format:check` passed.
+- `npm run lint` passed with existing warnings and no errors.
+
+## Residual Risk
+
+- The live production site will continue to reject the custom domain until the corrected Worker is deployed.
+- Full GitHub CI remains the merge gate.

--- a/infra/cloudflare/src/service/index.js
+++ b/infra/cloudflare/src/service/index.js
@@ -90,6 +90,12 @@ import { recordProvenanceEvent } from "./provenance.js";
  * @property {string} [MURAL_REFLEXIVE_MURAL_ID]
  */
 
+const RESEARCHOPS_CUSTOM_ORIGINS = new Set([
+	"https://research-operations.com",
+	"https://www.research-operations.com",
+	"https://govuk.research-operations.com"
+]);
+
 function corsHeaders(env, origin) {
 	const allowed = (env.ALLOWED_ORIGINS || "")
 		.split(",")
@@ -100,7 +106,7 @@ function corsHeaders(env, origin) {
 		"Access-Control-Allow-Headers": "Content-Type, Authorization",
 		"Vary": "Origin"
 	};
-	if (origin && allowed.includes(origin)) h["Access-Control-Allow-Origin"] = origin;
+	if (origin && (allowed.includes(origin) || RESEARCHOPS_CUSTOM_ORIGINS.has(origin))) h["Access-Control-Allow-Origin"] = origin;
 	return h;
 }
 

--- a/infra/cloudflare/src/worker.js
+++ b/infra/cloudflare/src/worker.js
@@ -31,6 +31,16 @@ function authErrorResponse(error) {
 	});
 }
 
+const RESEARCHOPS_CUSTOM_ORIGINS = new Set([
+	"https://research-operations.com",
+	"https://www.research-operations.com",
+	"https://govuk.research-operations.com"
+]);
+
+function isResearchOpsCustomDomainOrigin(origin) {
+	return RESEARCHOPS_CUSTOM_ORIGINS.has(origin);
+}
+
 function isResearchOpsPagesOrigin(origin) {
 	try {
 		const { hostname, protocol } = new URL(origin);
@@ -62,6 +72,7 @@ function resolveAllowedOrigin(env, request) {
 		const list = Array.isArray(raw) ? raw : String(raw || "").split(",").map(s => s.trim()).filter(Boolean);
 		if (!origin) return "*";
 		if (list.includes(origin)) return origin;
+		if (isResearchOpsCustomDomainOrigin(origin)) return origin;
 		if (isResearchOpsPagesOrigin(origin)) return origin;
 		if (isAllowedPreviewPagesOrigin(env, origin)) return origin;
 		return "null";
@@ -75,7 +86,7 @@ function isAllowedRequestOrigin(env, request) {
 	if (!origin) return true;
 	const raw = env.ALLOWED_ORIGINS;
 	const list = Array.isArray(raw) ? raw : String(raw || "").split(",").map(s => s.trim()).filter(Boolean);
-	return list.includes(origin) || isResearchOpsPagesOrigin(origin) || isAllowedPreviewPagesOrigin(env, origin);
+	return list.includes(origin) || isResearchOpsCustomDomainOrigin(origin) || isResearchOpsPagesOrigin(origin) || isAllowedPreviewPagesOrigin(env, origin);
 }
 
 function buildCorsHeaders(env, request) {

--- a/infra/cloudflare/wrangler.toml
+++ b/infra/cloudflare/wrangler.toml
@@ -35,7 +35,7 @@ RESEARCHOPS_ALLOW_PAGES_PREVIEW_ORIGINS = "false"
 RESEARCHOPS_RETENTION_ENFORCEMENT_ENABLED = "true"
 RESEARCHOPS_RETENTION_GRACE_DAYS = "7"
 
-ALLOWED_ORIGINS = "https://researchops.pages.dev,https://rops-api.digikev-kevin-rapley.workers.dev,https://reops-sourcebook.pages.dev"
+ALLOWED_ORIGINS = "https://researchops.pages.dev,https://research-operations.com,https://www.research-operations.com,https://govuk.research-operations.com,https://rops-api.digikev-kevin-rapley.workers.dev,https://reops-sourcebook.pages.dev"
 
 # Airtable tables
 AIRTABLE_TABLE_AI_LOG            = "AI_Usage"

--- a/tests/worker-cors-origin-policy.test.js
+++ b/tests/worker-cors-origin-policy.test.js
@@ -31,7 +31,7 @@ async function preflight(origin, env = {}) {
 
 function assertProductionConfigAllowsCustomDomains() {
 	for (const origin of researchOpsCustomOrigins) {
-		assert.match(wrangler, new RegExp(origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+		assert.equal(wrangler.includes(origin), true);
 	}
 }
 

--- a/tests/worker-cors-origin-policy.test.js
+++ b/tests/worker-cors-origin-policy.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+import worker from '../infra/cloudflare/src/worker.js';
+
+const wrangler = fs.readFileSync('infra/cloudflare/wrangler.toml', 'utf8');
+
+const researchOpsCustomOrigins = [
+	'https://research-operations.com',
+	'https://www.research-operations.com',
+	'https://govuk.research-operations.com',
+];
+
+async function preflight(origin, env = {}) {
+	return worker.fetch(
+		new Request('https://rops-api.digikev-kevin-rapley.workers.dev/api/auth/email/start', {
+			method: 'OPTIONS',
+			headers: {
+				Origin: origin,
+				'Access-Control-Request-Method': 'POST',
+			},
+		}),
+		{
+			ALLOWED_ORIGINS: '',
+			RESEARCHOPS_ALLOW_PAGES_PREVIEW_ORIGINS: 'false',
+			...env,
+		},
+		{ waitUntil() {} }
+	);
+}
+
+function assertProductionConfigAllowsCustomDomains() {
+	for (const origin of researchOpsCustomOrigins) {
+		assert.match(wrangler, new RegExp(origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+	}
+}
+
+async function assertWorkerAllowsCustomDomainsWithoutConfigDrift() {
+	for (const origin of researchOpsCustomOrigins) {
+		const response = await preflight(origin);
+		assert.equal(response.status, 204);
+		assert.equal(response.headers.get('access-control-allow-origin'), origin);
+		assert.equal(response.headers.get('access-control-allow-credentials'), 'true');
+	}
+}
+
+async function assertWorkerRejectsUnknownBrowserOrigins() {
+	const response = await preflight('https://example.com');
+	assert.equal(response.status, 204);
+	assert.equal(response.headers.get('access-control-allow-origin'), 'null');
+}
+
+assertProductionConfigAllowsCustomDomains();
+await assertWorkerAllowsCustomDomainsWithoutConfigDrift();
+await assertWorkerRejectsUnknownBrowserOrigins();


### PR DESCRIPTION
## Summary
- allow ResearchOps custom domains in the production Worker origin allowlist
- add Worker and service runtime fallback for the ResearchOps public domains if config drifts
- add a regression test for the sign-in preflight origin policy
- add the required audit trace for the fix/ branch

## Validation
- npm test -- tests/worker-cors-origin-policy.test.js
- node tests/auth-sign-in-route-state.test.js
- node tests/security-hardening-controls-route-state.test.js
- npm run format:check
- npm run lint
- npm run trace:coverage -- --date 2026-07-04

## Production note
Before the fix, the live Worker preflight for https://research-operations.com returned access-control-allow-origin: null, which matches the reported sign-in error.

Supersedes PR #465, which used the wrong branch prefix.