### PR TITLE
Fix production R2 bucket provisioning for ethics submission documents

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -137,7 +137,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          npx --yes wrangler@${WRANGLER_VERSION} r2 bucket list --json > r2-buckets.json
+          curl -sS \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets" \
+            > r2-buckets.json
           python - <<'PY'
           import json
           import os
@@ -145,8 +148,10 @@ jobs:
 
           target_name = os.environ["DOCUMENTS_R2_BUCKET"]
           data = json.loads(Path("r2-buckets.json").read_text())
-          buckets = data.get("result") if isinstance(data, dict) else data
-          exists = any(bucket.get("name") == target_name for bucket in buckets or [])
+          if not data.get("success", False):
+              raise RuntimeError(f"Cloudflare API error listing R2 buckets: {data.get('errors')}")
+          buckets = (data.get("result") or {}).get("buckets") or []
+          exists = any(bucket.get("name") == target_name for bucket in buckets)
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
               env_file.write(f"NEED_CREATE_DOCUMENTS_R2_BUCKET={'false' if exists else 'true'}\n")
@@ -474,7 +479,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          npx --yes wrangler@${WRANGLER_VERSION} r2 bucket list --json > r2-buckets.json
+          curl -sS \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets" \
+            > r2-buckets.json
           python - <<'PY'
           import json
           import os
@@ -482,8 +490,10 @@ jobs:
 
           target_name = os.environ["DOCUMENTS_R2_PREVIEW_BUCKET"]
           data = json.loads(Path("r2-buckets.json").read_text())
-          buckets = data.get("result") if isinstance(data, dict) else data
-          exists = any(bucket.get("name") == target_name for bucket in buckets or [])
+          if not data.get("success", False):
+              raise RuntimeError(f"Cloudflare API error listing R2 buckets: {data.get('errors')}")
+          buckets = (data.get("result") or {}).get("buckets") or []
+          exists = any(bucket.get("name") == target_name for bucket in buckets)
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
               env_file.write(f"NEED_CREATE_DOCUMENTS_R2_PREVIEW_BUCKET={'false' if exists else 'true'}\n")

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -137,8 +137,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          curl -sS \
+          curl -sS -G \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --data-urlencode "name_contains=${DOCUMENTS_R2_BUCKET}" \
+            --data-urlencode "per_page=50" \
             "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets" \
             > r2-buckets.json
           python - <<'PY'
@@ -479,8 +481,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          curl -sS \
+          curl -sS -G \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --data-urlencode "name_contains=${DOCUMENTS_R2_PREVIEW_BUCKET}" \
+            --data-urlencode "per_page=50" \
             "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets" \
             > r2-buckets.json
           python - <<'PY'

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -32,6 +32,8 @@ env:
   WRANGLER_PREVIEW_CONFIG: "infra/cloudflare/wrangler.preview.toml"
   D1_DATABASE_NAME: "researchops-d1"
   D1_PREVIEW_DATABASE_NAME: "researchops-d1-preview"
+  DOCUMENTS_R2_BUCKET: "researchops-documents"
+  DOCUMENTS_R2_PREVIEW_BUCKET: "researchops-documents-preview"
   AUTH_FOUNDATION_MIGRATION: "infra/cloudflare/migrations/0001_auth_foundation.sql"
   ROLE_ASSIGNMENT_ROUTE_MIGRATION: "infra/cloudflare/migrations/0002_auth_role_assignment_route.sql"
   PASSWORDLESS_MIGRATION: "infra/cloudflare/migrations/0003_auth_passwordless_sessions.sql"
@@ -129,6 +131,35 @@ jobs:
             --remote \
             --config "${WRANGLER_CONFIG}" \
             --file "${SECURITY_REVIEW_ROUTE_PERMISSIONS_MIGRATION}"
+
+      - name: Ensure production R2 documents bucket exists
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} r2 bucket list --json > r2-buckets.json
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          target_name = os.environ["DOCUMENTS_R2_BUCKET"]
+          data = json.loads(Path("r2-buckets.json").read_text())
+          buckets = data.get("result") if isinstance(data, dict) else data
+          exists = any(bucket.get("name") == target_name for bucket in buckets or [])
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              env_file.write(f"NEED_CREATE_DOCUMENTS_R2_BUCKET={'false' if exists else 'true'}\n")
+
+          print(f"R2 bucket {target_name} {'already exists' if exists else 'does not exist yet'}.")
+          PY
+
+      - name: Create production R2 documents bucket
+        if: env.NEED_CREATE_DOCUMENTS_R2_BUCKET == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: npx --yes wrangler@${WRANGLER_VERSION} r2 bucket create "${DOCUMENTS_R2_BUCKET}"
 
       - name: Deploy Worker with production secrets
         uses: cloudflare/wrangler-action@v4
@@ -346,6 +377,7 @@ jobs:
           content = replace_once(content, 'name                = "rops-api"', 'name                = "rops-api-passwordless-preview"')
           content = replace_once(content, 'database_name = "researchops-d1"', 'database_name = "researchops-d1-preview"')
           content = replace_once(content, 'database_id = "48b35a2e-52e8-4bc0-a8cf-88a7a1536f04"', f'database_id = "{preview_database_id}"')
+          content = replace_once(content, 'bucket_name         = "researchops-documents"', f'bucket_name         = "{os.environ["DOCUMENTS_R2_PREVIEW_BUCKET"]}"')
           content = replace_once(content, 'RESEARCHOPS_BUILD_SHA = "local"', f'RESEARCHOPS_BUILD_SHA = "{os.environ["GITHUB_SHA"]}"')
           content = replace_once(content, 'RESEARCHOPS_BUILD_BRANCH = "local"', f'RESEARCHOPS_BUILD_BRANCH = "{os.environ["GITHUB_REF_NAME"]}"')
           preview_allowed_origins = (
@@ -436,6 +468,35 @@ jobs:
             --remote \
             --config "${WRANGLER_PREVIEW_CONFIG}" \
             --file "${REPOSITORY_SEED_CLEANUP_MIGRATION}"
+
+      - name: Ensure preview R2 documents bucket exists
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@${WRANGLER_VERSION} r2 bucket list --json > r2-buckets.json
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          target_name = os.environ["DOCUMENTS_R2_PREVIEW_BUCKET"]
+          data = json.loads(Path("r2-buckets.json").read_text())
+          buckets = data.get("result") if isinstance(data, dict) else data
+          exists = any(bucket.get("name") == target_name for bucket in buckets or [])
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              env_file.write(f"NEED_CREATE_DOCUMENTS_R2_PREVIEW_BUCKET={'false' if exists else 'true'}\n")
+
+          print(f"R2 bucket {target_name} {'already exists' if exists else 'does not exist yet'}.")
+          PY
+
+      - name: Create preview R2 documents bucket
+        if: env.NEED_CREATE_DOCUMENTS_R2_PREVIEW_BUCKET == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: npx --yes wrangler@${WRANGLER_VERSION} r2 bucket create "${DOCUMENTS_R2_PREVIEW_BUCKET}"
 
       - name: Deploy preview Worker with secrets
         uses: cloudflare/wrangler-action@v4


### PR DESCRIPTION
## Summary
- Merging #469 broke the production Worker deploy: `wrangler deploy` failed validating the new `RESEARCHOPS_DOCUMENTS_R2` binding because the `researchops-documents` R2 bucket didn't exist and R2 had never been enabled for the Cloudflare account.
- Add self-provisioning steps (list-then-create, mirroring the existing D1 pattern) so the deploy workflow creates the production and preview documents buckets if missing, instead of failing deep inside `wrangler deploy` with an opaque Cloudflare auth error.
- Stop the preview Worker from silently sharing the production `researchops-documents` bucket — it now gets its own `researchops-documents-preview` bucket, consistent with how preview D1 is already kept separate from production D1.

## Root cause (confirmed)
1. R2 had never been enabled/activated for the Cloudflare account (Cloudflare API returned `10042: Please enable R2 through the Cloudflare Dashboard` even for a validly-authenticated, R2-scoped token) — a one-time dashboard step, now done.
2. The `CF_API_TOKEN` GitHub secret used by this workflow lacked R2 permission — confirmed by direct Cloudflare API calls returning `10000: Authentication error` for R2 endpoints while D1/Workers Scripts endpoints succeeded with the same token. The secret has since been rotated to a token with combined Workers Scripts + D1 + R2 scope.

## Validation
- `npm run validate`
- `git diff --check`
- Ran the full `Deploy ResearchOps Worker` workflow on this branch via `workflow_dispatch` — `Deploy preview Cloudflare Worker` completed successfully end-to-end, including the new bucket-provisioning steps and the actual `wrangler deploy`.
- The `Deploy production Cloudflare Worker` job only runs on `main` (existing `if` condition), so production deploy will be exercised on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)